### PR TITLE
Make linux builder more robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/**/*
+vendor/
 build/
 dist/
 release/
@@ -8,3 +9,5 @@ release/
 *.tgz
 .idea
 .DS_Store
+/Gemfile.lock
+/.bundle/config

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source "https://rubygems.org"
+gem "fpm"

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -33,13 +33,19 @@ The Windows build doesn't get signed until the packaging stage
 
 ## Linux Package
 
-The Linux package is build using [FPM][1] which is a tool that makes it easy to build different package systems. To install FPM just run:
+The Linux package is built using [FPM][1] which is a tool that makes it easy to build packages for different distributions. To install FPM you can do the following:
 
-`gem install fpm`
+```bash
+gem install fpm # For a global install
+bundle install --path vendor/bundle # For a local install.
+```
 
-FRM needs ruby and `gnu-tar`. You can install ruby using [RVM][2] and `gnu-tar` with:
+You can install ruby using [RVM][2] or on Ubuntu/Debian:
 
-`brew install gnu-tar`
+```bash
+sudo apt-get install ruby2.0 ruby2.0-dev # Ubuntu 14.04+/Debian Stable
+sudo apt-get install ruby2.3 ruby2.3-dev # Ubuntu 16.04+/Debian Unstable
+```
 
 [1]: https://github.com/jordansissel/fpm
 [2]: https://rvm.io/rvm/install

--- a/resources/build-scripts/package-linux.js
+++ b/resources/build-scripts/package-linux.js
@@ -44,6 +44,7 @@ cp.execSync( "cp -r release/Simplenote-linux-x64 release/tmp/usr/share/simplenot
 cp.execSync( "mv release/tmp/usr/share/simplenote/Simplenote release/tmp/usr/share/simplenote/simplenote", onErrorBail );	// rename binary to wpcom
 cp.execSync( "cp resources/linux/simplenote.desktop release/tmp/usr/share/applications/", onErrorBail );
 cp.execSync( "cp resources/images/icon_256x256.png release/tmp/usr/share/pixmaps/simplenote.png", onErrorBail );
+cp.execSync( "mkdir -p release/tmp/usr/bin && cd release/tmp/usr/bin && ln -sf /usr/share/simplenote/simplenote" );
 
 var cmd = [
 	usingBundler ? "bundle exec fpm" : "fpm",

--- a/resources/build-scripts/package-linux.js
+++ b/resources/build-scripts/package-linux.js
@@ -3,26 +3,38 @@
 /**
  * External Dependencies
  */
-var path = require( 'path' );
-var fs = require( 'fs' );
 
-/**
- * Internal dependencies
- */
-var config = require( '../lib/config' );
-var cp = require('child_process');
+var path = require("path")
+	, config = require("../lib/config")
+	, cp = require("child_process")
+	, fs = require("fs")
+	, usingBundler
+;
 
 /**
  * Module variables
  */
 console.log('Building Linux package...');
-
 var onErrorBail = function( error ) {
 	if (error) {
 		console.log("Error: " + error);
 		process.exit(1);
 	}
 };
+
+/**
+ * Detect FPM install type.
+ */
+
+try {
+	if (cp.execSync("bundle list fpm")) {
+		usingBundler = true
+	}
+}
+
+catch(e) {
+	usingBundler = false
+}
 
 // copy build into place for packaging
 cp.execSync( "rm -rf release/tmp", onErrorBail ); // clean start
@@ -34,7 +46,7 @@ cp.execSync( "cp resources/linux/simplenote.desktop release/tmp/usr/share/applic
 cp.execSync( "cp resources/images/icon_256x256.png release/tmp/usr/share/pixmaps/simplenote.png", onErrorBail );
 
 var cmd = [
-	'fpm',
+	usingBundler ? "bundle exec fpm" : "fpm",
 	'--version '  + config.version,
 	'--license "GPLv2"',
 	'--name "simplenote"',

--- a/resources/linux/simplenote.desktop
+++ b/resources/linux/simplenote.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Name=Simplenote
+GenericName=Note Taking
 Comment=Simplenote for Linux
+Categories=GNOME;GTK;Utility;Note;Notes;Development;
 Exec=/usr/share/simplenote/simplenote
 Icon=simplenote
 Type=Application
 StartupNotify=true
-Categories=Development;


### PR DESCRIPTION
This makes building on Linux a bit nicer by making so that we can use bundler if we are clean Rubyist's, so that we have a generic name, and more categories for more generic searching, and so that we can launch simplenote from our vterm.