### PR TITLE
Insert a tab character while tabbing in the editor

### DIFF
--- a/devServer.js
+++ b/devServer.js
@@ -18,7 +18,7 @@ app.get( '*', function( req, res ) {
 	res.send( compiler.outputFileSystem.readFileSync( path.join( __dirname, 'dist', 'index.html' ) ) );
 } );
 
-app.listen( 4000, 'localhost', function( err ) {
+app.listen( 4000, '0.0.0.0', function( err ) {
 	if ( err ) {
 		console.log( err );
 		return;

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -1,64 +1,58 @@
-import React, { PropTypes } from 'react';
-import marked from 'marked';
+import React, { Component, PropTypes } from 'react';
 import Textarea from 'react-textarea-autosize';
-import { noop, get, debounce } from 'lodash';
 import analytics from './analytics';
+import marked from 'marked';
+import { get, debounce, invoke } from 'lodash';
 import { viewExternalUrl } from './utils/url-utils';
 
-const uninitializedNoteEditor = { focus: noop };
 const saveDelay = 2000;
 
-export default React.createClass( {
+const isValidNote = note => note && note.id;
 
-	propTypes: {
+export default class NoteDetail extends Component {
+	static propTypes = {
 		note: PropTypes.object,
 		previewingMarkdown: PropTypes.bool,
 		fontSize: PropTypes.number,
 		onChangeContent: PropTypes.func.isRequired
-	},
+	};
 
-	componentWillMount: function() {
+	constructor( props ) {
+		super( props );
+
+		this.storeNoteEditor = r => this.noteEditor = r;
 		this.queueNoteSave = debounce( this.saveNote, saveDelay );
-		this.noteEditor = uninitializedNoteEditor;
-	},
+	}
 
-	componentDidMount: function() {
+	componentDidMount = () => {
 		// Ensures note gets saved if user abruptly quits the app
 		window.addEventListener( 'beforeunload', this.queueNoteSave.flush );
 		window.addEventListener( 'keydown', this.insertTabCharacter );
-	},
+	};
 
-	initializeNoteEditor: function( noteEditor ) {
-		this.noteEditor = noteEditor;
-	},
-
-	isValidNote: function( note ) {
-		return note && note.id;
-	},
-
-	componentWillReceiveProps: function() {
+	componentWillReceiveProps = () => {
 		this.queueNoteSave.flush();
-	},
+	};
 
-	componentDidUpdate: function() {
+	componentDidUpdate = () => {
 		const { note } = this.props;
 		const content = get( note, 'data.content', '' );
-		if ( this.isValidNote( note ) && this.noteEditor ) {
+		if ( isValidNote( note ) && this.noteEditor ) {
 			this.noteEditor.value = content;
 
 			// Let's focus the editor for new and empty notes
 			if ( content === '' ) {
-				this.noteEditor.focus();
+				invoke( this.noteEditor, 'focus' );
 			}
 		}
-	},
+	};
 
-	componentWillUnmount: function() {
+	componentWillUnmount = () => {
 		window.removeEventListener( 'beforeunload', this.queueNoteSave.flush );
 		window.removeEventListener( 'keydown', this.insertTabCharacter );
-	},
+	};
 
-	onPreviewClick: function( event ) {
+	onPreviewClick = event => {
 		// open markdown preview links in a new window
 		for ( let node = event.target; node != null; node = node.parentNode ) {
 			if ( node.tagName === 'A' ) {
@@ -67,9 +61,9 @@ export default React.createClass( {
 				break;
 			}
 		}
-	},
+	};
 
-	insertTabCharacter( event ) {
+	insertTabCharacter = event => {
 		if ( 'Tab' !== event.code ) {
 			return;
 		}
@@ -82,7 +76,7 @@ export default React.createClass( {
 			selectionStart,
 			selectionEnd,
 			value,
-		} = this.noteEditor
+		} = this.noteEditor;
 
 		this.noteEditor.value = [
 			value.substring( 0, selectionStart ),
@@ -97,59 +91,51 @@ export default React.createClass( {
 
 		event.preventDefault();
 		event.stopPropagation();
-	},
+	};
 
-	saveNote: function() {
-		const { note } = this.props;
+	saveNote = () => {
+		const {
+			note,
+			onChangeContent,
+		} = this.props;
 
-		if ( ! this.isValidNote( note ) ) return;
+		if ( ! isValidNote( note ) ) {
+			return;
+		}
 
-		this.props.onChangeContent( note, this.noteEditor.value );
+		onChangeContent( note, this.noteEditor.value );
 		analytics.tracks.recordEvent( 'editor_note_edited' );
-	},
+	};
 
-	render: function() {
-		var { previewingMarkdown, fontSize } = this.props;
+	render = () => {
+		var {
+			fontSize,
+			note,
+			previewingMarkdown,
+		} = this.props;
 
-		var divStyle = {
-			fontSize: fontSize + 'px'
-		};
+		const divStyle = { fontSize: fontSize + 'px' };
 
 		return (
 			<div className="note-detail">
-				{previewingMarkdown ?
-					this.renderMarkdown( divStyle )
-				:
-					this.renderEditable( divStyle )
+				{ previewingMarkdown &&
+					<div
+						className="note-detail-markdown theme-color-bg theme-color-fg"
+						dangerouslySetInnerHTML={ { __html: marked( get( note, 'data.content', '' ) ) } }
+						onClick={ this.onPreviewClick }
+						style={ divStyle }
+					/>
+				}
+				{ ! previewingMarkdown &&
+					<Textarea
+						ref={ this.storeNoteEditor }
+						className="note-detail-textarea theme-color-bg theme-color-fg"
+						disabled={ !! ( note && note.data.deleted ) }
+						onChange={ this.queueNoteSave }
+						style={ divStyle }
+					/>
 				}
 			</div>
 		);
-	},
-
-	renderMarkdown( divStyle ) {
-		const { content = '' } = this.props.note.data;
-		const markdownHTML = marked( content );
-
-		return (
-			<div className="note-detail-markdown theme-color-bg theme-color-fg"
-				dangerouslySetInnerHTML={ { __html: markdownHTML } }
-				onClick={ this.onPreviewClick }
-				style={ divStyle } />
-		);
-	},
-
-	renderEditable( divStyle ) {
-		const note = this.props.note;
-
-		return (
-			<Textarea
-				ref={ this.initializeNoteEditor }
-				className="note-detail-textarea theme-color-bg theme-color-fg"
-				disabled={ !!( note && note.data.deleted ) }
-				onChange={ this.queueNoteSave }
-				style={ divStyle }
-			/>
-		);
-	}
-
-} )
+	};
+};

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -25,6 +25,7 @@ export default React.createClass( {
 	componentDidMount: function() {
 		// Ensures note gets saved if user abruptly quits the app
 		window.addEventListener( 'beforeunload', this.queueNoteSave.flush );
+		window.addEventListener( 'keydown', this.insertTabCharacter );
 	},
 
 	initializeNoteEditor: function( noteEditor ) {
@@ -54,6 +55,7 @@ export default React.createClass( {
 
 	componentWillUnmount: function() {
 		window.removeEventListener( 'beforeunload', this.queueNoteSave.flush );
+		window.removeEventListener( 'keydown', this.insertTabCharacter );
 	},
 
 	onPreviewClick: function( event ) {
@@ -65,6 +67,36 @@ export default React.createClass( {
 				break;
 			}
 		}
+	},
+
+	insertTabCharacter( event ) {
+		if ( 'Tab' !== event.code ) {
+			return;
+		}
+
+		if ( ! this.noteEditor ) {
+			return;
+		}
+
+		const {
+			selectionStart,
+			selectionEnd,
+			value,
+		} = this.noteEditor
+
+		this.noteEditor.value = [
+			value.substring( 0, selectionStart ),
+			'\t',
+			value.substring( selectionEnd ),
+		].join( '' );
+		this.queueNoteSave();
+
+		this.noteEditor.selectionStart = selectionStart + 1;
+		this.noteEditor.selectionEnd = selectionStart + 1;
+		this.noteEditor.focus();
+
+		event.preventDefault();
+		event.stopPropagation();
 	},
 
 	saveNote: function() {
@@ -110,10 +142,13 @@ export default React.createClass( {
 		const note = this.props.note;
 
 		return (
-			<Textarea ref={ this.initializeNoteEditor } className="note-detail-textarea theme-color-bg theme-color-fg"
+			<Textarea
+				ref={ this.initializeNoteEditor }
+				className="note-detail-textarea theme-color-bg theme-color-fg"
 				disabled={ !!( note && note.data.deleted ) }
 				onChange={ this.queueNoteSave }
-				style={ divStyle } />
+				style={ divStyle }
+			/>
 		);
 	}
 

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -86,6 +86,31 @@ export default class NoteDetail extends Component {
 			: this.transformSelectedLines( prependTab );
 	};
 
+	onPreviewClick = event => {
+		// open markdown preview links in a new window
+		for ( let node = event.target; node != null; node = node.parentNode ) {
+			if ( node.tagName === 'A' ) {
+				event.preventDefault();
+				viewExternalUrl( node.href );
+				break;
+			}
+		}
+	};
+
+	saveNote = () => {
+		const {
+			note,
+			onChangeContent,
+		} = this.props;
+
+		if ( ! isValidNote( note ) ) {
+			return;
+		}
+
+		onChangeContent( note, this.noteEditor.value );
+		analytics.tracks.recordEvent( 'editor_note_edited' );
+	};
+
 	transformSelectedLines = transform => {
 		const {
 			selectionStart,
@@ -110,31 +135,6 @@ export default class NoteDetail extends Component {
 		document.execCommand( 'insertText', false, indented );
 
 		this.noteEditor.selectionStart = firstLineStart;
-	};
-
-	onPreviewClick = event => {
-		// open markdown preview links in a new window
-		for ( let node = event.target; node != null; node = node.parentNode ) {
-			if ( node.tagName === 'A' ) {
-				event.preventDefault();
-				viewExternalUrl( node.href );
-				break;
-			}
-		}
-	};
-
-	saveNote = () => {
-		const {
-			note,
-			onChangeContent,
-		} = this.props;
-
-		if ( ! isValidNote( note ) ) {
-			return;
-		}
-
-		onChangeContent( note, this.noteEditor.value );
-		analytics.tracks.recordEvent( 'editor_note_edited' );
 	};
 
 	render = () => {

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -73,7 +73,6 @@ export default class NoteDetail extends Component {
 		const {
 			selectionStart,
 			selectionEnd,
-			value,
 		} = this.noteEditor;
 
 		// if inserting at a cursor position

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -27,7 +27,7 @@ export default class NoteDetail extends Component {
 	componentDidMount = () => {
 		// Ensures note gets saved if user abruptly quits the app
 		window.addEventListener( 'beforeunload', this.queueNoteSave.flush );
-		window.addEventListener( 'keydown', this.insertTabCharacter );
+		window.addEventListener( 'keydown', this.interceptTabPresses );
 	};
 
 	componentWillReceiveProps = () => {
@@ -49,7 +49,24 @@ export default class NoteDetail extends Component {
 
 	componentWillUnmount = () => {
 		window.removeEventListener( 'beforeunload', this.queueNoteSave.flush );
-		window.removeEventListener( 'keydown', this.insertTabCharacter );
+		window.removeEventListener( 'keydown', this.interceptTabPresses );
+	};
+
+	interceptTabPresses = event => {
+		if (
+			'Tab' !== event.code ||
+			! this.noteEditor ||
+			'TEXTAREA' !== event.target.nodeName ||
+			this.props.previewingMarkdown
+		) {
+			console.log( 'skipping' );
+			return;
+		}
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		document.execCommand( 'insertText', false, '\t' );
 	};
 
 	onPreviewClick = event => {
@@ -61,36 +78,6 @@ export default class NoteDetail extends Component {
 				break;
 			}
 		}
-	};
-
-	insertTabCharacter = event => {
-		if ( 'Tab' !== event.code ) {
-			return;
-		}
-
-		if ( ! this.noteEditor ) {
-			return;
-		}
-
-		const {
-			selectionStart,
-			selectionEnd,
-			value,
-		} = this.noteEditor;
-
-		this.noteEditor.value = [
-			value.substring( 0, selectionStart ),
-			'\t',
-			value.substring( selectionEnd ),
-		].join( '' );
-		this.queueNoteSave();
-
-		this.noteEditor.selectionStart = selectionStart + 1;
-		this.noteEditor.selectionEnd = selectionStart + 1;
-		this.noteEditor.focus();
-
-		event.preventDefault();
-		event.stopPropagation();
 	};
 
 	saveNote = () => {


### PR DESCRIPTION
Resolves #299 

Previously, when editing a note and hitting the tab key the app would advance the focus to the next element. In this case, that element happened to be the tag list. Since previous Simplenote apps have all allowed inserting a tab character as seamlessly as we can do in normal text editors, this was a bug in the Electron version that broke our assumptions.

This PR updates the `NoteDetail` component and intercepts tab presses so that they do what's expected of them. It raises some accessibility questions since the tab behavior is odd in order to better support keyboard navigation of the site (screen-readers and blind users depend on this). On the other hand, none of the other Simplenote apps behave this way and we aren't presenting what would be considered a website even though it runs in a (hidden) browser.

**Questions**
 - [x] Is there a better way to intercept the keyboard events and make sure that they originate from the editor than `'TEXTURE' === event.target.nodeName` ?

**Testing**
Open a note and try to hit the tab key. A tab character should be inserted whereas in **master** the tab key will advance focus to the tag list. Make sure that you can undo a tab insertion. Try to see if the tab key interacts unexpectedly with other parts of the app (the keypress event is currently global on `window.addEventListener`.

cc: @roundhill @rodrigoi @jleandroperez