### PR TITLE
Clear search field on ESC keypress

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -505,8 +505,6 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 									</button>
 									<SearchField
 										onSearch={this.onSearch}
-										placeholder={state.listTitle}
-										searchFocus={state.searchFocus}
 										onSearchFocused={this.onSearchFocused} />
 									<button title="New Note" className="button button-borderless" disabled={state.showTrash} onClick={this.onNewNote}>
 										<NewNoteIcon />

--- a/lib/search-field.jsx
+++ b/lib/search-field.jsx
@@ -1,40 +1,60 @@
-import React, { PropTypes } from 'react'
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 
-export default React.createClass( {
+const KEY_ESC = 27;
 
-	propTypes: {
+export class SearchField extends Component {
+	static propTypes = {
 		placeholder: PropTypes.string.isRequired,
+		query: PropTypes.string.isRequired,
 		searchFocus: PropTypes.bool.isRequired,
 		onSearch: PropTypes.func.isRequired,
 		onSearchFocused: PropTypes.func.isRequired
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			placeholder: 'Search',
-			onSearch: function() {}
-		}
-	},
-
-	componentDidUpdate: function() {
+	componentDidUpdate() {
 		const { searchFocus, onSearchFocused } = this.props;
-		const { search } = this.refs;
-		if ( searchFocus ) {
-			search.focus();
+
+		if ( searchFocus && this.searchField ) {
+			searchField.focus();
 			onSearchFocused();
 		}
-	},
+	}
 
-	onSearch: function() {
-		var query = this.refs.search.value;
-		this.props.onSearch( query );
-	},
+	interceptEsc = ( { keyCode } ) =>
+		KEY_ESC === keyCode
+			? this.props.onSearch( '' )
+			: null;
 
-	render: function() {
+	storeInput = r => this.inputField = r;
+
+	update = ( { target: { value: query } } ) => this.props.onSearch( query );
+
+	render() {
+		const {
+			placeholder,
+			query,
+		} = this.props;
+
 		return (
 			<div className="search-field">
-				<input ref="search" type="text" placeholder={this.props.placeholder} onChange={this.onSearch} />
+				<input
+					ref={ this.storeInput }
+					type="text"
+					placeholder={ placeholder }
+					onChange={ this.update }
+					onKeyUp={ this.interceptEsc }
+					value={ query }
+				/>
 			</div>
 		);
 	}
+};
+
+const mapStateToProps = ( { appState } ) => ( {
+	query: appState.filter,
+	placeholder: appState.listTitle,
+	searchFocus: appState.searchFocus,
 } );
+
+export default connect( mapStateToProps )( SearchField );


### PR DESCRIPTION
This patch adds the behaviors where pressing the _escape_ key while in
the note search box will clear out any text already filled in.

This is a precursor to adding the clear button as requested in #411.

In order to make this work properly I had to make the search field
itself a controlled component whereas before the `value` was free as any
given HTML input would be. Now it's tied to the `filter` app state
property.

I have also taken the opportunity in this patch to refactor the
`<SearchField />` component, converting it to a `class`-based React
component and wrapping it in `connect()`, providing whichever props I
could without major app refactoring.

**Testing**

Type in search queries into the search field. Hitting <kbd>ESC</kbd> should both clear out the search field _and_ clear out the search itself, _i.e._ all the notes should become visible again.

We should make sure that this works when searching and changing the selected tag.

cc: @roundhill @drw158 