### PR TITLE
Editor: increase distance between note and tags

### DIFF
--- a/scss/editor.scss
+++ b/scss/editor.scss
@@ -143,6 +143,10 @@
     display: flex;
     flex-direction: row;
     justify-content: center;
+
+		div[data-contents] {
+			padding-bottom: 20px;
+		}
   }
 }
 

--- a/scss/tag-editor.scss
+++ b/scss/tag-editor.scss
@@ -1,5 +1,6 @@
 .tag-entry {
   border-left: 1px solid lighten($gray, 30%);
+	padding-top: 16px;
 }
 
 .tag-editor {

--- a/scss/tag-editor.scss
+++ b/scss/tag-editor.scss
@@ -1,6 +1,5 @@
 .tag-entry {
   border-left: 1px solid lighten($gray, 30%);
-	padding-top: 16px;
 }
 
 .tag-editor {
@@ -11,7 +10,7 @@
   white-space: nowrap;
   overflow: visible;
   max-height: 120px;
-  padding: 8px 48px 8px 12px;
+	padding: 8px 12px;
 
   &:focus {
     outline: none;


### PR DESCRIPTION
Fixes #492 

<img width="636" alt="screen shot 2017-01-23 at 17 18 52" src="https://cloud.githubusercontent.com/assets/2070010/22212250/388a4322-e190-11e6-97ea-4f3022716b91.png">

To keep the scrollbar, we need to allow the note to overflow vertically.
Unfortunately, this means that it overflows over its own padding.
Even the top one, by the way: the note has a top padding of `24px` (same as bottom), but it doesn't respect it and, scrolling, the note touches the top bar border.

I've added a top padding to the tags section in order to simulate the note's bottom padding.

To be clear: I've added a `16px` padding since the inner tags container already has an `8px` padding.
<img width="637" alt="screen shot 2017-01-23 at 17 19 10" src="https://cloud.githubusercontent.com/assets/2070010/22212249/386bbf4c-e190-11e6-946b-773cb896b861.png">

---

I must say though that, increasing only the padding–top, the tags look a bit awkward.
It would take me no time - and it makes sense to do it in this PR - to adjust the bottom padding too.
Same goes if we want to add a top padding for the notes, to separate them from the top bar.