### PR TITLE
Normalize how email tags are treated

### DIFF
--- a/lib/dialogs/share.jsx
+++ b/lib/dialogs/share.jsx
@@ -132,8 +132,8 @@ export default React.createClass({
             <div className="settings-group">
               <p>
                 Add an email address of another Simplenote user to share a note.
-                You'll both be able to edit and view the note. You can also add
-                the email as a tag.
+                You&apos;ll both be able to edit and view the note. You can also
+                add the email as a tag.
               </p>
               <div className="settings-items theme-color-border">
                 <form

--- a/lib/dialogs/share.jsx
+++ b/lib/dialogs/share.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import createHash from 'create-hash/browser';
+import isEmailTag from '../utils/is-email-tag';
 import { includes } from 'lodash';
 import TabbedDialog from '../tabbed-dialog';
 import ToggleControl from '../controls/toggle';
@@ -79,7 +80,7 @@ export default React.createClass({
   collaborators() {
     const { note } = this.props.params;
     const tags = (note.data && note.data.tags) || [];
-    const collaborators = tags.filter(tag => tag.indexOf('@') !== -1);
+    const collaborators = tags.filter(isEmailTag);
 
     collaborators.reverse();
 
@@ -131,8 +132,8 @@ export default React.createClass({
             <div className="settings-group">
               <p>
                 Add an email address of another Simplenote user to share a note.
-                You&apos;ll both be able to edit and view the note. You can also
-                add the email as a tag.
+                You'll both be able to edit and view the note. You can also add
+                the email as a tag.
               </p>
               <div className="settings-items theme-color-border">
                 <form

--- a/lib/email-tooltip.jsx
+++ b/lib/email-tooltip.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import appState from './flux/app-state';
+
+export const EmailToolTip = ({ openShareDialog }) => (
+  <div className="tag-email-tooltip">
+    <div className="tag-email-tooltip__arrow" />
+    <div className="tag-email-tooltip__inside">
+      Sharing notes is now accessed through the collaboration tab in the{' '}
+      <a href="#" onClick={openShareDialog}>
+        sharing page
+      </a>. You will find all email address tags in that list instead.
+    </div>
+  </div>
+);
+
+const mapDispatchToProps = (dispatch, { note }) => ({
+  openShareDialog: () =>
+    dispatch(
+      appState.actionCreators.showDialog({
+        dialog: {
+          type: 'Share',
+          modal: true,
+        },
+        params: { note },
+      })
+    ),
+});
+
+export default connect(null, mapDispatchToProps)(EmailToolTip);

--- a/lib/email-tooltip.jsx
+++ b/lib/email-tooltip.jsx
@@ -7,10 +7,11 @@ export const EmailToolTip = ({ openShareDialog }) => (
   <div className="tag-email-tooltip">
     <div className="tag-email-tooltip__arrow" />
     <div className="tag-email-tooltip__inside">
-      Sharing notes is now accessed through the collaboration tab in the{' '}
+      Collaboration has moved. Press the Share icon in the toolbar to access
+      the&nbsp;
       <a href="#" onClick={openShareDialog}>
-        sharing page
-      </a>. You will find all email address tags in that list instead.
+        Collaborate screen
+      </a>.
     </div>
   </div>
 );

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -1,13 +1,14 @@
 import { partition } from 'lodash';
 import update from 'react-addons-update';
 import ActionMap from './action-map';
+import isEmailTag from '../utils/is-email-tag';
 import throttle from '../utils/throttle';
 import analytics from '../analytics';
 import { util as simperiumUtil } from 'simperium';
 
 const typingThrottle = 3000;
 
-export const actionMap = new ActionMap({
+var actionMap = new ActionMap({
   namespace: 'App',
 
   initialState: {
@@ -447,7 +448,7 @@ export const actionMap = new ActionMap({
           const note = state.notes.find(n => n.id === noteId);
 
           if (!note) {
-            console.error(`Cannot find note (id=${noteId})!`); // eslint-disable-line no-console
+            console.error(`Cannot find note (id=${noteId})!`);
             return;
           }
 
@@ -520,7 +521,7 @@ export const actionMap = new ActionMap({
                 continue;
               }
 
-              if (tag.indexOf('@') !== -1) {
+              if (isEmailTag(tag)) {
                 continue;
               }
 
@@ -578,7 +579,7 @@ export const actionMap = new ActionMap({
         return dispatch => {
           noteBucket.getRevisions(note.id, (e, revisions) => {
             if (e) {
-              return console.warn('Failed to load revisions', e); // eslint-disable-line no-console
+              return console.warn('Failed to load revisions', e);
             }
 
             dispatch(this.action('noteRevisionsLoaded', { revisions }));

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -8,7 +8,7 @@ import { util as simperiumUtil } from 'simperium';
 
 const typingThrottle = 3000;
 
-var actionMap = new ActionMap({
+export const actionMap = new ActionMap({
   namespace: 'App',
 
   initialState: {
@@ -448,7 +448,7 @@ var actionMap = new ActionMap({
           const note = state.notes.find(n => n.id === noteId);
 
           if (!note) {
-            console.error(`Cannot find note (id=${noteId})!`);
+            console.error(`Cannot find note (id=${noteId})!`); // eslint-disable-line no-console
             return;
           }
 
@@ -579,7 +579,7 @@ var actionMap = new ActionMap({
         return dispatch => {
           noteBucket.getRevisions(note.id, (e, revisions) => {
             if (e) {
-              return console.warn('Failed to load revisions', e);
+              return console.warn('Failed to load revisions', e); // eslint-disable-line no-console
             }
 
             dispatch(this.action('noteRevisionsLoaded', { revisions }));

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -176,6 +176,7 @@ export const NoteEditor = React.createClass({
         {!isTrashed && (
           <TagField
             allTags={this.props.allTags.map(property('data.name'))}
+            note={this.props.note}
             tags={tags}
             onUpdateNoteTags={this.props.onUpdateNoteTags.bind(null, note)}
           />

--- a/lib/tag-field.jsx
+++ b/lib/tag-field.jsx
@@ -1,9 +1,10 @@
 import React, { PropTypes } from 'react';
+import isEmailTag from './utils/is-email-tag';
 import TagChip from './components/tag-chip';
 import TagInput from './tag-input';
 import classNames from 'classnames';
 import analytics from './analytics';
-import { differenceBy, intersectionBy, invoke, union } from 'lodash';
+import { differenceBy, intersectionBy, invoke, negate, union } from 'lodash';
 
 export default React.createClass({
   propTypes: {
@@ -161,14 +162,16 @@ export default React.createClass({
             tabIndex="-1"
             ref={this.storeHiddenTag}
           />
-          {tags.map(tag => (
-            <TagChip
-              key={tag}
-              tag={tag}
-              selected={tag === selectedTag}
-              onSelect={this.selectTag}
-            />
-          ))}
+          {tags
+            .filter(negate(isEmailTag))
+            .map(tag => (
+              <TagChip
+                key={tag}
+                tag={tag}
+                selected={tag === selectedTag}
+                onSelect={this.selectTag}
+              />
+            ))}
           <TagInput
             allTags={allTags}
             inputRef={this.storeInputRef}

--- a/lib/tag-field.jsx
+++ b/lib/tag-field.jsx
@@ -1,5 +1,7 @@
 import React, { PropTypes } from 'react';
+import { Overlay } from 'react-overlays';
 import isEmailTag from './utils/is-email-tag';
+import EmailToolTip from './email-tooltip';
 import TagChip from './components/tag-chip';
 import TagInput from './tag-input';
 import classNames from 'classnames';
@@ -48,6 +50,10 @@ export default React.createClass({
       .replace(/\s+/g, ',')
       .split(',');
 
+    if (newTags.some(isEmailTag)) {
+      this.showEmailTooltip();
+    }
+
     const nextTagList = union(
       existingTags, // tags already in note
       intersectionBy(allTags, newTags, s => s.toLocaleLowerCase()), // use existing case if tag known
@@ -84,22 +90,11 @@ export default React.createClass({
     }
   },
 
-  selectLastTag: function() {
-    this.setState({
-      selectedTag: this.props.tags.slice(-1).shift(),
-    });
+  hideEmailTooltip() {
+    this.setState({ showEmailTooltip: false });
   },
 
-  selectTag(event) {
-    const { target: { dataset: { tagName } } } = event;
-
-    event.preventDefault();
-    event.stopPropagation();
-
-    this.deleteTag(tagName);
-  },
-
-  onKeyDown: function(e) {
+  interceptKeys(e) {
     // only handle backspace
     if (8 !== e.which) {
       return;
@@ -115,6 +110,35 @@ export default React.createClass({
 
     this.selectLastTag();
     e.preventDefault();
+  },
+
+  selectLastTag: function() {
+    this.setState({
+      selectedTag: this.props.tags.slice(-1).shift(),
+    });
+  },
+
+  selectTag(event) {
+    const { target: { dataset: { tagName } } } = event;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.deleteTag(tagName);
+  },
+
+  showEmailTooltip() {
+    this.setState({ showEmailTooltip: true });
+
+    setTimeout(() => this.setState({ showEmailTooltip: false }), 5000);
+  },
+
+  onKeyDown: function(e) {
+    if (this.state.showEmailTooltip) {
+      this.hideEmailTooltip();
+    }
+
+    return this.interceptKeys(e);
   },
 
   storeHiddenTag(r) {
@@ -146,7 +170,7 @@ export default React.createClass({
 
   render: function() {
     const { allTags, tags } = this.props;
-    const { selectedTag, tagInput } = this.state;
+    const { selectedTag, showEmailTooltip, tagInput } = this.state;
 
     return (
       <div className="tag-entry theme-color-border">
@@ -180,6 +204,17 @@ export default React.createClass({
             onSelect={this.addTag}
             tagNames={differenceBy(allTags, tags, s => s.toLocaleLowerCase())}
           />
+          <Overlay
+            container={this}
+            onHide={this.hideEmailTooltip}
+            placement="top"
+            rootClose={true}
+            shouldUpdatePosition={true}
+            show={showEmailTooltip}
+            target={this.tagInput}
+          >
+            <EmailToolTip note={this.props.note} />
+          </Overlay>
         </div>
       </div>
     );

--- a/lib/utils/export/index.js
+++ b/lib/utils/export/index.js
@@ -10,18 +10,12 @@ import {
   uniqueId,
 } from 'lodash';
 
-export const LF_ONLY_NEWLINES = /(?!\r)\n/g;
-
-// needs three pieces
-//  - a mailbox without an `@`
-//  - an `@`
-//  - domain with at least `host.tld`
-const naiveEmailPattern = /[^@]+@[^.]+\.[^.]+/;
+import isEmailTag from '../is-email-tag';
 
 const mapNote = note => {
   const [collaboratorEmails, tags] = partition(
     sortBy(get(note, 'data.tags', []), a => a.toLocaleLowerCase()),
-    tag => naiveEmailPattern.test(tag)
+    isEmailTag
   );
 
   return Object.assign(

--- a/lib/utils/export/index.js
+++ b/lib/utils/export/index.js
@@ -12,6 +12,8 @@ import {
 
 import isEmailTag from '../is-email-tag';
 
+export const LF_ONLY_NEWLINES = /(?!\r)\n/g;
+
 const mapNote = note => {
   const [collaboratorEmails, tags] = partition(
     sortBy(get(note, 'data.tags', []), a => a.toLocaleLowerCase()),

--- a/lib/utils/is-email-tag.js
+++ b/lib/utils/is-email-tag.js
@@ -1,0 +1,33 @@
+/**
+ * @module utils/is-email-tag
+ */
+
+/**
+ * Naively matches what might appear to be an email address
+ *
+ * This is not spec-compliant but it does not need to
+ * be. Users of the app should assume that any tag
+ * name which has the general appearance of a valid
+ * email address will be treated as if they are actual
+ * email addresses and will be used for adding people
+ * to a note as collaborators.
+ *
+ * Three main components are required:
+ *   1. Mailbox piece _before_ the `@`
+ *   2. `@`
+ *   3. Host and domain piece ending in `[some host].[some TLD]`
+ *
+ * @type {RegExp}
+ */
+const naiveEmailPattern = /^(?:[^@]+)@(?:.+)(?:\.[^.]{2,})$/;
+
+/**
+ * Indicates if a given tag name string
+ * represents an email for collaboration
+ *
+ * @param {String} tagName name of tag which might be an email address
+ * @returns {Boolean} whether or not the tag is considered an email address
+ */
+export const isEmailTag = tagName => naiveEmailPattern.test(tagName);
+
+export default isEmailTag;

--- a/lib/utils/test/is-email-tag.js
+++ b/lib/utils/test/is-email-tag.js
@@ -1,0 +1,50 @@
+import isEmailTag from '../is-email-tag';
+
+describe('Utils', () => {
+  describe('#isEmailTag', () => {
+    expect.extend({
+      toBeAnEmail(received) {
+        const pass = isEmailTag(received);
+
+        return {
+          pass,
+          message: () =>
+            `${this.utils.matcherHint(
+              `${pass ? '.not' : ''}.toBeAnEmail`,
+              '',
+              '',
+              { secondArgument: false }
+            )}\n\n` +
+            `Expected value to${pass ? ' not' : ''} be an email address\n` +
+            `  ${this.utils.printReceived(received)}`,
+        };
+      },
+    });
+
+    it('should not match when no `@` present', () => {
+      ['test', 'test.at.test.com', 'tester.com'].forEach(tag =>
+        expect(tag).not.toBeAnEmail()
+      );
+    });
+
+    it('should not match when no domain is present', () => {
+      ['test@', 'test@host', 'test.com@host.', 'test@host.test.'].forEach(tag =>
+        expect(tag).not.toBeAnEmail()
+      );
+    });
+
+    it('should require at least a two-letter TLD', () => {
+      expect('a@b.c').not.toBeAnEmail();
+    });
+
+    it('should match valid email addresses', () => {
+      ['test@test.com', 'test@test.server.local.com', 'a@b.io'].forEach(tag =>
+        expect(tag).toBeAnEmail()
+      );
+    });
+
+    it('should match even with multiple `@`s', () => {
+      expect('test@inbox@host.domain.com').toBeAnEmail();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "browserslist": ["Chrome >= 58"],
   "jest": {
-    "rootDir": "lib"
+    "rootDir": "lib",
+    "testRegex": "(/test/.*\\.jsx?)|(test\\.jsx?)$"
   },
   "prettier": {
     "bracketSpacing": true,

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "react": "15.6.1",
     "react-addons-shallow-compare": "15.6.0",
     "react-addons-update": "15.6.0",
+    "react-overlays": "0.8.0",
     "react-redux": "5.0.6",
     "react-virtualized": "9.9.0",
     "redux": "3.7.2",

--- a/scss/tag-editor.scss
+++ b/scss/tag-editor.scss
@@ -76,34 +76,34 @@
 }
 
 .tag-email-tooltip {
-	position: absolute;
-	bottom: 40px;
-	padding: 5px 0;
-	max-width: 360px;
-	margin-left: 20px;
-	margin-right: 20px;
-	z-index: 100000;
-	opacity: 0.99999;
+  position: absolute;
+  bottom: 40px;
+  padding: 5px 0;
+  max-width: 360px;
+  margin-left: 20px;
+  margin-right: 20px;
+  z-index: 100000;
+  opacity: 0.99999;
 }
 
 .tag-email-tooltip__arrow {
-	position: absolute;
-	width: 0;
-	height: 0;
-	border: solid transparent;
-	opacity: .75;
-	bottom: 0;
-	left: 50px;
-	margin-left: -5px;
-	border-width: 5px 5px 0;
-	border-top-color: #000;
+  position: absolute;
+  width: 0;
+  height: 0;
+  border: solid transparent;
+  opacity: 0.75;
+  bottom: 0;
+  left: 50px;
+  margin-left: -5px;
+  border-width: 5px 5px 0;
+  border-top-color: #000;
 }
 
 .tag-email-tooltip__inside {
-	padding: 6px 8px;
-	color: #fff;
-	text-align: center;
-	border-radius: 3px;
-	background-color: #000;
-	opacity: .75;
+  padding: 6px 8px;
+  color: #fff;
+  text-align: center;
+  border-radius: 3px;
+  background-color: #000;
+  opacity: 0.75;
 }

--- a/scss/tag-editor.scss
+++ b/scss/tag-editor.scss
@@ -74,3 +74,36 @@
     background: transparent;
   }
 }
+
+.tag-email-tooltip {
+	position: absolute;
+	bottom: 40px;
+	padding: 5px 0;
+	max-width: 360px;
+	margin-left: 20px;
+	margin-right: 20px;
+	z-index: 100000;
+	opacity: 0.99999;
+}
+
+.tag-email-tooltip__arrow {
+	position: absolute;
+	width: 0;
+	height: 0;
+	border: solid transparent;
+	opacity: .75;
+	bottom: 0;
+	left: 50px;
+	margin-left: -5px;
+	border-width: 5px 5px 0;
+	border-top-color: #000;
+}
+
+.tag-email-tooltip__inside {
+	padding: 6px 8px;
+	color: #fff;
+	text-align: center;
+	border-radius: 3px;
+	background-color: #000;
+	opacity: .75;
+}


### PR DESCRIPTION
Resolves #143

Previously there was a mismatch between the native macOS app and this
app in how email tags were handled. In the native app if a tag contained
something like an email address it is hidden from the list of tags but
in the Electron app it has been shown in the tag list.

Now the behavior has been matched and in this patch we have normalized
all the places which are checking if a tag contains an email address by
using a new utility `utils/is-email-tag#isEmailTag( tagName )`

**Testing**
Try adding email addresses to the tag field. In this branch we can still add collaborators to a note by doing this. The tag will immediately disappear though and a popup should appear notifying you to use the collaboration tab in the sharing pane/page.

Try adding collaborators through the share dialog. The email addresses should not appear in the tag list.

Try exporting the notes and make sure that the right tags or collaborator email addresses appear in the export. The `source/notes.json` file is particularly helpful for this.

![addingemailtags](https://user-images.githubusercontent.com/5431237/29875158-ef0200c0-8d90-11e7-87d3-5a4b9cd36d52.gif)
