### PR TITLE
Reset RegExp lastIndex to 0 during filter-note (to resolve #535)

### DIFF
--- a/lib/utils/filter-notes.js
+++ b/lib/utils/filter-notes.js
@@ -3,10 +3,7 @@
  */
 import { escapeRegExp, get, includes, overEvery } from 'lodash';
 
-const includesSearch = ( text, search ) => {
-	search.lastIndex = 0;
-	return search.test( text || '' );
-}
+const includesSearch = ( text, search ) => ( new RegExp( escapeRegExp( search ), 'gi' ) ).test( text || '' );
 
 const matchesTrashView = isViewingTrash => note =>
 	isViewingTrash === !! get( note, 'data.deleted', false );
@@ -29,6 +26,6 @@ export default function filterNotes( state ) {
 		.filter( overEvery( [
 			matchesTrashView( showTrash ),
 			matchesTag( tag ),
-			matchesSearch( new RegExp( escapeRegExp( filter ), 'gi' ) ),
+			matchesSearch( filter ),
 		] ) );
 }

--- a/lib/utils/filter-notes.js
+++ b/lib/utils/filter-notes.js
@@ -3,7 +3,10 @@
  */
 import { escapeRegExp, get, includes, overEvery } from 'lodash';
 
-const includesSearch = ( text, search ) => search.test( text || '' );
+const includesSearch = ( text, search ) => {
+	search.lastIndex = 0;
+	return search.test( text || '' );
+}
 
 const matchesTrashView = isViewingTrash => note =>
 	isViewingTrash === !! get( note, 'data.deleted', false );


### PR DESCRIPTION
Resolves [Search doesn't find all the notes with search term #535](https://github.com/Automattic/simplenote-electron/issues/535)

When It comes to RegExp test with 'g' - global. If it can found a keyword inside a string, it will set the lastIndex to that position. So when we search multiple notes, if it can found a keyword in a note, then the next note RegExp won't start at the beginning but it will use lastIndex (last position in found in the previous note) to be its beginning. So I think we would need to reset the lastIndex to 0.  