### PR TITLE
added regexp  to remove initial '#' characters from title and preview…

### DIFF
--- a/lib/utils/note-title.js
+++ b/lib/utils/note-title.js
@@ -13,14 +13,21 @@ const noteTitleAndPreviewRegExp = /(\S[^\n]*)\s*(\S[^\n]*)?/;
  * Returns the title and excerpt for a given note
  *
  * @param {Object} note a note object
+ *
+ * Markdown title syntax characters (#) are stripped from
+ * the start of the lines.
+ *
  * @returns {Object} title and excerpt (if available)
  */
 export const noteTitleAndPreview = note => {
 	const content = note && note.data && note.data.content;
 	const match = noteTitleAndPreviewRegExp.exec( content || '' );
 
-	const title = match && match[1] && match[1].slice( 0, 200 ) || 'New note...';
-	const preview = match && match[2] || '';
+	const unstrippedTitle = match && match[1] && match[1].slice( 0, 200 ) || 'New note...';
+	const unstrippedPreview = match && match[2] || '';
+
+	const title = unstrippedTitle.replace( /^[#]+/, '' );
+	const preview = unstrippedPreview.replace( /^[#]+/, '' );
 
 	return { title, preview };
 };


### PR DESCRIPTION
… so that markdown syntax characters are not shown in the left sidebar note list

in order to keep it simple, this stripping of # characters is in operation for **all** notes (even ones that are not in Markdown) because otherwise there'd be a need for logic outside of `lib/utils/note-title.js` in order to detect whether the note was in Markdown mode or not.

``` 
note content:                                   returns:
# valid markdown h1 title                       match => valid markdown h1 title
#hashtag at start of a title                 no match => #hashtag at start of a title     
## valid markdown h2 title                      match => valid markdown h2 title
# markdown title with a #hashtag in it     part match => markdown title with a #hashtag in it
# title with a # randomly in it            part match => title with a # randomly in it
```

Hopefully this will allow Markdown users to have a nice clean view of the list of notes, without interfering with anything that non-markdown users might be doing, or preventing the use of hashtags in titles.

Marcus