### PR TITLE
escape fiter str before creating filter regexp

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
+import escapeStringRegexp from 'escape-string-regexp'
 import appState from './flux/app-state'
 import browserShell from './browser-shell'
 import { ContextMenu, MenuItem, Separator } from './context-menu';
@@ -319,7 +320,7 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 		var regexp;
 
 		if ( filter ) {
-			regexp = new RegExp( filter, 'gi' );
+			regexp = new RegExp( escapeStringRegexp( filter ), 'gi' );
 		}
 
 		function test( note ) {

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react';
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
-import escapeStringRegexp from 'escape-string-regexp'
 import appState from './flux/app-state'
 import browserShell from './browser-shell'
 import { ContextMenu, MenuItem, Separator } from './context-menu';
@@ -317,10 +316,9 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 
 	filterNotes: function() {
 		var { filter, showTrash, notes, tag } = this.props.appState;
-		var regexp;
 
 		if ( filter ) {
-			regexp = new RegExp( escapeStringRegexp( filter ), 'gi' );
+			filter = filter.toLowerCase();
 		}
 
 		function test( note ) {
@@ -332,7 +330,7 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 			if ( tag && note.data.tags.indexOf( tag.data.name ) === -1 ) {
 				return false;
 			}
-			if ( regexp && !regexp.test( note.data.content || '' ) ) {
+			if ( filter && ( note.data.content || '' ).toLowerCase().indexOf( filter ) === -1 ) {
 				return false;
 			}
 			return true;

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -330,7 +330,7 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 			if ( tag && note.data.tags.indexOf( tag.data.name ) === -1 ) {
 				return false;
 			}
-			if ( filter && ( note.data.content || '' ).toLowerCase().indexOf( filter ) === -1 ) {
+			if ( filter && ( note.data.content || '' ).toLowerCase().includes( filter ) ) {
 				return false;
 			}
 			return true;


### PR DESCRIPTION
currently if the filter string is eg. `(` search doesn't work because an un-escaped `(` is an invalid regexp