### PR TITLE
Electron Menu Improvements

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -397,7 +397,8 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 		const mainClasses = classNames( 'simplenote-app', {
 			'note-open': selectedNote,
 			'note-info-open': state.showNoteInfo,
-			'navigation-open': state.showNavigation
+			'navigation-open': state.showNavigation,
+			'is-electron': isElectron()
 		} );
 
 		return (

--- a/scss/navigation-bar.scss
+++ b/scss/navigation-bar.scss
@@ -64,7 +64,7 @@
 	flex: 0 1 auto;
 	overflow: hidden;
 	min-height: 9em;
-	padding: 12px 0;
+	padding: 12px 0 0;
 	border-top: 1px solid lighten($gray, 30%);
 
 	.tag-list-title {
@@ -89,6 +89,12 @@
 	align-items: center;
 	padding: 0 20px 20px 20px;
 	color: darken($gray, 20%);
+}
+
+.is-electron {
+	.navigation-tools, .navigation-footer {
+		display: none;
+	}
 }
 
 .navigation-footer-item {


### PR DESCRIPTION
- Settings, help and about buttons are removed from the nav drawer when running in electron.
- Menu items for Settings, help and about now open the app dialogs properly.
- Windows and linux have 'Exit' and 'Settings' added to the 'File' menu.
- Windows and linux have 'About' added in the 'Help' menu

The menu declaration is getting... unruly. I think in the future we'd want to abstract it out and also add support for localization. But for now this will have to do.

Fixes #182
