### PR TITLE
ES6ify BucketStore

### DIFF
--- a/lib/simperium/bucket-store.js
+++ b/lib/simperium/bucket-store.js
@@ -1,113 +1,84 @@
-var Promise = require('promise');
+class StoreProvider {
+	constructor( config ) {
+		this.setup = new Promise( ( resolve, reject ) => config( resolve, reject ) );
+	}
 
+	provider = () => bucket => new BucketStore( bucket, this.setup );
 
-module.exports = function(configure) {
-	return new StoreProvider(configure);
-};
+	reset = () => this.setup
+		.then( db => Promise.all(
+			Array.prototype.map.call( db.objectStoreNames, name =>
+				new Promise( ( resolve, reject ) => {
+					const tx = db.transaction( name, 'readwrite' );
+					const request = tx.objectStore( name ).clear();
 
-function StoreProvider(configure) {
-	var setup = this.setup = new Promise(function(resolve, reject){
-		configure(resolve, reject);
-	});
+					request.onsuccess = () => resolve( name );
+					request.onerror = e => reject( e );
+				} )
+			)
+		) )
+		.catch( e => console.error( 'Failed to reset stores', e ) );
 }
 
-StoreProvider.prototype.provider = function() {
-	var setup = this.setup;
-	return function(bucket) {
-		return new BucketStore(bucket, setup);
-	};
-};
+class BucketStore {
+	constructor( bucket, setup ) {
+		this.bucket = bucket;
+		this.setup = setup;
+		this.beforeIndex = a => a;
+	}
 
-StoreProvider.prototype.reset = function () {
-	return this.setup.then(
-		(db) => {
-			var ops = [].map.call(db.objectStoreNames, (name) => {
-				return new Promise((resolve, reject) => {
-					var tx = db.transaction(name, 'readwrite');
-					var request = tx.objectStore(name).clear();
-					request.onsuccess = (e) => {
-						resolve(name);
-					};
-					request.onerror = (e) => {
-						reject(e);
-					};
-				});
-			});
-			return Promise.all(ops);
-		},
-		(e) => { console.error("Failed to reset stores", e) }
-	)
-};
+	withBucket = callback => this.setup
+		.then( db => callback.call( this, db, this.bucket.name ) )
+		.catch( e => console.log( 'Failed', e ) );
 
-function BucketStore(bucket, setup) {
-	this.bucket = bucket;
-	this.setup = setup;
+	get = ( id, callback ) => this.withBucket(
+		( db, bucket ) => {
+			const req = db
+				.transaction( bucket )
+				.objectStore( bucket )
+				.get( id );
+
+			req.onsuccess = ( { target: { result } } ) => callback( null, result );
+			req.onerror = e => callback( e );
+		}
+	);
+
+	update = ( id, data, isIndexing, callback ) => this.withBucket(
+		( db, bucket ) => {
+			const req = db
+				.transaction( bucket, 'readwrite' )
+				.objectStore( bucket )
+				.put( this.beforeIndex( { id, data } ) );
+
+			req.onsuccess = () => this.get( id, callback );
+			req.onerror = e => callback( e );
+		}
+	);
+
+	remove = ( id, callback ) => this.withBucket(
+		( db, bucket ) => db
+			.transaction( bucket, 'readwrite' )
+			.objectStore( bucket )
+			.delete( id )
+			.onsuccess = ( { target: { result } } ) => callback( null, result )
+	);
+
+	find = ( query, callback ) => this.withBucket(
+		( db, bucket ) => {
+			const objects = [];
+			const request = db
+				.transaction( bucket )
+				.objectStore( bucket )
+				.openCursor();
+
+			request.onsuccess = ( { target: { result: cursor } } ) =>
+				cursor
+					? objects.push( cursor.value ) && cursor.continue()
+					: callback( null, objects );
+
+			request.onerror = e => callback( e );
+		}
+	);
 }
 
-BucketStore.prototype.withBucket = function(cb) {
-	var bucket = this.bucket,
-			self = this;
-
-	this.setup.then(function(db) {
-		cb.call(self, db, bucket.name);
-	}, function(e) {
-		console.error("Failed", e);
-	});
-};
-
-BucketStore.prototype.get = function(id, callback) {
-	this.withBucket(function(db, bucket) {
-		var req = db.transaction(bucket).objectStore(bucket).get(id);
-		req.onsuccess = function(e) {
-			callback(null, e.target.result);
-		};
-		req.onerror = function(e) {
-			callback(e);
-		};
-	});
-};
-
-BucketStore.prototype.update = function(id, data, isIndexing, callback) {
-	var beforeIndex = this.beforeIndex || function() { return arguments[0]; },
-			self = this;
-	this.withBucket(function(db, bucket) {
-		var object = {id: id, data: data};
-		var req = db.transaction(bucket, 'readwrite').objectStore(bucket).put(beforeIndex(object))
-		req.onsuccess = function(e) {
-			self.get(id, callback);
-		};
-		req.onerror = function(e) {
-			callback(e);
-		};
-	});
-};
-
-BucketStore.prototype.remove = function(id, callback) {
-	this.withBucket(function(db, bucket) {
-		db.transaction(bucket, 'readwrite').objectStore(bucket).delete(id).onsuccess = function(e) {
-			callback(null, e.target.result);
-		};
-	});
-};
-
-BucketStore.prototype.find = function(query, callback) {
-
-	this.withBucket(function(db, bucket) {
-
-		var objects = [];
-		var request = db.transaction(bucket).objectStore(bucket).openCursor();
-
-		request.onsuccess = function(e) {
-			var cursor = e.target.result;
-			if (cursor) {
-				objects.push(cursor.value);
-				cursor.continue();
-			} else {
-				callback(null, objects);
-			}
-		};
-		request.onerror = function(e) {
-			callback(e);
-		};
-	});
-};
+export default config => new StoreProvider( config );


### PR DESCRIPTION
 - convert constructor functions into `class`es
 - remove Promise library and use native Promises
 - utilize fat-arrow functions for lexical scoping

cc: @beaucollins 