### PR TITLE
Fix import error introduced in #468

### DIFF
--- a/lib/note-info.jsx
+++ b/lib/note-info.jsx
@@ -4,7 +4,7 @@ import ToggleControl from './controls/toggle';
 import moment from 'moment';
 import CrossIcon from './icons/cross';
 import { connect } from 'react-redux';
-import { actionCreators } from './flux/app-state';
+import appState from './flux/app-state';
 import { setMarkdown } from './state/settings/actions';
 import filterNotes from './utils/filter-notes';
 
@@ -157,7 +157,7 @@ const {
 	markdownNote,
 	pinNote,
 	toggleNoteInfo,
-} = actionCreators;
+} = appState.actionCreators;
 
 const mapStateToProps = ( { appState: state } ) => {
 	const filteredNotes = filterNotes( state );


### PR DESCRIPTION
See
[#468](https://github.com/Automattic/simplenote-electron/pull/468/files#diff-c4602e800d73b145b43560d7dcbc7df9R7)

In #468 the action creators were imported in `app.js` but they aren't a
named export in thier module. This patch fixes this.

cc: @copons @rodrigoi 