### PR TITLE
Fix Offline Sync Issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-transform-hmr": "1.0.4",
     "redbox-react": "1.2.2",
     "sass-loader": "3.1.2",
-    "simperium": "0.2.0",
+    "simperium": "0.2.2",
     "style-loader": "0.12.4",
     "webpack": "1.12.14",
     "webpack-dev-middleware": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-transform-hmr": "1.0.4",
     "redbox-react": "1.2.2",
     "sass-loader": "3.1.2",
-    "simperium": "0.2.2",
+    "simperium": "0.2.3",
     "style-loader": "0.12.4",
     "webpack": "1.12.14",
     "webpack-dev-middleware": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-transform-hmr": "1.0.4",
     "redbox-react": "1.2.2",
     "sass-loader": "3.1.2",
-    "simperium": "0.2.3",
+    "simperium": "0.2.4",
     "style-loader": "0.12.4",
     "webpack": "1.12.14",
     "webpack-dev-middleware": "1.5.1",


### PR DESCRIPTION
Update Simperium to 0.2.2 to fix syncing issue after coming back from being offline.

**To test:** 
* Turn off your network connection.
* Create a new note.
* Turn on your network connection.
* Ensure that the note synced to Simplenote on another device.

Fixes #318