### PR TITLE
Replace dependency on electron-prebuilt with electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "css-loader": "0.19.0",
     "electron-builder": "2.8.4",
     "electron-packager": "7.5.1",
-    "electron-prebuilt": "1.3.2",
+    "electron": "1.3.2",
     "eslint": "1.10.3",
     "eslint-loader": "1.3.0",
     "eslint-plugin-react": "3.16.1",


### PR DESCRIPTION
per http://electron.atom.io/blog/2016/08/16/npm-install-electron

the electron-prebuilt package is deprected and will stop receiving new updates at the end of 2016