### PR TITLE
Show a larger font-size for first line of the editor.

### DIFF
--- a/scss/editor.scss
+++ b/scss/editor.scss
@@ -171,6 +171,10 @@
 	min-height: 100%;
 	overflow: hidden;
 	cursor: text;
+
+	&::first-line {
+ 		font-size: 120%;
+	}
 }
 
 .note-detail-markdown {


### PR DESCRIPTION
Only works in webkit browsers. Fixes #330.

Props to @nsrosenqvist for the solution.