### PR TITLE
Use HTTPS URL for react-popover repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-addons-pure-render-mixin": "0.14.3",
     "react-addons-update": "0.14.3",
     "react-dom": "0.14.3",
-    "react-popover": "git://github.com/beaucollins/react-popover.git",
+    "react-popover": "https://github.com/beaucollins/react-popover.git",
     "react-redux": "4.4.0",
     "redux": "3.3.1",
     "redux-localstorage": "0.4.0",


### PR DESCRIPTION
Use the HTTPS URL so we can clone behind proxy.