### PR TITLE
Limit App to a Single Instance

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -67,6 +67,23 @@ module.exports = function main() {
 		} );
 	};
 
+	const shouldQuit = app.makeSingleInstance( () => {
+		if ( ! mainWindow ) {
+			return;
+		}
+
+		// Focus the main window if a second instance is attempted to be created
+		if ( mainWindow.isMinimized() ) {
+			mainWindow.restore();
+		}
+		mainWindow.focus();
+	} );
+
+	if ( shouldQuit ) {
+		app.quit();
+		return;
+	}
+
 	// Quit when all windows are closed.
 	app.on( 'window-all-closed', function() {
 		// On OS X it is common for applications and their menu bar


### PR DESCRIPTION
Fixes #376 by enforcing the app to run in a single instance. Took inspiration from the [guide on the topic here](https://github.com/electron/electron/blob/master/docs/api/app.md#appmakesingleinstancecallback).

**To Test**
Run the app in Windows, and minimize to the tray. Now run the app again by double clicking on the app icon. The app should maximize and remain in the single instance without a second instance ever appearing.

For the tester's convenience, here's a windows build with the patch applied: https://cloudup.com/caMB3LsO4Bz

