### PR TITLE
add define plugin to webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const autoprefixer = require( 'autoprefixer' );
 const AppCachePlugin = require( 'appcache-webpack-plugin' );
 const HtmlWebpackPlugin = require( 'html-webpack-plugin' );
+const DefinePlugin = require( 'webpack' ).DefinePlugin;
 
 module.exports = {
 	context: __dirname + '/lib',
@@ -32,7 +33,12 @@ module.exports = {
 			title: 'Simplenote',
 			templateContent: require( './index-builder.js' ),
 			inject: false
-		} )
+		} ),
+		new DefinePlugin( {
+			'process.env.NODE_ENV': JSON.stringify(
+				process.env.NODE_ENV || 'development'
+			)
+		} ),
 	],
 	postcss: [ autoprefixer() ]
 };


### PR DESCRIPTION
currently NODE_ENV wasn't being passed to the files being compiled, the `-p` flag doesn't do that (see http://webpack.github.io/docs/cli.html#production-shortcut-p). With this change we get faster production builds of react and redux.