### PR TITLE
fix access to wrong variable name

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -451,7 +451,7 @@ var actionMap = new ActionMap( {
 					const note = state.notes.find( n => n.id === noteId );
 
 					if ( ! note ) {
-						console.error( `Cannot find note (id=${id})!` );
+						console.error( `Cannot find note (id=${noteId})!` );
 						return;
 					}
 


### PR DESCRIPTION
`id` is not defined, I guess `noteId` is what was meant