### PR TITLE
Use cross-platform shortcuts for menu accelerators

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -100,7 +100,7 @@ function createMenuTemplate( settings ) {
 
 	const settingsMenuItem = {
 		label: 'P&references',
-		accelerator: 'Command+,',
+		accelerator: 'CommandOrControl+,',
 		click: function( item, focusedWindow ) {
 			if ( focusedWindow ) {
 				focusedWindow.webContents.send( 'appCommand', { action: 'showDialog', dialog: {
@@ -239,11 +239,11 @@ function createMenuTemplate( settings ) {
 				type: 'separator'
 			}, {
 				label: 'Hide ' + name,
-				accelerator: 'Command+H',
+				accelerator: 'CommandOrControl+H',
 				role: 'hide'
 			}, {
 				label: 'Hide Others',
-				accelerator: 'Command+Shift+H',
+				accelerator: 'CommandOrControl+Shift+H',
 				role: 'hideothers'
 			}, {
 				label: 'Show All',
@@ -252,7 +252,7 @@ function createMenuTemplate( settings ) {
 				type: 'separator'
 			}, {
 				label: 'Quit',
-				accelerator: 'Command+Q',
+				accelerator: 'CommandOrControl+Q',
 				click: function() {
 					app.quit();
 				}

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -126,7 +126,7 @@ function createMenuTemplate( settings ) {
 		label: '&File',
 		submenu: [ {
 				label: '&New Note',
-				accelerator: 'CmdOrCtrl+N',
+				accelerator: 'CommandOrControl+N',
 				click( item, focusedWindow ) {
 					if ( focusedWindow ) {
 						focusedWindow.webContents.send( 'appCommand', { action: 'newNote' } );
@@ -136,7 +136,7 @@ function createMenuTemplate( settings ) {
 				type: 'separator'
 			}, {
 				label: '&Print',
-				accelerator: 'CmdOrCtrl+P',
+				accelerator: 'CommandOrControl+P',
 				click( item, focusedWindow ) {
 					if ( focusedWindow ) {
 						focusedWindow.webContents.send( 'appCommand', { action: 'setShouldPrintNote' } );
@@ -174,35 +174,35 @@ function createMenuTemplate( settings ) {
 		label: '&Edit',
 		submenu: [ {
 			label: '&Undo',
-			accelerator: 'CmdOrCtrl+Z',
+			accelerator: 'CommandOrControl+Z',
 			role: 'undo'
 		}, {
 			label: '&Redo',
-			accelerator: 'Shift+CmdOrCtrl+Z',
+			accelerator: 'Shift+CommandOrControl+Z',
 			role: 'redo'
 		}, {
 			type: 'separator'
 		}, {
 			label: '&Cut',
-			accelerator: 'CmdOrCtrl+X',
+			accelerator: 'CommandOrControl+X',
 			role: 'cut'
 		}, {
 			label: 'C&opy',
-			accelerator: 'CmdOrCtrl+C',
+			accelerator: 'CommandOrControl+C',
 			role: 'copy'
 		}, {
 			label: '&Paste',
-			accelerator: 'CmdOrCtrl+V',
+			accelerator: 'CommandOrControl+V',
 			role: 'paste'
 		}, {
 			label: '&Select All',
-			accelerator: 'CmdOrCtrl+A',
+			accelerator: 'CommandOrControl+A',
 			role: 'selectall'
 		}, {
 			type: 'separator'
 		}, {
 			label: 'Search &Notes',
-			accelerator: 'CmdOrCtrl+F',
+			accelerator: 'CommandOrControl+F',
 			click( item, focusedWindow ) {
 				if ( focusedWindow ) {
 					focusedWindow.webContents.send( 'appCommand', { action: 'setSearchFocus' } );
@@ -214,11 +214,11 @@ function createMenuTemplate( settings ) {
 		role: 'window',
 		submenu: [ {
 			label: '&Minimize',
-			accelerator: 'CmdOrCtrl+M',
+			accelerator: 'CommandOrControl+M',
 			role: 'minimize'
 		}, {
 			label: '&Close',
-			accelerator: 'CmdOrCtrl+W',
+			accelerator: 'CommandOrControl+W',
 			role: 'close'
 		} ]
 	}, helpMenu ];

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -50,8 +50,8 @@ var buildViewMenu = function( settings ) {
 				// For the oddity with "Command" vs "Cmd"
 				// Cite: https://github.com/atom/electron/issues/1507
 				[ '&Bigger', 'CommandOrControl+=', 'increaseFontSize' ],
-				[ '&Smaller', 'CmdOrCtrl+-', 'decreaseFontSize' ],
-				[ '&Reset', 'CmdOrCtrl+0', 'resetFontSize' ]
+				[ '&Smaller', 'CommandOrControl+-', 'decreaseFontSize' ],
+				[ '&Reset', 'CommandOrControl+0', 'resetFontSize' ]
 			].map( buildFontGroup )
 		}, {
 			label: '&Sort Type',


### PR DESCRIPTION
Resolves #378

Previously we were using `Command+` shortcuts in some menu accelerators.
This works on Mac computers but fails on Windows and Linux computers
(whre the app actually runs).

Now these have been replaced with `CommandOrControl+` shortcuts which
still mean that on Mac computers it will catch on the <kbd>⌘</kbd> key but on
the other platforms it will catch on the<kbd>Ctrl</kbd> key. See [the Electron
docs](http://electron.atom.io/docs/api/accelerator/#platform-notice) for clarification.

**Testing**
Open the app in Electron on Windows or on Linux and try to open the preferences dialog using the shortcut. In **master** it should not open with <kbd>Ctrl ,</kbd> but in this branch it should.

Thanks @ghost for bringing this up!

cc: @roundhill @drw158 @rodrigoi 