### PR TITLE
Open link previews on external browser instead of webview.

### DIFF
--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -2,7 +2,8 @@ import React, { PropTypes } from 'react';
 import marked from 'marked';
 import Textarea from 'react-textarea-autosize';
 import { noop, get, debounce } from 'lodash';
-import analytics from './analytics'
+import analytics from './analytics';
+import { viewExternalUrl } from './utils/url-utils';
 
 const uninitializedNoteEditor = { focus: noop };
 const saveDelay = 2000;
@@ -60,7 +61,7 @@ export default React.createClass( {
 		for ( let node = event.target; node != null; node = node.parentNode ) {
 			if ( node.tagName === 'A' ) {
 				event.preventDefault();
-				window.open( node.href );
+				viewExternalUrl( node.href );
 				break;
 			}
 		}


### PR DESCRIPTION
Links should be opened on user's default browser instead of a new
electron window. This fixes issue #264.