### PR TITLE
Adds support for the 'noteDisplay' setting.

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -366,7 +366,7 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 		const selectedNote = isSmallScreen || state.note ? state.note : filteredNotes[ noteIndex ];
 		const selectedNoteId = get( selectedNote, 'id', state.selectedNoteId );
 
-		const appClasses = classNames( 'app', `theme-${this.props.settings.theme}`, {
+		const appClasses = classNames( 'app', `theme-${settings.theme}`, {
 			'touch-enabled': ( 'ontouchstart' in document.body ),
 		} );
 
@@ -408,6 +408,7 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 								<NoteList
 									notes={filteredNotes}
 									selectedNoteId={selectedNoteId}
+									noteDisplay={settings.noteDisplay}
 									onSelectNote={this.onSelectNote}
 									onPinNote={this.onPinNote}
 									onEmptyTrash={state.showTrash && this.onEmptyTrash} />

--- a/lib/flux/settings.js
+++ b/lib/flux/settings.js
@@ -18,7 +18,8 @@ export default new ActionMap( {
 			sortType: 'modificationDate',
 			sortReversed: false,
 			theme: 'light',
-			fontSize: defaultFontSize
+			fontSize: defaultFontSize,
+			noteDisplay: 'comfy'
 		}, settings );
 	},
 

--- a/lib/note-list.jsx
+++ b/lib/note-list.jsx
@@ -11,15 +11,18 @@ export default React.createClass( {
 		selectedNoteId: PropTypes.any,
 		onSelectNote: PropTypes.func.isRequired,
 		onPinNote: PropTypes.func.isRequired,
+		noteDisplay: PropTypes.string.isRequired,
 		onEmptyTrash: PropTypes.func
 	},
 
 	render() {
-		var { selectedNoteId, onSelectNote, onEmptyTrash } = this.props;
+		var { selectedNoteId, onSelectNote, onEmptyTrash, noteDisplay } = this.props;
+
+		const listItemsClasses = classNames( 'note-list-items', noteDisplay );
 
 		return (
 			<div className="note-list">
-				<div className="note-list-items">
+				<div className={listItemsClasses}>
 					{this.props.notes.map( note => {
 						let text = this.noteTitleAndPreview( note );
 

--- a/scss/note-list.scss
+++ b/scss/note-list.scss
@@ -60,6 +60,15 @@
 .note-list {
 	display: flex;
 	flex-direction: column;
+
+	.condensed .note-list-item-excerpt {
+		display: none;
+	}
+
+	.expanded .note-list-item-excerpt {
+		white-space: normal;
+		max-height: 88px;
+	}
 }
 
 .note-list-items {


### PR DESCRIPTION
The settings was being saved to the store, but it didn't have a default set and wasn't applied to the list. Must have got lost in the dev rush.

The app should default to 'Comfy'. The Display settings should work like this:
- _Comfy_: Title and one line of preview are displayed
- _Compact_: Only the title is displayed
- _Expanded_: Title and up to four lines of preview are displayed

Fixes #195 
