### PR TITLE
Set the modification date when updating a note.

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -440,6 +440,7 @@ var actionMap = new ActionMap( {
 				return dispatch => {
 					if ( note ) {
 						note.data.content = content;
+						note.data.modificationDate = Math.floor( Date.now() / 1000 );
 
 						// update the bucket but don't fire a sync immediately
 						noteBucket.update( note.id, note.data, { sync: false } );


### PR DESCRIPTION
You can test by editing a note, waiting a few seconds, then make another edit. View the history slider after that and you should see the correct timestamps.

Fixes #157
