### PR TITLE
Add todo lists in the markdown preview

### DIFF
--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -17,179 +17,181 @@ const renderToNode = (node, content) => {
   node.querySelectorAll('pre code').forEach(highlight.highlightBlock);
 };
 
-export default React.createClass( {
+export default React.createClass({
+  propTypes: {
+    note: PropTypes.object,
+    previewingMarkdown: PropTypes.bool,
+    fontSize: PropTypes.number,
+    onChangeContent: PropTypes.func.isRequired,
+  },
 
-	propTypes: {
-		note: PropTypes.object,
-		previewingMarkdown: PropTypes.bool,
-		fontSize: PropTypes.number,
-		onChangeContent: PropTypes.func.isRequired
-	},
+  componentWillMount: function() {
+    this.queueNoteSave = debounce(this.saveNote, saveDelay);
+    document.addEventListener('copy', this.copyRenderedNote, false);
+  },
 
-	componentWillMount: function() {
-		this.queueNoteSave = debounce( this.saveNote, saveDelay );
-		document.addEventListener( 'copy', this.copyRenderedNote, false );
-	},
+  componentDidMount: function() {
+    // Ensures note gets saved if user abruptly quits the app
+    window.addEventListener('beforeunload', this.queueNoteSave.flush);
+  },
 
-	componentDidMount: function() {
-		// Ensures note gets saved if user abruptly quits the app
-		window.addEventListener( 'beforeunload', this.queueNoteSave.flush );
-	},
+  saveEditorRef(ref) {
+    this.editor = ref;
+  },
 
-	saveEditorRef( ref ) {
-		this.editor = ref
-	},
+  isValidNote: function(note) {
+    return note && note.id;
+  },
 
-	isValidNote: function( note ) {
-		return note && note.id;
-	},
+  componentWillReceiveProps: function() {
+    this.queueNoteSave.flush();
+  },
 
-	componentWillReceiveProps: function() {
-		this.queueNoteSave.flush();
-	},
+  componentDidUpdate: function(prevProps) {
+    const { note, previewingMarkdown } = this.props;
+    const content = get(note, 'data.content', '');
+    if (this.isValidNote(note) && content === '') {
+      // Let's focus the editor for new and empty notes
+      invoke(this, 'editor.focus');
+    }
 
-	componentDidUpdate: function( prevProps ) {
-		const { note, previewingMarkdown } = this.props;
-		const content = get( note, 'data.content', '' );
-		if ( this.isValidNote( note ) && content === '' ) {
-			// Let's focus the editor for new and empty notes
-			invoke( this, 'editor.focus' );
-		}
+    const prevContent = get(prevProps, 'note.data.content', '');
+    const nextContent = get(this.props, 'note.data.content', '');
 
-		const prevContent = get( prevProps, 'note.data.content', '' );
-		const nextContent = get( this.props, 'note.data.content', '' );
+    if (
+      (previewingMarkdown &&
+        (prevProps.note !== note || prevContent !== nextContent)) ||
+      (!prevProps.previewingMarkdown && this.props.previewingMarkdown)
+    ) {
+      this.updateMarkdown();
+    }
+  },
 
-		if (
-			( previewingMarkdown && ( prevProps.note !== note || prevContent !== nextContent ) ) ||
-			( ! prevProps.previewingMarkdown && this.props.previewingMarkdown )
-		) {
-			this.updateMarkdown();
-		}
-	},
+  componentWillUnmount: function() {
+    window.removeEventListener('beforeunload', this.queueNoteSave.flush);
+    document.removeEventListener('copy', this.copyRenderedNote, false);
+  },
 
-	componentWillUnmount: function() {
-		window.removeEventListener( 'beforeunload', this.queueNoteSave.flush );
-		document.removeEventListener( 'copy', this.copyRenderedNote, false );
-	},
+  copyRenderedNote(event) {
+    // Only copy the rendered content if we're in the preview mode
+    if (!this.props.previewingMarkdown) {
+      return true;
+    }
 
-	copyRenderedNote( event ) {
-		// Only copy the rendered content if we're in the preview mode
-		if ( ! this.props.previewingMarkdown ) {
-			return true;
-		}
+    // Only copy the rendered content if nothing is selected
+    if (!document.getSelection().isCollapsed) {
+      return true;
+    }
 
-		// Only copy the rendered content if nothing is selected
-		if ( ! document.getSelection().isCollapsed ) {
-			return true;
-		}
+    const node = document.createDocumentFragment();
+    const div = document.createElement('div');
+    renderToNode(div, this.props.note.data.content);
+    node.appendChild(div);
 
-		const node = document.createDocumentFragment();
-		const div = document.createElement( 'div' );
-		renderToNode( div, this.props.note.data.content );
-		node.appendChild( div );
+    event.clipboardData.setData('text/plain', div.innerHTML);
+    event.preventDefault();
+  },
 
-		event.clipboardData.setData( 'text/plain', div.innerHTML );
-		event.preventDefault();
-	},
+  onPreviewClick: function(event) {
+    // open markdown preview links in a new window
+    for (let node = event.target; node !== null; node = node.parentNode) {
+      if (node.tagName === 'A') {
+        event.preventDefault();
+        viewExternalUrl(node.href);
+        break;
+      }
+    }
+  },
 
-	onPreviewClick: function( event ) {
-		// open markdown preview links in a new window
-		for ( let node = event.target; node !== null; node = node.parentNode ) {
-			if ( node.tagName === 'A' ) {
-				event.preventDefault();
-				viewExternalUrl( node.href );
-				break;
-			}
-		}
-	},
+  saveNote: function(content) {
+    const { note } = this.props;
 
-	saveNote: function( content ) {
-		const { note } = this.props;
+    if (!this.isValidNote(note)) return;
 
-		if ( ! this.isValidNote( note ) ) return;
+    this.props.onChangeContent(note, content);
+    analytics.tracks.recordEvent('editor_note_edited');
+  },
 
-		this.props.onChangeContent( note, content );
-		analytics.tracks.recordEvent( 'editor_note_edited' );
-	},
+  toggleTodo(index) {
+    const { note } = this.props;
+    const { content } = note.data;
+    const todoPattern = /(\s*- \[)(o|x|\s)(]\s)/gi;
+    let i = -1;
 
-	toggleTodo( index ) {
-		const { note } = this.props;
-		const { content } = note.data;
-		const todoPattern = /(\s*- \[)(o|x|\s)(\]\s)/ig;
-		let i = -1;
+    const toggled = content.replace(
+      todoPattern,
+      (match, prefix, indicator, rest) => {
+        i++;
 
-		const toggled = content.replace( todoPattern, ( match, prefix, indicator, rest ) => {
-			i++;
+        if (i < index || i > index) {
+          return match;
+        }
 
-			if ( i < index || i > index ) {
-				return match;
-			}
+        return indicator === 'x' || indicator === 'X'
+          ? `${prefix} ${rest}`
+          : `${prefix}x${rest}`;
+      }
+    );
 
-			return ( indicator === 'x' || indicator === 'X' )
-				? `${ prefix } ${ rest }`
-				: `${ prefix }x${ rest }`;
-		} );
+    this.saveNote(toggled);
+    this.updateMarkdown();
+  },
 
-		this.saveNote( toggled );
-		this.updateMarkdown();
-	},
+  storePreview(ref) {
+    this.previewNode = ref;
+  },
 
-	storePreview( ref ) {
-		this.previewNode = ref;
-	},
+  updateMarkdown() {
+    if (!this.previewNode) {
+      return;
+    }
 
-	updateMarkdown() {
-		if ( ! this.previewNode ) {
-			return;
-		}
+    const node = this.previewNode;
 
-		const node = this.previewNode;
+    node.innerHTML = markdownConverter.makeHtml(this.props.note.data.content);
 
-		node.innerHTML = markdownConverter.makeHtml( this.props.note.data.content );
+    const toggler = (box, i) =>
+      box.addEventListener('click', () => this.toggleTodo(i), false);
 
-		const toggler = ( box, i ) => box.addEventListener( 'click', () => this.toggleTodo( i ), false );
+    node.querySelectorAll('.task-list-item').forEach(toggler);
+    node
+      .querySelectorAll('.task-list-item p input[type="checkbox"]')
+      .forEach(toggler);
 
-		node.querySelectorAll( '.task-list-item' ).forEach( toggler );
-		node.querySelectorAll( '.task-list-item p input[type="checkbox"]' ).forEach( toggler );
+    renderToNode(this.previewNode, this.props.note.data.content);
+  },
 
-		renderToNode( this.previewNode, this.props.note.data.content );
-	},
+  render: function() {
+    const { filter, fontSize, previewingMarkdown } = this.props;
 
-	render: function() {
-		const {
-			filter,
-			fontSize,
-			previewingMarkdown,
-		} = this.props;
+    const content = get(this.props, 'note.data.content', '');
+    const divStyle = { fontSize: `${fontSize}px` };
 
-		const content = get( this.props, 'note.data.content', '' );
-		const divStyle = { fontSize: `${ fontSize }px` };
+    return (
+      <div className="note-detail">
+        {previewingMarkdown && (
+          <div
+            ref={this.storePreview}
+            className="note-detail-markdown theme-color-bg theme-color-fg"
+            onClick={this.onPreviewClick}
+            style={divStyle}
+          />
+        )}
 
-		return (
-			<div className="note-detail">
-				{ previewingMarkdown && (
-					<div
-						ref={ this.storePreview }
-						className="note-detail-markdown theme-color-bg theme-color-fg"
-						onClick={ this.onPreviewClick }
-						style={ divStyle }
-					/>
-				) }
-
-				{ ! previewingMarkdown && (
-					<div
-						className="note-detail-textarea theme-color-bg theme-color-fg"
-						style={ divStyle }
-					>
-						<NoteContentEditor
-							ref={ this.saveEditorRef }
-							content={ content }
-							filter={ filter }
-							onChangeContent={ this.queueNoteSave }
-						/>
-					</div>
-				) }
-			</div>
-		);
-	},
-} );
+        {!previewingMarkdown && (
+          <div
+            className="note-detail-textarea theme-color-bg theme-color-fg"
+            style={divStyle}
+          >
+            <NoteContentEditor
+              ref={this.saveEditorRef}
+              content={content}
+              filter={filter}
+              onChangeContent={this.queueNoteSave}
+            />
+          </div>
+        )}
+      </div>
+    );
+  },
+});

--- a/scss/markdown-preview.scss
+++ b/scss/markdown-preview.scss
@@ -36,11 +36,19 @@
     font-size: 85%;
     background: $gray-lightest;
   }
+
+  li {
+    p:last-child {
+      margin-bottom: 0;
+    }
+  }
+
   pre {
     border: 1px solid lighten($gray, 20%);
     padding: 1em;
     border-radius: $border-radius;
   }
+
   pre code {
     color: darken($gray, 10%);
     background: transparent;


### PR DESCRIPTION
Formerly this was not working because `marked` didn't render todo lists.
I have switched to a newer markdown parser and added the logic to tie
the render to the underlying note.

Test by viewing the markdown preview and clicking on a todo. The syntax
follows Github Flavored Markdown.

Further, I believe that some of the code highlighting issues may have
been resolved as `highlight.js` now is trying to infer the language on a
block-by-block basis.