### PR TITLE
Markdown: Remove global setting

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -70,7 +70,7 @@ function mapDispatchToProps( dispatch, { noteBucket } ) {
 			'increaseFontSize',
 			'resetFontSize',
 			'setNoteDisplay',
-			'toggleMarkdown',
+			'setMarkdown',
 			'setAccountName'
 		] ), dispatch ),
 		setSortType: thenReloadNotes( settingsActions.setSortType ),
@@ -214,6 +214,9 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 			noteBucket: this.props.noteBucket,
 			note, markdown
 		} );
+
+		// Update global setting to set markdown flag for new notes
+		this.props.setMarkdown( markdown );
 	},
 
 	onNotesIndex: function() {
@@ -529,7 +532,6 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 								shouldPrint={state.shouldPrint}
 								onNotePrinted={this.onNotePrinted} />
 							<NoteInfo
-								markdownEnabled={ settings.markdownEnabled }
 								note={selectedNote}
 								onPinNote={this.onPinNote}
 								onMarkdownNote={this.onMarkdownNote}

--- a/lib/dialogs/settings.jsx
+++ b/lib/dialogs/settings.jsx
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 import TabbedDialog from '../tabbed-dialog';
-import ToggleControl from '../controls/toggle';
 import { viewExternalUrl } from '../utils/url-utils';
 import TopRightArrowIcon from '../icons/arrow-top-right';
 
@@ -8,7 +7,10 @@ import RadioGroup from './radio-settings-group';
 import ToggleGroup from './toggle-settings-group';
 import SettingsGroup, { Item } from './settings-group';
 
-const settingTabs = [ 'account', 'display', 'writing' ];
+const settingTabs = [
+	'account',
+	'display'
+];
 
 export const SettingsDialog = React.createClass( {
 	propTypes: {
@@ -63,13 +65,11 @@ export const SettingsDialog = React.createClass( {
 			activateTheme,
 			setNoteDisplay,
 			setSortType,
-			toggleMarkdown,
 			toggleSortOrder,
 		} = this.props;
 
 		const { settings: {
 			theme: activeTheme,
-			markdownEnabled: markdownIsEnabled,
 			noteDisplay,
 			sortType,
 			sortReversed: sortIsReversed,
@@ -141,32 +141,6 @@ export const SettingsDialog = React.createClass( {
 							<Item title="Light" slug="light" />
 							<Item title="Dark" slug="dark" />
 						</SettingsGroup>
-					</div>
-				);
-
-			case 'writing':
-				return (
-					<div className="dialog-column settings-writing">
-						<div className="settings-group">
-							<div className="settings-items theme-color-border">
-								<label htmlFor="settings-field-markdown" className="settings-item theme-color-border">
-									<div className="settings-item-label">
-										Enable Markdown
-									</div>
-									<div className="settings-item-control">
-										<ToggleControl name="markdownEnabled" value="enabled"
-											id="settings-field-markdown"
-											checked={ markdownIsEnabled }
-											onChange={ toggleMarkdown } />
-									</div>
-								</label>
-							</div>
-							<p>
-								Markdown lets you write notes with links, lists, and
-								other styles using regular characters and
-								punctuation marks. <a target="_blank" href="http://simplenote.com/help/#markdown">Learn more…</a>
-							</p>
-						</div>
 					</div>
 				);
 		}

--- a/lib/flux/actions-settings.js
+++ b/lib/flux/actions-settings.js
@@ -45,9 +45,3 @@ export const setMarkdown = markdownEnabled => ( {
 export const setAccountName = accountName => ( {
 	type: 'setAccountName', accountName
 } );
-
-export const toggleMarkdown = () => ( dispatch, getState ) => {
-	const { settings: { markdownEnabled } } = getState();
-
-	dispatch( setMarkdown( ! markdownEnabled ) );
-};

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -254,8 +254,9 @@ var actionMap = new ActionMap( {
 		newNote: {
 			creator( { noteBucket } ) {
 				return ( dispatch, getState ) => {
-					var state = getState().appState;
-					var timestamp = ( new Date() ).getTime() / 1000;
+					const state = getState().appState;
+					const settings = getState().settings;
+					const timestamp = ( new Date() ).getTime() / 1000;
 
 					if ( state.showTrash ) {
 						dispatch( this.action( 'selectAllNotes' ) );
@@ -265,7 +266,7 @@ var actionMap = new ActionMap( {
 					noteBucket.add( {
 						content: '',
 						deleted: false,
-						systemTags: [],
+						systemTags: settings.markdownEnabled ? [ 'markdown' ] : [],
 						creationDate: timestamp,
 						modificationDate: timestamp,
 						shareURL: '',

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -13,7 +13,6 @@ export const NoteEditor = React.createClass( {
 		editorMode: PropTypes.oneOf( [ 'edit', 'markdown' ] ),
 		note: PropTypes.object,
 		revisions: PropTypes.array,
-		markdownEnabled: PropTypes.bool,
 		fontSize: PropTypes.number,
 		shouldPrint: PropTypes.bool,
 		onSetEditorMode: PropTypes.func.isRequired,
@@ -86,14 +85,14 @@ export const NoteEditor = React.createClass( {
 	},
 
 	render: function() {
-		var { editorMode, note, revisions, markdownEnabled, fontSize, shouldPrint } = this.props;
-		var noteContent = '';
+		let noteContent = '';
+		const { editorMode, note, revisions, fontSize, shouldPrint } = this.props;
 		const revision = this.state.revision || note;
 		const isViewingRevisions = this.state.isViewingRevisions;
 		const tags = revision && revision.data && revision.data.tags || [];
 		const isTrashed = !!( note && note.data.deleted );
 
-		markdownEnabled = markdownEnabled && revision &&
+		const markdownEnabled = revision &&
 			revision.data && revision.data.systemTags &&
 			revision.data.systemTags.indexOf( 'markdown' ) !== -1;
 

--- a/lib/note-info.jsx
+++ b/lib/note-info.jsx
@@ -87,7 +87,7 @@ export const NoteInfo = React.createClass( {
 						</span>
 					</label>
 				</div>
-				{!!markdownEnabled && <div className="note-info-panel note-info-markdown theme-color-border">
+				<div className="note-info-panel note-info-markdown theme-color-border">
 					<label className="note-info-item" htmlFor="note-info-markdown-checkbox">
 						<span className="note-info-item-text">
 							<span className="note-info-name">Markdown</span>
@@ -99,7 +99,7 @@ export const NoteInfo = React.createClass( {
 							<ToggleControl id="note-info-markdown-checkbox" checked={isMarkdown} onChange={this.onMarkdownChanged} />
 						</span>
 					</label>
-				</div>}
+				</div>
 				{ isPublished &&
 					<div className="note-info-panel note-info-public-link theme-color-border">
 							<span className="note-info-item-text">

--- a/lib/note-info.jsx
+++ b/lib/note-info.jsx
@@ -40,7 +40,7 @@ export const NoteInfo = React.createClass( {
 	},
 
 	render: function() {
-		const { note, markdownEnabled } = this.props;
+		const { note } = this.props;
 		const data = note && note.data || {};
 		const { modificationDate } = data;
 		const formattedDate = modificationDate && formatTimestamp( modificationDate );


### PR DESCRIPTION
Matches up behavior to the iOS/Android app where we always show the markdown toggle in the note info panel. 

The original global setting is still used to set the markdown flag for a new note. The 'Writing' section of `Settings` has been completely removed since it only contained the Markdown setting.

Fixes #259