### PR TITLE
Enable syntax highlighting (#309)

### DIFF
--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -7,6 +7,7 @@ import { viewExternalUrl } from './utils/url-utils';
 import NoteContentEditor from './note-content-editor';
 
 const saveDelay = 2000;
+const highlighter = code => highlight.highlightAuto( code ).value;
 
 export default React.createClass( {
 
@@ -91,11 +92,7 @@ export default React.createClass( {
 
 	renderMarkdown( divStyle ) {
 		const { content = '' } = this.props.note.data;
-		const markdownHTML = marked( content, {
-			highlight: function( code ) {
-				return highlight.highlightAuto( code ).value;
-			}
-		} );
+		const markdownHTML = marked( content, { highlight: highlighter } );
 
 		return (
 			<div className="note-detail-markdown theme-color-bg theme-color-fg"

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import highlight from 'highlight.js';
 import marked from 'marked';
 import { get, debounce, invoke } from 'lodash';
 import analytics from './analytics';
@@ -90,7 +91,11 @@ export default React.createClass( {
 
 	renderMarkdown( divStyle ) {
 		const { content = '' } = this.props.note.data;
-		const markdownHTML = marked( content );
+		const markdownHTML = marked( content, {
+			highlight: function( code ) {
+				return highlight.highlightAuto( code ).value;
+			}
+		} );
 
 		return (
 			<div className="note-detail-markdown theme-color-bg theme-color-fg"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "cookie": "0.2.3",
     "create-hash": "1.1.2",
     "draft-js": "0.9.1",
-    "highlight.js": "^9.7.0",
+    "highlight.js": "9.7.0",
     "lodash": "4.6.1",
     "marked": "0.3.5",
     "moment": "2.12.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "cookie": "0.2.3",
     "create-hash": "1.1.2",
     "draft-js": "0.9.1",
+    "highlight.js": "^9.7.0",
     "lodash": "4.6.1",
     "marked": "0.3.5",
     "moment": "2.12.0",

--- a/scss/markdown-preview.scss
+++ b/scss/markdown-preview.scss
@@ -1,5 +1,5 @@
 .note-detail-markdown {
-	@import "../node_modules/highlight.js/styles/hybrid.css";
+	@import "../node_modules/highlight.js/styles/solarized-light.css";
 
 	user-select: all;
 

--- a/scss/markdown-preview.scss
+++ b/scss/markdown-preview.scss
@@ -1,6 +1,8 @@
 .note-detail-markdown {
+	@import "../node_modules/highlight.js/styles/hybrid.css";
+
 	user-select: all;
-		
+
 	h1,
 	h2,
 	h3,
@@ -9,7 +11,7 @@
 	h6 {
 		line-height: 1.15;
 	}
-	
+
 	h1 {
 		font-weight: $light;
 	}
@@ -17,19 +19,19 @@
 	h6 {
 		text-transform: uppercase;
 	}
-	
+
 	hr {
 		border: 0;
 		border-top: 1px solid lighten($gray, 20%);
 	}
-	
+
 	blockquote {
 		font-style: italic;
 		border-left: 4px solid lighten($gray, 20%);
 		margin-left: 0;
 		padding-left: 1em;
 	}
-	
+
 	code {
 		font-size: 85%;
 		background: $gray-lightest;
@@ -41,6 +43,6 @@
 	}
 	pre code {
 		color: darken($gray, 10%);
-		background: transparent;	
+		background: transparent;
 	}
 }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -68,7 +68,7 @@
 	input::placeholder {
 		color: $gray;
 	}
-	
+
 	.transparent-input::placeholder {
 		color: darken($gray, 10%);
 	}
@@ -84,11 +84,11 @@
 			color: lighten($gray, 10%);
 		}
 	}
-	
+
 	.dialogs-overlay {
 		background: rgba($gray-darkest, 0.75);
 	}
-	
+
 	.note-list-item {
 		&:hover .note-list-item-pinner {
 			box-shadow: inset 0 0 0 2px darken($gray, 30%), inset 0 0 0 3px $gray-darkest;
@@ -116,16 +116,18 @@
 			}
 		}
 	}
-	
+
 	.note-detail-markdown {
+		@import "../node_modules/highlight.js/styles/solarized-dark.css";
+
 		hr {
 			border-color: darken($gray, 20%);
 		}
-		
+
 		blockquote {
 			border-color: darken($gray, 20%);
 		}
-		
+
 		code {
 			background: darken($gray, 30%);
 		}
@@ -134,7 +136,7 @@
 		}
 		pre code {
 			color: $gray;
-			background: transparent;	
+			background: transparent;
 		}
 	}
 }


### PR DESCRIPTION
I decided to take a swing at adding syntax highlighting for the markdown preview. It uses highlight.js and the "hybrid" theme that seems to work well for both light and dark modes. Everything passes eslint and I think I followed the style guides, but let me know if you want any tweaks. 

![screenshot from 2016-10-18 21-10-45](https://cloud.githubusercontent.com/assets/445976/19502058/352c2006-9578-11e6-9f58-d7319592fd25.png)
![screenshot from 2016-10-18 21-11-02](https://cloud.githubusercontent.com/assets/445976/19502059/352d65ce-9578-11e6-98f0-942186cd59e4.png)
