### PR TITLE
Center Preview/Edit mode selector in Safari

### DIFF
--- a/scss/editor.scss
+++ b/scss/editor.scss
@@ -55,7 +55,7 @@
 	display: flex;
 	align-items: center;
 	padding: 0 15px;
-	
+
 	@media only screen and ( max-width: $single-column ) {
 		width: 100%;
 		justify-content: space-between;
@@ -65,7 +65,7 @@
 		flex: none;
 		margin-right: 14px;
 		text-align: center;
-		
+
 		&:last-child {
 			margin-right: 0;
 		}
@@ -118,7 +118,8 @@
 	flex: none;
 	margin: 0 auto;
 	padding-top: 24px;
-	display: auto;
+	display: flex;
+	justify-content: center;
 	transition: all .3s ease-in-out;
 
 	.button-segmented-control {
@@ -160,7 +161,7 @@
 	&:focus {
 		outline: none;
 	}
-	
+
 	@media only screen and ( max-width: $medium ) {
 		padding: 24px;
 	}


### PR DESCRIPTION
Resolves #147

Previously the mode bar in the note editor wasn't centered in Safari 9.
This was probably due to `margin: 0 auto` being set without having a
`width` set as well.

Now, the mode bar has been nested inside another `<div />` to setup
relative positioning and translations to make sure the bar gets centered
in all browsers.

cc: @drw158 please review the way I accomplished this with CSS
