### PR TITLE
Move accountName to persisted store.

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -70,7 +70,8 @@ function mapDispatchToProps( dispatch, { noteBucket } ) {
 			'increaseFontSize',
 			'resetFontSize',
 			'setNoteDisplay',
-			'toggleMarkdown'
+			'toggleMarkdown',
+			'setAccountName'
 		] ), dispatch ),
 		setSortType: thenReloadNotes( settingsActions.setSortType ),
 		toggleSortOrder: thenReloadNotes( settingsActions.toggleSortOrder )

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -4,6 +4,7 @@ import App from './app'
 import simperium from './simperium'
 import store from './flux/store'
 import appState from './flux/app-state'
+import { setAccountName } from './flux/actions-settings';
 import analytics from './analytics'
 import { Auth } from 'simperium'
 import { parse } from 'cookie'
@@ -93,9 +94,7 @@ let props = {
 						.dispatch( appState.action( 'authFailed' ) );
 				}
 
-				store.dispatch( appState.action( 'setAccountName', {
-					accountName: username
-				} ) );
+				store.dispatch( setAccountName( username ) );
 				localStorage.access_token = user.access_token;
 				client.setUser( user );
 				analytics.tracks.recordEvent( 'user_signed_in' );
@@ -106,6 +105,7 @@ let props = {
 	},
 	onSignOut: () => {
 		delete localStorage.access_token;
+		store.dispatch( setAccountName( null ) );
 		client.deauthorize();
 		if ( config.signout ) {
 			config.signout( function() {

--- a/lib/dialogs/settings.jsx
+++ b/lib/dialogs/settings.jsx
@@ -59,7 +59,6 @@ export const SettingsDialog = React.createClass( {
 	},
 
 	renderTabContent( tabName ) {
-		const { accountName } = this.props.appState;
 		const {
 			activateTheme,
 			setNoteDisplay,
@@ -73,7 +72,8 @@ export const SettingsDialog = React.createClass( {
 			markdownEnabled: markdownIsEnabled,
 			noteDisplay,
 			sortType,
-			sortReversed: sortIsReversed
+			sortReversed: sortIsReversed,
+			accountName
 		} } = this.props;
 
 		switch ( tabName ) {
@@ -83,7 +83,7 @@ export const SettingsDialog = React.createClass( {
 						<h3 className="panel-title theme-color-fg-dim">Account</h3>
 						<div className="settings-items theme-color-border">
 							<div className="settings-item theme-color-border">
-								<span className="settings-item-text-input transparent-input">{accountName}</span>
+								<span className="settings-account-name">{accountName}</span>
 							</div>
 						</div>
 

--- a/lib/flux/actions-settings.js
+++ b/lib/flux/actions-settings.js
@@ -42,6 +42,10 @@ export const setMarkdown = markdownEnabled => ( {
 	type: 'setMarkdownEnabled', markdownEnabled
 } );
 
+export const setAccountName = accountName => ( {
+	type: 'setAccountName', accountName
+} );
+
 export const toggleMarkdown = () => ( dispatch, getState ) => {
 	const { settings: { markdownEnabled } } = getState();
 

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -13,7 +13,6 @@ var actionMap = new ActionMap( {
 	initialState: {
 		authorized: null,
 		authPending: false,
-		accountName: null,
 		editorMode: 'edit',
 		selectedNoteId: null,
 		previousIndex: -1,
@@ -59,12 +58,6 @@ var actionMap = new ActionMap( {
 			return update( state, {
 				authPending: { $set: false },
 				authorized: { $set: false }
-			} );
-		},
-
-		setAccountName( state, { accountName } ) {
-			return update( state, {
-				accountName: { $set: accountName }
 			} );
 		},
 

--- a/lib/flux/settings-reducer.js
+++ b/lib/flux/settings-reducer.js
@@ -41,6 +41,14 @@ const noteDisplay = ( state = 'comfy', action ) => {
 	return action.noteDisplay;
 };
 
+const accountName = ( state = null, action ) => {
+	if ( 'setAccountName' !== action.type ) {
+		return state;
+	}
+
+	return action.accountName;
+};
+
 const markdownEnabled = ( state = false, action ) => {
 	if ( 'setMarkdownEnabled' !== action.type ) {
 		return state;
@@ -50,6 +58,7 @@ const markdownEnabled = ( state = false, action ) => {
 };
 
 export default combineReducers( {
+	accountName,
 	fontSize,
 	markdownEnabled,
 	noteDisplay,

--- a/scss/settings.scss
+++ b/scss/settings.scss
@@ -19,6 +19,12 @@
 		padding-top: 60px;
 	}
 
+	.settings-account-name {
+		font-size: 115%;
+		text-align: center;
+		width: 100%;
+	}
+
 	.settings-writing {
 		padding-top: 48px;
 	}


### PR DESCRIPTION
Fixes #315 by moving the `accountName` to the `settings` store, so it persists. The `app-state` store is not persisted, which I think makes sense :thinking-face:

Also updated the css to look a bit better for the account name display.

**To test:**
* Sign out of the app, then back in again.
* View settings, you should see your account email.
* Quit the app, and open it again and go back to settings.
* You should still see your email in the settings panel.

Needs review @dmsnell @rodrigoi 