### PR TITLE
Fix: Can't navigate to note list on small widths without resize

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -349,12 +349,13 @@ export const App = connect( mapStateToProps, mapDispatchToProps )( React.createC
 			appState: state,
 			authIsPending,
 			isAuthorized,
+			isSmallScreen,
 			noteBucket,
+			settings,
 			tagBucket,
 		} = this.props;
 		const electron = get( this.state, 'electron' );
 		const isMacApp = isElectronMac();
-		const { settings, isSmallScreen } = this.props;
 		const filteredNotes = filterNotes( state );
 
 		const noteIndex = Math.max( state.previousIndex, 0 );

--- a/lib/browser-shell.jsx
+++ b/lib/browser-shell.jsx
@@ -1,35 +1,47 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-// Simple wrapper that tracks small screen state
-export default function browserShell( Component ) {
-	return React.createClass( {
-		getInitialState: function() {
-			return {
-				windowWidth: 1024,
-				isSmallScreen: false
-			};
-		},
+/**
+ * Get window-related attributes
+ *
+ * There is no need for `this` here; `window` is global
+ *
+ * @returns {{windowWidth: Number, isSmallScreen: boolean}} window attributes
+ */
+const getState = () => {
+	const windowWidth = window.innerWidth;
 
-		componentDidMount: function() {
-			window.addEventListener( 'resize', this.updateWindowSize );
-		},
+	return {
+		windowWidth,
+		isSmallScreen: windowWidth <= 750, // Magic number here corresponds to $single-column value in variables.scss
+	}
+};
 
-		componentWillUnmount: function() {
-			window.removeEventListener( 'resize', this.updateWindowSize );
-		},
+/**
+ * Passes window-related attributes into child component
+ *
+ * Passes:
+ *   - viewport width (including scrollbar)
+ *   - whether width is considered small
+ *
+ * @param {Element} Wrapped React component dependent on window attributes
+ * @returns {Component} wrapped React component with window attributes as props
+ */
+export const browserShell = Wrapped => class extends Component {
+	state = getState();
 
-		updateWindowSize: function() {
-			const { innerWidth } = window;
+	componentDidMount() {
+		window.addEventListener( 'resize', this.updateWindowSize );
+	}
 
-			// Magic number here corresponds to $single-column value in variables.scss
-			this.setState( {
-				windowWidth: innerWidth,
-				isSmallScreen: innerWidth <= 750
-			} );
-		},
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.updateWindowSize );
+	}
 
-		render: function() {
-			return <Component { ...this.state } { ...this.props } />
-		}
-	} );
-}
+	updateWindowSize = () => this.setState( getState() );
+
+	render() {
+		return <Wrapped { ...this.state } { ...this.props } />
+	}
+};
+
+export default browserShell;


### PR DESCRIPTION
When starting the app in a narrow-width state it can be impossible to
navigate back to the list of notes unles a manual resize of the window
is performed.

The reason for this behavior appears to be improperly initialized state
from the browser window in the `browserShell` wrapper. Instead of
grabbing the width attributes from the window when initializing we were
setting default values of 1024 px and a wide screen. In turn, these
values remained until a resize corrected them, therefore prohibiting the
navigation.

The values are now initialized directly from `window` and the
`browserShell` higher-order component's style has been updated from
`React.createClass()` to return a `React.Component`.

**Testing**
Open the app with a small screen width. In **master** it should be stuck in the note view until resizing. In this branch it should work as expected.