### PR TITLE
Stop "authenticating" for the "undefined" access token

### DIFF
--- a/lib/auth.jsx
+++ b/lib/auth.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react'
+import { get } from 'lodash';
 import SimplenoteLogo from './icons/simplenote';
 
 export default React.createClass( {
@@ -9,7 +10,9 @@ export default React.createClass( {
 	},
 
 	componentDidMount() {
-		this.refs.username.focus();
+		if ( this.usernameInput ) {
+			this.usernameInput.focus();
+		}
 	},
 
 	render() {
@@ -24,11 +27,15 @@ export default React.createClass( {
 					<div className="login-fields theme-color-border theme-color-fg">
 						<label className="login-field theme-color-border" htmlFor="login-field-username">
 							<span className="login-field-label">Email</span>
-							<span className="login-field-control"><input ref="username" id="login-field-username" type="email" /></span>
+							<span className="login-field-control">
+								<input ref={ ref => this.usernameInput = ref } id="login-field-username" type="email" />
+							</span>
 						</label>
 						<label className="login-field theme-color-border" htmlFor="login-field-password">
 							<span className="login-field-label">Password</span>
-							<span className="login-field-control"><input ref="password" id="login-field-password" type="password" /></span>
+							<span className="login-field-control">
+								<input ref={ ref => this.passwordInput = ref } id="login-field-password" type="password" />
+							</span>
 						</label>
 					</div>
 					{ ( isAuthenticated === false ) &&
@@ -52,10 +59,14 @@ export default React.createClass( {
 	onLogin( event ) {
 		event.preventDefault();
 
-		this.props.onAuthenticate(
-			this.refs.username.value,
-			this.refs.password.value
-		)
+		const username = get( this.usernameInput, 'value' );
+		const password = get( this.passwordInput, 'value' );
+
+		if ( ! ( username && password ) ) {
+			return;
+		}
+
+		this.props.onAuthenticate( username, password );
 	},
 
 	onForgot( event ) {

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -81,9 +81,18 @@ let props = {
 	noteBucket: client.bucket( 'note' ),
 	tagBucket: client.bucket( 'tag' ),
 	onAuthenticate: ( username, password ) => {
+		if ( ! ( username && password ) ) {
+			return;
+		}
+
 		store.dispatch( appState.action( 'resetAuth' ) );
 		auth.authorize( username, password )
 			.then( user => {
+				if ( ! user.access_token ) {
+					return store
+						.dispatch( appState.action( 'authFailed' ) );
+				}
+
 				store.dispatch( appState.action( 'setAccountName', {
 					accountName: username
 				} ) );

--- a/main.js
+++ b/main.js
@@ -30,12 +30,12 @@ module.exports = function main( url ) {
 
 		// Create the browser window.
 		var iconPath = path.join( __dirname, '/lib/icons/app-icon/icon_256x256.png' );
-		mainWindow = new BrowserWindow( { 
-			width: 1024, 
+		mainWindow = new BrowserWindow( {
+			width: 1024,
 			height: 768,
 			minWidth: 370,
 			minHeight: 520,
-			icon: iconPath 
+			icon: iconPath
 		} );
 
 		// and load the index of the app.


### PR DESCRIPTION
Resolves #212

Previously the app would allow sending an authentication attempt with no
values written in the username or password fields. This returned a valid
response, but the app didn't interpret that response properly and thus
entered an authenticated state without having a valid login.

Technically, the response came back as valid JSON, but the
`access_token` property was undefined, which got saved in `localStorage`
as `'undefined'`, a value that failed to test as empty but which in
reality was.

If an app is currently in this undefined state, it might need to have
its localStorage reset. This not should occur moving forward since the
guards are in the authentication function.
- Prevents sending the auth request with empty username or password
- Placed multiple guards against using invalid login states

cc: @roundhill 
