### PR TITLE
Add command-line option to open devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Install electron globally `npm install -g electron-prebuilt`, then:
 1. Run `npm run build`
 2. Run `electron .`
 
+You can also pass along the `--devtools` option after `electron .` to open the developer tools
+
 ## Coding Guidelines
 
 Please adhere to the same guidelines as found in [wp-calypso](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines.md).

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -56,8 +56,9 @@ module.exports = function main() {
 			mainWindow.loadUrl( url );
 		}
 
-		// Uncomment me to debug in the electron window
-		//mainWindow.openDevTools();
+		if ( process.argv.includes( '--devtools' ) ) {
+			mainWindow.openDevTools();
+		}
 
 		// Configure and set the application menu
 		const menuTemplate = createMenuTemplate();


### PR DESCRIPTION
Previously one needed to change the source code of the app in order to
open the developer tools. This also meant that one needed to undo those
changes before checking in and committing code.

Now, we can pass in a command-line option after the app has been built
in order to determine if the tools open or not. This means no risk of
accidentally merging in changes which open the tools by default and it
means we don't have to recompile in order to inspect the running app
inside of Electron.