### PR TITLE
Add Export (to zip) to app when running in Electron

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -164,7 +164,7 @@ function createMenuTemplate( settings ) {
 		}, {
 			type: 'separator'
 		}, {
-			label: '&Export',
+			label: '&Export Notes',
 			accelerator: 'CommandOrControl+Shift+E',
 			click( item, focusedWindow ) {
 				if ( focusedWindow ) {

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -3,6 +3,7 @@
 const {
 	app,
 	BrowserWindow,
+	dialog,
 	ipcMain,
 	shell,
 	Menu
@@ -153,23 +154,38 @@ function createMenuTemplate( settings ) {
 	var fileMenu = {
 		label: '&File',
 		submenu: [ {
-				label: '&New Note',
-				accelerator: 'CommandOrControl+N',
-				click( item, focusedWindow ) {
-					if ( focusedWindow ) {
-						focusedWindow.webContents.send( 'appCommand', { action: 'newNote' } );
-					}
+			label: '&New Note',
+			accelerator: 'CommandOrControl+N',
+			click( item, focusedWindow ) {
+				if ( focusedWindow ) {
+					focusedWindow.webContents.send( 'appCommand', { action: 'newNote' } );
 				}
-			}, {
-				type: 'separator'
-			}, {
-				label: '&Print',
-				accelerator: 'CommandOrControl+P',
-				click( item, focusedWindow ) {
-					if ( focusedWindow ) {
-						focusedWindow.webContents.send( 'appCommand', { action: 'setShouldPrintNote' } );
-					}
+			}
+		}, {
+			type: 'separator'
+		}, {
+			label: '&Export',
+			accelerator: 'CommandOrControl+Shift+E',
+			click( item, focusedWindow ) {
+				if ( focusedWindow ) {
+					dialog.showSaveDialog(
+						focusedWindow,
+						{
+							title: 'Save export as .zip archive',
+							defaultPath: path.join( app.getPath( 'desktop' ), 'notes.zip'),
+						},
+						filename => focusedWindow.webContents.send( 'appCommand', { action: 'exportZipArchive', filename } )
+					);
 				}
+			}
+		}, {
+			label: '&Print',
+			accelerator: 'CommandOrControl+P',
+			click( item, focusedWindow ) {
+				if ( focusedWindow ) {
+					focusedWindow.webContents.send( 'appCommand', { action: 'setShouldPrintNote' } );
+				}
+			}
 		} ]
 	};
 

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -14,6 +14,7 @@ import browserShell from './browser-shell'
 import { ContextMenu, MenuItem, Separator } from './context-menu';
 import * as Dialogs from './dialogs/index'
 import exportNotes from './utils/export';
+import exportToZip from './utils/export/to-zip';
 import NoteInfo from './note-info'
 import NoteList from './note-list'
 import NoteEditor	from './note-editor'
@@ -44,11 +45,18 @@ window.exportNotes = () =>
 	exportNotes()
 		.then( data => {
 			const link = document.createElement( 'a' );
-			link.href = 'data:application/json;charset=utf-8,' + encodeURI( data );
+			const jsonData = encodeURI( JSON.stringify( data, null, 2 ) );
+			link.href = 'data:application/json;charset=utf-8,' + jsonData;
 			link.target = '_blank';
 			link.download = 'notes.json';
 			link.click();
 		} )
+		.catch( console.log );
+
+window.exportToZip = () =>
+	exportNotes()
+		.then( exportToZip )
+		.then( data => location.href='data:application/zip;base64,' + data )
 		.catch( console.log );
 
 import * as settingsActions from './state/settings/actions';

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -13,6 +13,7 @@ import {
 import browserShell from './browser-shell'
 import { ContextMenu, MenuItem, Separator } from './context-menu';
 import * as Dialogs from './dialogs/index'
+import exportNotes from './utils/export';
 import NoteInfo from './note-info'
 import NoteList from './note-list'
 import NoteEditor	from './note-editor'
@@ -38,6 +39,17 @@ import {
 	pick,
 	values,
 } from 'lodash';
+
+window.exportNotes = () =>
+	exportNotes()
+		.then( data => {
+			const link = document.createElement( 'a' );
+			link.href = 'data:application/json;charset=utf-8,' + encodeURI( data );
+			link.target = '_blank';
+			link.download = 'notes.json';
+			link.click();
+		} )
+		.catch( console.log );
 
 import * as settingsActions from './state/settings/actions';
 

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -180,7 +180,11 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 		if ( 'exportZipArchive' === get( command, 'action' ) ) {
 			return exportNotes()
 				.then( exportToZip )
-				.then( zip => zip.generateAsync( { type: 'base64' } ) )
+				.then( zip => zip.generateAsync( {
+					compression: 'DEFLATE',
+					platform: get( window, 'process.platform', 'DOS' ),
+					type: 'base64',
+				} ) )
 				.then( blob => fs.writeFile( command.filename, blob, 'base64' ) )
 				.catch( console.log );
 		}

--- a/lib/utils/export/README.md
+++ b/lib/utils/export/README.md
@@ -1,0 +1,62 @@
+# Simplenote Export
+
+This module provides a function which can be used to export all of the notes for a given account.
+
+The output format is a single JSON file containing a map of two arrays: the active notes in an account; the trashed notes in an account.
+
+The notes will be sorted by last modification time with the most recently-modified notes appearing first in the list.
+
+Currently the export functionality is only available through the developer console and has no corresponding component in the main app.
+
+## How to export
+
+Open the developer console. This will require either a modified version of the app enabling the console or running the app locally in a development environment inside a browser.
+
+Creating an export is as simple as running the following command from the developer console since the export function is made available in the global namespace.
+
+```js
+exportNotes()
+```
+
+After the export finishes it will trigger a download in the browser window.
+
+## Example export
+
+```json
+{
+  "activeNotes": [ {
+    "id": "some-auto-generated-id",
+    "content": "Simplenote is so simple! I love it.",
+    "creationDate": "2016-11-18T23:28:42.957Z",
+    "lastModified": "2016-12-22T21:59:36.623Z"
+  }, {
+    "id": "some-auto-generated-id-that-is-unique",
+    "content": "This note can be accessed from a secret URL",
+    "creationDate": "2016-07-02T07:24:22.699Z",
+    "lastModified": "2016-11-29T16:55:49.890Z",
+    "publicURL": "http://simp.ly/p/short-url-string"
+  }, {
+    "id": "some-auto-generated-id-again",
+    "content": "Sharing is caring",
+    "creationDate": "2016-10-01T08:40:33.968Z",
+    "lastModified": "2016-10-30T01:57:56.050Z",
+    "tags": [
+      "reminders",
+      "people"
+    ],
+    "collaboratorEmails": [
+      "prince@example.com",
+      "pauper@example.com"
+    ]
+  } ],
+  "trashedNotes": [ {
+    "id": "some-different-auto-generated-id",
+    "content": "This note is no longer relevant",
+    "creationDate": "2015-11-18T10:13:42.138Z",
+    "lastModified": "2016-01-13T14:03:33.583Z",
+    "tags": [
+      "the departed"
+    ]
+  } ]
+}
+```

--- a/lib/utils/export/README.md
+++ b/lib/utils/export/README.md
@@ -1,25 +1,13 @@
 # Simplenote Export
 
-This module provides a function which can be used to export all of the notes for a given account.
+This module provides a couple of functions for exporting all of the notes in the active account.
 
-The output format is a single JSON file containing a map of two arrays: the active notes in an account; the trashed notes in an account.
+The output of `exportNote()` is an object containing a map of two arrays: the active notes in an account; the trashed notes in an account.
 
 The notes will be sorted by last modification time with the most recently-modified notes appearing first in the list.
 
-Currently the export functionality is only available through the developer console and has no corresponding component in the main app.
-
-## How to export
-
-Open the developer console. This will require either a modified version of the app enabling the console or running the app locally in a development environment inside a browser.
-
-Creating an export is as simple as running the following command from the developer console since the export function is made available in the global namespace.
-
-```js
-exportNotes()
-exportToZip()
-```
-
-After the export finishes it will trigger a download in the browser window.
+The output from `exportNotes()` can be fed into `noteExportToZip()` to generate a [JSZip](https://github.com/Stuk/jszip) object containing the information for creating a zip archive of the notes.
+This archive contains each note as its own file with a generated filename and the list of associated tags at the end of the content.
 
 ## Example export
 

--- a/lib/utils/export/README.md
+++ b/lib/utils/export/README.md
@@ -16,6 +16,7 @@ Creating an export is as simple as running the following command from the develo
 
 ```js
 exportNotes()
+exportToZip()
 ```
 
 After the export finishes it will trigger a download in the browser window.

--- a/lib/utils/export/index.js
+++ b/lib/utils/export/index.js
@@ -1,0 +1,97 @@
+import {
+	filter,
+	flowRight as compose,
+	get,
+	partialRight,
+	partition,
+	property,
+	reverse,
+	sortBy,
+	uniqueId,
+} from 'lodash';
+
+// needs three pieces
+//  - a mailbox without an `@`
+//  - an `@`
+//  - domain with at least `host.tld`
+const naiveEmailPattern = /[^@]+@[^.]+\.[^.]+/;
+
+const mapNote = note => {
+	const [ collaboratorEmails, tags ] = partition(
+		sortBy(
+			get( note, 'data.tags', [] ),
+			a => a.toLocaleLowerCase()
+		),
+		tag => naiveEmailPattern.test( tag ),
+	);
+
+	return Object.assign(
+		{
+			id: get( note, 'id', uniqueId( 'unknown_note_' ) ),
+			content: get( note, 'data.content', '' ),
+			creationDate: ( new Date( note.data.creationDate * 1000 ) ).toISOString(),
+			lastModified: ( new Date( note.data.modificationDate * 1000 ) ).toISOString(),
+		},
+		get( note, 'pinned', false ) && { pinned: true },
+		tags.length && { tags },
+		(
+			get( note, 'data.systemTags', [] ).includes( 'published' ) &&
+			get( note, 'data.publishURL', '' ).length
+		) && { publicURL: `http://simp.ly/p/${ get( note, 'data.publishURL', '' ) }` },
+		(
+			get( note, 'data.systemTags', [] ).includes( 'shared' ) &&
+			collaboratorEmails.length
+		) && { collaboratorEmails },
+	);
+};
+
+const nonEmptyByRecentEdits = compose(
+	reverse,
+	partialRight( sortBy, property( 'data.modificationDate' ) ),
+	partialRight( filter, property( 'data.content' ) ),
+);
+
+const mapNotes = notes => {
+	const [ trashedNotes, activeNotes ] = partition(
+		nonEmptyByRecentEdits( notes ),
+		note => !! get( note, 'data.deleted', false )
+	).map( list => list.map( mapNote ) );
+
+	return Promise.resolve( JSON.stringify( {
+		activeNotes,
+		trashedNotes,
+	}, null, 2 ) );
+};
+
+const readNotes = db =>
+	new Promise( ( resolve, reject ) => {
+		const request = db
+			.transaction( 'note' )
+			.objectStore( 'note' )
+			.openCursor();
+
+		const notes = [];
+		request.onsuccess = ( { target: { result: cursor } } ) =>
+			cursor
+				? notes.push( cursor.value ) && cursor.continue()
+				: resolve( notes );
+
+		request.onerror = reject;
+	} );
+
+const openDatabase = () =>
+	new Promise( ( resolve, reject ) => {
+		const idb = window
+			.indexedDB
+			.open( 'simplenote' );
+
+		idb.onsuccess = ( { target: { result: db } } ) => resolve( db );
+		idb.onerror = reject;
+	} );
+
+export const exportNotes = () =>
+	openDatabase()
+		.then( readNotes )
+		.then( mapNotes );
+
+export default exportNotes;

--- a/lib/utils/export/index.js
+++ b/lib/utils/export/index.js
@@ -57,10 +57,10 @@ const mapNotes = notes => {
 		note => !! get( note, 'data.deleted', false )
 	).map( list => list.map( mapNote ) );
 
-	return Promise.resolve( JSON.stringify( {
+	return Promise.resolve( {
 		activeNotes,
 		trashedNotes,
-	}, null, 2 ) );
+	} );
 };
 
 const readNotes = db =>

--- a/lib/utils/export/to-zip.js
+++ b/lib/utils/export/to-zip.js
@@ -1,0 +1,21 @@
+import JSZip from 'jszip';
+
+export const noteExportToZip = notes => {
+	const zip = new JSZip();
+
+	notes
+		.activeNotes
+		.forEach(
+			( { id, content } ) => zip.file( `${ id }.txt`, content )
+		);
+
+	notes
+		.trashedNotes
+		.forEach(
+			( { id, content } ) => zip.file( `trash-${ id }.txt`, content )
+		);
+
+	return zip.generateAsync( { type: 'base64' } );
+};
+
+export default noteExportToZip;

--- a/lib/utils/export/to-zip.js
+++ b/lib/utils/export/to-zip.js
@@ -1,19 +1,52 @@
 import JSZip from 'jszip';
+import sanitize from 'sanitize-filename';
+import { identity, update } from 'lodash';
+
+const addFilename = note => {
+	const { content } = note;
+
+	const fileName = content
+		.split( '\n' ) // base filename off of a single line
+		.map( line => line.trim() ) // and ignore leading/trailing spaces
+		.map( sanitize ) // strip away any invalid characters for a filename (such as `/`)
+		.filter( identity ) // remove blank lines
+		.concat( 'untitled' ) // use this as a default if there are no non-blank lines
+		.shift() // take the first remaining line
+		.slice( 0, 40 ); // and truncate to the first 40 characters
+
+	return { ...note, fileName };
+};
+
+const toUniqueNames = ( [ notes, nameCounts ], note ) => {
+	const newNameCounts = update( nameCounts, note.fileName, n => n || 0 === n ? n + 1 : 0 );
+	const count = newNameCounts[ note.fileName ];
+	const fileName = count > 0
+		? `${ note.fileName }-(${ count })`
+		: note.fileName;
+
+	return [ [ ...notes, { ...note, fileName } ], newNameCounts ];
+};
 
 export const noteExportToZip = notes => {
 	const zip = new JSZip();
 
 	notes
 		.activeNotes
+		.map( addFilename ) // generate filename from content
+		.reduce( toUniqueNames, [ [], {} ] ) // add `(n)` if there are duplicates
+		.shift() // the list of notes is the first item in the pair returned from above
 		.forEach(
-			( { id, content } ) => zip.file( `${ id }.txt`, content )
-		);
+			( { content, fileName } ) => zip.file( `${ fileName }.txt`, content )
+		); // add the note as a file in the zip
 
 	notes
 		.trashedNotes
+		.map( addFilename ) // generate filename from content
+		.reduce( toUniqueNames, [ [], {} ] ) // add `(n)` if there are duplicates
+		.shift() // the list of notes is the first item in the pair returned from above
 		.forEach(
-			( { id, content } ) => zip.file( `trash-${ id }.txt`, content )
-		);
+			( { content, fileName } ) => zip.file( `trash-${ fileName }.txt`, content )
+		); // add the note as a file in the zip
 
 	return zip.generateAsync( { type: 'base64' } );
 };

--- a/lib/utils/export/to-zip.js
+++ b/lib/utils/export/to-zip.js
@@ -14,7 +14,7 @@ import { identity, update } from 'lodash';
  */
 const addFilename = note => ( {
 	...note,
-	filename: note.content
+	fileName: note.content
 		.split( '\n' ) // base filename off of a single line
 		.map( line => line.trim() ) // and ignore leading/trailing spaces
 		.map( sanitize ) // strip away any invalid characters for a filename (such as `/`)
@@ -43,7 +43,7 @@ const addFilename = note => ( {
  * appendTags( { content: 'the fleeb has the fleeb juice' } )
  *
  * @param {Object} note note object
- * @returns Object augmented note whose
+ * @returns {Object} augmented note whose
  */
 const appendTags = note => note.tags
 	? { ...note, content: `${ note.content }\n\nTags:\n${ note.tags.map( tag => ` - #${ tag }` ).join( '\n' ) }` }
@@ -56,8 +56,7 @@ const appendTags = note => note.tags
  * // when given `Yummy Recipe` and `Yummy Recipe` as duplicates
  * // will return `Yummy Recipe` and `Yummy Recipe (1)`
  *
- * @param {Array} notes final list of note objects for export
- * @param {Object} nameCounts pairs of filename/how many previous occurances in loop
+ * @param {[Array, Object]} accumulator list of note objects for export and filename counts
  * @param {Object} note note object
  * @returns {[Array, Object]} final note list and accumulating filename counts
  */
@@ -94,7 +93,7 @@ export const noteExportToZip = notes => {
 			( { content, fileName } ) => zip.file( `trash-${ fileName }.txt`, content )
 		); // add the note as a file in the zip
 
-	return zip.generateAsync( { type: 'base64' } );
+	return zip;
 };
 
 export default noteExportToZip;

--- a/lib/utils/export/to-zip.js
+++ b/lib/utils/export/to-zip.js
@@ -2,26 +2,70 @@ import JSZip from 'jszip';
 import sanitize from 'sanitize-filename';
 import { identity, update } from 'lodash';
 
-const addFilename = note => {
-	const { content } = note;
-
-	const fileName = content
+/**
+ * Generates filename for note based on note content
+ *
+ * Please see code for algorithm. The goal is to
+ * find the first usable and non-blank line of text
+ * from the note to generate the title.
+ *
+ * @param {Object} note object
+ * @returns {Object} augmented note object with new filename
+ */
+const addFilename = note => ( {
+	...note,
+	filename: note.content
 		.split( '\n' ) // base filename off of a single line
 		.map( line => line.trim() ) // and ignore leading/trailing spaces
 		.map( sanitize ) // strip away any invalid characters for a filename (such as `/`)
 		.filter( identity ) // remove blank lines
 		.concat( 'untitled' ) // use this as a default if there are no non-blank lines
 		.shift() // take the first remaining line
-		.slice( 0, 40 ); // and truncate to the first 40 characters
+		.slice( 0, 40 ), // and truncate to the first 40 characters
+} );
 
-	return { ...note, fileName };
-};
+/**
+ * Appends associated tags as a list at end of note content if available
+ *
+ * @example
+ * // returns the following
+ * """
+ * a regular plumbus
+ *
+ * Tags:
+ *  - #plumbus
+ *  - #howisitmade
+ * """
+ * appendTags( { content: 'a regular plumbus', tags: [ 'plumbus', 'howisitmade' ] } )
+ *
+ * @example
+ * // returns note content unchanged
+ * appendTags( { content: 'the fleeb has the fleeb juice' } )
+ *
+ * @param {Object} note note object
+ * @returns Object augmented note whose
+ */
+const appendTags = note => note.tags
+	? { ...note, content: `${ note.content }\n\nTags:\n${ note.tags.map( tag => ` - #${ tag }` ).join( '\n' ) }` }
+	: note;
 
+/**
+ * Maps over notes and replaces duplicate filenames with ones appended by an increasing number
+ *
+ * @example
+ * // when given `Yummy Recipe` and `Yummy Recipe` as duplicates
+ * // will return `Yummy Recipe` and `Yummy Recipe (1)`
+ *
+ * @param {Array} notes final list of note objects for export
+ * @param {Object} nameCounts pairs of filename/how many previous occurances in loop
+ * @param {Object} note note object
+ * @returns {[Array, Object]} final note list and accumulating filename counts
+ */
 const toUniqueNames = ( [ notes, nameCounts ], note ) => {
 	const newNameCounts = update( nameCounts, note.fileName, n => n || 0 === n ? n + 1 : 0 );
 	const count = newNameCounts[ note.fileName ];
 	const fileName = count > 0
-		? `${ note.fileName }-(${ count })`
+		? `${ note.fileName } (${ count })`
 		: note.fileName;
 
 	return [ [ ...notes, { ...note, fileName } ], newNameCounts ];
@@ -32,6 +76,7 @@ export const noteExportToZip = notes => {
 
 	notes
 		.activeNotes
+		.map( appendTags ) // add tags to end of content
 		.map( addFilename ) // generate filename from content
 		.reduce( toUniqueNames, [ [], {} ] ) // add `(n)` if there are duplicates
 		.shift() // the list of notes is the first item in the pair returned from above
@@ -41,6 +86,7 @@ export const noteExportToZip = notes => {
 
 	notes
 		.trashedNotes
+		.map( appendTags ) // add tags to end of content
 		.map( addFilename ) // generate filename from content
 		.reduce( toUniqueNames, [ [], {} ] ) // add `(n)` if there are duplicates
 		.shift() // the list of notes is the first item in the pair returned from above

--- a/lib/utils/export/to-zip.js
+++ b/lib/utils/export/to-zip.js
@@ -115,7 +115,7 @@ export const noteExportToZip = notes => {
 		.reduce( toUniqueNames, [ [], {} ] ) // add `(n)` if there are duplicates
 		.shift() // the list of notes is the first item in the pair returned from above
 		.forEach(
-			( { content, fileName } ) => zip.file( `trash-${ fileName }.txt`, content )
+			( { content, fileName } ) => zip.file( `trash/${ fileName }.txt`, content )
 		); // add the note as a file in the zip
 
 	return zip;

--- a/lib/utils/export/to-zip.js
+++ b/lib/utils/export/to-zip.js
@@ -2,6 +2,9 @@ import JSZip from 'jszip';
 import sanitize from 'sanitize-filename';
 import { identity, update } from 'lodash';
 
+const FILENAME_LENGTH = 40;
+const TAG_LINE_LENGTH = 75;
+
 /**
  * Generates filename for note based on note content
  *
@@ -21,11 +24,15 @@ const addFilename = note => ( {
 		.filter( identity ) // remove blank lines
 		.concat( 'untitled' ) // use this as a default if there are no non-blank lines
 		.shift() // take the first remaining line
-		.slice( 0, 40 ), // and truncate to the first 40 characters
+		.slice( 0, FILENAME_LENGTH ), // and truncate to some reasonable number of characters
 } );
 
 /**
  * Appends associated tags as a list at end of note content if available
+ *
+ * This lines up the tags in an indented block separated by commas.
+ * It does not attempt to control widows and orphans on the tag lines
+ * which could be an eyesore for notes with enough tags.
  *
  * @example
  * // returns the following
@@ -33,8 +40,7 @@ const addFilename = note => ( {
  * a regular plumbus
  *
  * Tags:
- *  - #plumbus
- *  - #howisitmade
+ *   plumbus, howisitmade
  * """
  * appendTags( { content: 'a regular plumbus', tags: [ 'plumbus', 'howisitmade' ] } )
  *
@@ -45,9 +51,26 @@ const addFilename = note => ( {
  * @param {Object} note note object
  * @returns {Object} augmented note whose
  */
-const appendTags = note => note.tags
-	? { ...note, content: `${ note.content }\n\nTags:\n${ note.tags.map( tag => ` - #${ tag }` ).join( '\n' ) }` }
-	: note;
+const appendTags = note => {
+	if ( ! note.tags ) {
+		return note;
+	}
+
+	const tagLines = note
+		.tags
+		.reduce( ( [ lines, lastLine ], tag ) =>
+			( lastLine.length + tag.length ) > TAG_LINE_LENGTH // is line full (width)?
+				? [ [ ...lines, lastLine ], tag ] // if so, then start a new line
+				: [ lines, `${ lastLine }, ${ tag }` ] // else continue the previous line
+			, [ [], '' ] )
+		.reduce( ( a, b ) => [ ...a, b ] ) // join trailing line from reduction
+		.map( line => line.replace( /^, /, '' ) ); // remove leading commas
+
+	return {
+		...note,
+		content: `${ note.content }\n\nTags:\n  ${ tagLines.join( '\n  ' ) }`,
+	};
+};
 
 /**
  * Maps over notes and replaces duplicate filenames with ones appended by an increasing number

--- a/lib/utils/export/to-zip.js
+++ b/lib/utils/export/to-zip.js
@@ -96,6 +96,8 @@ const toUniqueNames = ( [ notes, nameCounts ], note ) => {
 export const noteExportToZip = notes => {
 	const zip = new JSZip();
 
+	zip.file( 'source/notes.json', JSON.stringify( notes, null, 2 ) );
+
 	notes
 		.activeNotes
 		.map( appendTags ) // add tags to end of content

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "redux": "3.6.0",
     "redux-localstorage": "0.4.1",
     "redux-thunk": "1.0.3",
+    "sanitize-filename": "1.6.1",
     "serve-favicon": "2.3.2",
     "simperium": "0.2.5"
   }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "draft-js": "0.9.1",
     "electron-window-state": "4.0.1",
     "highlight.js": "9.9.0",
+    "jszip": "3.1.3",
     "lodash": "4.17.2",
     "marked": "0.3.6",
     "moment": "2.17.1",


### PR DESCRIPTION
Addresses #332
Addresses #323

The Simplenote app receives updates from the Simperium library
(`node-simperium`) and stores those updates inside of `IndexedDB`. This
provides us with a fairly reliable local copy of the note data, but that
data is not very accessible from outside of the app.

The web app on simplenote.com offers a `.zip` archives of an account's
notes with one file per note but the client applications do not offer
any kind of an export.

This patch introduces an export function into the Electron app which can
be called to export a single _JSON_ file or a single _zip_ file with all the relevant note
information. This export contains metadata unavailable from the existing
export on the web.

<del>There is not piece of this built into the user interface yet and so this
PR introduces a feature for testing and development only. The export
function is made available in the global scope and can be called from
the running console as `exportNotes()` or as `exportToZip()`. 
It should trigger a download of the `notes.json` or `notes.zip` file.</del>

All notes are being exported but trashed notes and normal "active" notes
are separated as two different lists.

```js
exportNotes()
exportToZip()
```

Access via **File** > **Export**

Please see the `README.md` for additional information and an example 
of exported data.

cc: @roundhill @drw158 @rodrigoi @beaucollins 