### PR TITLE
Focuses the text editor when the note content is blank.

### DIFF
--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -1,8 +1,7 @@
 import React, { PropTypes } from 'react';
 import marked from 'marked';
 import Textarea from 'react-textarea-autosize';
-import { noop } from 'lodash';
-import { get } from 'lodash';
+import { noop, get } from 'lodash';
 
 const uninitializedNoteEditor = { focus: noop };
 


### PR DESCRIPTION
To test:
1. Start the app.
2. Click new note button
3. You should be able to type in the note editor without clicking on it first.

Fixes #90
