### PR TITLE
Listen to `0.0.0.0` instead of `localhost` for devServer.js

### DIFF
--- a/devServer.js
+++ b/devServer.js
@@ -18,7 +18,7 @@ app.get( '*', function( req, res ) {
 	res.send( compiler.outputFileSystem.readFileSync( path.join( __dirname, 'dist', 'index.html' ) ) );
 } );
 
-app.listen( 4000, 'localhost', function( err ) {
+app.listen( 4000, '0.0.0.0', function( err ) {
 	if ( err ) {
 		console.log( err );
 		return;


### PR DESCRIPTION
This change to the devServer opens up listening to all connections
instead of just connections on the "same" `localhost`.

The problem appeared when running inside of a Docker container where the
outside world wasn't resolved as `localhost` but `0.0.0.0` worked fine.

**Hint**
Since I couldn't build locally due to `node` version issues, I ran it inside the official node Docker image. By running inside of the container, we can eliminate all global version and runtime conflicts.

```bash
# to build the npm modules
docker run -it --rm --name simplenote-electron -v "$PWD":/usr/src/app -p 4000:4000 -w /usr/src/app node:5 npm install

# to run the dev server
docker run -it --rm --name simplenote-electron -v "$PWD":/usr/src/app -p 4000:4000 -w /usr/src/app node:5 npm start

# to build for electron
docker run -it --rm --name simplenote-electron -v "$PWD":/usr/src/app -p 4000:4000 -w /usr/src/app node:5 make build
```

cc: @roundhill @rodrigoi 