### PR TITLE
Fixes a bug in the logout flow where the app becomes unresponsive

### DIFF
--- a/lib/tag-input.jsx
+++ b/lib/tag-input.jsx
@@ -30,8 +30,8 @@ export class TagInput extends Component {
 	};
 
 	componentWillUnmount() {
-		this.inputField && this.inputField.removeEventListener( 'paste', this.removePastedFormatting, false );
-	}
+		invoke( this, 'inputField.removeEventListener', 'paste', this.removePastedFormatting, false );
+	};
 
 	completeSuggestion = ( andThen = identity ) => {
 		const { onChange, tagNames, value } = this.props;

--- a/lib/tag-input.jsx
+++ b/lib/tag-input.jsx
@@ -115,7 +115,7 @@ export class TagInput extends Component {
 	storeInput = ref => {
 		this.inputField = ref;
 		this.props.inputRef( ref );
-		this.inputField.addEventListener( 'paste', this.removePastedFormatting, false );
+		invoke( this, 'inputField.addEventListener', 'paste', this.removePastedFormatting, false );
 	};
 
 	submitTag = event => {


### PR DESCRIPTION
Previously but after some auth state structure, when logging out of an
account, the app would become unresponsive. The cause of this was an
error raised in the tag input component which was attempting to add an
event listener to a component which was no longer mounted.

This fixes the symptom and may fix the root cause but at this time I am
not certain what that root cause it. At this time I believe that the
`ref` function is being called on component unmount which I did not
anticipate, passing in `null` and thus failing to add the event
listener.

**Update**

I have confirmed this behavior and realized that I shouldn't have made the error because I knew about the behavior with `ref`. The callback is called not only when initializing a component but also when unmounting it, and when unmounting the `ref` value is `null`

You can view this with [the demonstration fiddle](https://jsfiddle.net/69z2wepo/67872/) if you open the developer console and toggle the button.