### PR TITLE
Fix/revision slider

### DIFF
--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -113,7 +113,7 @@ export const NoteEditor = React.createClass( {
 		return (
 			<div className={classes}>
 				<RevisionSelector
-					revisions={revisions}
+					revisions={revisions || []}
 					onViewRevision={this.onViewRevision}
 					onSelectRevision={this.onSelectRevision}
 					onCancelRevision={this.onCancelRevision} />

--- a/lib/revision-selector.jsx
+++ b/lib/revision-selector.jsx
@@ -1,15 +1,9 @@
 import React, { PropTypes } from 'react'
 import moment from 'moment'
-import { property } from 'lodash';
+import { orderBy } from 'lodash';
 
-const lastUpdateOf = property( 'data.modificationDate' );
-const revisionSorter = ( a, b ) => lastUpdateOf( a ) - lastUpdateOf( b );
-
-const sortedRevisions = revisions => (
-	revisions
-		.slice()
-		.sort( revisionSorter )
-);
+const sortedRevisions = revisions =>
+	orderBy( revisions, 'data.modificationDate', 'asc' );
 
 export const RevisionSelector = React.createClass( {
 	mixins: [

--- a/lib/revision-selector.jsx
+++ b/lib/revision-selector.jsx
@@ -7,12 +7,6 @@ export default React.createClass( {
 		require( 'react-onclickoutside' )
 	],
 
-	getDefaultProps: function() {
-		return {
-			revisions: []
-		}
-	},
-
 	getInitialState() {
 		return {
 			selection: Infinity,
@@ -74,7 +68,7 @@ export default React.createClass( {
 	},
 
 	sortedRevisions() {
-		return this.props.revisions
+		return ( this.props.revisions || [] )
 			.slice()
 			.sort( ( a, b ) => a.data.modificationDate - b.data.modificationDate );
 	},


### PR DESCRIPTION
Fixes some problems with the revision selector. Could be the reason behind the syncing issues.

Previously, the revision slider would open up in a strange state and hold onto that state until a different revision were explicitly selected. That is to say, the selection was `-1` and 'Latest' was showing up in position `1` on the slider.

**Before**
![broken revision slider](https://cloud.githubusercontent.com/assets/5431237/19022590/62cad4c0-8890-11e6-8ddc-1c4d3f5ac40f.gif)

**After**
![fixed revision slider](https://cloud.githubusercontent.com/assets/5431237/19022592/6856ca84-8890-11e6-982f-1a8567cf965d.gif)

**Testing**

Start with a fresh login and cleared browser state (open the DevTools and clear the application data, cache, IndexedDB, etc…).

Open a note and click on the history button to open the revision slider. In **master** it should load with `Latest` in the second position, position `1`, and that revision should probably be the second-most-recent revision. After interacting with the slider _or_ after navigating back to the list view and reselecting the note, the slider should have `Latest` at the far-right. It should remain to be the second-most-recent revision, however, with the latest actual revision found on the far left. Position `1` may still be selected and now that position should be a blank note, the original version before any text was entered.

In _this branch_ none of this unexpected behavior should be present. The revisions should load instantly in the proper order with `Latest` on the far right and with `Latest` actually being the most-recent revision.

**Further Work**

We need to get a test build of this built and tested. I think that there's a good chance this will take care of many of our sync issues. Actually, I believe that this could be the smokescreen hiding the fact that sync'ing may not be broken, but when loading notes the Electron app ends up reverting to the original blank revision.

cc: @roundhill @rodrigoi 