### PR TITLE
Strip formatting from selected text on copy and cut

### DIFF
--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -155,6 +155,25 @@ export default class NoteContentEditor extends React.Component {
 		)
 	}
 
+	componentWillMount() {
+		document.addEventListener( 'copy', this.stripFormattingFromSelectedText );
+		document.addEventListener( 'cut', this.stripFormattingFromSelectedText );
+	}
+
+	componentWillUnmount() {
+		document.removeEventListener( 'copy', this.stripFormattingFromSelectedText );
+		document.removeEventListener( 'cut', this.stripFormattingFromSelectedText );
+	}
+
+	stripFormattingFromSelectedText( event ) {
+		if ( event.path.filter( elem => includes( elem.className, 'note-detail-textarea' ) ).length ) {
+			const selectedText = window.getSelection().toString();
+			event.clipboardData.setData( 'text/plain', selectedText );
+			event.clipboardData.setData( 'text/html', selectedText.replace( /(?:\r\n|\r|\n)/g, '<br />' ) );
+			event.preventDefault();
+		}
+	}
+
 	saveEditorRef = ( ref ) => {
 		this.editor = ref
 	}


### PR DESCRIPTION
Fix https://github.com/Automattic/simplenote-electron/issues/469

This only exists inside the note content editor.
Everywhere else, including the note markdown preview, the copy and cut events keep their default behaviour.

Note: I don't consider this to be a bug, since copying the formatted text is the correct behaviour and the onus of stripping the formatting usually falls on who handles the pasting event, or to the users themselves via the `cmd/ctrl+shift+v` shortcut.
Although, I've always found myself hitting `cmd+shift+v` way more often than `cmd+v`, so in my opinion this would be a good workflow improvement.