### PR TITLE
NoteEditor: Redux refactor

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -309,7 +309,7 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 								<SearchBar noteBucket={ noteBucket } />
 								<NoteList noteBucket={ noteBucket } />
 							</div>
-							<NoteEditor allTags={ state.tags } noteBucket={ noteBucket } tagBucket={ tagBucket } />
+							<NoteEditor noteBucket={ noteBucket } tagBucket={ tagBucket } />
 							{ state.showNoteInfo &&
 								<NoteInfo noteBucket={ noteBucket } />
 							}

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -225,12 +225,6 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 		analytics.initialize( accountName );
 	},
 
-	onNotePrinted: function() {
-		this.props.actions.setShouldPrintNote( {
-			shouldPrint: false
-		} );
-	},
-
 	onNotesIndex: function() {
 		this.props.actions.loadNotes( {
 			noteBucket: this.props.noteBucket
@@ -263,83 +257,6 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 				Menu: remote.Menu
 			}
 		} );
-	},
-
-	onSetEditorMode: function( mode ) {
-		this.props.actions.setEditorMode( { mode } );
-	},
-
-	onUpdateContent: function( note, content ) {
-		this.props.actions.updateNoteContent( {
-			noteBucket: this.props.noteBucket,
-			note, content
-		} );
-	},
-
-	onUpdateNoteTags: function( note, tags ) {
-		this.props.actions.updateNoteTags( {
-			noteBucket: this.props.noteBucket,
-			tagBucket: this.props.tagBucket,
-			note, tags
-		} );
-	},
-
-	onTrashNote: function( note ) {
-		const previousIndex = this.getPreviousNoteIndex( note );
-		this.props.actions.trashNote( {
-			noteBucket: this.props.noteBucket,
-			note,
-			previousIndex
-		} );
-		analytics.tracks.recordEvent( 'editor_note_deleted' );
-	},
-
-	// gets the index of the note located before the currently selected one
-	getPreviousNoteIndex: function( note ) {
-		const filteredNotes = filterNotes( this.props.appState );
-
-		const noteIndex = function( filteredNote ) {
-			return note.id === filteredNote.id;
-		};
-
-		return Math.max( filteredNotes.findIndex( noteIndex ) - 1, 0 );
-	},
-
-	onRestoreNote: function( note ) {
-		const previousIndex = this.getPreviousNoteIndex( note );
-		this.props.actions.restoreNote( {
-			noteBucket: this.props.noteBucket,
-			note,
-			previousIndex
-		} );
-		analytics.tracks.recordEvent( 'editor_note_restored' );
-	},
-
-	onShareNote: function( note ) {
-		this.props.actions.showDialog( {
-			dialog: {
-				type: 'Share',
-				modal: true
-			},
-			params: { note }
-		} );
-	},
-
-	onDeleteNoteForever: function( note ) {
-		const previousIndex = this.getPreviousNoteIndex( note );
-		this.props.actions.deleteNoteForever( {
-			noteBucket: this.props.noteBucket,
-			note,
-			previousIndex
-		} );
-	},
-
-	onRevisions: function( note ) {
-		this.props.actions.noteRevisions( {
-			noteBucket: this.props.noteBucket,
-			note
-		} );
-		analytics.tracks.recordEvent( 'editor_versions_accessed' );
 	},
 
 	render: function() {
@@ -392,24 +309,7 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 								<SearchBar noteBucket={ noteBucket } />
 								<NoteList noteBucket={ noteBucket } />
 							</div>
-							<NoteEditor
-								allTags={ state.tags }
-								editorMode={state.editorMode}
-								filter={state.filter}
-								note={selectedNote}
-								revisions={state.revisions}
-								onSetEditorMode={this.onSetEditorMode}
-								onUpdateContent={this.onUpdateContent}
-								onUpdateNoteTags={this.onUpdateNoteTags}
-								onTrashNote={this.onTrashNote}
-								onRestoreNote={this.onRestoreNote}
-								onShareNote={this.onShareNote}
-								onDeleteNoteForever={this.onDeleteNoteForever}
-								onRevisions={this.onRevisions}
-								onCloseNote={() => this.props.actions.closeNote()}
-								onNoteInfo={() => this.props.actions.toggleNoteInfo()}
-								shouldPrint={state.shouldPrint}
-								onNotePrinted={this.onNotePrinted} />
+							<NoteEditor allTags={ state.tags } noteBucket={ noteBucket } tagBucket={ tagBucket } />
 							{ state.showNoteInfo &&
 								<NoteInfo noteBucket={ noteBucket } />
 							}

--- a/lib/mode-bar.jsx
+++ b/lib/mode-bar.jsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import appState from './flux/app-state';
+
+const { setEditorMode } = appState.actionCreators;
+
+const buttonClasses = 'button button-segmented-control button-compact';
+
+export const ModeBar = ( {
+	isPreviewing,
+	onSetEditorModeEdit,
+	onSetEditorModeMarkdown,
+} ) =>
+	<div className="note-editor-mode-bar segmented-control">
+		<button
+			className={ classNames( buttonClasses, { active: ! isPreviewing } ) }
+			onClick={ onSetEditorModeEdit }
+			type="button"
+		>
+			Edit
+		</button>
+		<button
+			className={ classNames( buttonClasses, { active: isPreviewing } ) }
+			onClick={ onSetEditorModeMarkdown }
+			type="button"
+		>
+			Preview
+		</button>
+	</div>;
+
+const mapStateToProps = ( { appState: state } ) => ( { isPreviewing: 'markdown' === state.editorMode } );
+
+const mapDispatchToProps = dispatch => ( {
+	onSetEditorModeEdit: () => dispatch( setEditorMode( { mode: 'edit' } ) ),
+	onSetEditorModeMarkdown: () => dispatch( setEditorMode( { mode: 'markdown' } ) ),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( ModeBar );

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -79,6 +79,7 @@ export const NoteDetail = React.createClass( {
 
 	render: function() {
 		const {
+			filter,
 			fontSize,
 			previewingMarkdown,
 		} = this.props;
@@ -103,9 +104,10 @@ export const NoteDetail = React.createClass( {
 						style={ divStyle }
 					>
 						<NoteContentEditor
-							ref={ this.saveEditorRef }
 							content={ content }
+							filter={ filter }
 							onChangeContent={ this.queueNoteSave }
+							ref={ this.saveEditorRef }
 						/>
 					</div>
 				) }
@@ -123,6 +125,7 @@ const mapStateToProps = ( {
 	const previewingMarkdown = get( revision, 'data.systemTags', '' ).indexOf( 'markdown' ) !== -1
 		&& state.editorMode === 'markdown';
 	return {
+		filter: state.filter,
 		fontSize,
 		note: revision,
 		previewingMarkdown,

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -117,16 +117,18 @@ export const NoteDetail = React.createClass( {
 const mapStateToProps = ( {
 	appState: state,
 	revision: { selectedRevision },
-	settings: { fontSize, markdownEnabled },
+	settings: { fontSize },
 } ) => {
 	const filteredNotes = filterNotes( state );
 	const noteIndex = Math.max( state.previousIndex, 0 );
 	const note = state.note ? state.note : filteredNotes[ noteIndex ];
 	const revision = selectedRevision || note;
+	const previewingMarkdown = get( revision, 'data.systemTags', '' ).indexOf( 'markdown' ) !== -1
+		&& state.editorMode === 'markdown';
 	return {
 		fontSize,
 		note: revision,
-		previewingMarkdown: markdownEnabled && state.editorMode === 'markdown',
+		previewingMarkdown,
 	};
 };
 

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -7,7 +7,7 @@ import analytics from './analytics';
 import { viewExternalUrl } from './utils/url-utils';
 import NoteContentEditor from './note-content-editor';
 import appState from './flux/app-state';
-import filterNotes from './utils/filter-notes';
+import getNote from './utils/get-note';
 
 const { updateNoteContent } = appState.actionCreators;
 
@@ -119,10 +119,7 @@ const mapStateToProps = ( {
 	revision: { selectedRevision },
 	settings: { fontSize },
 } ) => {
-	const filteredNotes = filterNotes( state );
-	const noteIndex = Math.max( state.previousIndex, 0 );
-	const note = state.note ? state.note : filteredNotes[ noteIndex ];
-	const revision = selectedRevision || note;
+	const revision = selectedRevision || getNote( state );
 	const previewingMarkdown = get( revision, 'data.systemTags', '' ).indexOf( 'markdown' ) !== -1
 		&& state.editorMode === 'markdown';
 	return {

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import highlight from 'highlight.js';
 import marked from 'marked';
-import { get, debounce, invoke } from 'lodash';
+import { get, debounce, includes, invoke } from 'lodash';
 import analytics from './analytics';
 import { viewExternalUrl } from './utils/url-utils';
 import NoteContentEditor from './note-content-editor';
@@ -18,7 +18,7 @@ export const NoteDetail = React.createClass( {
 
 	propTypes: {
 		note: PropTypes.object,
-		previewingMarkdown: PropTypes.bool,
+		isPreviewing: PropTypes.bool,
 		fontSize: PropTypes.number,
 		onChangeContent: PropTypes.func.isRequired
 	},
@@ -81,7 +81,7 @@ export const NoteDetail = React.createClass( {
 		const {
 			filter,
 			fontSize,
-			previewingMarkdown,
+			isPreviewing,
 		} = this.props;
 
 		const content = get( this.props, 'note.data.content', '' );
@@ -89,7 +89,7 @@ export const NoteDetail = React.createClass( {
 
 		return (
 			<div className="note-detail">
-				{ previewingMarkdown && (
+				{ isPreviewing && (
 					<div
 						className="note-detail-markdown theme-color-bg theme-color-fg"
 						dangerouslySetInnerHTML={ { __html: marked( content, { highlight: highlighter } ) } }
@@ -98,7 +98,7 @@ export const NoteDetail = React.createClass( {
 					/>
 				) }
 
-				{ ! previewingMarkdown && (
+				{ ! isPreviewing && (
 					<div
 						className="note-detail-textarea theme-color-bg theme-color-fg"
 						style={ divStyle }
@@ -122,13 +122,13 @@ const mapStateToProps = ( {
 	settings: { fontSize },
 } ) => {
 	const revision = selectedRevision || getNote( state );
-	const previewingMarkdown = get( revision, 'data.systemTags', '' ).indexOf( 'markdown' ) !== -1
-		&& state.editorMode === 'markdown';
+	const isMarkdown = includes( get( revision, 'data.systemTags', '' ), 'markdown' );
+	const isPreviewing = isMarkdown && 'markdown' === state.editorMode;
 	return {
 		filter: state.filter,
 		fontSize,
 		note: revision,
-		previewingMarkdown,
+		isPreviewing,
 	};
 };
 

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -6,7 +6,7 @@ import TagField from './tag-field'
 import NoteToolbar from './note-toolbar'
 import RevisionSelector from './revision-selector'
 import marked from 'marked'
-import { get, property } from 'lodash'
+import { get } from 'lodash'
 import appState from './flux/app-state';
 import getNote from './utils/get-note';
 import ModeBar from './mode-bar';
@@ -88,11 +88,7 @@ export const NoteEditor = React.createClass( {
 					dangerouslySetInnerHTML={ { __html: noteContent } } />
 				}
 				{ ! isTrashed &&
-					<TagField
-						allTags={ this.props.allTags.map( property( 'data.name' ) ) }
-						noteBucket={ noteBucket }
-						tagBucket={ tagBucket }
-					/>
+					<TagField noteBucket={ noteBucket } tagBucket={ tagBucket } />
 				}
 			</div>
 		)

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -8,7 +8,7 @@ import RevisionSelector from './revision-selector'
 import marked from 'marked'
 import { get, property } from 'lodash'
 import appState from './flux/app-state';
-import filterNotes from './utils/filter-notes';
+import getNote from './utils/get-note';
 import ModeBar from './mode-bar';
 import { selectRevision } from './state/revision/actions';
 
@@ -104,9 +104,7 @@ const mapStateToProps = ( {
 	revision: { selectedRevision },
 	settings: { fontSize },
 } ) => {
-	const filteredNotes = filterNotes( state );
-	const noteIndex = Math.max( state.previousIndex, 0 );
-	const note = state.note ? state.note : filteredNotes[ noteIndex ];
+	const note = getNote( state );
 	const revision = selectedRevision || note;
 	return {
 		fontSize,

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -12,17 +12,11 @@ import filterNotes from './utils/filter-notes';
 import ModeBar from './mode-bar';
 import { selectRevision } from './state/revision/actions';
 
-const {
-	setShouldPrintNote,
-	updateNoteTags,
-} = appState.actionCreators;
+const { setShouldPrintNote } = appState.actionCreators;
 
 export const NoteEditor = React.createClass( {
 	propTypes: {
-		note: PropTypes.object,
-		fontSize: PropTypes.number,
 		shouldPrint: PropTypes.bool,
-		onUpdateNoteTags: PropTypes.func.isRequired,
 		onPrintNote: PropTypes.func
 	},
 
@@ -53,15 +47,13 @@ export const NoteEditor = React.createClass( {
 		const {
 			fontSize,
 			isTrashed,
-			note,
+			markdownEnabled,
 			noteBucket,
 			revision,
 			selectedRevision,
 			shouldPrint,
-			tags,
+			tagBucket,
 		} = this.props;
-
-		const markdownEnabled = get( revision, 'data.systemTags', '' ).indexOf( 'markdown' ) !== -1;
 
 		const classes = classNames( 'note-editor', 'theme-color-bg', 'theme-color-fg', {
 			revisions: selectedRevision,
@@ -98,8 +90,9 @@ export const NoteEditor = React.createClass( {
 				{ ! isTrashed &&
 					<TagField
 						allTags={ this.props.allTags.map( property( 'data.name' ) ) }
-						tags={tags}
-						onUpdateNoteTags={this.props.onUpdateNoteTags.bind( null, note ) } />
+						noteBucket={ noteBucket }
+						tagBucket={ tagBucket }
+					/>
 				}
 			</div>
 		)
@@ -109,7 +102,7 @@ export const NoteEditor = React.createClass( {
 const mapStateToProps = ( {
 	appState: state,
 	revision: { selectedRevision },
-	settings: { fontSize, markdownEnabled },
+	settings: { fontSize },
 } ) => {
 	const filteredNotes = filterNotes( state );
 	const noteIndex = Math.max( state.previousIndex, 0 );
@@ -118,21 +111,17 @@ const mapStateToProps = ( {
 	return {
 		fontSize,
 		isTrashed: !! ( note && note.data.deleted ),
-		markdownEnabled,
-		note,
+		markdownEnabled: get( revision, 'data.systemTags', '' ).indexOf( 'markdown' ) !== -1,
 		revision,
 		selectedRevision,
 		shouldPrint: state.shouldPrint,
-		tags: get( revision, 'data.tags', [] ),
 	};
 };
 
-const mapDispatchToProps = ( dispatch, { noteBucket, tagBucket } ) => ( {
+const mapDispatchToProps = dispatch => ( {
 	onCancelRevision: () => dispatch( selectRevision( null ) ),
 	onNotePrinted: () =>
 		dispatch( setShouldPrintNote( { shouldPrint: false } ) ),
-	onUpdateNoteTags: ( note, tags ) =>
-		dispatch( updateNoteTags( { noteBucket, tagBucket, note, tags } ) ),
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( NoteEditor );

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -10,7 +10,7 @@ import { get, property } from 'lodash'
 import appState from './flux/app-state';
 import filterNotes from './utils/filter-notes';
 import ModeBar from './mode-bar';
-import { setIsViewingRevisions, selectRevision } from './state/revision/actions';
+import { selectRevision } from './state/revision/actions';
 
 const {
 	setShouldPrintNote,
@@ -42,7 +42,7 @@ export const NoteEditor = React.createClass( {
 	},
 
 	componentWillMount: function() {
-		this.props.onSelectRevision( null );
+		this.props.onCancelRevision();
 	},
 
 	componentDidUpdate: function() {
@@ -62,17 +62,11 @@ export const NoteEditor = React.createClass( {
 			return;
 		}
 
-		const { note, onUpdateContent } = this.props;
+		const { note, onCancelRevision, onUpdateContent } = this.props;
 		const { data: { content } } = revision;
 
 		onUpdateContent( note, content );
-		this.props.onSetIsViewingRevisions( false );
-	},
-
-	onCancelRevision: function() {
-		// clear out the revision
-		this.props.onSelectRevision( null );
-		this.props.onSetIsViewingRevisions( false );
+		onCancelRevision();
 	},
 
 	render: function() {
@@ -80,10 +74,9 @@ export const NoteEditor = React.createClass( {
 		const {
 			editorMode,
 			fontSize,
-			isViewingRevisions,
 			note,
 			noteBucket,
-			onSetIsViewingRevisions,
+			onCancelRevision,
 			onSelectRevision,
 			selectedRevision,
 			revisions,
@@ -99,7 +92,7 @@ export const NoteEditor = React.createClass( {
 			revision.data.systemTags.indexOf( 'markdown' ) !== -1;
 
 		const classes = classNames( 'note-editor', 'theme-color-bg', 'theme-color-fg', {
-			revisions: isViewingRevisions,
+			revisions: selectedRevision,
 			markdown: markdownEnabled
 		} );
 
@@ -116,14 +109,11 @@ export const NoteEditor = React.createClass( {
 			<div className={classes}>
 				<RevisionSelector
 					revisions={revisions || []}
-					onViewRevision={ onSelectRevision }
-					onSelectRevision={this.onSelectRevision}
-					onCancelRevision={this.onCancelRevision} />
+					onViewRevision={ this.onViewRevision }
+					onSelectRevision={ onSelectRevision }
+					onCancelRevision={ onCancelRevision } />
 				<div className="note-editor-controls theme-color-border">
-					<NoteToolbar
-						noteBucket={ noteBucket }
-						setIsViewingRevisions={ onSetIsViewingRevisions }
-					/>
+					<NoteToolbar noteBucket={ noteBucket } />
 				</div>
 				<div className="note-editor-content theme-color-border">
 					{ !! markdownEnabled &&
@@ -175,10 +165,9 @@ const mapStateToProps = ( {
 };
 
 const mapDispatchToProps = ( dispatch, { noteBucket, tagBucket } ) => ( {
+	onCancelRevision: () => dispatch( selectRevision( null ) ),
 	onNotePrinted: () =>
 		dispatch( setShouldPrintNote( { shouldPrint: false } ) ),
-	onSetIsViewingRevisions: isViewing =>
-		dispatch( setIsViewingRevisions( isViewing ) ),
 	onSelectRevision: revision =>
 		dispatch( selectRevision( revision ) ),
 	onUpdateContent: ( note, content ) =>

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -14,24 +14,20 @@ import { selectRevision } from './state/revision/actions';
 
 const {
 	setShouldPrintNote,
-	updateNoteContent,
 	updateNoteTags,
 } = appState.actionCreators;
 
 export const NoteEditor = React.createClass( {
 	propTypes: {
-		editorMode: PropTypes.oneOf( [ 'edit', 'markdown' ] ),
 		note: PropTypes.object,
 		fontSize: PropTypes.number,
 		shouldPrint: PropTypes.bool,
-		onUpdateContent: PropTypes.func.isRequired,
 		onUpdateNoteTags: PropTypes.func.isRequired,
 		onPrintNote: PropTypes.func
 	},
 
 	getDefaultProps: function() {
 		return {
-			editorMode: 'edit',
 			note: {
 				data: {
 					tags: []
@@ -55,7 +51,6 @@ export const NoteEditor = React.createClass( {
 	render: function() {
 		let noteContent = '';
 		const {
-			editorMode,
 			fontSize,
 			isTrashed,
 			note,
@@ -93,12 +88,7 @@ export const NoteEditor = React.createClass( {
 						<ModeBar />
 					}
 					<div className="note-editor-detail">
-						<NoteDetail
-							filter={this.props.filter}
-							note={revision}
-							previewingMarkdown={markdownEnabled && editorMode === 'markdown'}
-							onChangeContent={this.props.onUpdateContent}
-							fontSize={fontSize} />
+						<NoteDetail noteBucket={ noteBucket } />
 					</div>
 				</div>
 				{ shouldPrint &&
@@ -121,20 +111,18 @@ const mapStateToProps = ( {
 	revision: { selectedRevision },
 	settings: { fontSize, markdownEnabled },
 } ) => {
-	const { editorMode, shouldPrint } = state;
 	const filteredNotes = filterNotes( state );
 	const noteIndex = Math.max( state.previousIndex, 0 );
 	const note = state.note ? state.note : filteredNotes[ noteIndex ];
 	const revision = selectedRevision || note;
 	return {
-		editorMode,
 		fontSize,
 		isTrashed: !! ( note && note.data.deleted ),
 		markdownEnabled,
 		note,
 		revision,
 		selectedRevision,
-		shouldPrint,
+		shouldPrint: state.shouldPrint,
 		tags: get( revision, 'data.tags', [] ),
 	};
 };
@@ -143,8 +131,6 @@ const mapDispatchToProps = ( dispatch, { noteBucket, tagBucket } ) => ( {
 	onCancelRevision: () => dispatch( selectRevision( null ) ),
 	onNotePrinted: () =>
 		dispatch( setShouldPrintNote( { shouldPrint: false } ) ),
-	onUpdateContent: ( note, content ) =>
-		dispatch( updateNoteContent( { noteBucket, note, content } ) ),
 	onUpdateNoteTags: ( note, tags ) =>
 		dispatch( updateNoteTags( { noteBucket, tagBucket, note, tags } ) ),
 } );

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -11,6 +11,15 @@ import appState from './flux/app-state';
 import { tracks } from './analytics'
 import filterNotes from './utils/filter-notes';
 
+const {
+	noteRevisions,
+	setEditorMode,
+	setShouldPrintNote,
+	updateNoteContent,
+	updateNoteTags,
+} = appState.actionCreators;
+const { recordEvent } = tracks;
+
 export const NoteEditor = React.createClass( {
 	propTypes: {
 		editorMode: PropTypes.oneOf( [ 'edit', 'markdown' ] ),
@@ -186,15 +195,6 @@ export const NoteEditor = React.createClass( {
 		);
 	}
 } );
-
-const {
-	noteRevisions,
-	setEditorMode,
-	setShouldPrintNote,
-	updateNoteContent,
-	updateNoteTags,
-} = appState.actionCreators;
-const { recordEvent } = tracks;
 
 const mapStateToProps = ( {
 	appState: state,

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -57,19 +57,16 @@ export const NoteEditor = React.createClass( {
 		const {
 			editorMode,
 			fontSize,
+			isTrashed,
 			note,
 			noteBucket,
+			revision,
 			selectedRevision,
 			shouldPrint,
+			tags,
 		} = this.props;
 
-		const revision = selectedRevision || note;
-		const tags = revision && revision.data && revision.data.tags || [];
-		const isTrashed = !!( note && note.data.deleted );
-
-		const markdownEnabled = revision &&
-			revision.data && revision.data.systemTags &&
-			revision.data.systemTags.indexOf( 'markdown' ) !== -1;
+		const markdownEnabled = get( revision, 'data.systemTags', '' ).indexOf( 'markdown' ) !== -1;
 
 		const classes = classNames( 'note-editor', 'theme-color-bg', 'theme-color-fg', {
 			revisions: selectedRevision,
@@ -128,13 +125,17 @@ const mapStateToProps = ( {
 	const filteredNotes = filterNotes( state );
 	const noteIndex = Math.max( state.previousIndex, 0 );
 	const note = state.note ? state.note : filteredNotes[ noteIndex ];
+	const revision = selectedRevision || note;
 	return {
 		editorMode,
 		fontSize,
+		isTrashed: !! ( note && note.data.deleted ),
 		markdownEnabled,
 		note,
+		revision,
 		selectedRevision,
 		shouldPrint,
+		tags: get( revision, 'data.tags', [] ),
 	};
 };
 

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -10,10 +10,10 @@ import { get, property } from 'lodash'
 import appState from './flux/app-state';
 import { tracks } from './analytics'
 import filterNotes from './utils/filter-notes';
+import ModeBar from './mode-bar';
 
 const {
 	noteRevisions,
-	setEditorMode,
 	setShouldPrintNote,
 	updateNoteContent,
 	updateNoteTags,
@@ -27,7 +27,6 @@ export const NoteEditor = React.createClass( {
 		revisions: PropTypes.array,
 		fontSize: PropTypes.number,
 		shouldPrint: PropTypes.bool,
-		onSetEditorMode: PropTypes.func.isRequired,
 		onUpdateContent: PropTypes.func.isRequired,
 		onUpdateNoteTags: PropTypes.func.isRequired,
 		onRevisions: PropTypes.func.isRequired,
@@ -140,7 +139,9 @@ export const NoteEditor = React.createClass( {
 					/>
 				</div>
 				<div className="note-editor-content theme-color-border">
-					{!!markdownEnabled && this.renderModeBar()}
+					{ !! markdownEnabled &&
+						<ModeBar />
+					}
 					<div className="note-editor-detail">
 						<NoteDetail
 							filter={this.props.filter}
@@ -163,37 +164,6 @@ export const NoteEditor = React.createClass( {
 			</div>
 		)
 	},
-
-	renderModeBar() {
-		const { editorMode } = this.props;
-
-		const isPreviewing = ( editorMode === 'markdown' );
-
-		return (
-			<div className="note-editor-mode-bar segmented-control">
-				<button type="button"
-					className={ classNames(
-						'button button-segmented-control button-compact',
-						{ active: ! isPreviewing },
-					) }
-					data-editor-mode="edit"
-					onClick={ this.setEditorMode }
-				>
-					Edit
-				</button>
-				<button type="button"
-					className={ classNames(
-						'button button-segmented-control button-compact',
-						{ active: isPreviewing },
-					) }
-					data-editor-mode="markdown"
-					onClick={ this.setEditorMode }
-				>
-					Preview
-				</button>
-			</div>
-		);
-	}
 } );
 
 const mapStateToProps = ( {
@@ -221,8 +191,6 @@ const mapDispatchToProps = ( dispatch, { noteBucket, tagBucket } ) => ( {
 		dispatch( noteRevisions( { noteBucket, note } ) );
 		recordEvent( 'editor_versions_accessed' );
 	},
-	onSetEditorMode: mode =>
-		dispatch( setEditorMode( { mode } ) ),
 	onUpdateContent: ( note, content ) =>
 		dispatch( updateNoteContent( { noteBucket, note, content } ) ),
 	onUpdateNoteTags: ( note, tags ) =>

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -22,7 +22,6 @@ export const NoteEditor = React.createClass( {
 	propTypes: {
 		editorMode: PropTypes.oneOf( [ 'edit', 'markdown' ] ),
 		note: PropTypes.object,
-		revisions: PropTypes.array,
 		fontSize: PropTypes.number,
 		shouldPrint: PropTypes.bool,
 		onUpdateContent: PropTypes.func.isRequired,
@@ -53,22 +52,6 @@ export const NoteEditor = React.createClass( {
 		}
 	},
 
-	onViewRevision: function( revision ) {
-		this.props.onSelectRevision( revision );
-	},
-
-	onSelectRevision: function( revision ) {
-		if ( ! revision ) {
-			return;
-		}
-
-		const { note, onCancelRevision, onUpdateContent } = this.props;
-		const { data: { content } } = revision;
-
-		onUpdateContent( note, content );
-		onCancelRevision();
-	},
-
 	render: function() {
 		let noteContent = '';
 		const {
@@ -76,10 +59,7 @@ export const NoteEditor = React.createClass( {
 			fontSize,
 			note,
 			noteBucket,
-			onCancelRevision,
-			onSelectRevision,
 			selectedRevision,
-			revisions,
 			shouldPrint,
 		} = this.props;
 
@@ -107,11 +87,7 @@ export const NoteEditor = React.createClass( {
 
 		return (
 			<div className={classes}>
-				<RevisionSelector
-					revisions={revisions || []}
-					onViewRevision={ this.onViewRevision }
-					onSelectRevision={ onSelectRevision }
-					onCancelRevision={ onCancelRevision } />
+				<RevisionSelector noteBucket={ noteBucket } />
 				<div className="note-editor-controls theme-color-border">
 					<NoteToolbar noteBucket={ noteBucket } />
 				</div>
@@ -145,21 +121,19 @@ export const NoteEditor = React.createClass( {
 
 const mapStateToProps = ( {
 	appState: state,
-	revision: { isViewingRevisions, selectedRevision },
+	revision: { selectedRevision },
 	settings: { fontSize, markdownEnabled },
 } ) => {
-	const { editorMode, revisions, shouldPrint } = state;
+	const { editorMode, shouldPrint } = state;
 	const filteredNotes = filterNotes( state );
 	const noteIndex = Math.max( state.previousIndex, 0 );
 	const note = state.note ? state.note : filteredNotes[ noteIndex ];
 	return {
 		editorMode,
 		fontSize,
-		isViewingRevisions,
 		markdownEnabled,
 		note,
 		selectedRevision,
-		revisions,
 		shouldPrint,
 	};
 };
@@ -168,8 +142,6 @@ const mapDispatchToProps = ( dispatch, { noteBucket, tagBucket } ) => ( {
 	onCancelRevision: () => dispatch( selectRevision( null ) ),
 	onNotePrinted: () =>
 		dispatch( setShouldPrintNote( { shouldPrint: false } ) ),
-	onSelectRevision: revision =>
-		dispatch( selectRevision( revision ) ),
 	onUpdateContent: ( note, content ) =>
 		dispatch( updateNoteContent( { noteBucket, note, content } ) ),
 	onUpdateNoteTags: ( note, tags ) =>

--- a/lib/note-toolbar.jsx
+++ b/lib/note-toolbar.jsx
@@ -4,8 +4,12 @@ import InfoIcon from './icons/info'
 import RevisionsIcon from './icons/revisions'
 import TrashIcon from './icons/trash'
 import ShareIcon from './icons/share'
+import { connect } from 'react-redux';
+import appState from './flux/app-state';
+import { tracks } from './analytics'
+import filterNotes from './utils/filter-notes';
 
-export default React.createClass( {
+export const NoteToolbar = React.createClass( {
 
 	propTypes: {
 		note: PropTypes.object,
@@ -57,3 +61,58 @@ export default React.createClass( {
 	}
 
 } );
+
+const {
+	closeNote,
+	deleteNoteForever,
+	noteRevisions,
+	restoreNote,
+	showDialog,
+	toggleNoteInfo,
+	trashNote,
+} = appState.actionCreators;
+const { recordEvent } = tracks;
+
+// gets the index of the note located before the currently selected one
+function getPreviousNoteIndex( note, filteredNotes ) {
+	const noteIndex = function( filteredNote ) {
+		return note.id === filteredNote.id;
+	};
+	return Math.max( filteredNotes.findIndex( noteIndex ) - 1, 0 );
+}
+
+const mapStateToProps = ( { appState: state } ) => {
+	const filteredNotes = filterNotes( state );
+	const noteIndex = Math.max( state.previousIndex, 0 );
+	const note = state.note ? state.note : filteredNotes[ noteIndex ];
+	const previousIndex = getPreviousNoteIndex( note, filteredNotes );
+	return { note, previousIndex };
+};
+
+const mapDispatchToProps = ( dispatch, { noteBucket, previousIndex } ) => ( {
+	onCloseNote: () =>
+		dispatch( closeNote() ),
+	onDeleteNoteForever: note =>
+		dispatch( deleteNoteForever( { noteBucket, note, previousIndex } ) ),
+	onNoteInfo: () =>
+		dispatch( toggleNoteInfo() ),
+	onRestoreNote: note => {
+		dispatch( restoreNote( { noteBucket, note, previousIndex } ) );
+		recordEvent( 'editor_note_restored' );
+	},
+	onRevisions: note => {
+		dispatch( noteRevisions( { noteBucket, note } ) );
+		recordEvent( 'editor_versions_accessed' );
+	},
+	onShareNote: note =>
+		dispatch( showDialog( {
+			dialog: { modal: true, type: 'Share' },
+			params: { note },
+		} ) ),
+	onTrashNote: note => {
+		dispatch( trashNote( { noteBucket, note, previousIndex } ) );
+		recordEvent( 'editor_note_deleted' );
+	},
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( NoteToolbar );

--- a/lib/note-toolbar.jsx
+++ b/lib/note-toolbar.jsx
@@ -9,6 +9,25 @@ import appState from './flux/app-state';
 import { tracks } from './analytics'
 import filterNotes from './utils/filter-notes';
 
+const {
+	closeNote,
+	deleteNoteForever,
+	noteRevisions,
+	restoreNote,
+	showDialog,
+	toggleNoteInfo,
+	trashNote,
+} = appState.actionCreators;
+const { recordEvent } = tracks;
+
+// gets the index of the note located before the currently selected one
+function getPreviousNoteIndex( note, filteredNotes ) {
+	const noteIndex = function( filteredNote ) {
+		return note.id === filteredNote.id;
+	};
+	return Math.max( filteredNotes.findIndex( noteIndex ) - 1, 0 );
+}
+
 export const NoteToolbar = React.createClass( {
 
 	propTypes: {
@@ -61,25 +80,6 @@ export const NoteToolbar = React.createClass( {
 	}
 
 } );
-
-const {
-	closeNote,
-	deleteNoteForever,
-	noteRevisions,
-	restoreNote,
-	showDialog,
-	toggleNoteInfo,
-	trashNote,
-} = appState.actionCreators;
-const { recordEvent } = tracks;
-
-// gets the index of the note located before the currently selected one
-function getPreviousNoteIndex( note, filteredNotes ) {
-	const noteIndex = function( filteredNote ) {
-		return note.id === filteredNote.id;
-	};
-	return Math.max( filteredNotes.findIndex( noteIndex ) - 1, 0 );
-}
 
 const mapStateToProps = ( { appState: state } ) => {
 	const filteredNotes = filterNotes( state );

--- a/lib/note-toolbar.jsx
+++ b/lib/note-toolbar.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import appState from './flux/app-state';
 import { tracks } from './analytics'
 import filterNotes from './utils/filter-notes';
+import { selectRevision } from './state/revision/actions';
 
 const {
 	closeNote,
@@ -39,11 +40,9 @@ export const NoteToolbar = React.createClass( {
 		onShareNote: PropTypes.func.isRequired,
 		onCloseNote: PropTypes.func.isRequired,
 		onNoteInfo: PropTypes.func.isRequired,
-		setIsViewingRevisions: PropTypes.func.isRequired
 	},
 
 	showRevisions: function() {
-		this.props.setIsViewingRevisions( true );
 		this.props.onRevisions( this.props.note );
 	},
 
@@ -102,6 +101,7 @@ const mapDispatchToProps = ( dispatch, { noteBucket, previousIndex } ) => ( {
 	},
 	onRevisions: note => {
 		dispatch( noteRevisions( { noteBucket, note } ) );
+		dispatch( selectRevision( note ) );
 		recordEvent( 'editor_versions_accessed' );
 	},
 	onShareNote: note =>

--- a/lib/revision-selector.jsx
+++ b/lib/revision-selector.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import moment from 'moment'
 import { orderBy } from 'lodash';
 import appState from './flux/app-state';
-import filterNotes from './utils/filter-notes';
+import getNote from './utils/get-note';
 import { selectRevision } from './state/revision/actions';
 
 const { updateNoteContent } = appState.actionCreators;
@@ -145,9 +145,7 @@ RevisionSelector.propTypes = {
 };
 
 const mapStateToProps = ( { appState: state } ) => {
-	const filteredNotes = filterNotes( state );
-	const noteIndex = Math.max( state.previousIndex, 0 );
-	const note = state.note ? state.note : filteredNotes[ noteIndex ];
+	const note = getNote( state );
 	return {
 		note,
 		revisions: state.revisions || [],

--- a/lib/state/action-types.js
+++ b/lib/state/action-types.js
@@ -1,3 +1,2 @@
 export const AUTH_SET = Symbol();
-export const REVISION_IS_VIEWING = 'REVISION_IS_VIEWING';
 export const REVISION_SELECT = 'REVISION_SELECT';

--- a/lib/state/action-types.js
+++ b/lib/state/action-types.js
@@ -1,1 +1,3 @@
 export const AUTH_SET = Symbol();
+export const REVISION_IS_VIEWING = 'REVISION_IS_VIEWING';
+export const REVISION_SELECT = 'REVISION_SELECT';

--- a/lib/state/index.js
+++ b/lib/state/index.js
@@ -11,11 +11,13 @@ import persistState from 'redux-localstorage';
 import appState from '../flux/app-state';
 
 import auth from './auth/reducer';
+import revision from './revision/reducer';
 import settings from './settings/reducer';
 
 export const reducers = combineReducers( {
 	appState: appState.reducer.bind( appState ),
 	auth,
+	revision,
 	settings,
 } );
 

--- a/lib/state/revision/actions.js
+++ b/lib/state/revision/actions.js
@@ -1,15 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	REVISION_IS_VIEWING,
-	REVISION_SELECT,
-} from '../action-types';
-
-export const setIsViewingRevisions = isViewing => ( {
-	type: REVISION_IS_VIEWING,
-	isViewing,
-} );
+import { REVISION_SELECT } from '../action-types';
 
 export const selectRevision = revision => ( {
 	type: REVISION_SELECT,

--- a/lib/state/revision/actions.js
+++ b/lib/state/revision/actions.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import {
+	REVISION_IS_VIEWING,
+	REVISION_SELECT,
+} from '../action-types';
+
+export const setIsViewingRevisions = isViewing => ( {
+	type: REVISION_IS_VIEWING,
+	isViewing,
+} );
+
+export const selectRevision = revision => ( {
+	type: REVISION_SELECT,
+	revision,
+} );

--- a/lib/state/revision/reducer.js
+++ b/lib/state/revision/reducer.js
@@ -6,18 +6,11 @@ import { combineReducers } from 'redux';
 /**
  * Internal dependencies
  */
-import {
-	REVISION_IS_VIEWING,
-	REVISION_SELECT,
-} from '../action-types';
-
-export const isViewingRevisions = ( state = false, { type, isViewing } ) =>
-	REVISION_IS_VIEWING === type ? isViewing : state;
+import { REVISION_SELECT } from '../action-types';
 
 export const selectedRevision = ( state = null, { type, revision } ) =>
 	REVISION_SELECT === type ? revision : state;
 
 export default combineReducers( {
-	isViewingRevisions,
 	selectedRevision,
 } );

--- a/lib/state/revision/reducer.js
+++ b/lib/state/revision/reducer.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import {
+	REVISION_IS_VIEWING,
+	REVISION_SELECT,
+} from '../action-types';
+
+export const isViewingRevisions = ( state = false, { type, isViewing } ) =>
+	REVISION_IS_VIEWING === type ? isViewing : state;
+
+export const selectedRevision = ( state = null, { type, revision } ) =>
+	REVISION_SELECT === type ? revision : state;
+
+export default combineReducers( {
+	isViewingRevisions,
+	selectedRevision,
+} );

--- a/lib/tag-field.jsx
+++ b/lib/tag-field.jsx
@@ -6,8 +6,10 @@ import classNames from 'classnames';
 import analytics from './analytics';
 import {
 	differenceBy,
+	get,
 	intersectionBy,
 	invoke,
+	property,
 	union,
 } from 'lodash';
 import appState from './flux/app-state';
@@ -194,6 +196,7 @@ const mapStateToProps = ( {
 	const note = getNote( state );
 	const revision = selectedRevision || note;
 	return {
+		allTags: state.tags.map( property( 'data.name' ) ),
 		note,
 		tags: get( revision, 'data.tags', [] ),
 	};

--- a/lib/tag-field.jsx
+++ b/lib/tag-field.jsx
@@ -11,7 +11,7 @@ import {
 	union,
 } from 'lodash';
 import appState from './flux/app-state';
-import filterNotes from './utils/filter-notes';
+import getNote from './utils/get-note';
 
 const { updateNoteTags } = appState.actionCreators;
 
@@ -191,9 +191,7 @@ const mapStateToProps = ( {
 	appState: state,
 	revision: { selectedRevision },
 } ) => {
-	const filteredNotes = filterNotes( state );
-	const noteIndex = Math.max( state.previousIndex, 0 );
-	const note = state.note ? state.note : filteredNotes[ noteIndex ];
+	const note = getNote( state );
 	const revision = selectedRevision || note;
 	return {
 		note,

--- a/lib/tag-field.jsx
+++ b/lib/tag-field.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react'
+import { connect } from 'react-redux';
 import TagChip from './components/tag-chip';
 import TagInput from './tag-input';
 import classNames from 'classnames';
@@ -9,8 +10,12 @@ import {
 	invoke,
 	union,
 } from 'lodash';
+import appState from './flux/app-state';
+import filterNotes from './utils/filter-notes';
 
-export default React.createClass( {
+const { updateNoteTags } = appState.actionCreators;
+
+export const TagField = React.createClass( {
 
 	propTypes: {
 		unusedTags: PropTypes.arrayOf( PropTypes.string ),
@@ -48,6 +53,8 @@ export default React.createClass( {
 	addTag: function( tags ) {
 		const {
 			allTags,
+			onUpdateNoteTags,
+			note,
 			tags: existingTags,
 		} = this.props;
 
@@ -58,7 +65,7 @@ export default React.createClass( {
 			intersectionBy( allTags, newTags, s => s.toLocaleLowerCase() ), // use existing case if tag known
 			differenceBy( newTags, allTags, s => s.toLocaleLowerCase() ), // add completely new tags
 		);
-		this.props.onUpdateNoteTags( nextTagList );
+		onUpdateNoteTags( note, nextTagList );
 		this.storeTagInput( '' );
 		invoke( this, 'tagInput.focus' );
 		analytics.tracks.recordEvent( 'editor_tag_added' );
@@ -69,10 +76,10 @@ export default React.createClass( {
 	},
 
 	deleteTag: function( tagName ) {
-		const { onUpdateNoteTags, tags } = this.props;
+		const { onUpdateNoteTags, note, tags } = this.props;
 		const { selectedTag } = this.state;
 
-		onUpdateNoteTags( differenceBy( tags, [ tagName ], s => s.toLocaleLowerCase() ) );
+		onUpdateNoteTags( note, differenceBy( tags, [ tagName ], s => s.toLocaleLowerCase() ) );
 
 		if ( selectedTag === tagName ) {
 			this.setState( { selectedTag: '' } );
@@ -179,3 +186,24 @@ export default React.createClass( {
 	}
 
 } );
+
+const mapStateToProps = ( {
+	appState: state,
+	revision: { selectedRevision },
+} ) => {
+	const filteredNotes = filterNotes( state );
+	const noteIndex = Math.max( state.previousIndex, 0 );
+	const note = state.note ? state.note : filteredNotes[ noteIndex ];
+	const revision = selectedRevision || note;
+	return {
+		note,
+		tags: get( revision, 'data.tags', [] ),
+	};
+};
+
+const mapDispatchToProps = ( dispatch, { noteBucket, tagBucket } ) => ( {
+	onUpdateNoteTags: ( note, tags ) =>
+		dispatch( updateNoteTags( { noteBucket, tagBucket, note, tags } ) ),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( TagField );

--- a/lib/utils/get-note.js
+++ b/lib/utils/get-note.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import filterNotes from './filter-notes';
+
+export default function getNote( state ) {
+	if ( state.note ) {
+		return state.note;
+	}
+	const filteredNotes = filterNotes( state );
+	const noteIndex = Math.max( state.previousIndex, 0 );
+	return filteredNotes[ noteIndex ];
+}


### PR DESCRIPTION
First step of the complete `NoteEditor` refactor.

In this PR we aim to move props and actions away from `app.jsx` and instead `connect` them to the component.

_Note_: ~~to refactor `RevisionSelector` it's necessary to move the `NoteEditor` state into Redux.
This may be out of scope for this PR, though, and also could conflict with https://github.com/Automattic/simplenote-electron/pull/402.~~
Eventually I got around doing it. See https://github.com/Automattic/simplenote-electron/pull/479/commits/ec67f0f25c88776f79577d31392879e248b1ab60 for more info.

## Components refactor checklist

- [x] `NoteEditor`
- [x] `RevisionSelector`
- [x] `NoteToolbar`
- [x] `NoteDetail`
- [x] `TagField`
- [x] `ModeBar` (new)
- [x] `revision` Redux state subtree (new)

## Clean up

- [ ] Revision state subtree discussions
- [x] DRY-fy or Reduxify the note/revision selector