### PR TITLE
Add support for creating accounts directly from the app

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -118,12 +118,14 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 		noteBucket: PropTypes.object.isRequired,
 		tagBucket: PropTypes.object.isRequired,
 		onAuthenticate: PropTypes.func.isRequired,
+		onCreateUser: PropTypes.func.isRequired,
 		onSignOut: PropTypes.func.isRequired,
 	},
 
 	getDefaultProps: function() {
 		return {
 			onAuthenticate: () => {},
+			onCreateUser: () => {},
 			onSignOut: () => {}
 		};
 	},
@@ -419,6 +421,7 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 						authPending={ authIsPending }
 						isAuthenticated={ isAuthorized }
 						onAuthenticate={ this.props.onAuthenticate }
+						onCreateUser={ this.props.onCreateUser }
 						isMacApp={ isMacApp }
 					/>
 				}

--- a/lib/auth.jsx
+++ b/lib/auth.jsx
@@ -188,4 +188,4 @@ const mapStateToProps = state => ( {
 	hasLoginError: hasLoginError( state ),
 } );
 
-export default connect( mapStateToProps, null, null, { pure: false } )( Auth );
+export default connect( mapStateToProps )( Auth );

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -117,6 +117,28 @@ let props = {
 				}
 			} );
 	},
+	onCreateUser: ( username, password ) => {
+		if ( ! ( username && password ) ) {
+			return;
+		}
+
+		store.dispatch( setPendingAuth() );
+		auth.create( username, password )
+			.then( user => {
+				if ( ! user.access_token ) {
+					return store.dispatch( resetAuth );
+				}
+
+				store.dispatch( setAccountName( username ) );
+				store.dispatch( setAuthorized() );
+				localStorage.access_token = user.access_token;
+				client.setUser( user );
+				analytics.tracks.recordEvent( 'user_signed_in' );
+			} )
+			.catch( () => {
+				store.dispatch( setLoginError() );
+			} );
+	},
 	onSignOut: () => {
 		delete localStorage.access_token;
 		store.dispatch( setAccountName( null ) );

--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
     "redux-thunk": "1.0.3",
     "sanitize-filename": "1.6.1",
     "serve-favicon": "2.3.2",
-    "simperium": "0.2.5"
+    "simperium": "0.2.6"
   }
 }


### PR DESCRIPTION
This PR allows a user to create an account from directly within the app.

**To Test**
* Sign out of the app.
* Click on 'Sign Up'
* Fill in your credentials, and click 'Sign Up'.
* You should be signed in to the app.
* Also test that the regular sign in flow still works as expected.

This is dependent on https://github.com/Simperium/node-simperium/pull/48. You can link to it from the package.json or clone it locally and link to it from there.

<img width="399" alt="screen shot 2017-06-20 at 4 46 32 pm" src="https://user-images.githubusercontent.com/789137/27360791-13a120f0-55d8-11e7-9b88-d74f576cc741.png">