### PR TITLE
Small Screen Positioning and Transition Fixes

### DIFF
--- a/scss/general.scss
+++ b/scss/general.scss
@@ -59,15 +59,31 @@ a {
 
 	@media only screen and ( max-width: $single-column ) {
 		.note-editor {
-			flex: 1 0 100%;
+			position: absolute;
+			flex: none;
 			width: 100%;
+			height: 100%;
+			top: 0;
+			left: 0;
+			opacity: 0.0;
+			z-index: -1;
 			transition: $anim-transition;
-			transform: translate3d(0, 0, 0);
 		}
 
 		&.note-open .note-editor {
-			transform: translate3d(-100%, 0, 0);
-			transition-property: transform;
+			opacity: 1.0;
+		}
+
+		&.note-info-open {
+			.note-editor {
+				opacity: $fade-alpha;
+			}
+		}
+
+		&.navigation-open {
+			.note-editor {
+				opacity: 0;
+			}
 		}
 	}
 }

--- a/scss/general.scss
+++ b/scss/general.scss
@@ -65,13 +65,13 @@ a {
 			height: 100%;
 			top: 0;
 			left: 0;
-			opacity: 0.0;
+			opacity: 0;
 			z-index: -1;
 			transition: $anim-transition;
 		}
 
 		&.note-open .note-editor {
-			opacity: 1.0;
+			opacity: 1;
 		}
 
 		&.note-info-open {

--- a/scss/note-list.scss
+++ b/scss/note-list.scss
@@ -17,11 +17,11 @@
 		width: 100%;
 		height: 100%;
 		transition: $anim-transition;
-		opacity: 1.0;
+		opacity: 1;
 		pointer-events: auto;
 
 		.note-open & {
-			opacity: 0.0;
+			opacity: 0;
 			pointer-events: none;
 		}
 	}

--- a/scss/note-list.scss
+++ b/scss/note-list.scss
@@ -11,7 +11,6 @@
 
 	@media only screen and ( max-width: $single-column ) {
 		flex: none;
-		display: block;
 		position: absolute;
 		top: 0;
 		left: 0;

--- a/scss/note-list.scss
+++ b/scss/note-list.scss
@@ -10,11 +10,20 @@
 	}
 
 	@media only screen and ( max-width: $single-column ) {
-		flex: 0 0 100%;
-		transform: translate3d(0, 0, 0);
+		flex: none;
+		display: block;
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		transition: $anim-transition;
+		opacity: 1.0;
+		pointer-events: auto;
 
 		.note-open & {
-			transform: scale3d(0.95, 0.95, 1);
+			opacity: 0.0;
+			pointer-events: none;
 		}
 	}
 


### PR DESCRIPTION
@drw158 here's my attempt at fixing #160.

I think this wasn't a problem before because we didn't have the note info panel that was positioned at 100% to the left (off the screen). When the flex properties are changed all sorts of weirdness happens, including showing the info panel when it should still be off-screen.

To fix it, I changed the positioning of the list and editor divs so that they are essentially on top of one another. When the transition happens, the list fades out and the editor fades in. It's not quite as fancy as the slide transition but I still think it looks nice.

Feel free to play around with this, and it won't hurt my feelings if you don't like the new transition :)
