### PR TITLE
Create docker-compose.yml to allow building from inside Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ module.exports = function() {
 };
 ```
 
-4. npm install
-5. npm start
+4. `npm install` _or_ `docker-compose up install` (if Docker installed)
+5. `npm start` _or_ `docker-compose up dev` (if Docker installed)
 6. Open http://localhost:4000. You can sign in to the app with your Simperium credentials.
 
 _Note: Simplenote API features such as sharing and publishing will not work with development builds._

--- a/devServer.js
+++ b/devServer.js
@@ -18,7 +18,7 @@ app.get( '*', function( req, res ) {
 	res.send( compiler.outputFileSystem.readFileSync( path.join( __dirname, 'dist', 'index.html' ) ) );
 } );
 
-app.listen( 4000, 'localhost', function( err ) {
+app.listen( 4000, '0.0.0.0', function( err ) {
 	if ( err ) {
 		console.log( err );
 		return;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+
+services:
+  install:
+    image: node:5.12.0
+    command: npm install
+    volumes:
+      - $PWD:/app
+    working_dir: /app
+  
+  dev:
+    image: node:5.12.0
+    command: npm start
+    ports:
+      - "4000:4000"
+    volumes:
+      - $PWD:/app
+    working_dir: /app


### PR DESCRIPTION
Previously I have had issues managing `node` versions between this and
other projects on my machine. By building inside of a Docker container
we can eliminate these issues.

This patch allows starting the app with `docker-compose up dev` instead of
`npm start` which runs inside the contained environment.

cc: @roundhill - I was tired of running the long `docker` command each time. this shouldn't hurt anything in the app, just adds a new way of starting it.

cc: @rodrigoi @vindl 