### PR TITLE
Replace emoji in title with non-bolded variants

### DIFF
--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -3,6 +3,8 @@ import marked from 'marked';
 import Textarea from 'react-textarea-autosize';
 import { noop, get } from 'lodash';
 
+import { unbold } from './note-display-mixin';
+
 const uninitializedNoteEditor = { focus: noop };
 
 export default React.createClass( {
@@ -79,7 +81,7 @@ export default React.createClass( {
 	},
 
 	renderMarkdown( divStyle ) {
-		var markdownHTML = marked( this.state.content );
+		var markdownHTML = marked( unbold( this.state.content ) );
 
 		return (
 			<div className="note-detail-markdown theme-color-bg theme-color-fg"

--- a/lib/note-display-mixin.js
+++ b/lib/note-display-mixin.js
@@ -1,12 +1,35 @@
+import React from 'react';
+
 const noteTitleAndPreviewRegExp = /(\S[^\n]*)\s*(\S[^\n]*)?/;
+
+const unbold = string => {
+	var html = [ ...string ].map( c => {
+		const a = c[0];
+		const b = [ ...c ][0];
+
+		if ( a !== b ) {
+			return React.createElement( 'span', {
+				children: b,
+				style: { fontWeight: 'normal !important' }
+			} );
+		}
+
+		return b;
+	} );
+
+	return React.createElement( 'div', { children: html } );
+};
 
 export default {
 	noteTitleAndPreview: function( note ) {
 		var content = note && note.data && note.data.content;
 		var match = noteTitleAndPreviewRegExp.exec( content || '' );
 
-		var title = match && match[1] && match[1].slice( 0, 200 ) || 'New note...';
-		var preview = match && match[2] || '';
+		var title = unbold( match && match[1] && match[1].slice( 0, 200 ) || 'New note...' );
+
+		// Unbold emoji - https://github.com/Automattic/simplenote-electron/issues/107
+
+		var preview = unbold( match && match[2] || '' );
 
 		return { title, preview };
 	}

--- a/lib/note-display-mixin.js
+++ b/lib/note-display-mixin.js
@@ -2,7 +2,17 @@ import React from 'react';
 
 const noteTitleAndPreviewRegExp = /(\S[^\n]*)\s*(\S[^\n]*)?/;
 
-const unbold = string => {
+export const unbold = string => [ ...string ]
+	.reduce( ( s, c ) => {
+		const a = c[0];
+		const b = [ ...c ][0];
+
+		return ( a === b )
+			? s + b
+			: `${ s }<span style="font-weight: normal !important">${ b }</span>`;
+	}, '' );
+
+export const unboldComponent = string => {
 	var html = [ ...string ].map( c => {
 		const a = c[0];
 		const b = [ ...c ][0];
@@ -25,11 +35,10 @@ export default {
 		var content = note && note.data && note.data.content;
 		var match = noteTitleAndPreviewRegExp.exec( content || '' );
 
-		var title = unbold( match && match[1] && match[1].slice( 0, 200 ) || 'New note...' );
-
 		// Unbold emoji - https://github.com/Automattic/simplenote-electron/issues/107
+		var title = unboldComponent( match && match[1] && match[1].slice( 0, 200 ) || 'New note...' );
 
-		var preview = unbold( match && match[2] || '' );
+		var preview = match && match[2] || '';
 
 		return { title, preview };
 	}

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -5,6 +5,7 @@ import TagField from './tag-field'
 import NoteToolbar from './note-toolbar'
 import RevisionSelector from './revision-selector'
 import marked from 'marked'
+import { unbold } from './note-display-mixin'
 import { get } from 'lodash'
 
 export default React.createClass( {
@@ -104,7 +105,7 @@ export default React.createClass( {
 
 		if ( shouldPrint ) {
 			const content = get( revision, 'data.content', '' );
-			noteContent = markdownEnabled ? marked( content ) : content;
+			noteContent = markdownEnabled ? marked( unbold( content ) ) : content;
 		}
 
 		const printStyle = {

--- a/lib/note-info.jsx
+++ b/lib/note-info.jsx
@@ -114,12 +114,6 @@ function wordCount( content ) {
 	return ( ( content || '' ).match( /\b\S+\b/g ) || [] ).length;
 }
 
-// https://mathiasbynens.be/notes/javascript-unicode
-const surrogatePairs = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g;
 function characterCount( content ) {
-	return ( content || '' )
-		// replace every surrogate pair with a BMP symbol
-		.replace( surrogatePairs, '_' )
-		// then get the length
-		.length;
+	return [ ...content || '' ].length;
 }


### PR DESCRIPTION
Resolves #107 

Chromium doesn't display emoji and some other characters which have a font-weight other than the default set. We might be able to solve this by loading a webfoot, but this solution also is working somewhat. I've noticed some issues with certain Emoji that behave differently than others, such as the  :heart: or :airplane: which are appearing as a box in most cases but sometimes correctly.

This patch also doesn't fix the preview pane when Markdown is enabled, but I'm done for the day. Will need to run that preview through the `unbold()` or whatever also to fix there.