### PR TITLE
Change "Sign Out" to "Log Out"

### DIFF
--- a/lib/dialogs/settings.jsx
+++ b/lib/dialogs/settings.jsx
@@ -83,7 +83,7 @@ export default React.createClass( {
 						</div>
 
 						<ul className="dialog-actions">
-							<li><button type="button" className="button button-primary" onClick={this.props.onSignOut}>Sign Out</button></li>
+							<li><button type="button" className="button button-primary" onClick={this.props.onSignOut}>Log Out</button></li>
 							<li><button type="button" className="button button button-borderless" onClick={this.onEditAccount}>Edit Account <TopRightArrowIcon /></button></li>
 						</ul>
 					</div>


### PR DESCRIPTION
Resolves #219 

@drw158 the Electron menu shows "Preferences" but doesn't have a sign-out option, just quit. Do you think we need to add this or were you just wanting to make sure we don't mix terminology?