### PR TITLE
Start building a webpack dll to decrease build repeated times

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "NODE_ENV=development `npm bin`/webpack --config ./webpack.config.js",
-    "build:prod": "NODE_ENV=production `npm bin`/webpack -p --config ./webpack.config.js",
+    "build": "NODE_ENV=development npm run build:dll && npm run build:app",
+    "build:app": "`npm bin`/webpack --config ./webpack.config.js",
+    "build:dll": "`npm bin`/webpack --config ./webpack.config.dll.js",
+    "build:prod": "NODE_ENV=production `npm bin`/webpack -p --config ./webpack.config.dll.js && `npm bin`/webpack -p --config ./webpack.config.js",
     "lint": "`npm bin`/eslint lib",
-    "start": "NODE_ENV=hot `npm bin`/webpack-dev-server --config ./webpack.config.js --host 0.0.0.0 --port 4000 --hot --inline"
+    "start": "NODE_ENV=hot npm run build && `npm bin`/webpack-dev-server --config ./webpack.config.js --content-base dist --host 0.0.0.0 --port 4000 --hot --inline"
   },
   "author": "",
   "license": "ISC",
@@ -49,12 +51,9 @@
     "react-transform-hmr": "1.0.4",
     "redbox-react": "1.2.2",
     "sass-loader": "3.1.2",
-    "simperium": "0.2.5",
     "style-loader": "0.12.4",
     "webpack": "1.13.2",
-    "webpack-dev-middleware": "1.5.1",
-    "webpack-dev-server": "1.16.2",
-    "webpack-hot-middleware": "2.10.0"
+    "webpack-dev-server": "1.16.2"
   },
   "dependencies": {
     "cookie": "0.2.3",
@@ -73,6 +72,7 @@
     "redux": "3.3.1",
     "redux-localstorage": "0.4.0",
     "redux-thunk": "1.0.3",
-    "serve-favicon": "2.3.0"
+    "serve-favicon": "2.3.0",
+    "simperium": "0.2.5"
   }
 }

--- a/views/app.jade
+++ b/views/app.jade
@@ -11,5 +11,5 @@ html(manifest=o.htmlWebpackPlugin.files.manifest)
     script(type="text/javascript")
       != 'var config=' + JSON.stringify( Object.assign( { version: pkg.version }, config ) ) + ';'
   body
-    each chunk in o.htmlWebpackPlugin.files.chunks
-      script(type="text/javascript" charset="utf-8" src=chunk.entry)
+    script(src="vendor.dll.js")
+    script(src="app.js")

--- a/webpack.config.dll.js
+++ b/webpack.config.dll.js
@@ -1,0 +1,46 @@
+const webpack = require( 'webpack' );
+
+module.exports = {
+	context: process.cwd(),
+
+	entry: {
+		vendor: [
+			'cookie',
+			'create-hash',
+			'draft-js',
+			'highlight.js',
+			'lodash',
+			'marked',
+			'moment',
+			'promise',
+			'react',
+			'react-addons-pure-render-mixin',
+			'react-addons-update',
+			'react-redux',
+			'redux',
+			'redux-localstorage',
+			'redux-thunk',
+			'simperium',
+			'sockjs-client'
+		]
+	},
+
+	module: {
+		loaders: [
+			{ test: /\.json$/, loader: 'json-loader'},
+		]
+	},
+
+	output: {
+		filename: '[name].dll.js',
+		path: __dirname + '/dist/',
+		library: '[name]'
+	},
+
+	plugins: [
+		new webpack.DllPlugin( {
+			name: '[name]',
+			path: __dirname + '/dist/[name].json'
+		} )
+	]
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const autoprefixer = require( 'autoprefixer' );
+const webpack = require( 'webpack' );
 const AppCachePlugin = require( 'appcache-webpack-plugin' );
 const HtmlWebpackPlugin = require( 'html-webpack-plugin' );
-const DefinePlugin = require( 'webpack' ).DefinePlugin;
 
 module.exports = {
 	context: __dirname + '/lib',
@@ -28,17 +28,21 @@ module.exports = {
 		moduleDirectories: [ 'lib', 'node_modules' ]
 	},
 	plugins: [
+		new webpack.DllReferencePlugin( {
+			context: process.cwd(),
+			manifest: require( process.cwd() + '/dist/vendor.json' )
+		} ),
 		new AppCachePlugin(),
 		new HtmlWebpackPlugin( {
 			title: 'Simplenote',
 			templateContent: require( './index-builder.js' ),
 			inject: false
 		} ),
-		new DefinePlugin( {
+		new webpack.DefinePlugin( {
 			'process.env.NODE_ENV': JSON.stringify(
 				process.env.NODE_ENV || 'development'
 			)
-		} ),
+		} )
 	],
 	postcss: [ autoprefixer() ]
 };


### PR DESCRIPTION
> Depends on #439 because it's easier to run this from webpack dev server than to deal with `devServer.js`. That custom dev server injects and loads almost 100 additional webpack modules into the bundle in order to support itself. This is not needed.
> Merge _after_ #439

Previously we were building around 900 different webpack modules on every change. This took more time than necessary when rapidly iterating on a design.

This PR introduces a new webpack DLL so that the relatively static dependencies can be build and persist through the iteration. This leaves only around 100 webpack modules that need to be built on every change and those are mostly related to the app itself and not the dependencies.

The new process will build the DLL whenever starting the development server, but on incremental changes it does not.

cc: @roundhill @rodrigoi @nfcampos 