### PR TITLE
Markdown: Replace `marked` with `showdown` parser/printer

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "highlight.js": "9.9.0",
     "jszip": "3.1.3",
     "lodash": "4.17.2",
-    "marked": "0.3.6",
     "moment": "2.17.1",
     "promise": "7.1.1",
     "react": "15.4.2",
@@ -81,6 +80,7 @@
     "redux-thunk": "1.0.3",
     "sanitize-filename": "1.6.1",
     "serve-favicon": "2.3.2",
+    "showdown": "1.7.1",
     "simperium": "0.2.6"
   }
 }

--- a/scss/markdown-preview.scss
+++ b/scss/markdown-preview.scss
@@ -1,7 +1,7 @@
 .note-detail-markdown {
 	@import "../node_modules/highlight.js/styles/solarized-light.css";
 
-	user-select: all;
+	user-select: auto;
 
 	h1,
 	h2,


### PR DESCRIPTION
`marked` doesn't appear to have been maintained for a while while
`showdown` has more recent contributions. Further, `marked` was missing
some functionality that we wanted. Namely, we wanted an equivalence with
Github-flavored Markdown (gfm) and `showdown` does it better.

In this patch we've changed the way we are inserting the content.
Instead of using `dangerouslySetInnerHTML` we're statefully rendering
the content into the DOM and then manipulating it. This change provides
an easier way to interact with the rendered content because we can
operate at the DOM level instead of at the string level. For example,
this is how highlighting now gets inserted.

**Notable changes**
 - Todo items render (though they can only be changed in the plaintext
   view)
 - Tables render
 - Code blocks highlight based on their language
 - Certain dirty/malicious content gets sanitized before display

**Questions**
 - Since the todo items render but aren't editable it could be confusing
   for someone to use, misleading them into thinking it's supposed to
   work