### PR TITLE
Highlight search result matches

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -499,6 +499,7 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 							<NoteEditor
 								allTags={ state.tags }
 								editorMode={state.editorMode}
+								filter={state.filter}
 								note={selectedNote}
 								revisions={state.revisions}
 								onSetEditorMode={this.onSetEditorMode}

--- a/lib/editor/css-class-wrapper.jsx
+++ b/lib/editor/css-class-wrapper.jsx
@@ -1,0 +1,10 @@
+import React, { PropTypes } from 'react';
+
+export const CssClassWrapper = ( { children, className } ) =>
+	<span { ...{ className } }>{ children }</span>;
+
+CssClassWrapper.propTypes = {
+	className: PropTypes.string.isRequired,
+};
+
+export default CssClassWrapper;

--- a/lib/editor/matching-text-decorator.js
+++ b/lib/editor/matching-text-decorator.js
@@ -1,0 +1,48 @@
+import SimpleDecorator from 'draft-js-simpledecorator';
+
+import CssClassWrapper from './css-class-wrapper';
+
+const matchIndices = ( text, matcher ) => {
+	const chunks = [];
+	let match;
+
+	while ( ( match = matcher.exec( text ) ) !== null ) {
+		chunks.push( [ match.index, matcher.lastIndex ] );
+	}
+
+	return chunks;
+};
+
+const dispatch = callback => ( [ start, end ] ) =>
+	callback( start, end, { className: 'search-match' } );
+
+export const findMatchingText = matcher => ( contentBlock, callback ) => {
+	const text = contentBlock
+		.getText()
+		.toLocaleLowerCase();
+
+	if ( ! matcher || ! text ) {
+		return;
+	}
+
+	matchIndices( text, matcher ).forEach( dispatch( callback ) );
+};
+
+/**
+ * Decorator to highlight text matching given search string
+ *
+ * @param {string} search text to search for
+ * @returns {null|Object}
+ */
+export const matchingTextDecorator = search => {
+	if ( ! search ) {
+		return null;
+	}
+
+	const query = search.toLocaleLowerCase();
+	const matcher = new RegExp( query, 'g' );
+
+	return new SimpleDecorator( findMatchingText( matcher ), CssClassWrapper );
+};
+
+export default matchingTextDecorator;

--- a/lib/editor/matching-text-decorator.js
+++ b/lib/editor/matching-text-decorator.js
@@ -1,4 +1,5 @@
 import SimpleDecorator from 'draft-js-simpledecorator';
+import { escapeRegExp } from 'lodash';
 
 import CssClassWrapper from './css-class-wrapper';
 
@@ -17,9 +18,7 @@ const dispatch = callback => ( [ start, end ] ) =>
 	callback( start, end, { className: 'search-match' } );
 
 export const findMatchingText = matcher => ( contentBlock, callback ) => {
-	const text = contentBlock
-		.getText()
-		.toLocaleLowerCase();
+	const text = contentBlock.getText()
 
 	if ( ! matcher || ! text ) {
 		return;
@@ -39,8 +38,7 @@ export const matchingTextDecorator = search => {
 		return null;
 	}
 
-	const query = search.toLocaleLowerCase();
-	const matcher = new RegExp( query, 'g' );
+	const matcher = new RegExp( escapeRegExp( search ), 'gi' );
 
 	return new SimpleDecorator( findMatchingText( matcher ), CssClassWrapper );
 };

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -7,6 +7,8 @@ import {
 } from 'draft-js';
 import { includes, invoke, noop } from 'lodash';
 
+import matchingTextDecorator from './editor/matching-text-decorator';
+
 function plainTextContent( editorState ) {
 	return editorState.getCurrentContent().getPlainText( '\n' )
 }
@@ -148,7 +150,8 @@ export default class NoteContentEditor extends React.Component {
 
 	state = {
 		editorState: EditorState.createWithContent(
-			ContentState.createFromText( this.props.content, '\n' )
+			ContentState.createFromText( this.props.content, '\n' ),
+			matchingTextDecorator( this.props.filter ),
 		)
 	}
 
@@ -171,20 +174,20 @@ export default class NoteContentEditor extends React.Component {
 		this.setState( { editorState }, announceChanges );
 	}
 
-	componentWillReceiveProps( { content: newContent } ) {
-		const { content: oldContent } = this.props;
+	componentWillReceiveProps( { content: newContent, filter: nextFilter } ) {
+		const { filter: prevFilter } = this.props;
 		const { editorState: oldEditorState } = this.state;
 
-		if ( newContent === oldContent ) {
-			return; // identical to previous `content` prop
-		}
-
-		if ( newContent === plainTextContent( oldEditorState ) ) {
+		if (
+			( newContent === plainTextContent( oldEditorState ) ) &&
+			( nextFilter === prevFilter )
+		) {
 			return; // identical to rendered content
 		}
 
 		let newEditorState = EditorState.createWithContent(
-			ContentState.createFromText( newContent, '\n' )
+			ContentState.createFromText( newContent, '\n' ),
+			matchingTextDecorator( nextFilter ),
 		)
 
 		// avoids weird caret position if content is changed

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -112,6 +112,7 @@ export default React.createClass( {
 				<NoteContentEditor
 					ref={this.saveEditorRef}
 					content={content}
+					filter={ this.props.filter }
 					onChangeContent={this.queueNoteSave} />
 			</div>
 		);

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -73,49 +73,40 @@ export default React.createClass( {
 	},
 
 	render: function() {
-		var { previewingMarkdown, fontSize } = this.props;
+		const {
+			filter,
+			fontSize,
+			previewingMarkdown,
+		} = this.props;
 
-		var divStyle = {
-			fontSize: fontSize + 'px'
-		};
+		const content = get( this.props, 'note.data.content', '' );
+		const divStyle = { fontSize: `${ fontSize }px` };
 
 		return (
 			<div className="note-detail">
-				{previewingMarkdown ?
-					this.renderMarkdown( divStyle )
-				:
-					this.renderEditable( divStyle )
-				}
+				{ previewingMarkdown && (
+					<div
+						className="note-detail-markdown theme-color-bg theme-color-fg"
+						dangerouslySetInnerHTML={ { __html: marked( content, { highlight: highlighter } ) } }
+						onClick={ this.onPreviewClick }
+						style={ divStyle }
+					/>
+				) }
+
+				{ ! previewingMarkdown && (
+					<div
+						className="note-detail-textarea theme-color-bg theme-color-fg"
+						style={ divStyle }
+					>
+						<NoteContentEditor
+							ref={ this.saveEditorRef }
+							content={ content }
+							filter={ filter }
+							onChangeContent={ this.queueNoteSave }
+						/>
+					</div>
+				) }
 			</div>
 		);
 	},
-
-	renderMarkdown( divStyle ) {
-		const { content = '' } = this.props.note.data;
-		const markdownHTML = marked( content, { highlight: highlighter } );
-
-		return (
-			<div className="note-detail-markdown theme-color-bg theme-color-fg"
-				dangerouslySetInnerHTML={ { __html: markdownHTML } }
-				onClick={ this.onPreviewClick }
-				style={ divStyle } />
-		);
-	},
-
-	renderEditable( divStyle ) {
-		const content = get( this.props, 'note.data.content', '' );
-
-		return (
-			<div
-				className="note-detail-textarea theme-color-bg theme-color-fg"
-				style={ divStyle }>
-				<NoteContentEditor
-					ref={this.saveEditorRef}
-					content={content}
-					filter={ this.props.filter }
-					onChangeContent={this.queueNoteSave} />
-			</div>
-		);
-	}
-
-} )
+} );

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -133,6 +133,7 @@ export const NoteEditor = React.createClass( {
 					{!!markdownEnabled && this.renderModeBar()}
 					<div className="note-editor-detail">
 						<NoteDetail
+							filter={this.props.filter}
 							note={revision}
 							previewingMarkdown={markdownEnabled && editorMode === 'markdown'}
 							onChangeContent={this.props.onUpdateContent}

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -80,6 +80,16 @@ export const NoteEditor = React.createClass( {
 		this.setIsViewingRevisions( false );
 	},
 
+	setEditorMode( event ) {
+		const editorMode = get( event, 'target.dataset.editorMode' );
+
+		if ( ! editorMode ) {
+			return;
+		}
+
+		this.props.onSetEditorMode( editorMode );
+	},
+
 	setIsViewingRevisions: function( isViewing ) {
 		this.setState( { isViewingRevisions: isViewing } );
 	},
@@ -155,16 +165,32 @@ export const NoteEditor = React.createClass( {
 	},
 
 	renderModeBar() {
-		var { editorMode } = this.props;
+		const { editorMode } = this.props;
+
+		const isPreviewing = ( editorMode === 'markdown' );
 
 		return (
 			<div className="note-editor-mode-bar segmented-control">
 				<button type="button"
-					className={classNames( 'button button-segmented-control button-compact', { active: editorMode === 'edit' } )}
-					onClick={this.props.onSetEditorMode.bind( null, 'edit' )}>Edit</button>
+					className={ classNames(
+						'button button-segmented-control button-compact',
+						{ active: ! isPreviewing },
+					) }
+					data-editor-mode="edit"
+					onClick={ this.setEditorMode }
+				>
+					Edit
+				</button>
 				<button type="button"
-					className={classNames( 'button button-segmented-control button-compact', { active: editorMode === 'markdown' } )}
-					onClick={this.props.onSetEditorMode.bind( null, 'markdown' )}>Preview</button>
+					className={ classNames(
+						'button button-segmented-control button-compact',
+						{ active: isPreviewing },
+					) }
+					data-editor-mode="markdown"
+					onClick={ this.setEditorMode }
+				>
+					Preview
+				</button>
 			</div>
 		);
 	}

--- a/lib/note-list.jsx
+++ b/lib/note-list.jsx
@@ -160,17 +160,20 @@ const getRowHeight = rowHeightCache( computeRowHeight );
  * our level of recursion should be practically limited by the length of the
  * notes and the frequency of search terms.
  *
+ * Nonetheless we will hard limit it just in case.
+ *
  * @param {RegExp} filter used to split the text
  * @param {Number} sliceLength length of original search text
  * @param {String} text text to split
  * @param {(Object<String, String>)[]} [splits=[]] list of split segments
+ * @param {Number} [maxDepth=1000] limits the number of matches and prevents stack overflow on recursion
  * @returns {(Object<String, String>)[]} split segments with type indications
  */
-const splitWith = ( filter, sliceLength, text, splits = [] ) => {
+const splitWith = ( filter, sliceLength, text, splits = [], maxDepth = 1000 ) => {
 	// prevent splitting a string when the filter is empty
 	// because this could easily cause stack-overflow
-	if ( ! sliceLength ) {
-		return [ { type: 'text', text } ];
+	if ( ! sliceLength || ! maxDepth ) {
+		return [ ...splits, { type: 'text', text } ];
 	}
 
 	const index = text.search( filter );
@@ -186,6 +189,7 @@ const splitWith = ( filter, sliceLength, text, splits = [] ) => {
 				{ type: 'text', text: text.slice( 0, index ) }, // text _before_ the match
 				{ type: 'match', text: text.slice( index, index + sliceLength ) }, // the match itself
 			],
+			maxDepth - 1, // prevent stack overflow on recursion
 		);
 };
 

--- a/lib/utils/filter-notes.js
+++ b/lib/utils/filter-notes.js
@@ -1,12 +1,9 @@
 /**
  * External dependencies
  */
-import { get, includes, overEvery } from 'lodash';
+import { escapeRegExp, get, includes, overEvery } from 'lodash';
 
-const includesSearch = ( text, search ) =>
-	( text || '' )
-		.toLocaleLowerCase()
-		.includes( ( search || '' ).toLocaleLowerCase() );
+const includesSearch = ( text, search ) => search.test( text || '' );
 
 const matchesTrashView = isViewingTrash => note =>
 	isViewingTrash === !! get( note, 'data.deleted', false );
@@ -29,6 +26,6 @@ export default function filterNotes( state ) {
 		.filter( overEvery( [
 			matchesTrashView( showTrash ),
 			matchesTag( tag ),
-			matchesSearch( filter ),
+			matchesSearch( new RegExp( escapeRegExp( filter ), 'gi' ) ),
 		] ) );
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "cookie": "0.3.1",
     "create-hash": "1.1.2",
     "draft-js": "0.9.1",
+    "draft-js-simpledecorator": "1.0.1",
     "electron-window-state": "4.0.1",
     "highlight.js": "9.9.0",
     "jszip": "3.1.3",

--- a/scss/editor.scss
+++ b/scss/editor.scss
@@ -199,3 +199,10 @@
 		height: auto;
 	}
 }
+
+.DraftEditor-editorContainer {
+	& .search-match {
+		background-color: $yellow;
+		color: $black;
+	}
+}

--- a/scss/editor.scss
+++ b/scss/editor.scss
@@ -199,10 +199,3 @@
 		height: auto;
 	}
 }
-
-.DraftEditor-editorContainer {
-	& .search-match {
-		background-color: $yellow;
-		color: $black;
-	}
-}

--- a/scss/general.scss
+++ b/scss/general.scss
@@ -131,7 +131,9 @@ a {
 }
 
 .search-match {
-	background-color: $yellow;
+	background-color: $blue;
 	border-radius: 3px;
-	color: $black;
+	padding-left: 2px;
+	padding-right: 2px;
+	color: $white;
 }

--- a/scss/general.scss
+++ b/scss/general.scss
@@ -129,3 +129,9 @@ a {
 		-webkit-app-region: no-drag;
 	}
 }
+
+.search-match {
+	background-color: $yellow;
+	border-radius: 3px;
+	color: $black;
+}


### PR DESCRIPTION
Resolves #52

Previously when searching through the notes there was no indication
where inside a note the searched-for text could be found.

This patch introduces a new decorator that will match the searched
filter and highlight those results by means of an added CSS class.

> <del>Note that this isn't yet finished and ready. There is currently no highlighting in the note list. I am getting on a plane and have to go nonetheless!</del>

This PR is ready for final testing and review. I have created a new global CSS class `.search-match` which can be used to style matches in the note title, preview, and content.

**Testing**

Simply play with the search. Try to break it with internationalized text input or with Emoji. Test the performance.

![searching in simplenote](https://cloud.githubusercontent.com/assets/5431237/22045637/a5e24896-dcd8-11e6-9568-b747c0b290bd.gif)

cc: @drw158 @roundhill @mnmami