### PR TITLE
Fix Publish URL From Disappearing

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -449,8 +449,11 @@ var actionMap = new ActionMap( {
 
 					state.note.data = rebased;
 
-					dispatch( this.action( 'updateNoteContent', {
-						noteBucket, note, content: note.data.content
+					// update the bucket and sync
+					noteBucket.update( noteId, rebased );
+
+					dispatch( this.action( 'selectNote', {
+						noteId
 					} ) );
 				};
 			}


### PR DESCRIPTION
The app was ignoring changes to the `publishURL` property of a note after a change was received from the network. This is because we were only saving the `content` property of the note instead of saving the entire object with all of its properties to the bucket (and the IndexedDB store).

The solution I'm presenting here is to remove the call to the `updateNoteContent` action, which doesn't make sense to apply here since it only deals with the content of the note and not all the properties of the note. Instead, we simply update the bucket with the new object and select the note.

*To Test*
Create a note, and open the share dialog and publish it.
Once the publish Url arrives, refresh/restart the app.
Select the note info dialog. You should see the publish url displayed successfully there.
Also try opening a the same note on another Simplenote app. Changes made in that app should still be applied and appear in the editor.

Fixes #466 