### PR TITLE
Set a 100% height for the tag area of the navigation bar.

### DIFF
--- a/scss/navigation-bar.scss
+++ b/scss/navigation-bar.scss
@@ -59,6 +59,7 @@
 
 .navigation-tags {
 	display: flex;
+	height: 100%;
 	flex-direction: column;
 	flex: 0 1 auto;
 	overflow: hidden;


### PR DESCRIPTION
Fixes #145
