### PR TITLE
Feature: Toggle the menu bar by pressing the `ALT` key

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -46,6 +46,7 @@ module.exports = function main() {
 			minWidth: 370,
 			minHeight: 520,
 			icon: iconPath,
+			autoHideMenuBar: true,
 			titleBarStyle: 'hidden'
 		} );
 


### PR DESCRIPTION
Hello!
Absolutely love the app! 💓
I thought it would be a nice addition, to be able to toggle the menu bar whenever you need it, just by pressing the <kbd>ALT</kbd> key, especially on Windows and Linux where it might be a bit of a distraction for some people.

All it took was to add and set as **true** the boolean **autoHideMenuBar** option under the **BrowserWindow** class, following the [Electron API docs](https://github.com/electron/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions).

![screen](https://cloud.githubusercontent.com/assets/12670537/26276543/375cc38c-3d82-11e7-9e30-da53d56be9c3.png)

🚀 Tested on **Windows 10 Pro**, **Linux Ubuntu 16.04** & **Mac OS Sierra**!

🔧 It probably covers issue #293 

📷 Here is in action .gif running the windows build!

![in-action](https://cloud.githubusercontent.com/assets/12670537/26276540/17b0521a-3d82-11e7-8312-2a0c03fe74e3.gif)

Hope it's helpful 😄 

