### PR TITLE
Set initial filter (search query) state to ''

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -14,6 +14,7 @@ var actionMap = new ActionMap( {
 		authorized: null,
 		authPending: false,
 		editorMode: 'edit',
+		filter: '',
 		selectedNoteId: null,
 		previousIndex: -1,
 		notes: [],


### PR DESCRIPTION
Previously the initial filter on the notes was undefined until someone
actually typed something into the search field.

Now, the filter is set as an empty string on boot. This not only
provides us with the inital filter required by the search field but it
also keeps the filter state in line with the expected type of data it
needs to be: a string.

> There should be no visual or functional changes in this PR. The only difference will be the presence or absence of a warning message about the `query` prop on the `<SearchField />` and another warning when typing something in it for the first time.

**Testing**
Same as for #416 - smoke-test searching.

cc: @roundhill 