### PR TITLE
Hide native toolbar on macOS

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -36,7 +36,8 @@ module.exports = function main() {
 			height: 768,
 			minWidth: 370,
 			minHeight: 520,
-			icon: iconPath
+			icon: iconPath,
+			titleBarStyle: 'hidden'
 		} );
 
 		// and load the index of the app.

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -34,6 +34,7 @@ import {
 	includes,
 	isObject,
 	map,
+	matchesProperty,
 	overEvery,
 	pick,
 	values,
@@ -99,10 +100,7 @@ const isElectron = ( () => {
 	return () => foundElectron;
 } )();
 
-const isElectronMac = () => {
-	return isElectron() &&
-		get( window, 'process.platform', '' ) === 'darwin';
-}
+const isElectronMac = () => matchesProperty( 'process.platform', 'darwin' )( window );
 
 const includesSearch = ( text, search ) =>
 	( text || '' )

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -99,6 +99,11 @@ const isElectron = ( () => {
 	return () => foundElectron;
 } )();
 
+const isElectronMac = () => {
+	return isElectron() &&
+		get( window, 'process.platform', '' ) === 'darwin';
+}
+
 const includesSearch = ( text, search ) =>
 	( text || '' )
 		.toLocaleLowerCase()
@@ -490,7 +495,8 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 			'note-open': selectedNote,
 			'note-info-open': state.showNoteInfo,
 			'navigation-open': state.showNavigation,
-			'is-electron': isElectron()
+			'is-electron': isElectron(),
+			'is-macos': isElectronMac()
 		} );
 
 		return (

--- a/scss/general.scss
+++ b/scss/general.scss
@@ -120,5 +120,9 @@ a {
 		box-sizing: border-box;
 		-webkit-app-region: drag;
 	}
+
+	.navigation, .note-info {
+		padding-top: 10px;
+	}
 }
 

--- a/scss/general.scss
+++ b/scss/general.scss
@@ -108,3 +108,17 @@ a {
 	}
 }
 
+.is-macos { 
+	.note-editor-controls {
+		box-sizing: border-box;
+		-webkit-app-region: drag;
+		padding: 40px 0 30px;
+	}
+
+	.search-bar {
+		padding: 40px 15px 30px;
+		box-sizing: border-box;
+		-webkit-app-region: drag;
+	}
+}
+


### PR DESCRIPTION
For us brave souls using the macOS build of the app, this PR removes the toolbar and instead adds some padding to the top of the app for a very slick look:

<img width="1055" alt="screen shot 2016-11-30 at 1 23 56 pm" src="https://cloud.githubusercontent.com/assets/789137/20772027/c9f3f3ea-b700-11e6-94a4-55e934c4e0f5.png">
