### PR TITLE
Fix app not dragging on macOS when viewing revisions

### DIFF
--- a/scss/general.scss
+++ b/scss/general.scss
@@ -128,4 +128,8 @@ a {
 	.button, .search-field {
 		-webkit-app-region: no-drag;
 	}
+
+	.revision-selector {
+		-webkit-app-region: drag;
+	}
 }


### PR DESCRIPTION
Fixes the app not being able to drag when viewing the versions slider on macOS.

To test: View the revisions slider when in macOS and click and drag it. The app should move around!