### PR TITLE
NoteList: Redux refactor

### DIFF
--- a/lib/utils/filter-notes.js
+++ b/lib/utils/filter-notes.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { get, includes, overEvery } from 'lodash';
+
+const includesSearch = ( text, search ) =>
+	( text || '' )
+		.toLocaleLowerCase()
+		.includes( ( search || '' ).toLocaleLowerCase() );
+
+const matchesTrashView = isViewingTrash => note =>
+	isViewingTrash === !! get( note, 'data.deleted', false );
+
+const matchesTag = tag => note =>
+	! tag || includes( get( note, 'data.tags', [] ), get( tag, 'data.name', '' ) );
+
+const matchesSearch = query => note =>
+	! query || includesSearch( get( note, 'data.content' ), query );
+
+export default function filterNotes( state ) {
+	const {
+		filter,    // {string} search query from input
+		notes,     // {[note]} list of all available notes
+		showTrash, // {bool} whether we are looking at the trashed notes
+		tag,       // {tag|null} whether we are looking at a specific tag
+	} = state;
+
+	return notes
+		.filter( overEvery( [
+			matchesTrashView( showTrash ),
+			matchesTag( tag ),
+			matchesSearch( filter ),
+		] ) );
+}


### PR DESCRIPTION
First step of the complete `NoteList` refactor.

In this PR we aim to move props and actions away from `app.jsx` and instead `connect` them to the component.

In addition to this, the `filterNotes()` and its dependant functions have been moved into a new `utils/filter-notes.js` file.

One doubt I have is related to the whole (or part of) `filteredNotes` ➡️ `noteIndex` ➡️ `selectedNote` ➡️ `selectedNoteId` thing.
It's used in several places throughout `app.jsx` (e.g. `NoteList`, `NoteEditor`, `NoteInfo`, `getPreviousNoteIndex()`, `render()`).
I've chosen to duplicate it into `NoteList`, but I'd say it could be improved by turning it into a Redux selector.
As everything else, though, it all will become more clear and obvious once everything will be moved away from `app.jsx`, and we'll finally be able to see exactly what goes where. :)