### PR TITLE
Automatically insert - and * in lists

### DIFF
--- a/devServer.js
+++ b/devServer.js
@@ -18,7 +18,7 @@ app.get( '*', function( req, res ) {
 	res.send( compiler.outputFileSystem.readFileSync( path.join( __dirname, 'dist', 'index.html' ) ) );
 } );
 
-app.listen( 4000, 'localhost', function( err ) {
+app.listen( 4000, '0.0.0.0', function( err ) {
 	if ( err ) {
 		console.log( err );
 		return;

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -1,64 +1,58 @@
-import React, { PropTypes } from 'react';
-import marked from 'marked';
+import React, { Component, PropTypes } from 'react';
 import Textarea from 'react-textarea-autosize';
-import { noop, get, debounce } from 'lodash';
 import analytics from './analytics';
+import marked from 'marked';
+import { get, debounce, invoke } from 'lodash';
 import { viewExternalUrl } from './utils/url-utils';
 
-const uninitializedNoteEditor = { focus: noop };
 const saveDelay = 2000;
 
-export default React.createClass( {
+const isValidNote = note => note && note.id;
 
-	propTypes: {
+export default class NoteDetail extends Component {
+	static propTypes = {
 		note: PropTypes.object,
 		previewingMarkdown: PropTypes.bool,
 		fontSize: PropTypes.number,
 		onChangeContent: PropTypes.func.isRequired
-	},
+	};
 
-	componentWillMount: function() {
+	constructor( props ) {
+		super( props );
+
+		this.storeNoteEditor = r => this.noteEditor = r;
 		this.queueNoteSave = debounce( this.saveNote, saveDelay );
-		this.noteEditor = uninitializedNoteEditor;
-	},
+	}
 
-	componentDidMount: function() {
+	componentDidMount = () => {
 		// Ensures note gets saved if user abruptly quits the app
 		window.addEventListener( 'beforeunload', this.queueNoteSave.flush );
 		window.addEventListener( 'keydown', this.insertTabCharacter );
-	},
+	};
 
-	initializeNoteEditor: function( noteEditor ) {
-		this.noteEditor = noteEditor;
-	},
-
-	isValidNote: function( note ) {
-		return note && note.id;
-	},
-
-	componentWillReceiveProps: function() {
+	componentWillReceiveProps = () => {
 		this.queueNoteSave.flush();
-	},
+	};
 
-	componentDidUpdate: function() {
+	componentDidUpdate = () => {
 		const { note } = this.props;
 		const content = get( note, 'data.content', '' );
-		if ( this.isValidNote( note ) && this.noteEditor ) {
+		if ( isValidNote( note ) && this.noteEditor ) {
 			this.noteEditor.value = content;
 
 			// Let's focus the editor for new and empty notes
 			if ( content === '' ) {
-				this.noteEditor.focus();
+				invoke( this.noteEditor, 'focus' );
 			}
 		}
-	},
+	};
 
-	componentWillUnmount: function() {
+	componentWillUnmount = () => {
 		window.removeEventListener( 'beforeunload', this.queueNoteSave.flush );
 		window.removeEventListener( 'keydown', this.insertTabCharacter );
-	},
+	};
 
-	onPreviewClick: function( event ) {
+	onPreviewClick = event => {
 		// open markdown preview links in a new window
 		for ( let node = event.target; node != null; node = node.parentNode ) {
 			if ( node.tagName === 'A' ) {
@@ -67,9 +61,9 @@ export default React.createClass( {
 				break;
 			}
 		}
-	},
+	};
 
-	insertTabCharacter( event ) {
+	insertTabCharacter = event => {
 		if ( 'Tab' !== event.code ) {
 			return;
 		}
@@ -82,7 +76,7 @@ export default React.createClass( {
 			selectionStart,
 			selectionEnd,
 			value,
-		} = this.noteEditor
+		} = this.noteEditor;
 
 		this.noteEditor.value = [
 			value.substring( 0, selectionStart ),
@@ -97,59 +91,51 @@ export default React.createClass( {
 
 		event.preventDefault();
 		event.stopPropagation();
-	},
+	};
 
-	saveNote: function() {
-		const { note } = this.props;
+	saveNote = () => {
+		const {
+			note,
+			onChangeContent,
+		} = this.props;
 
-		if ( ! this.isValidNote( note ) ) return;
+		if ( ! isValidNote( note ) ) {
+			return;
+		}
 
-		this.props.onChangeContent( note, this.noteEditor.value );
+		onChangeContent( note, this.noteEditor.value );
 		analytics.tracks.recordEvent( 'editor_note_edited' );
-	},
+	};
 
-	render: function() {
-		var { previewingMarkdown, fontSize } = this.props;
+	render = () => {
+		var {
+			fontSize,
+			note,
+			previewingMarkdown,
+		} = this.props;
 
-		var divStyle = {
-			fontSize: fontSize + 'px'
-		};
+		const divStyle = { fontSize: fontSize + 'px' };
 
 		return (
 			<div className="note-detail">
-				{previewingMarkdown ?
-					this.renderMarkdown( divStyle )
-				:
-					this.renderEditable( divStyle )
+				{ previewingMarkdown &&
+					<div
+						className="note-detail-markdown theme-color-bg theme-color-fg"
+						dangerouslySetInnerHTML={ { __html: marked( get( note, 'data.content', '' ) ) } }
+						onClick={ this.onPreviewClick }
+						style={ divStyle }
+					/>
+				}
+				{ ! previewingMarkdown &&
+					<Textarea
+						ref={ this.storeNoteEditor }
+						className="note-detail-textarea theme-color-bg theme-color-fg"
+						disabled={ !! ( note && note.data.deleted ) }
+						onChange={ this.queueNoteSave }
+						style={ divStyle }
+					/>
 				}
 			</div>
 		);
-	},
-
-	renderMarkdown( divStyle ) {
-		const { content = '' } = this.props.note.data;
-		const markdownHTML = marked( content );
-
-		return (
-			<div className="note-detail-markdown theme-color-bg theme-color-fg"
-				dangerouslySetInnerHTML={ { __html: markdownHTML } }
-				onClick={ this.onPreviewClick }
-				style={ divStyle } />
-		);
-	},
-
-	renderEditable( divStyle ) {
-		const note = this.props.note;
-
-		return (
-			<Textarea
-				ref={ this.initializeNoteEditor }
-				className="note-detail-textarea theme-color-bg theme-color-fg"
-				disabled={ !!( note && note.data.deleted ) }
-				onChange={ this.queueNoteSave }
-				style={ divStyle }
-			/>
-		);
-	}
-
-} )
+	};
+};

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -74,7 +74,7 @@ export default class NoteDetail extends Component {
 
 		const prevLineStart = value.lastIndexOf( '\n', selectionStart - 1 ) + 1;
 		const prevLine = value.substring( prevLineStart, selectionStart - 1 );
-		const prevIndent = prevLine.match( /^(\s+)([-*])/ );
+		const prevIndent = prevLine.match( /^(\s+[-*])/ );
 
 		// The previous line did not start with
 		// indentation, so continue as normal
@@ -82,9 +82,7 @@ export default class NoteDetail extends Component {
 			return true;
 		}
 
-		const indent = prevIndent[ 1 ];
-		const bullet = prevIndent[ 2 ];
-		const nextIndent = `\n${ indent }${ bullet } `;
+		const nextIndent = `\n${ prevIndent[ 1 ] } `;
 
 		// If going a second time in a row that means we
 		// want to escape the list structure, so unwind

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -147,6 +147,18 @@ export default class NoteDetail extends Component {
 			return document.execCommand( 'insertText', false, '\t' );
 		}
 
+		// if "outdenting" when previous character is a tab
+		if (
+			event.shiftKey &&
+			selectionStart === selectionEnd &&
+			selectionStart > 0 &&
+			value[ selectionStart - 1 ] === '\t'
+		) {
+			document.execCommand( 'delete', false, null );
+
+			return;
+		}
+
 		return event.shiftKey
 			? this.transformSelectedLines( removeLeadingTab )
 			: this.transformSelectedLines( prependTab );

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -30,11 +30,11 @@ export default class NoteDetail extends Component {
 	componentDidMount() {
 		// Ensures note gets saved if user abruptly quits the app
 		window.addEventListener( 'beforeunload', this.queueNoteSave.flush );
-	};
+	}
 
 	componentWillReceiveProps() {
 		this.queueNoteSave.flush();
-	};
+	}
 
 	componentDidUpdate() {
 		const { note } = this.props;
@@ -47,11 +47,11 @@ export default class NoteDetail extends Component {
 				invoke( this.noteEditor, 'focus' );
 			}
 		}
-	};
+	}
 
 	componentWillUnmount() {
 		window.removeEventListener( 'beforeunload', this.queueNoteSave.flush );
-	};
+	}
 
 	handleKey = event => {
 		if ( ! this.noteEditor || this.props.previewingMarkdown ) {

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -25,6 +25,7 @@ export default React.createClass( {
 	componentDidMount: function() {
 		// Ensures note gets saved if user abruptly quits the app
 		window.addEventListener( 'beforeunload', this.queueNoteSave.flush );
+		window.addEventListener( 'keydown', this.insertTabCharacter );
 	},
 
 	initializeNoteEditor: function( noteEditor ) {
@@ -54,6 +55,7 @@ export default React.createClass( {
 
 	componentWillUnmount: function() {
 		window.removeEventListener( 'beforeunload', this.queueNoteSave.flush );
+		window.removeEventListener( 'keydown', this.insertTabCharacter );
 	},
 
 	onPreviewClick: function( event ) {
@@ -65,6 +67,36 @@ export default React.createClass( {
 				break;
 			}
 		}
+	},
+
+	insertTabCharacter( event ) {
+		if ( 'Tab' !== event.code ) {
+			return;
+		}
+
+		if ( ! this.noteEditor ) {
+			return;
+		}
+
+		const {
+			selectionStart,
+			selectionEnd,
+			value,
+		} = this.noteEditor
+
+		this.noteEditor.value = [
+			value.substring( 0, selectionStart ),
+			'\t',
+			value.substring( selectionEnd ),
+		].join( '' );
+		this.queueNoteSave();
+
+		this.noteEditor.selectionStart = selectionStart + 1;
+		this.noteEditor.selectionEnd = selectionStart + 1;
+		this.noteEditor.focus();
+
+		event.preventDefault();
+		event.stopPropagation();
 	},
 
 	saveNote: function() {
@@ -110,10 +142,13 @@ export default React.createClass( {
 		const note = this.props.note;
 
 		return (
-			<Textarea ref={ this.initializeNoteEditor } className="note-detail-textarea theme-color-bg theme-color-fg"
+			<Textarea
+				ref={ this.initializeNoteEditor }
+				className="note-detail-textarea theme-color-bg theme-color-fg"
 				disabled={ !!( note && note.data.deleted ) }
 				onChange={ this.queueNoteSave }
-				style={ divStyle } />
+				style={ divStyle }
+			/>
 		);
 	}
 

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -86,6 +86,31 @@ export default class NoteDetail extends Component {
 			: this.transformSelectedLines( prependTab );
 	};
 
+	onPreviewClick = event => {
+		// open markdown preview links in a new window
+		for ( let node = event.target; node != null; node = node.parentNode ) {
+			if ( node.tagName === 'A' ) {
+				event.preventDefault();
+				viewExternalUrl( node.href );
+				break;
+			}
+		}
+	};
+
+	saveNote = () => {
+		const {
+			note,
+			onChangeContent,
+		} = this.props;
+
+		if ( ! isValidNote( note ) ) {
+			return;
+		}
+
+		onChangeContent( note, this.noteEditor.value );
+		analytics.tracks.recordEvent( 'editor_note_edited' );
+	};
+
 	transformSelectedLines = transform => {
 		const {
 			selectionStart,
@@ -110,31 +135,6 @@ export default class NoteDetail extends Component {
 		document.execCommand( 'insertText', false, indented );
 
 		this.noteEditor.selectionStart = firstLineStart;
-	};
-
-	onPreviewClick = event => {
-		// open markdown preview links in a new window
-		for ( let node = event.target; node != null; node = node.parentNode ) {
-			if ( node.tagName === 'A' ) {
-				event.preventDefault();
-				viewExternalUrl( node.href );
-				break;
-			}
-		}
-	};
-
-	saveNote = () => {
-		const {
-			note,
-			onChangeContent,
-		} = this.props;
-
-		if ( ! isValidNote( note ) ) {
-			return;
-		}
-
-		onChangeContent( note, this.noteEditor.value );
-		analytics.tracks.recordEvent( 'editor_note_edited' );
 	};
 
 	render = () => {

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -9,7 +9,7 @@ const saveDelay = 2000;
 
 const isValidNote = note => note && note.id;
 const prependTab = l => `\t${ l }`;
-const removeLeadingTab = l => l[0] === '\t' ? l.substring( 1 ) : l;
+const removeLeadingTab = l => l && l.length && l[0] === '\t' ? l.substring( 1 ) : l;
 
 export default class NoteDetail extends Component {
 	static propTypes = {
@@ -54,6 +54,60 @@ export default class NoteDetail extends Component {
 		window.removeEventListener( 'keydown', this.interceptTabPresses );
 	};
 
+	handleKey = event => {
+		if (
+			'Enter' !== event.key ||
+			! this.noteEditor ||
+			this.props.previewingMarkdown ||
+			event.shiftKey ||
+			event.altKey ||
+			event.ctrlKey ||
+			event.metaKey
+		) {
+			return true;
+		}
+
+		const {
+			selectionStart,
+			value,
+		} = this.noteEditor;
+
+		const prevLineStart = value.lastIndexOf( '\n', selectionStart - 1 ) + 1;
+		const prevLine = value.substring( prevLineStart, selectionStart - 1 );
+		const prevIndent = prevLine.match( /^(\s+)([-*])/ );
+
+		// The previous line did not start with
+		// indentation, so continue as normal
+		if ( null === prevIndent ) {
+			return true;
+		}
+
+		const indent = prevIndent[ 1 ];
+		const bullet = prevIndent[ 2 ];
+		const nextIndent = `\n${ indent }${ bullet } `;
+
+		// If going a second time in a row that means we
+		// want to escape the list structure, so unwind
+		// and move back to the beginning of the line
+		if ( prevLine.trim() === nextIndent.trim() ) {
+			this.noteEditor.selectionStart = prevLineStart;
+			this.noteEditor.selectionEnd = Math.min( value.indexOf( '\n', prevLineStart ), value.length );
+			document.execCommand( 'delete', false, null );
+			this.noteEditor.selectionStart = prevLineStart - 1;
+			return true;
+		}
+
+		// Prepend the next list prefix to the line
+		document.execCommand( 'insertText', false, nextIndent );
+		this.noteEditor.selectionStart = selectionStart + nextIndent.length;
+		this.noteEditor.selectionEnd = selectionStart + nextIndent.length;
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		return false;
+	};
+
 	interceptTabPresses = event => {
 		if (
 			'Tab' !== event.code ||
@@ -73,10 +127,31 @@ export default class NoteDetail extends Component {
 		const {
 			selectionStart,
 			selectionEnd,
+			value,
 		} = this.noteEditor;
 
 		// if inserting at a cursor position
 		if ( ! event.shiftKey && selectionStart === selectionEnd ) {
+
+			// handle list indents too
+			const currentLineStart = value.lastIndexOf( '\n', selectionStart - 1 ) + 1;
+			const currentLine = value.substring( currentLineStart, selectionStart );
+			console.log( `currentLine: '${ currentLine }'` );
+
+			// line is a list point
+			if ( /^\s+[-*]\s?$/.test( currentLine ) ) {
+				this.noteEditor.selectionStart = currentLineStart;
+				this.noteEditor.selectionEnd = currentLineStart;
+
+				document.execCommand( 'insertText', false, '\t' );
+
+				this.noteEditor.selectionStart = selectionStart + 1;
+				this.noteEditor.selectionEnd = selectionStart + 1;
+
+				return;
+			}
+
+			// line is not a list point
 			return document.execCommand( 'insertText', false, '\t' );
 		}
 
@@ -117,7 +192,7 @@ export default class NoteDetail extends Component {
 			value,
 		} = this.noteEditor;
 
-		const firstLineStart = value.lastIndexOf( '\n', selectionStart ) + 1;
+		const firstLineStart = value.lastIndexOf( '\n', selectionStart - 1 ) + 1;
 		const lastLineEnd = Math.max( value.indexOf( '\n', selectionEnd ), 0 ) || value.length;
 
 		this.noteEditor.selectionStart = firstLineStart;
@@ -161,6 +236,7 @@ export default class NoteDetail extends Component {
 						className="note-detail-textarea theme-color-bg theme-color-fg"
 						disabled={ !! ( note && note.data.deleted ) }
 						onChange={ this.queueNoteSave }
+						onKeyPress={ this.handleKey }
 						style={ divStyle }
 					/>
 				}

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -7,7 +7,7 @@ import { viewExternalUrl } from './utils/url-utils';
 
 const saveDelay = 2000;
 
-const hasModKeys = ( keys, event ) => keys.some( k => get( event, k ) );
+const hasModKeys = ( keys, event ) => keys.some( k => get( event, `${ k }Key` ) );
 const isValidNote = note => note && note.id;
 const prependTab = l => `\t${ l }`;
 const removeLeadingTab = l => l && l.length && l[0] === '\t' ? l.substring( 1 ) : l;
@@ -70,7 +70,7 @@ export default class NoteDetail extends Component {
 			value,
 		} = this.noteEditor;
 
-		if ( hasModKeys( [ 'altKey', 'ctrlKey', 'metaKey', 'shiftKey' ], event ) ) {
+		if ( hasModKeys( [ 'alt', 'ctrl', 'meta', 'shift' ], event ) ) {
 			return true;
 		}
 
@@ -109,7 +109,7 @@ export default class NoteDetail extends Component {
 	};
 
 	interceptTabPresses = event => {
-		if ( hasModKeys( [ 'altKey', 'ctrlKey', 'metaKey' ], event ) ) {
+		if ( hasModKeys( [ 'alt', 'ctrl', 'meta' ], event ) ) {
 			return;
 		}
 

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -27,16 +27,16 @@ export default class NoteDetail extends Component {
 		this.queueNoteSave = debounce( this.saveNote, saveDelay );
 	}
 
-	componentDidMount = () => {
+	componentDidMount() {
 		// Ensures note gets saved if user abruptly quits the app
 		window.addEventListener( 'beforeunload', this.queueNoteSave.flush );
 	};
 
-	componentWillReceiveProps = () => {
+	componentWillReceiveProps() {
 		this.queueNoteSave.flush();
 	};
 
-	componentDidUpdate = () => {
+	componentDidUpdate() {
 		const { note } = this.props;
 		const content = get( note, 'data.content', '' );
 		if ( isValidNote( note ) && this.noteEditor ) {
@@ -49,7 +49,7 @@ export default class NoteDetail extends Component {
 		}
 	};
 
-	componentWillUnmount = () => {
+	componentWillUnmount() {
 		window.removeEventListener( 'beforeunload', this.queueNoteSave.flush );
 	};
 

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -73,7 +73,6 @@ export default class NoteDetail extends Component {
 		const {
 			selectionStart,
 			selectionEnd,
-			value,
 		} = this.noteEditor;
 
 		// if inserting at a cursor position

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -27,7 +27,7 @@ export default class NoteDetail extends Component {
 	componentDidMount = () => {
 		// Ensures note gets saved if user abruptly quits the app
 		window.addEventListener( 'beforeunload', this.queueNoteSave.flush );
-		window.addEventListener( 'keydown', this.insertTabCharacter );
+		window.addEventListener( 'keydown', this.interceptTabPresses );
 	};
 
 	componentWillReceiveProps = () => {
@@ -49,7 +49,24 @@ export default class NoteDetail extends Component {
 
 	componentWillUnmount = () => {
 		window.removeEventListener( 'beforeunload', this.queueNoteSave.flush );
-		window.removeEventListener( 'keydown', this.insertTabCharacter );
+		window.removeEventListener( 'keydown', this.interceptTabPresses );
+	};
+
+	interceptTabPresses = event => {
+		if (
+			'Tab' !== event.code ||
+			! this.noteEditor ||
+			'TEXTAREA' !== event.target.nodeName ||
+			this.props.previewingMarkdown
+		) {
+			console.log( 'skipping' );
+			return;
+		}
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		document.execCommand( 'insertText', false, '\t' );
 	};
 
 	onPreviewClick = event => {
@@ -61,36 +78,6 @@ export default class NoteDetail extends Component {
 				break;
 			}
 		}
-	};
-
-	insertTabCharacter = event => {
-		if ( 'Tab' !== event.code ) {
-			return;
-		}
-
-		if ( ! this.noteEditor ) {
-			return;
-		}
-
-		const {
-			selectionStart,
-			selectionEnd,
-			value,
-		} = this.noteEditor;
-
-		this.noteEditor.value = [
-			value.substring( 0, selectionStart ),
-			'\t',
-			value.substring( selectionEnd ),
-		].join( '' );
-		this.queueNoteSave();
-
-		this.noteEditor.selectionStart = selectionStart + 1;
-		this.noteEditor.selectionEnd = selectionStart + 1;
-		this.noteEditor.focus();
-
-		event.preventDefault();
-		event.stopPropagation();
 	};
 
 	saveNote = () => {


### PR DESCRIPTION
Depends on #386 
Resolves #371

Previously, there was a missing behavior in this app that was present in
the other Simplenote apps: when creating a new line after a line
starting with a list bullet, the new line should start with the same
bullet at the same level of indentation.

This PR adds that behavior into the app.

**Testing**
Create a list in a note, such as the following…

```
List:
	- One
	- Two
```

On either of those lines, if you hit _enter_ to create a new line, the tab and dash should come with it as expected. Attempt to indent or outdent those lines. Try to add a second line with _enter, enter_ and the list prefix should disappear, returning the line to normal.

cc: @roundhill @rodrigoi @drw158 