### PR TITLE
Add snap install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ A Simplenote [React](https://facebook.github.io/react/) client packaged in [Elec
 * A Simperium account. [Sign up here](https://simperium.com/signup/)
 * A Simperium Application ID and key. [Create a new app here](https://simperium.com/app/new/)
 
+## Installing pre-built Snap
+
+On [snap supported](https://snapcraft.io/docs/core/install) systems, install the pre-built snap from the store.
+
+    snap install simplenote --beta
+
+
 ## Running
 
 1. Clone the repo: `git clone https://github.com/Automattic/simplenote-electron.git`


### PR DESCRIPTION
This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install). Snaps enable ISVs and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Snaps of stable desktop applications will also be available via the desktop Software Center, improving the discoverability of your software. Your software can be installed with a simple `snap install simplenote --beta` simplifying the installation instructions for your users.

Once the snap is released into the stable channel in the store, users no longer need to add the ```--beta``` and will appear in the desktop Software Center
