### PR TITLE
Add an icon in the list view for published notes

### DIFF
--- a/lib/icons/feed.jsx
+++ b/lib/icons/feed.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default function FeedIcon() {
+	return (
+		<svg className="icon-feed" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" >
+			<path
+				d="M2,8.667V12c5.515,0,10,4.485,10,10h3.333C15.333,14.637,9.363,8.667,2,8.667z M2,2v3.333
+				c9.19,0,16.667,7.477,16.667,16.667H22C22,10.955,13.045,2,2,2z M4.5,17C3.118,17,2,18.12,2,19.5S3.118,22,4.5,22S7,20.88,7,19.5
+				S5.882,17,4.5,17z"/>
+		</svg>
+	);
+}
+

--- a/lib/note-list.jsx
+++ b/lib/note-list.jsx
@@ -28,6 +28,7 @@ export default React.createClass( {
 					{this.props.notes.map( note => {
 						let text = this.noteTitleAndPreview( note );
 						const isPublished = ! isEmpty( note.data.publishURL );
+						const showPublishIcon = isPublished && ( 'condensed' !== noteDisplay );
 
 						let classes = classNames( 'note-list-item', {
 							'note-list-item-selected': selectedNoteId === note.id,
@@ -41,7 +42,7 @@ export default React.createClass( {
 								<div className="note-list-item-text theme-color-border" tabIndex="0" onClick={onSelectNote.bind( null, note.id )}>
 									<div className="note-list-item-title">
 										<span>{text.title}</span>
-										{ isPublished &&
+										{ showPublishIcon &&
 											<div className="note-list-item-published-icon"><PublishIcon /></div> }
 									</div>
 									<div className="note-list-item-excerpt">{text.preview}</div>

--- a/lib/note-list.jsx
+++ b/lib/note-list.jsx
@@ -39,11 +39,13 @@ export default React.createClass( {
 							<div key={note.id} className={classes}>
 								<div className="note-list-item-pinner" tabIndex="0" onClick={this.onPinNote.bind( this, note )}></div>
 								<div className="note-list-item-text theme-color-border" tabIndex="0" onClick={onSelectNote.bind( null, note.id )}>
-									<div className="note-list-item-title">{text.title}</div>
+									<div className="note-list-item-title">
+										<span>{text.title}</span>
+										{ isPublished &&
+											<div className="note-list-item-published-icon"><PublishIcon /></div> }
+									</div>
 									<div className="note-list-item-excerpt">{text.preview}</div>
 								</div>
-								{ isPublished &&
-									<div className="note-list-item-published-icon"><PublishIcon /></div> }
 							</div>
 						);
 					} )}

--- a/lib/note-list.jsx
+++ b/lib/note-list.jsx
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react'
 import NoteDisplayMixin from './note-display-mixin'
+import PublishIcon from './icons/feed'
 import classNames from 'classnames'
+import { isEmpty } from 'lodash';
 
 export default React.createClass( {
 
@@ -25,10 +27,12 @@ export default React.createClass( {
 				<div className={listItemsClasses}>
 					{this.props.notes.map( note => {
 						let text = this.noteTitleAndPreview( note );
+						const isPublished = ! isEmpty( note.data.publishURL );
 
 						let classes = classNames( 'note-list-item', {
 							'note-list-item-selected': selectedNoteId === note.id,
-							'note-list-item-pinned': note.pinned
+							'note-list-item-pinned': note.pinned,
+							'published-note': isPublished
 						} );
 
 						return (
@@ -38,6 +42,8 @@ export default React.createClass( {
 									<div className="note-list-item-title">{text.title}</div>
 									<div className="note-list-item-excerpt">{text.preview}</div>
 								</div>
+								{ isPublished &&
+									<div className="note-list-item-published-icon"><PublishIcon /></div> }
 							</div>
 						);
 					} )}

--- a/scss/note-list.scss
+++ b/scss/note-list.scss
@@ -86,7 +86,6 @@
 }
 
 .note-list-item {
-	position: relative;
 	display: flex;
 	padding-left: 8px;
 	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
@@ -154,9 +153,7 @@
 	}
 
 	.note-list-item-published-icon {
-		position: absolute;
-		left: 13px;
-		top: 35px;
+		margin-left: auto;
 
 		& svg {
 			fill: $gray;
@@ -166,7 +163,13 @@
 	}
 
 	.note-list-item-title {
+		display: flex;
 		font-size: 16px;
+
+		& span {
+			width: calc(100% - 24px);
+			text-overflow: ellipsis;
+		}
 	}
 
 	.note-list-item-excerpt {

--- a/scss/note-list.scss
+++ b/scss/note-list.scss
@@ -86,6 +86,7 @@
 }
 
 .note-list-item {
+	position: relative;
 	display: flex;
 	padding-left: 8px;
 	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
@@ -149,6 +150,18 @@
 	&.note-list-item-selected {
 		.note-list-item-title, .note-list-item-excerpt {
 			color: $blue;
+		}
+	}
+
+	.note-list-item-published-icon {
+		position: absolute;
+		left: 13px;
+		top: 35px;
+
+		& svg {
+			fill: $gray;
+			height: 12px;
+			width: 12px;
 		}
 	}
 

--- a/scss/note-list.scss
+++ b/scss/note-list.scss
@@ -167,8 +167,8 @@
 		font-size: 16px;
 
 		& span {
-			width: calc(100% - 24px);
 			text-overflow: ellipsis;
+			overflow: hidden;
 		}
 	}
 


### PR DESCRIPTION
Resolves #220

Previously this app lacked the icon that the existing Simplenote web app
has for notes that are published.

This path adds the "signal" or "feed" icon to the left of the note
snippet in the list view for those notes.

**Before**
<img width="376" alt="screen shot 2016-03-15 at 10 28 35 am" src="https://cloud.githubusercontent.com/assets/5431237/13787552/a8c4ef0a-ea99-11e5-85cf-b45f8ad31eb5.png">

**After**
<img width="358" alt="screen shot 2016-03-15 at 10 28 50 am" src="https://cloud.githubusercontent.com/assets/5431237/13787558/adc4a7e8-ea99-11e5-910e-080e0069a0f4.png">

cc: @drw158 for CSS review. I think I didn't break anything :smile:
