### PR TITLE
New menu items and keyboard shortcuts for New Note and Search

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -114,7 +114,12 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 
 	onAppCommand: function( command ) {
 		if ( command != null && typeof command === 'object' && command.action != null && this.props.actions.hasOwnProperty( command.action ) ) {
-			this.props.actions[ command.action ]( command );
+			// newNote expects a bucket to be passed in, but the action method itself wouldn't do that
+			if ( command.action === 'newNote' ) {
+				this.onNewNote();
+			} else {
+				this.props.actions[ command.action ]( command );
+			}
 		}
 	},
 
@@ -147,6 +152,12 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 	onNotePrinted: function() {
 		this.props.actions.setShouldPrintNote( {
 			shouldPrint: false
+		} );
+	},
+
+	onSearchFocused: function() {
+		this.props.actions.setSearchFocus( {
+			searchFocus: false
 		} );
 	},
 
@@ -436,7 +447,11 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 									<button className="button button-borderless" onClick={() => this.props.actions.toggleNavigation() }>
 										<TagsIcon />
 									</button>
-									<SearchField onSearch={this.onSearch} placeholder={state.listTitle} />
+									<SearchField
+										onSearch={this.onSearch}
+										placeholder={state.listTitle}
+										searchFocus={state.searchFocus}
+										onSearchFocused={this.onSearchFocused} />
 									<button className="button button-borderless" disabled={state.showTrash} onClick={this.onNewNote}>
 										<NewNoteIcon />
 									</button>

--- a/lib/auth.jsx
+++ b/lib/auth.jsx
@@ -18,10 +18,8 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { isAuthenticated, authPending } = this.props;
-		const submitClasses = classNames( 'button', 'button-primary', {
-			'pending': authPending
-		} );
+		const { isAuthenticated, authPending: pending } = this.props;
+		const submitClasses = classNames( 'button', 'button-primary', { pending } );
 
 		return (
 			<div className="login">

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -26,7 +26,8 @@ var actionMap = new ActionMap( {
 		editingTags: false,
 		dialogs: [],
 		nextDialogKey: 0,
-		shouldPrint: false
+		shouldPrint: false,
+		searchFocus: false
 	},
 
 	handlers: {
@@ -356,6 +357,12 @@ var actionMap = new ActionMap( {
 		setShouldPrintNote( state, { shouldPrint = true } ) {
 			return update( state, {
 				shouldPrint: { $set: shouldPrint }
+			} );
+		},
+
+		setSearchFocus( state, { searchFocus = true } ) {
+			return update( state, {
+				searchFocus: { $set: searchFocus }
 			} );
 		},
 

--- a/lib/search-field.jsx
+++ b/lib/search-field.jsx
@@ -1,11 +1,27 @@
-import React from 'react'
+import React, { PropTypes } from 'react'
 
 export default React.createClass( {
+
+	propTypes: {
+		placeholder: PropTypes.string.isRequired,
+		searchFocus: PropTypes.bool.isRequired,
+		onSearch: PropTypes.func.isRequired,
+		onSearchFocused: PropTypes.func.isRequired
+	},
 
 	getDefaultProps: function() {
 		return {
 			placeholder: 'Search',
 			onSearch: function() {}
+		}
+	},
+
+	componentDidUpdate: function() {
+		const { searchFocus, onSearchFocused } = this.props;
+		const { search } = this.refs;
+		if ( searchFocus ) {
+			search.focus();
+			onSearchFocused();
 		}
 	},
 


### PR DESCRIPTION
I had to add a special case for `newNote` in the `onAppCommand` method because it needs to pass the note bucket to the actions method.

Search field focus works by adding a new boolean state that instantly gets set back to false once the field has been focused.

Fixes #249