### PR TITLE
Improve word counter to handle more languages

### DIFF
--- a/lib/note-info.jsx
+++ b/lib/note-info.jsx
@@ -137,8 +137,8 @@ function wordCount( content ) {
 	const matches = ( content || '' )
 		.replace( /[\u200B]+/, '' )
 		.trim()
-		.replace(/['";:,.?¿\-!¡]+/g, '')
-		.match(/\S+/g);
+		.replace( /['";:,.?¿\-!¡]+/g, '' )
+		.match( /\S+/g );
 
 	return ( matches || [] ).length;
 }

--- a/lib/note-info.jsx
+++ b/lib/note-info.jsx
@@ -132,8 +132,15 @@ function formatTimestamp( unixTime ) {
 	return moment.unix( unixTime ).format( 'MMM D, YYYY h:mm a' );
 }
 
+// https://github.com/RadLikeWhoa/Countable
 function wordCount( content ) {
-	return ( ( content || '' ).match( /\b\S+\b/g ) || [] ).length;
+	const matches = ( content || '' )
+		.replace( /[\u200B]+/, '' )
+		.trim()
+		.replace(/['";:,.?¿\-!¡]+/g, '')
+		.match(/\S+/g);
+
+	return ( matches || [] ).length;
 }
 
 // https://mathiasbynens.be/notes/javascript-unicode


### PR DESCRIPTION
Resolves #337

Previously the word counting algorithm failed poorly in languages which
use non-ASCII symbols. It was counting `0` for languages such as Russian
and Greek, etc...

Now, we have borrowed the counting mechanism from
https://github.com/RadLikeWhoa/Countable which does a much better job of
handling multilingual inputs.

We still have a problem handling languages such as several Asian
languages where there are no spacing boundaries between words, but it
doesn't appear like many web apps at all handle these as there is
significant parsing of the text involved to figure out which words are
there.

**Testing**
Insert some text from various languages using Unicode characters. See if the word counts match.

`Ты ыам мальорум эпикюре` > Should show 4
`世の中を　憂しとやさしと　おもへども　飛び立ちかねつ　鳥にしあらねば` > should show 7 I think, but definitely more than 5
`μῆνιν ἄειδε θεὰ Πηληϊάδεω Ἀχιλῆος` > Should show 5

cc: @roundhill @rodrigoi 