### PR TITLE
Adds copy button to note info panel.

### DIFF
--- a/lib/dialogs/share.jsx
+++ b/lib/dialogs/share.jsx
@@ -3,6 +3,7 @@ import createHash from 'create-hash/browser';
 import { includes } from 'lodash';
 import TabbedDialog from '../tabbed-dialog';
 import ToggleControl from '../controls/toggle';
+import { isEmpty } from 'lodash';
 
 const shareTabs = [ 'collaborate', 'publish' ];
 
@@ -38,6 +39,10 @@ export default React.createClass( {
 		}
 
 		this.copyUrlElement.focus();
+	},
+
+	getPublishURL( url ) {
+		return isEmpty( url ) ? null : `http://simp.ly/p/${url}`;
 	},
 
 	onAddCollaborator( event ) {
@@ -111,7 +116,7 @@ export default React.createClass( {
 		const { note } = this.props.params;
 		const data = note && note.data || {};
 		const isPublished = includes( data.systemTags, 'published' );
-		const publishURL = isPublished && data.publishURL !== '' && data.publishURL && `http://simp.ly/publish/${data.publishURL}` || null;
+		const publishURL = this.getPublishURL( data.publishURL );
 
 		switch ( tabName ) {
 			case 'collaborate':

--- a/lib/note-info.jsx
+++ b/lib/note-info.jsx
@@ -3,6 +3,7 @@ import { includes } from 'lodash';
 import ToggleControl from './controls/toggle';
 import moment from 'moment';
 import CrossIcon from './icons/cross';
+import { isEmpty } from 'lodash';
 
 export default React.createClass( {
 
@@ -22,6 +23,22 @@ export default React.createClass( {
 		this.props.onOutsideClick( false );
 	},
 
+	copyPublishURL: function() {
+		this.publishUrlElement.select();
+
+		try {
+			document.execCommand( 'copy' );
+		} catch ( err ) {
+			return;
+		}
+
+		this.copyUrlElement.focus();
+	},
+
+	getPublishURL: function( url ) {
+		return isEmpty( url ) ? null : `http://simp.ly/p/${url}`;
+	},
+
 	render: function() {
 		const { note, markdownEnabled } = this.props;
 		const data = note && note.data || {};
@@ -30,7 +47,7 @@ export default React.createClass( {
 		const isPinned = includes( data.systemTags, 'pinned' );
 		const isMarkdown = includes( data.systemTags, 'markdown' );
 		const isPublished = includes( data.systemTags, 'published' );
-		const publishURL = isPublished && data.publishURL !== '' && data.publishURL && `http://simp.ly/publish/${data.publishURL}` || null;
+		const publishURL = this.getPublishURL( data.publishURL );
 
 		return (
 			<div className="note-info theme-color-bg theme-color-fg theme-color-border">
@@ -85,12 +102,17 @@ export default React.createClass( {
 				</div>}
 				{ isPublished &&
 					<div className="note-info-panel note-info-public-link theme-color-border">
-						<p className="note-info-item">
 							<span className="note-info-item-text">
 								<span className="note-info-name">Public link</span>
-								<br /><span className="note-info-detail">{publishURL}</span>
+								<div className="note-info-form">
+									<input ref={e => this.publishUrlElement = e} className="note-info-detail note-info-link-text" value={publishURL} />
+									<button
+										ref={e => this.copyUrlElement = e}
+										type="button"
+										className="button button-borderless note-info-copy-button"
+										onClick={this.copyPublishURL}>Copy</button>
+								</div>
 							</span>
-						</p>
 					</div>
 				}
 			</div>

--- a/scss/note-info.scss
+++ b/scss/note-info.scss
@@ -60,7 +60,23 @@
 		color: $gray;
 	}
 
-	.note-info-public-link {
+	.note-info-link-text {
+		width: 100%;
+		border: none;
+		padding: 0 8px 0 0;
+		text-overflow: ellipsis;
+		
+		&:focus {
+			outline: none;
+		}
+	}
+	
+	.note-info-form {
+		display: flex;
+	}
+
+	.note-info-copy-button {
+		padding: 0;
 		flex: 1 0 auto;
 	}
 }


### PR DESCRIPTION
I pretty much copied (ha!) how the copy button worked in the publish panel.

@drw158 The copy button didn't really fit next to the Url so I put it beneath it:

<img width="267" alt="screen shot 2016-03-21 at 4 56 37 pm" src="https://cloud.githubusercontent.com/assets/789137/13937885/e90e9c78-ef85-11e5-8ebd-7f2aa54e3b81.png">

Fixes #241