### PR TITLE
Set a 100% min-height for the textarea.

### DIFF
--- a/scss/editor.scss
+++ b/scss/editor.scss
@@ -167,6 +167,7 @@
 }
 
 .note-detail-textarea {
+	min-height: 100%;
 	overflow: hidden;
 	cursor: text;
 }


### PR DESCRIPTION
Fixes #168
