### PR TITLE
Fix naming of search input field.

### DIFF
--- a/lib/search-field.jsx
+++ b/lib/search-field.jsx
@@ -17,8 +17,8 @@ export class SearchField extends Component {
 	componentDidUpdate() {
 		const { searchFocus, onSearchFocused } = this.props;
 
-		if ( searchFocus && this.searchField ) {
-			searchField.focus();
+		if ( searchFocus && this.inputField ) {
+			this.inputField.focus();
 			onSearchFocused();
 		}
 	}


### PR DESCRIPTION
Looks like somewhere along the way the variable tied to the search field was renamed. This PR matches up the naming.

**To test**
Open in electron, and press cmd or ctrl + f, the cursor should move to the search field.

Fixes #507.