### PR TITLE
Fix minimatch dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "classnames": "2.2.5",
     "css-loader": "0.26.1",
     "electron": "1.4.13",
-    "electron-builder": "2.8.4",
+    "electron-builder": "16.7.1",
     "electron-packager": "7.5.1",
     "enzyme": "2.7.0",
     "eslint": "3.12.2",


### PR DESCRIPTION
Resolves one of three dependency issues in #357 

No errors thrown in my installation, but I don't have syncing set up, etc. and can use some outside testing