### PR TITLE
Packager: fixes error during packing the app for MacOS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/**/*
-build/
+desktop-build/
 dist/
 release/
 /config.js

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ RESET=`tput sgr0`
 START_APP := @$(NPM_BIN)/electron .
 ELECTRON_TEST := ELECTRON_PATH=$(NPM_BIN)/electron $(NPM_BIN)/electron-mocha
 CONFIG := $(THIS_DIR)/config.json
+DESKTOP_BUILD_DIR := $(THIS_DIR)/desktop-build
 BUILDER := $(THIS_DIR)/builder.js
 BUILD_CONFIG := $(THIS_DIR)/resources/build-scripts/build-config-file.js
 PACKAGE_DMG := $(THIS_DIR)/resources/build-scripts/package-dmg.js
@@ -36,16 +37,24 @@ build-if-changed: build-if-not-exists
 	@if [ $(SIMPLENOTE_CHANGES_STD) -eq 0 ]; then true; else make build; fi;
 
 # Build packages
-osx: config-release build-if-changed
+osx: config-release package
 	@node $(BUILDER) darwin
 
-linux: config-release build-if-changed
+linux: config-release package
 	@node $(BUILDER) linux
 
-win32: config-release build-if-changed
+win32: config-release package
 	@node $(BUILDER) win32
 
 # Packagers
+package: build-if-changed
+	@rm -rf $(DESKTOP_BUILD_DIR)/node_modules $(DESKTOP_BUILD_DIR)/desktop $(DESKTOP_BUILD_DIR)/dist
+	@mkdir -p $(DESKTOP_BUILD_DIR)
+	@cp -rf $(THIS_DIR)/package.json $(DESKTOP_BUILD_DIR)
+	@cp -R $(THIS_DIR)/node_modules $(DESKTOP_BUILD_DIR)
+	@cp -R $(THIS_DIR)/desktop $(DESKTOP_BUILD_DIR)
+	@cp -R $(THIS_DIR)/dist $(DESKTOP_BUILD_DIR)
+
 package-win32: win32
 	@$(PACKAGE_WIN32) ./release/Simplenote-win32-ia32 --platform=win --out=./release --config=./resources/build-config/win32.json
 	@node $(THIS_DIR)/resources/build-scripts/rename-with-version-win.js

--- a/builder.js
+++ b/builder.js
@@ -38,6 +38,7 @@ var opts = {
 	overwrite: true,
 	asar: false,
 	sign: false,
+	prune: true,
 	'version-string': {
 		CompanyName: config.author,
 		LegalCopyright: config.copyright,
@@ -50,21 +51,22 @@ var opts = {
 	}
 };
 
-function whitelistInDirectory( directory, whitelist ) {
-	var client = fs.readdirSync( directory );
-	var ignore = [];
-
-	for ( key = 0; key < client.length; key++ ) {
-		if ( whitelist.indexOf( client[key] ) === -1 ) {
-			ignore.push( path.join( directory, client[key] ) );
-		}
-	}
-
-	return ignore;
-}
-
-opts.ignore = opts.ignore.concat( whitelistInDirectory( './dist', [ 'index.html', 'app.js', 'manifest.appcache' ] ) );
-opts.ignore = opts.ignore.concat( whitelistInDirectory( './', [ 'package.json', 'dist', 'desktop' ] ) );
+// function whitelistInDirectory( directory, whitelist ) {
+// 	var client = fs.readdirSync( directory );
+// 	var ignore = [];
+//
+// 	for ( key = 0; key < client.length; key++ ) {
+// 		if ( whitelist.indexOf( client[key] ) === -1 ) {
+// 			ignore.push( path.join( directory, client[key] ) );
+// 		}
+// 	}
+//
+// 	return ignore;
+// }
+//
+// opts.ignore = opts.ignore.concat( whitelistInDirectory( './node_modules', [ 'deep-equal', 'electron-window-state', 'jsonfile', 'mkdirp' ] ) );
+// opts.ignore = opts.ignore.concat( whitelistInDirectory( './dist', [ 'index.html', 'app.js', 'manifest.appcache' ] ) );
+// opts.ignore = opts.ignore.concat( whitelistInDirectory( './', [ 'package.json', 'dist', 'desktop', 'node_modules' ] ) );
 
 builder.beforeBuild( __dirname, opts, function( error ) {
 	if ( error ) {

--- a/builder.js
+++ b/builder.js
@@ -19,7 +19,7 @@ var electronVersion = pkg.devDependencies['electron'].replace( '^', '' );
 var key;
 
 var opts = {
-	dir: './',
+	dir: './desktop-build',
 	name: config.name,
 	author: config.author,
 	platform: builder.getPlatform( process.argv ),
@@ -34,11 +34,11 @@ var opts = {
 	'app-category-type': 'public.app-category.social-networking',
 	'app-version': config.version,
 	'build-version': config.version,
-	ignore: [],
 	overwrite: true,
 	asar: false,
 	sign: false,
 	prune: true,
+	ignore: [],
 	'version-string': {
 		CompanyName: config.author,
 		LegalCopyright: config.copyright,
@@ -50,23 +50,6 @@ var opts = {
 		ProductVersion: config.version
 	}
 };
-
-// function whitelistInDirectory( directory, whitelist ) {
-// 	var client = fs.readdirSync( directory );
-// 	var ignore = [];
-//
-// 	for ( key = 0; key < client.length; key++ ) {
-// 		if ( whitelist.indexOf( client[key] ) === -1 ) {
-// 			ignore.push( path.join( directory, client[key] ) );
-// 		}
-// 	}
-//
-// 	return ignore;
-// }
-//
-// opts.ignore = opts.ignore.concat( whitelistInDirectory( './node_modules', [ 'deep-equal', 'electron-window-state', 'jsonfile', 'mkdirp' ] ) );
-// opts.ignore = opts.ignore.concat( whitelistInDirectory( './dist', [ 'index.html', 'app.js', 'manifest.appcache' ] ) );
-// opts.ignore = opts.ignore.concat( whitelistInDirectory( './', [ 'package.json', 'dist', 'desktop', 'node_modules' ] ) );
 
 builder.beforeBuild( __dirname, opts, function( error ) {
 	if ( error ) {

--- a/resources/platform/darwin.js
+++ b/resources/platform/darwin.js
@@ -49,7 +49,7 @@ function cleanBuild( appPath, buildOpts ) {
 	console.log( ' - Removing unused localization folders' );
 	var lprojFolders = app.getFileList( '' );
 	lprojFolders.forEach( function( lprojFolder ) {
-		if ( [ 'app', 'atom.asar', 'atom.icns' ].indexOf( lprojFolder ) === -1 ) {
+		if ( [ 'app', 'electron.asar', 'electron.icns' ].indexOf( lprojFolder ) === -1 ) {
 			builder.rmdir( app.getResourcesPath( lprojFolder ) );
 		}
 	} );


### PR DESCRIPTION
During one of the version updates, the `asar` and `icns` filename changed. This is preventing the app to be built for MacOS (`make package-osx`).

From now on,`make package-osx` should produce a valid `.app` folder and `.dmg` packages.