### PR TITLE
Update build instructions to use dev app and key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules/**/*
 desktop-build/
 dist/
 release/
-/config.*
 *.pvk
 *.spc
 *.tgz

--- a/README.md
+++ b/README.md
@@ -4,26 +4,13 @@
 
 A Simplenote [React](https://facebook.github.io/react/) client packaged in [Electron](http://electron.atom.io). Learn more about Simplenote at [Simplenote.com](https://simplenote.com).
 
-## Development Requirements
-* A Simperium account. [Sign up here](https://simperium.com/signup/)
-* A Simperium Application ID and key. [Create a new app here](https://simperium.com/app/new/)
-
 ## Running
 
 1. Clone the repo: `git clone https://github.com/Automattic/simplenote-electron.git`
-2. Create a new file in the root directory, named `config.json`
-3. Add the Simplenote application id and token to `config.json`
-
-```json
-{
-  "app_id":     "your-app-id",
-  "app_key":    "yourappkey"
-}
-```
-
-4. `npm install` _or_ `docker-compose up install` (if Docker installed)
-5. `npm start` _or_ `docker-compose up dev` (if Docker installed)
-6. Open http://localhost:4000. You can sign in to the app with your Simperium credentials.
+2. `npm install` _or_ `docker-compose up install` (if Docker installed)
+3. `npm start` _or_ `docker-compose up dev` (if Docker installed)
+4. Open http://localhost:4000.
+5. Sign up for a new account within the app. Use the account for **testing purposes only** as all note data will be periodically cleared out on the server.
 
 _Note: Simplenote API features such as sharing and publishing will not work with development builds._
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "app_id":     "history-analyst-dad",
+  "app_key":    "be606bcfa3db4377bf488900281aa1cc"
+}


### PR DESCRIPTION
This PR adds a hard coded dev app key to the app so that developers will not need to create a Simperium account and app in order to build and test the app.