### PR TITLE
Update Makefile to allow for either style of config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SIMPLENOTE_BRANCH = $(shell git --git-dir .git branch | sed -n -e 's/^\* \(.*\)/
 
 # check for config
 config:
-	@test -s $(THIS_DIR)/config.js || { echo "config.js not found. Required file, see docs"; exit 1; }
+	@test -s $(THIS_DIR)/config.js || test -s $(THIS_DIR)/config.json || { echo "config.json not found. Required file, see docs"; exit 1; }
 
 # Builds Calypso (desktop)
 build: install


### PR DESCRIPTION
We recently moved to a JSON-based config but a JavaScript config file
which exports a single object is also valid. This reflects those changes
and prevents a bug where the build was failing on account of it.