### PR TITLE
Manually sort notes when updating store

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -17,7 +17,13 @@ import TagsIcon from './icons/tags'
 import NoteDisplayMixin from './note-display-mixin'
 import analytics from './analytics'
 import classNames	from 'classnames'
-import { noop, get, has } from 'lodash';
+import {
+	get,
+	has,
+	includes,
+	matchesProperty,
+	noop
+} from 'lodash';
 
 let ipc = getIpc();
 
@@ -53,6 +59,19 @@ const isElectron = ( () => {
 
 	return () => foundElectron;
 } )();
+
+/* Note filters */
+const untrashedAndVisibleTrash = showTrash =>
+	matchesProperty( 'data.deleted', showTrash );
+
+const matchingSelectedTag = tag => note =>
+	! tag || includes( note.data.tags, tag.data.name );
+
+const matchesSearch = regexp => note =>
+	! regexp || regexp.test( get( note, 'data.content', '' ) );
+
+const matchesAll = ( ...filters ) => o =>
+	filters.reduce( (t, c) => t && c(o), true );
 
 export const App = connect( mapStateToProps, mapDispatchToProps )( React.createClass( {
 
@@ -264,29 +283,15 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 	},
 
 	filterNotes: function() {
-		var { filter, showTrash, notes, tag } = this.props.appState;
-		var regexp;
+		const  { filter, showTrash, notes, tag } = this.props.appState;
+		const regexp = filter && new RegExp( filter, 'gi' );
 
-		if ( filter ) {
-			regexp = new RegExp( filter, 'gi' );
-		}
-
-		function test( note ) {
-			// if and only if trash is being viewed, return trashed notes
-			if ( showTrash !== !!note.data.deleted ) {
-				return false;
-			}
-			// if tag is selected only return those with the tag
-			if ( tag && note.data.tags.indexOf( tag.data.name ) === -1 ) {
-				return false;
-			}
-			if ( regexp && !regexp.test( note.data.content || '' ) ) {
-				return false;
-			}
-			return true;
-		}
-
-		return notes.filter( test );
+		return notes
+			.filter( matchesAll(
+				untrashedAndVisibleTrash( showTrash ),
+				matchingSelectedTag( tag ),
+				matchesSearch( regexp )
+			) );
 	},
 
 	onSetEditorMode: function( mode ) {

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -4,6 +4,7 @@ import ActionMap from './action-map'
 import throttle from '../utils/throttle'
 import analytics from '../analytics'
 import { util as simperiumUtil } from 'simperium'
+import { get } from 'lodash';
 
 const typingThrottle = 3000;
 
@@ -307,7 +308,7 @@ var actionMap = new ActionMap( {
 								notes.push( cursor.value );
 								cursor.continue();
 							} else {
-								dispatch( this.action( 'notesLoaded', { notes: notes } ) );
+								dispatch( this.action( 'notesLoaded', { notes: notes, sortType, sortReversed } ) );
 							}
 						};
 					} );
@@ -315,8 +316,21 @@ var actionMap = new ActionMap( {
 			}
 		},
 
-		notesLoaded( state, { notes } ) {
-			const [ pinned, notPinned ] = partition( notes, note => note.pinned );
+		notesLoaded( state, { notes, sortType, sortReversed } ) {
+			const partitionedNotes = partition( notes, note => note.pinned );
+
+			const sorts = key => get( {
+				alphabetical: ( a, b ) => a.data.content.localeCompare( b.data.content ),
+				creationDate: ( a, b ) => b.data.creationDate - a.data.creationDate,
+				modificationDate: ( a, b ) => b.data.modificationDate - a.data.modificationDate
+			}, key, (a, b) => 0 );
+
+			const reverser = sorter => sortReversed
+				? (a, b) => -1 * sorter( a, b )
+				: sorter;
+
+			const [ pinned, notPinned ] = partitionedNotes
+				.map( l => l.sort( reverser( sorts( sortType ) ) ) );
 
 			return update( state, {
 				notes: { $set: [ ...pinned, ...notPinned ] }


### PR DESCRIPTION
Resolves #144

Previously, the sort or the notes was determined by **indexdb**, which
apparently didn't work as expected in Firefox.

Now, the notes are manually sorted in JavaScript to guarantee sort
order. This works in Firefox and should work universally.

I changed the note filtering function a bit too.

@roundhill you might want to verify the performance with a big bucket of notes