### PR TITLE
Reload notes list after deleting a note forever.

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -559,6 +559,7 @@ var actionMap = new ActionMap( {
 					noteBucket.remove( note.id );
 
 					dispatch( this.action( 'closeNote', { previousIndex } ) );
+					dispatch( this.action( 'loadNotes', { noteBucket } ) );
 				};
 			}
 		},


### PR DESCRIPTION
The note _was_ being deleted forever, but the UI wasn't being told to refresh.

Fixes #238