### PR TITLE
Allow reopening app after closing but while still docked

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,18 +11,14 @@ module.exports = function main( url ) {
 	// be closed automatically when the JavaScript object is GCed.
 	var mainWindow = null;
 
-	// Quit when all windows are closed.
-	app.on( 'window-all-closed', function() {
-		// On OS X it is common for applications and their menu bar
-		// to stay active until the user quits explicitly with Cmd + Q
-		if ( process.platform !== 'darwin' ) {
-			app.quit();
-		}
-	} );
+	const activateWindow = function() {
 
-	// This method will be called when Electron has finished
-	// initialization and is ready to create browser windows.
-	app.on( 'ready', function() {
+		// Only allow a single window
+		// to be open at any given time
+		if ( mainWindow ) {
+			return;
+		}
+
 		// Configure and set the application menu
 		var menuTemplate = createMenuTemplate();
 		var menu = Menu.buildFromTemplate( menuTemplate );
@@ -30,12 +26,12 @@ module.exports = function main( url ) {
 
 		// Create the browser window.
 		var iconPath = path.join( __dirname, '/lib/icons/app-icon/icon_256x256.png' );
-		mainWindow = new BrowserWindow( { 
-			width: 1024, 
+		mainWindow = new BrowserWindow( {
+			width: 1024,
 			height: 768,
 			minWidth: 370,
 			minHeight: 520,
-			icon: iconPath 
+			icon: iconPath
 		} );
 
 		// and load the index of the app.
@@ -55,7 +51,21 @@ module.exports = function main( url ) {
 			// when you should delete the corresponding element.
 			mainWindow = null;
 		} );
+	};
+
+	// Quit when all windows are closed.
+	app.on( 'window-all-closed', function() {
+		// On OS X it is common for applications and their menu bar
+		// to stay active until the user quits explicitly with Cmd + Q
+		if ( process.platform !== 'darwin' ) {
+			app.quit();
+		}
 	} );
+
+	// This method will be called when Electron has finished
+	// initialization and is ready to create browser windows.
+	app.on( 'ready', activateWindow );
+	app.on( 'activate', activateWindow );
 };
 
 function createMenuTemplate() {


### PR DESCRIPTION
Resolves #188
See:
https://github.com/atom/electron/blob/master/docs/api/app.md#event-open-file

Previously, if you closed the Electron app in OSX, the icon remained in
the dock, but clicking on that icon didn't reopen the window. This has
now been fixed.

Changes:
- Split window opening code into its own function
- Call that function now on the app.activate event

cc: @drw158 @roundhill 
