### PR TITLE
Copy note content: replace \n with \r\n to keep line breaks on Windows

### DIFF
--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -7,6 +7,7 @@ import {
 } from 'draft-js';
 import { includes, invoke, noop } from 'lodash';
 
+import { CRLF_NEWLINE, LF_ONLY_NEWLINES } from './utils/export';
 import matchingTextDecorator from './editor/matching-text-decorator';
 
 function plainTextContent( editorState ) {
@@ -169,7 +170,7 @@ export default class NoteContentEditor extends React.Component {
 		if ( event.path.filter( elem => includes( elem.className, 'note-detail-textarea' ) ).length ) {
 			const selectedText = window.getSelection().toString();
 			// Replace \n with \r\n to keep line breaks on Windows
-			event.clipboardData.setData( 'text/plain', selectedText.replace( /(?!\r)\n/g, '\r\n' ) );
+			event.clipboardData.setData( 'text/plain', selectedText.replace( LF_ONLY_NEWLINES, CRLF_NEWLINE ) );
 			event.clipboardData.setData( 'text/html', selectedText.replace( /(?:\r\n|\r|\n)/g, '<br />' ) );
 			event.preventDefault();
 		}

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -7,7 +7,7 @@ import {
 } from 'draft-js';
 import { includes, invoke, noop } from 'lodash';
 
-import { CRLF_NEWLINE, LF_ONLY_NEWLINES } from './utils/export';
+import { LF_ONLY_NEWLINES } from './utils/export';
 import matchingTextDecorator from './editor/matching-text-decorator';
 
 function plainTextContent( editorState ) {
@@ -170,7 +170,7 @@ export default class NoteContentEditor extends React.Component {
 		if ( event.path.filter( elem => includes( elem.className, 'note-detail-textarea' ) ).length ) {
 			const selectedText = window.getSelection().toString();
 			// Replace \n with \r\n to keep line breaks on Windows
-			event.clipboardData.setData( 'text/plain', selectedText.replace( LF_ONLY_NEWLINES, CRLF_NEWLINE ) );
+			event.clipboardData.setData( 'text/plain', selectedText.replace( LF_ONLY_NEWLINES, '\r\n' ) );
 			event.clipboardData.setData( 'text/html', selectedText.replace( /(?:\r\n|\r|\n)/g, '<br />' ) );
 			event.preventDefault();
 		}

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -168,7 +168,8 @@ export default class NoteContentEditor extends React.Component {
 	stripFormattingFromSelectedText( event ) {
 		if ( event.path.filter( elem => includes( elem.className, 'note-detail-textarea' ) ).length ) {
 			const selectedText = window.getSelection().toString();
-			event.clipboardData.setData( 'text/plain', selectedText );
+			// Replace \n with \r\n to keep line breaks on Windows
+			event.clipboardData.setData( 'text/plain', selectedText.replace( /(?!\r)\n/g, '\r\n' ) );
 			event.clipboardData.setData( 'text/html', selectedText.replace( /(?:\r\n|\r|\n)/g, '<br />' ) );
 			event.preventDefault();
 		}

--- a/lib/utils/export/index.js
+++ b/lib/utils/export/index.js
@@ -10,7 +10,6 @@ import {
 	uniqueId,
 } from 'lodash';
 
-export const CRLF_NEWLINE = '\r\n';
 export const LF_ONLY_NEWLINES = /(?!\r)\n/g;
 
 // needs three pieces
@@ -31,7 +30,7 @@ const mapNote = note => {
 	return Object.assign(
 		{
 			id: get( note, 'id', uniqueId( 'unknown_note_' ) ),
-			content: get( note, 'data.content', '' ).replace( LF_ONLY_NEWLINES, CRLF_NEWLINE ),
+			content: get( note, 'data.content', '' ).replace( LF_ONLY_NEWLINES, '\r\n' ),
 			creationDate: ( new Date( note.data.creationDate * 1000 ) ).toISOString(),
 			lastModified: ( new Date( note.data.modificationDate * 1000 ) ).toISOString(),
 		},

--- a/lib/utils/export/index.js
+++ b/lib/utils/export/index.js
@@ -10,6 +10,9 @@ import {
 	uniqueId,
 } from 'lodash';
 
+export const CRLF_NEWLINE = '\r\n';
+export const LF_ONLY_NEWLINES = /(?!\r)\n/g;
+
 // needs three pieces
 //  - a mailbox without an `@`
 //  - an `@`
@@ -28,7 +31,7 @@ const mapNote = note => {
 	return Object.assign(
 		{
 			id: get( note, 'id', uniqueId( 'unknown_note_' ) ),
-			content: get( note, 'data.content', '' ).replace( /(?!\r)\n/g, '\r\n' ),
+			content: get( note, 'data.content', '' ).replace( LF_ONLY_NEWLINES, CRLF_NEWLINE ),
 			creationDate: ( new Date( note.data.creationDate * 1000 ) ).toISOString(),
 			lastModified: ( new Date( note.data.modificationDate * 1000 ) ).toISOString(),
 		},

--- a/lib/utils/export/index.js
+++ b/lib/utils/export/index.js
@@ -28,7 +28,7 @@ const mapNote = note => {
 	return Object.assign(
 		{
 			id: get( note, 'id', uniqueId( 'unknown_note_' ) ),
-			content: get( note, 'data.content', '' ),
+			content: get( note, 'data.content', '' ).replace( /(?!\r)\n/g, '\r\n' ),
 			creationDate: ( new Date( note.data.creationDate * 1000 ) ).toISOString(),
 			lastModified: ( new Date( note.data.modificationDate * 1000 ) ).toISOString(),
 		},

--- a/lib/utils/export/to-zip.js
+++ b/lib/utils/export/to-zip.js
@@ -2,6 +2,8 @@ import JSZip from 'jszip';
 import sanitize from 'sanitize-filename';
 import { identity, update } from 'lodash';
 
+import { CRLF_NEWLINE, LF_ONLY_NEWLINES } from './';
+
 const FILENAME_LENGTH = 40;
 const TAG_LINE_LENGTH = 75;
 
@@ -96,7 +98,7 @@ const toUniqueNames = ( [ notes, nameCounts ], note ) => {
 export const noteExportToZip = notes => {
 	const zip = new JSZip();
 
-	zip.file( 'source/notes.json', JSON.stringify( notes, null, 2 ) );
+	zip.file( 'source/notes.json', JSON.stringify( notes, null, 2 ).replace( LF_ONLY_NEWLINES, CRLF_NEWLINE ) );
 
 	notes
 		.activeNotes

--- a/lib/utils/export/to-zip.js
+++ b/lib/utils/export/to-zip.js
@@ -2,7 +2,7 @@ import JSZip from 'jszip';
 import sanitize from 'sanitize-filename';
 import { identity, update } from 'lodash';
 
-import { CRLF_NEWLINE, LF_ONLY_NEWLINES } from './';
+import { LF_ONLY_NEWLINES } from './';
 
 const FILENAME_LENGTH = 40;
 const TAG_LINE_LENGTH = 75;
@@ -98,7 +98,7 @@ const toUniqueNames = ( [ notes, nameCounts ], note ) => {
 export const noteExportToZip = notes => {
 	const zip = new JSZip();
 
-	zip.file( 'source/notes.json', JSON.stringify( notes, null, 2 ).replace( LF_ONLY_NEWLINES, CRLF_NEWLINE ) );
+	zip.file( 'source/notes.json', JSON.stringify( notes, null, 2 ).replace( LF_ONLY_NEWLINES, '\r\n' ) );
 
 	notes
 		.activeNotes


### PR DESCRIPTION
Fixes https://github.com/Automattic/simplenote-electron/issues/512

This PR fixes a bug introduced in https://github.com/Automattic/simplenote-electron/pull/480, where artificially filling the clipboard didn't took into consideration the Windows newline quirks.

## Testing instructions

1. Open Simplenote on Windows.
2. Select and copy a note content spanning multiple line breaks.
3. Paste it on Notepad.

The pasted text should have all the line breaks were expected.

I'd appreciate a quick test on Windows, since I'm not currently able to do it.