### PR TITLE
NoteEditor: Redux refactor [1] - Revisions state and selectors

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -389,7 +389,6 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 								allTags={ state.tags }
 								editorMode={state.editorMode}
 								filter={state.filter}
-								revisions={state.revisions}
 								onSetEditorMode={this.onSetEditorMode}
 								onUpdateContent={this.onUpdateContent}
 								onUpdateNoteTags={this.onUpdateNoteTags}

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -334,14 +334,6 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 		} );
 	},
 
-	onRevisions: function( note ) {
-		this.props.actions.noteRevisions( {
-			noteBucket: this.props.noteBucket,
-			note
-		} );
-		analytics.tracks.recordEvent( 'editor_versions_accessed' );
-	},
-
 	render: function() {
 		const {
 			appState: state,
@@ -393,6 +385,7 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 								<NoteList noteBucket={ noteBucket } />
 							</div>
 							<NoteEditor
+								noteBucket={ noteBucket }
 								allTags={ state.tags }
 								editorMode={state.editorMode}
 								filter={state.filter}
@@ -404,7 +397,6 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 								onRestoreNote={this.onRestoreNote}
 								onShareNote={this.onShareNote}
 								onDeleteNoteForever={this.onDeleteNoteForever}
-								onRevisions={this.onRevisions}
 								onCloseNote={() => this.props.actions.closeNote()}
 								onNoteInfo={() => this.props.actions.toggleNoteInfo()}
 								shouldPrint={state.shouldPrint}

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -396,7 +396,6 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 								allTags={ state.tags }
 								editorMode={state.editorMode}
 								filter={state.filter}
-								note={selectedNote}
 								revisions={state.revisions}
 								onSetEditorMode={this.onSetEditorMode}
 								onUpdateContent={this.onUpdateContent}

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -1,15 +1,17 @@
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 import highlight from 'highlight.js';
 import marked from 'marked';
 import { get, debounce, invoke } from 'lodash';
 import analytics from './analytics';
 import { viewExternalUrl } from './utils/url-utils';
 import NoteContentEditor from './note-content-editor';
+import getActiveNote from './utils/get-active-note';
 
 const saveDelay = 2000;
 const highlighter = code => highlight.highlightAuto( code ).value;
 
-export default React.createClass( {
+export const NoteDetail = React.createClass( {
 
 	propTypes: {
 		note: PropTypes.object,
@@ -110,3 +112,15 @@ export default React.createClass( {
 		);
 	},
 } );
+
+const mapStateToProps = ( {
+	appState: state,
+	revision: { selectedRevision },
+} ) => {
+	const revision = selectedRevision || getActiveNote( state );
+	return {
+		note: revision,
+	};
+};
+
+export default connect( mapStateToProps )( NoteDetail );

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -116,11 +116,8 @@ export const NoteDetail = React.createClass( {
 const mapStateToProps = ( {
 	appState: state,
 	revision: { selectedRevision },
-} ) => {
-	const revision = selectedRevision || getActiveNote( state );
-	return {
-		note: revision,
-	};
-};
+} ) => ( {
+	note: selectedRevision || getActiveNote( state ),
+} );
 
 export default connect( mapStateToProps )( NoteDetail );

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -61,10 +61,11 @@ export const NoteEditor = React.createClass( {
 		const {
 			editorMode,
 			note,
-			selectedRevision: revision,
+			selectedRevision,
 			fontSize,
 			shouldPrint,
 		} = this.props;
+		const revision = selectedRevision || note;
 		const tags = revision && revision.data && revision.data.tags || [];
 		const isTrashed = !!( note && note.data.deleted );
 
@@ -73,7 +74,7 @@ export const NoteEditor = React.createClass( {
 			revision.data.systemTags.indexOf( 'markdown' ) !== -1;
 
 		const classes = classNames( 'note-editor', 'theme-color-bg', 'theme-color-fg', {
-			revisions: revision,
+			revisions: selectedRevision,
 			markdown: markdownEnabled
 		} );
 

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -24,7 +24,6 @@ export const NoteEditor = React.createClass( {
 		onRestoreNote: PropTypes.func.isRequired,
 		onShareNote: PropTypes.func.isRequired,
 		onDeleteNoteForever: PropTypes.func.isRequired,
-		onRevisions: PropTypes.func.isRequired,
 		onCloseNote: PropTypes.func.isRequired,
 		onNoteInfo: PropTypes.func.isRequired,
 		onPrintNote: PropTypes.func
@@ -116,12 +115,11 @@ export const NoteEditor = React.createClass( {
 				/>
 				<div className="note-editor-controls theme-color-border">
 					<NoteToolbar
-						note={note}
+						noteBucket={ this.props.noteBucket }
 						onTrashNote={this.props.onTrashNote}
 						onRestoreNote={this.props.onRestoreNote}
 						onShareNote={this.props.onShareNote}
 						onDeleteNoteForever={this.props.onDeleteNoteForever}
-						onRevisions={this.props.onRevisions}
 						setIsViewingRevisions={this.setIsViewingRevisions}
 						onCloseNote={this.props.onCloseNote}
 						onNoteInfo={this.props.onNoteInfo} />

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -144,7 +144,6 @@ export const NoteEditor = React.createClass( {
 					<div className="note-editor-detail">
 						<NoteDetail
 							filter={this.props.filter}
-							note={revision}
 							previewingMarkdown={markdownEnabled && editorMode === 'markdown'}
 							onChangeContent={this.props.onUpdateContent}
 							fontSize={fontSize} />

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -8,13 +8,11 @@ import RevisionSelector from './revision-selector'
 import marked from 'marked'
 import { get, property } from 'lodash'
 import getActiveNote from './utils/get-active-note';
-import { selectRevision } from './state/revision/actions';
 
 export const NoteEditor = React.createClass( {
 	propTypes: {
 		editorMode: PropTypes.oneOf( [ 'edit', 'markdown' ] ),
 		note: PropTypes.object,
-		revisions: PropTypes.array,
 		fontSize: PropTypes.number,
 		shouldPrint: PropTypes.bool,
 		onSetEditorMode: PropTypes.func.isRequired,
@@ -40,33 +38,12 @@ export const NoteEditor = React.createClass( {
 		};
 	},
 
-	componentWillReceiveProps: function() {
-		this.setState( { revision: null } );
-	},
-
-	getInitialState: function() {
-		return {
-			revision: null,
-			isViewingRevisions: false
-		}
-	},
-
 	componentDidUpdate: function() {
 		// Immediately print once `shouldPrint` has been set
 		if ( this.props.shouldPrint ) {
 			window.print();
 			this.props.onNotePrinted();
 		}
-	},
-
-	onViewRevision: function( revision ) {
-		this.setState( { revision: revision } );
-	},
-
-	onCancelRevision: function() {
-		// clear out the revision
-		this.setState( { revision: null } );
-		this.setIsViewingRevisions( false );
 	},
 
 	setEditorMode( event ) {
@@ -79,14 +56,10 @@ export const NoteEditor = React.createClass( {
 		this.props.onSetEditorMode( editorMode );
 	},
 
-	setIsViewingRevisions: function( isViewing ) {
-		this.setState( { isViewingRevisions: isViewing } );
-	},
-
 	render: function() {
 		let noteContent = '';
 		const { editorMode, note, selectedRevision, fontSize, shouldPrint } = this.props;
-		const revision = this.state.revision || note;
+		const revision = selectedRevision;
 		const tags = revision && revision.data && revision.data.tags || [];
 		const isTrashed = !!( note && note.data.deleted );
 
@@ -120,7 +93,6 @@ export const NoteEditor = React.createClass( {
 						onRestoreNote={this.props.onRestoreNote}
 						onShareNote={this.props.onShareNote}
 						onDeleteNoteForever={this.props.onDeleteNoteForever}
-						setIsViewingRevisions={this.setIsViewingRevisions}
 						onCloseNote={this.props.onCloseNote}
 						onNoteInfo={this.props.onNoteInfo} />
 				</div>
@@ -194,8 +166,4 @@ const mapStateToProps = ( {
 	};
 };
 
-const mapDispatchToProps = dispatch => ( {
-	onCancelRevision: () => dispatch( selectRevision( null ) ),
-} );
-
-export default connect( mapStateToProps, mapDispatchToProps )( NoteEditor );
+export default connect( mapStateToProps )( NoteEditor );

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -58,8 +58,13 @@ export const NoteEditor = React.createClass( {
 
 	render: function() {
 		let noteContent = '';
-		const { editorMode, note, selectedRevision, fontSize, shouldPrint } = this.props;
-		const revision = selectedRevision;
+		const {
+			editorMode,
+			note,
+			selectedRevision: revision,
+			fontSize,
+			shouldPrint,
+		} = this.props;
 		const tags = revision && revision.data && revision.data.tags || [];
 		const isTrashed = !!( note && note.data.deleted );
 
@@ -68,7 +73,7 @@ export const NoteEditor = React.createClass( {
 			revision.data.systemTags.indexOf( 'markdown' ) !== -1;
 
 		const classes = classNames( 'note-editor', 'theme-color-bg', 'theme-color-fg', {
-			revisions: selectedRevision,
+			revisions: revision,
 			markdown: markdownEnabled
 		} );
 

--- a/lib/note-info.jsx
+++ b/lib/note-info.jsx
@@ -6,7 +6,7 @@ import CrossIcon from './icons/cross';
 import { connect } from 'react-redux';
 import appState from './flux/app-state';
 import { setMarkdown } from './state/settings/actions';
-import filterNotes from './utils/filter-notes';
+import getActiveNote from './utils/get-active-note';
 
 export const NoteInfo = React.createClass( {
 
@@ -160,9 +160,7 @@ const {
 } = appState.actionCreators;
 
 const mapStateToProps = ( { appState: state } ) => {
-	const filteredNotes = filterNotes( state );
-	const noteIndex = Math.max( state.previousIndex, 0 );
-	const note = state.note ? state.note : filteredNotes[ noteIndex ];
+	const note = getActiveNote( state );
 	return {
 		note,
 		isMarkdown: note.data.systemTags.includes( 'markdown' ),

--- a/lib/note-toolbar.jsx
+++ b/lib/note-toolbar.jsx
@@ -1,11 +1,19 @@
 import React, { PropTypes } from 'react'
+import { connect } from 'react-redux';
 import BackIcon from './icons/back'
 import InfoIcon from './icons/info'
 import RevisionsIcon from './icons/revisions'
 import TrashIcon from './icons/trash'
 import ShareIcon from './icons/share'
+import appState from './flux/app-state';
+import { tracks } from './analytics'
+import getActiveNote from './utils/get-active-note';
+import { selectRevision } from './state/revision/actions';
 
-export default React.createClass( {
+const { noteRevisions } = appState.actionCreators;
+const { recordEvent } = tracks;
+
+export const NoteToolbar = React.createClass( {
 
 	propTypes: {
 		note: PropTypes.object,
@@ -20,7 +28,6 @@ export default React.createClass( {
 	},
 
 	showRevisions: function() {
-		this.props.setIsViewingRevisions( true );
 		this.props.onRevisions( this.props.note );
 	},
 
@@ -57,3 +64,17 @@ export default React.createClass( {
 	}
 
 } );
+
+const mapStateToProps = ( { appState: state } ) => ( {
+	note: getActiveNote( state ),
+} );
+
+const mapDispatchToProps = ( dispatch, { noteBucket } ) => ( {
+	onRevisions: note => {
+		dispatch( noteRevisions( { noteBucket, note } ) );
+		dispatch( selectRevision( note ) );
+		recordEvent( 'editor_note_restored' );
+	},
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( NoteToolbar );

--- a/lib/note-toolbar.jsx
+++ b/lib/note-toolbar.jsx
@@ -24,7 +24,6 @@ export const NoteToolbar = React.createClass( {
 		onShareNote: PropTypes.func.isRequired,
 		onCloseNote: PropTypes.func.isRequired,
 		onNoteInfo: PropTypes.func.isRequired,
-		setIsViewingRevisions: PropTypes.func.isRequired
 	},
 
 	showRevisions: function() {

--- a/lib/revision-selector.jsx
+++ b/lib/revision-selector.jsx
@@ -1,6 +1,9 @@
 import React, { PropTypes } from 'react'
+import { connect } from 'react-redux';
 import moment from 'moment'
 import { orderBy } from 'lodash';
+import getActiveNote from './utils/get-active-note';
+import { selectRevision } from './state/revision/actions';
 
 const sortedRevisions = revisions =>
 	orderBy( revisions, 'data.modificationDate', 'asc' );
@@ -59,7 +62,17 @@ export const RevisionSelector = React.createClass( {
 			selection,
 		} = this.state;
 
-		this.props.onSelectRevision( revisions[ selection ] );
+		if ( revisions[ selection ] ) {
+			const {
+				note,
+				onCancelRevision,
+				onUpdateContent,
+			} = this.props;
+			const { data: { content } } = revisions[ selection ];
+
+			onUpdateContent( note, content );
+			onCancelRevision();
+		}
 		this.resetSelection();
 	},
 
@@ -131,4 +144,17 @@ RevisionSelector.propTypes = {
 	revisions: PropTypes.array.isRequired,
 };
 
-export default RevisionSelector;
+const mapStateToProps = ( { appState: state } ) => {
+	const note = getActiveNote( state );
+	return {
+		note,
+		revisions: state.revisions || [],
+	}
+};
+
+const mapDispatchToProps = dispatch => ( {
+	onCancelRevision: () => dispatch( selectRevision( null ) ),
+	onViewRevision: revision => dispatch( selectRevision( revision ) ),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( RevisionSelector );

--- a/lib/revision-selector.jsx
+++ b/lib/revision-selector.jsx
@@ -144,13 +144,10 @@ RevisionSelector.propTypes = {
 	revisions: PropTypes.array.isRequired,
 };
 
-const mapStateToProps = ( { appState: state } ) => {
-	const note = getActiveNote( state );
-	return {
-		note,
-		revisions: state.revisions || [],
-	}
-};
+const mapStateToProps = ( { appState: state } ) => ( {
+	note: getActiveNote( state ),
+	revisions: state.revisions || [],
+} );
 
 const mapDispatchToProps = dispatch => ( {
 	onCancelRevision: () => dispatch( selectRevision( null ) ),

--- a/lib/state/action-types.js
+++ b/lib/state/action-types.js
@@ -1,1 +1,2 @@
 export const AUTH_SET = Symbol();
+export const REVISION_SELECT = 'REVISION_SELECT';

--- a/lib/state/index.js
+++ b/lib/state/index.js
@@ -11,11 +11,13 @@ import persistState from 'redux-localstorage';
 import appState from '../flux/app-state';
 
 import auth from './auth/reducer';
+import revision from './revision/reducer';
 import settings from './settings/reducer';
 
 export const reducers = combineReducers( {
 	appState: appState.reducer.bind( appState ),
 	auth,
+	revision,
 	settings,
 } );
 

--- a/lib/state/revision/actions.js
+++ b/lib/state/revision/actions.js
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { REVISION_SELECT } from '../action-types';
+
+export const selectRevision = revision => ( {
+	type: REVISION_SELECT,
+	revision,
+} );

--- a/lib/state/revision/reducer.js
+++ b/lib/state/revision/reducer.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { REVISION_SELECT } from '../action-types';
+
+export const selectedRevision = ( state = null, { type, revision } ) =>
+	REVISION_SELECT === type ? revision : state;
+
+export default combineReducers( {
+	selectedRevision,
+} );

--- a/lib/utils/get-active-note.js
+++ b/lib/utils/get-active-note.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import filterNotes from './filter-notes';
+
+export default function getActiveNote( state ) {
+	if ( state.note ) {
+		return state.note;
+	}
+	const filteredNotes = filterNotes( state );
+	const noteIndex = Math.max( state.previousIndex, 0 );
+	return filteredNotes[ noteIndex ];
+}


### PR DESCRIPTION
First step of the complete NoteEditor refactor (rework of https://github.com/Automattic/simplenote-electron/pull/479).

In this PR we create a new `revisions` Redux subtree and connect it to all the involved components.
In the same effort, we also create a new `getActiveNote` utility to DRY-fy the active note selection.

I've tried my best to keep the code as clean as possible, but still, when reviewing, please disregard the use of some odd conventions (such as not using shorthands even when possible).
Hopefully those oddities will be fixed in the following steps of the refactor or, if needed, in a single final dedicated PR.