### PR TITLE
Replace value link in tag list for controlled state changes

### DIFF
--- a/lib/tag-list.jsx
+++ b/lib/tag-list.jsx
@@ -1,18 +1,48 @@
-import React, { PropTypes } from 'react'
+import React, { Component, PropTypes } from 'react'
 import classNames from 'classnames'
 import EditableList from './editable-list'
 import { get } from 'lodash'
 
-export default React.createClass( {
-
-	propTypes: {
+export default class TagList extends Component {
+	static propTypes = {
 		onSelectTag: PropTypes.func.isRequired,
 		onEditTags: PropTypes.func.isRequired,
 		onRenameTag: PropTypes.func.isRequired,
 		onTrashTag: PropTypes.func.isRequired,
 		onReorderTags: PropTypes.func.isRequired,
 		tags: PropTypes.array.isRequired
-	},
+	};
+
+	renderItem = ( tag ) => {
+		const {
+			onRenameTag,
+			selectedTag,
+		} = this.props;
+		const isSelected = tag.data.name === get( selectedTag, 'data.name', '' );
+		const classes = classNames( 'tag-list-input', 'theme-color-fg', {
+			active: isSelected
+		} );
+
+		const renameTag = ( { target: { value } } ) => onRenameTag( tag, value );
+
+		return (
+			<input
+				className={classes}
+				readOnly={!this.props.editingTags}
+				onClick={this.onSelectTag.bind( this, tag )}
+				value={ tag.data.name }
+				onChange={ renameTag }
+			/>
+		);
+	};
+
+	onSelectTag = ( tag, event ) => {
+		if ( !this.props.editingTags ) {
+			event.preventDefault();
+			event.currentTarget.blur();
+			this.props.onSelectTag( tag );
+		}
+	};
 
 	render() {
 		var classes = classNames( 'tag-list', {
@@ -37,34 +67,7 @@ export default React.createClass( {
 					selectedTag={this.props.selectedTag} />
 			</div>
 		);
-	},
-
-	renderItem( tag ) {
-		const { selectedTag } = this.props;
-		const valueLink = {
-			value: tag.data.name,
-			requestChange: this.props.onRenameTag.bind( null, tag )
-		};
-
-		const isSelected = tag.data.name === get( selectedTag, 'data.name', '' );
-		const classes = classNames( 'tag-list-input', 'theme-color-fg', {
-			active: isSelected
-		} );
-
-		return (
-			<input
-				className={classes}
-				readOnly={!this.props.editingTags}
-				onClick={this.onSelectTag.bind( this, tag )}
-				valueLink={valueLink} />
-		);
-	},
-
-	onSelectTag( tag, event ) {
-		if ( !this.props.editingTags ) {
-			event.preventDefault();
-			event.currentTarget.blur();
-			this.props.onSelectTag( tag );
-		}
 	}
-} );
+}
+
+export default TagList;


### PR DESCRIPTION
Related to #392 

Removes the use of `valueLink` in the `TagList` so that React will stop complaining in the console. `valueLink` is deprecated. I did not merge this into that other PR because I felt like the changes here have a higher risk value and aren't simpler version-bumps etc…

> Despite the larger PR, only a few lines really change here. I have updated the style of the component into a `class` component which has muddied the diff.

**Teting**
 - Open the tag list
 - Click _Edit_
 - Rename a tag.

Look for issues with the tag list. For example, at one point during the development, renaming a tag resulted in the app showing `[Object object]` instead of the tag name (this has been fixed).

cc: @roundhill 