### PR TITLE
Handle failed login attempts and notify the user

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -475,7 +475,10 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 								onOutsideClick={this.onToolbarOutsideClick} />
 						</div>
 				:
-					<Auth onAuthenticate={this.props.onAuthenticate} />
+					<Auth
+						isAuthenticated={state.authorized}
+						onAuthenticate={this.props.onAuthenticate}
+					/>
 				}
 				{this.renderDialogs()}
 			</div>

--- a/lib/auth.jsx
+++ b/lib/auth.jsx
@@ -4,6 +4,7 @@ import SimplenoteLogo from './icons/simplenote';
 export default React.createClass( {
 
 	propTypes: {
+		isAuthenticated: PropTypes.bool,
 		onAuthenticate: PropTypes.func.isRequired
 	},
 
@@ -12,6 +13,8 @@ export default React.createClass( {
 	},
 
 	render() {
+		const { isAuthenticated } = this.props;
+
 		return (
 			<div className="login">
 				<form className="login-form" onSubmit={this.onLogin}>
@@ -28,6 +31,9 @@ export default React.createClass( {
 							<span className="login-field-control"><input ref="password" id="login-field-password" type="password" /></span>
 						</label>
 					</div>
+					{ ( isAuthenticated === false ) &&
+						<p className="login-failed">The credentials you entered don't match.</p>
+					}
 					<div className="login-actions">
 						<button type="submit" className="button button-primary">Log in</button>
 						<p className="login-forgot">

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -81,14 +81,19 @@ let props = {
 	noteBucket: client.bucket( 'note' ),
 	tagBucket: client.bucket( 'tag' ),
 	onAuthenticate: ( username, password ) => {
-		auth.authorize( username, password ).then( user => {
-			store.dispatch( appState.action( 'setAccountName', {
-				accountName: username
-			} ) );
-			localStorage.access_token = user.access_token;
-			client.setUser( user );
-			analytics.tracks.recordEvent( 'user_signed_in' );
-		} );
+		store.dispatch( appState.action( 'resetAuth' ) );
+		auth.authorize( username, password )
+			.then( user => {
+				store.dispatch( appState.action( 'setAccountName', {
+					accountName: username
+				} ) );
+				localStorage.access_token = user.access_token;
+				client.setUser( user );
+				analytics.tracks.recordEvent( 'user_signed_in' );
+			} )
+			.catch( () => {
+				store.dispatch( appState.action( 'authFailed' ) )
+			} );
 	},
 	onSignOut: () => {
 		delete localStorage.access_token;

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -11,7 +11,7 @@ var actionMap = new ActionMap( {
 	namespace: 'App',
 
 	initialState: {
-		authorized: false,
+		authorized: null,
 		accountName: null,
 		editorMode: 'edit',
 		selectedNoteId: null,
@@ -29,6 +29,11 @@ var actionMap = new ActionMap( {
 	},
 
 	handlers: {
+		resetAuth( state ) {
+			return update( state, {
+				authorized: { $set: null }
+			} );
+		},
 
 		authChanged( state, { authorized } ) {
 			if ( authorized ) {
@@ -38,10 +43,16 @@ var actionMap = new ActionMap( {
 			}
 
 			return update( state, {
-				authorized: { $set: false },
+				authorized: { $set: null },
 				notes: { $set: [] },
 				tags: { $set: [] },
 				dialogs: { $set: [] }
+			} );
+		},
+
+		authFailed( state ) {
+			return update( state, {
+				authorized: { $set: false }
 			} );
 		},
 

--- a/scss/login-signup.scss
+++ b/scss/login-signup.scss
@@ -67,6 +67,11 @@
 		}
 	}
 
+	.login-failed {
+		color: $red;
+		text-align: center;
+	}
+
 	.login-actions {
 		margin-top: 22px;
 		text-align: center;


### PR DESCRIPTION
Resolves #174 

A bug in [node-simperium](https://github.com/Simperium/node-simperium/pull/24) was hiding a failed authentication attempt after throwing an exception inside a promise. This branch depends on the fix to that bug.

`state.authorized` has been altered from a simple boolean to a tri-state value. `null` now means that no authentication attempt has been made while `false` means that an attempt has failed and `true` means that an attempt succeeded.

This value then gets passed into the `<Auth />` component which can make the appropriate visualizations to notify the user if there was an issue with the login attempt.

cc: @roundhill 
