### PR TITLE
Default app to running React version instead of redirecting to web app

### DIFF
--- a/lib/boot.js
+++ b/lib/boot.js
@@ -19,8 +19,8 @@ require( '../scss/app.scss' );
 const token = cookie.token || localStorage.access_token;
 const appId = config.app_id;
 
-// If no token, and no app key, we're probably on the server, so redirect to simplenote login
-if ( !token && !config.app_key ) {
+// Redirect to web sign in if running on App Engine
+if ( config.is_app_engine ) {
 	window.location = 'https://app.simplenote.com/signin';
 }
 

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -20,7 +20,7 @@ const token = cookie.token || localStorage.access_token;
 const appId = config.app_id;
 
 // Redirect to web sign in if running on App Engine
-if ( config.is_app_engine ) {
+if ( ! token && config.is_app_engine ) {
 	window.location = 'https://app.simplenote.com/signin';
 }
 


### PR DESCRIPTION
Require a specific `is_app_engine` property to be set in `config.js` in order to run from the web service.

Fixes issue noticed at https://github.com/Automattic/simplenote-electron/pull/370#issuecomment-252103110 where a new contributor could be confused if they haven't set up `config.js` yet and are redirected to the web app by default.

**To test**
1) Remove your `config.js` and run the app, you should not be taken to app engine.
2) Add back your `config.js` and add `is_app_engine: true` and run the app again. It should take you to the app engine login.