### PR TITLE
[#64] Add babel/register require to webpack hot config

### DIFF
--- a/webpack.config.hot.js
+++ b/webpack.config.hot.js
@@ -1,3 +1,4 @@
+require( 'babel/register' );
 var webpack = require( 'webpack' );
 var baseConfig = require( './webpack.config.js' );
 


### PR DESCRIPTION
Fixes missing Object.assign on node < 4.0.0
