### PR TITLE
Fix PageUp/Down Keys from Showing Info Panel

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -559,11 +559,13 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 								onNoteInfo={() => this.props.actions.toggleNoteInfo()}
 								shouldPrint={state.shouldPrint}
 								onNotePrinted={this.onNotePrinted} />
-							<NoteInfo
-								note={selectedNote}
-								onPinNote={this.onPinNote}
-								onMarkdownNote={this.onMarkdownNote}
-								onOutsideClick={this.onToolbarOutsideClick} />
+							{ state.showNoteInfo &&
+								<NoteInfo
+									note={selectedNote}
+									onPinNote={this.onPinNote}
+									onMarkdownNote={this.onMarkdownNote}
+									onOutsideClick={this.onToolbarOutsideClick} />
+							}
 						</div>
 				:
 					<Auth

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -508,21 +508,23 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 				}
 				{ isAuthorized ?
 						<div className={mainClasses}>
-							<NavigationBar
-								onSelectAllNotes={() => this.props.actions.selectAllNotes() }
-								onSelectTrash={() => this.props.actions.selectTrash() }
-								onSelectTag={this.onSelectTag}
-								onSettings={this.onSettings}
-								onAbout={this.onAbout}
-								onEditTags={() => this.props.actions.editTags() }
-								onRenameTag={this.onRenameTag}
-								onTrashTag={this.onTrashTag}
-								onReorderTags={this.onReorderTags}
-								editingTags={state.editingTags}
-								showTrash={state.showTrash}
-								selectedTag={state.tag}
-								tags={state.tags}
-								onOutsideClick={this.onToolbarOutsideClick} />
+							{ state.showNavigation &&
+								<NavigationBar
+									onSelectAllNotes={() => this.props.actions.selectAllNotes() }
+									onSelectTrash={() => this.props.actions.selectTrash() }
+									onSelectTag={this.onSelectTag}
+									onSettings={this.onSettings}
+									onAbout={this.onAbout}
+									onEditTags={() => this.props.actions.editTags() }
+									onRenameTag={this.onRenameTag}
+									onTrashTag={this.onTrashTag}
+									onReorderTags={this.onReorderTags}
+									editingTags={state.editingTags}
+									showTrash={state.showTrash}
+									selectedTag={state.tag}
+									tags={state.tags}
+									onOutsideClick={this.onToolbarOutsideClick} />
+							}
 							<div className="source-list theme-color-bg theme-color-fg">
 								<div className="search-bar theme-color-border">
 									<button title="Tags" className="button button-borderless" onClick={() => this.props.actions.toggleNavigation() }>


### PR DESCRIPTION
Something about adding `drafts-js` was causing the note info panel to appear when you pressed the Page Up or Page Down keys when the editor had focus.

It looks to me like the form elements that are present in the info panel are getting focus when these keys are pressed. The info panel is absolutely positioned 100% to the left to sort of hide it, so the browser window actually moves over to show the element that received focus.

At first, I thought I could fix this by changing where the note info panel was rendered to be _before_ where the editor renders, but it didn't fix the issue.

The solution I came up with was to simply not render the note info panel until we want to show it. It might have a slightly longer delay when animating in, but I haven't noticed any difference.

**To Test**
1. Compile a windows or linux version, and sign in.
2. Select a long note in the editor, and press the page up or page down keys.
3. The editor should scroll down or up, and the note info panel should remain hidden.

 Fixes #408