### PR TITLE
Fix Revisions Selector from Showing in Print View

### DIFF
--- a/scss/print.scss
+++ b/scss/print.scss
@@ -9,8 +9,9 @@
 		height: auto;
 	}
 
-	.navigation, .source-list, .revisions-selector, .note-editor-controls, .note-editor-detail, 
-	.note-editor-detail .note-detail, .note-editor-mode-bar, .note-info, .tag-entry {
+	.navigation, .source-list, .revision-selector, .note-editor-controls,
+	.note-editor-detail, .note-editor-detail .note-detail,
+	.note-editor-mode-bar, .note-info, .tag-entry {
 		display: none;
 	}
 }


### PR DESCRIPTION
Fixed incorrectly named `revisions-selector` class name to `revision-selector`.

To test: Print a note (to PDF if you like saving trees). You should see just the text of the note.

Fixes #457