### PR TITLE
Finds note from `state.notes` instead of using `state.note`

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -429,7 +429,6 @@ var actionMap = new ActionMap( {
 			creator( { noteBucket, noteId, original, data, patch, isIndexing } ) {
 				return ( dispatch, getState ) => {
 					var state = getState().appState;
-					var note = state.note;
 
 					if ( isIndexing ) {
 						// Increase index counter
@@ -449,6 +448,13 @@ var actionMap = new ActionMap( {
 					}
 
 					// working is the state of the note in the editor
+					const note = state.notes.find( n => n.id === noteId );
+
+					if ( ! note ) {
+						console.error( `Cannot find note (id=${id})!` );
+						return;
+					}
+
 					let working = state.note.data;
 
 					// diff of working and original will produce the modifications the client has currently made


### PR DESCRIPTION
When `onNoteUpdate` was being called it was looking for `state.note` but
that didn't exist in at least some calls. I have not fully understood
the `state.note` variable or when it should exist.

In this patch, I have manually scanned the stores list of notes to try
and find it, working around the need for `state.note` to be set.

This is fixing some exceptions that were raised. I am not sure how many
other issues it will resolve but it was preventing the call to
`updateNoteContent`

cc: @roundhill @rodrigoi @beaucollins 