### PR TITLE
Pressing enter logs in user now.

### DIFF
--- a/lib/auth.jsx
+++ b/lib/auth.jsx
@@ -30,13 +30,23 @@ export default React.createClass( {
 						<label className="login-field theme-color-border" htmlFor="login-field-username">
 							<span className="login-field-label">Email</span>
 							<span className="login-field-control">
-								<input ref={ ref => this.usernameInput = ref } id="login-field-username" type="email" />
+								<input
+									ref={ ref => this.usernameInput = ref }
+									id="login-field-username"
+									type="email"
+									onKeyDown={ this.onLogin }
+                />
 							</span>
 						</label>
 						<label className="login-field theme-color-border" htmlFor="login-field-password">
 							<span className="login-field-label">Password</span>
 							<span className="login-field-control">
-								<input ref={ ref => this.passwordInput = ref } id="login-field-password" type="password" />
+								<input
+									ref={ ref => this.passwordInput = ref }
+									id="login-field-password"
+									type="password"
+									onKeyDown={ this.onLogin }
+								/>
 							</span>
 						</label>
 					</div>
@@ -68,6 +78,9 @@ export default React.createClass( {
 	},
 
 	onLogin( event ) {
+		if ( event.type === 'keydown' && event.keyCode !== 13 ) {
+			return;
+		}
 		event.preventDefault();
 
 		const username = get( this.usernameInput, 'value' );


### PR DESCRIPTION
This fixed issue #248.

Enter key bindings were missing on auth.jsx. I added onKeyDown props to
both of the inputs to handle the case of if user enters password, or case of
typing invalid credentials.

In onLogin method added event type check to determine if the event is
keypress or mouseclick. If it is a keypress and it is not Enter key,
just keeps continue regular event handling.
I placed check before preventDefault to make sure the event handling works as
expected on other keypresses than Enter key.