### PR TITLE
Fixes a bug where the note list was shrinking for notes with many tags

### DIFF
--- a/lib/note-list.jsx
+++ b/lib/note-list.jsx
@@ -326,7 +326,7 @@ const NoteList = React.createClass( {
 										: getRowHeight( this.props.notes, { noteDisplay, width } )
 								) }
 								rowRenderer={ renderNoteRow }
-								width={ 328 }
+								width={ width }
 							/>
 						}
 					</AutoSizer>

--- a/lib/note-list.jsx
+++ b/lib/note-list.jsx
@@ -36,6 +36,19 @@ import noteTitle from './utils/note-title';
  */
 const TYPING_DEBOUNCE_DELAY = 70;
 
+/**
+ * Maximum delay when debouncing the row height calculation
+ *
+ * this is used to make sure that we don't endlessly delay
+ * the row height recalculation in situations like when we
+ * are constantly typing without pause. by setting this value
+ * we can make sure that the updates don't happen
+ * less-frequently than the number of ms set here
+ *
+ * @type {Number} maximum number of ms between calls when debouncing recomputeRowHeights in virtual/list
+ */
+const TYPING_DEBOUNCE_MAX = 1000;
+
 /** @type {Number} height of title + vertical padding in list rows */
 const ROW_HEIGHT_BASE = 24 + 18;
 
@@ -269,7 +282,8 @@ const NoteList = React.createClass( {
 		 */
 		this.recomputeHeights = debounce(
 			() => this.list && this.list.recomputeRowHeights(),
-			TYPING_DEBOUNCE_DELAY
+			TYPING_DEBOUNCE_DELAY,
+			{ maxWait: TYPING_DEBOUNCE_MAX }
 		);
 
 		window.addEventListener( 'resize', this.recomputeHeights );
@@ -368,11 +382,35 @@ const mapStateToProps = ( {
 	const noteIndex = Math.max( state.previousIndex, 0 );
 	const selectedNote = state.note ? state.note : filteredNotes[ noteIndex ];
 	const selectedNoteId = get( selectedNote, 'id', state.selectedNoteId );
+
+	/**
+	 * Although not used directly in the React component this value
+	 * is used to bust the cache when editing a note and the number
+	 * of lines in the preview in the notes list needs to also update.
+	 *
+	 * React virtualized hides data in the DOM in a stateful way in
+	 * the way it has optimized the scrolling performance. This then
+	 * is missed when connect() decides whether or not to redraw the
+	 * component. Even with `{ pure: false }` set in `connect()` it
+	 * misses the updates and I think that is because they come in
+	 * asynchronously through events and not directly
+	 *
+	 * Therefore we have to calculate the height of the note here to
+	 * signal to `connect()` to redraw the component. This could also
+	 * happen in `areStatesEqual()` (option to `connect()`) but since
+	 * we're already grabbing the other data here we can skip a slight
+	 * amount of overhead by just passing it along here.
+	 *
+	 * @type {String} preview excerpt for the current note
+	 */
+	const selectedNoteTitle = selectedNote && getNoteTitle( selectedNote );
+
 	return {
 		filter: state.filter,
 		noteDisplay,
 		notes: filteredNotes,
-		selectedNoteContent: get( selectedNote, 'contentKey' ),
+		selectedNoteTitle,
+		selectedNoteContent: get( selectedNote, 'data.content' ),
 		selectedNoteId,
 		showTrash: state.showTrash,
 	};

--- a/lib/note-list.jsx
+++ b/lib/note-list.jsx
@@ -278,7 +278,8 @@ const NoteList = React.createClass( {
 	componentWillReceiveProps( nextProps ) {
 		if (
 			nextProps.noteDisplay !== this.props.noteDisplay ||
-			nextProps.notes !== this.props.notes
+			nextProps.notes !== this.props.notes ||
+			nextProps.selectedNoteContent !== this.props.selectedNoteContent
 		) {
 			this.recomputeHeights();
 		}
@@ -371,6 +372,7 @@ const mapStateToProps = ( {
 		filter: state.filter,
 		noteDisplay,
 		notes: filteredNotes,
+		selectedNoteContent: get( selectedNote, 'contentKey' ),
 		selectedNoteId,
 		showTrash: state.showTrash,
 	};

--- a/lib/note-list.jsx
+++ b/lib/note-list.jsx
@@ -311,10 +311,8 @@ const NoteList = React.createClass( {
 		return (
 			<div className="note-list">
 				<div className={listItemsClasses}>
-					<AutoSizer
-						disableWidth
-					>
-						{ ( { height } ) =>
+					<AutoSizer>
+						{ ( { height, width } ) =>
 							<List
 								ref={ this.refList }
 								estimatedRowSize={ ROW_HEIGHT_BASE + ROW_HEIGHT_LINE * maxPreviewLines[ noteDisplay ] }
@@ -325,7 +323,7 @@ const NoteList = React.createClass( {
 								rowHeight={ (
 									'condensed' === noteDisplay
 										? ROW_HEIGHT_BASE
-										: getRowHeight( this.props.notes, { noteDisplay, width: 328 } )
+										: getRowHeight( this.props.notes, { noteDisplay, width } )
 								) }
 								rowRenderer={ renderNoteRow }
 								width={ 328 }

--- a/lib/note-list.jsx
+++ b/lib/note-list.jsx
@@ -138,7 +138,7 @@ const rowHeightCache = f => ( notes, { noteDisplay, width } ) => ( { index } ) =
  * @returns {Number} height of the row in the list
  */
 const computeRowHeight = ( width, noteDisplay, preview ) => {
-	const lines = Math.ceil( getTextWidth( preview, width - 30 ) / ( width - 30 ) );
+	const lines = Math.ceil( getTextWidth( preview, width - 24 ) / ( width - 24 ) );
 	return ROW_HEIGHT_BASE + ROW_HEIGHT_LINE * Math.min( maxPreviewLines[ noteDisplay ], lines );
 };
 
@@ -271,6 +271,8 @@ const NoteList = React.createClass( {
 			() => this.list && this.list.recomputeRowHeights(),
 			TYPING_DEBOUNCE_DELAY
 		);
+
+		window.addEventListener( 'resize', this.recomputeHeights );
 	},
 
 	componentWillReceiveProps( nextProps ) {
@@ -280,6 +282,10 @@ const NoteList = React.createClass( {
 		) {
 			this.recomputeHeights();
 		}
+	},
+
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.recomputeHeights );
 	},
 
 	refList( r ) {

--- a/lib/note-list.jsx
+++ b/lib/note-list.jsx
@@ -311,8 +311,10 @@ const NoteList = React.createClass( {
 		return (
 			<div className="note-list">
 				<div className={listItemsClasses}>
-					<AutoSizer>
-						{ ( { height, width } ) =>
+					<AutoSizer
+						disableWidth
+					>
+						{ ( { height } ) =>
 							<List
 								ref={ this.refList }
 								estimatedRowSize={ ROW_HEIGHT_BASE + ROW_HEIGHT_LINE * maxPreviewLines[ noteDisplay ] }
@@ -323,10 +325,10 @@ const NoteList = React.createClass( {
 								rowHeight={ (
 									'condensed' === noteDisplay
 										? ROW_HEIGHT_BASE
-										: getRowHeight( this.props.notes, { noteDisplay, width } )
+										: getRowHeight( this.props.notes, { noteDisplay, width: 328 } )
 								) }
 								rowRenderer={ renderNoteRow }
-								width={ width }
+								width={ 328 }
 							/>
 						}
 					</AutoSizer>

--- a/scss/note-list.scss
+++ b/scss/note-list.scss
@@ -1,5 +1,6 @@
 .source-list {
 	width: 328px;
+	min-width: 328px;
 	background: $white;
 	display: flex;
 	flex-direction: column;
@@ -7,6 +8,7 @@
 
 	@media only screen and ( max-width: $medium ) {
 		width: 300px;
+		min-width: 300px;
 	}
 
 	@media only screen and ( max-width: $single-column ) {


### PR DESCRIPTION
Previously when selecting a note with lots of tags the note list would
shrink to a narrow width.

This has now been prevented by disabling the auto-width setting of the
`<AutoSizer>` wrapper in the note list.

We may be able to remove the `<AutoSizer />` if we can set a fixed
height but this is sufficient for now and it doesn't appear to be
costing much in terms of performance if at all.