### PR TITLE
Set focus tag input whenever the div ContentEditable is rendered to make sure that the caret position will be at the end when typing

### DIFF
--- a/lib/tag-field.jsx
+++ b/lib/tag-field.jsx
@@ -65,7 +65,7 @@ export default React.createClass( {
 	},
 
 	hasSelection: function() {
-		return !! this.state.selectedTag && this.state.selectedTag.length;
+		return this.state.selectedTag && !! this.state.selectedTag.length;
 	},
 
 	deleteTag: function( tagName ) {

--- a/lib/tag-field.jsx
+++ b/lib/tag-field.jsx
@@ -65,7 +65,7 @@ export default React.createClass( {
 	},
 
 	hasSelection: function() {
-		return !! this.state.selectedTag.length;
+		return !! this.state.selectedTag && this.state.selectedTag.length;
 	},
 
 	deleteTag: function( tagName ) {

--- a/lib/tag-input.jsx
+++ b/lib/tag-input.jsx
@@ -128,13 +128,16 @@ export class TagInput extends Component {
 		invoke( event, 'stopPropagation' );
 	};
 
+	componentDidUpdate() {
+		this.focusInput();
+	}
+
 	render() {
 		const {
 			value,
 			tagNames,
 		} = this.props;
 
-		this.focusInput();
 		const suggestion = value.length && tagNames.find( startsWith( value ) );
 
 		return (

--- a/lib/tag-input.jsx
+++ b/lib/tag-input.jsx
@@ -134,6 +134,7 @@ export class TagInput extends Component {
 			tagNames,
 		} = this.props;
 
+		this.focusInput();
 		const suggestion = value.length && tagNames.find( startsWith( value ) );
 
 		return (


### PR DESCRIPTION
This is regarding to the issue #548 I found recently.

Did some research and found an issue on React https://github.com/facebook/react/issues/2047 which relates to this issue.

When a user types into tag-input which mutates the DOM and cause the tag-input to re render then the caret position jumps. So I think we would need to reset it to the end of the string by using focusInput