### PR TITLE
Strips `font-weight` property for note title in list

### DIFF
--- a/scss/note-list.scss
+++ b/scss/note-list.scss
@@ -4,7 +4,7 @@
 	display: flex;
 	flex-direction: column;
 	transition: transform 200ms ease-in-out;
-	
+
 	@media only screen and ( max-width: $medium ) {
 		width: 300px;
 	}
@@ -154,7 +154,6 @@
 
 	.note-list-item-title {
 		font-size: 16px;
-		font-weight: $bold;
 	}
 
 	.note-list-item-excerpt {


### PR DESCRIPTION
Resolves #107

Previously Chromium was glitching with `font-weight: bold` when trying
to show Emoji. Instead of the Emoji, it showed nothing.

An attempt was made to dynamically replace the Emoji with short spans
with priority on `font-weight: normal` but performance was an issue.

Since the trunk build of Chromium has resolved this and another
Emoji-related bug, this patch removes the bold property for now to get
around the problem.