### PR TITLE
Allow usage of the Redux DevTools browser extension.

### DIFF
--- a/lib/state/index.js
+++ b/lib/state/index.js
@@ -21,7 +21,8 @@ export const reducers = combineReducers( {
 
 export const store = createStore( reducers, compose(
 	persistState( 'settings', { key: 'simpleNote' } ),
-	applyMiddleware( thunk )
+	applyMiddleware( thunk ),
+	window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
 ) );
 
 export default store;


### PR DESCRIPTION
This PR will allow the [Redux DevTools browser extension](https://github.com/zalmoxisus/redux-devtools-extension#usage) to work with our Redux store.

**Testing**
* Be sure the [extension](https://github.com/zalmoxisus/redux-devtools-extension) is installed.
* From `master`, note that the Redux panel in DevTools doesn't connect.
* Switch to this PR, and see that the extension has connected.