### PR TITLE
Add/copy rendered markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "highlight.js": "9.9.0",
     "jszip": "3.1.3",
     "lodash": "4.17.2",
-    "marked": "0.3.6",
     "moment": "2.17.1",
     "promise": "7.1.1",
     "react": "15.4.2",
@@ -81,6 +80,7 @@
     "redux-thunk": "1.0.3",
     "sanitize-filename": "1.6.1",
     "serve-favicon": "2.3.2",
+    "showdown": "1.7.1",
     "simperium": "0.2.6"
   }
 }

--- a/scss/markdown-preview.scss
+++ b/scss/markdown-preview.scss
@@ -1,7 +1,7 @@
 .note-detail-markdown {
 	@import "../node_modules/highlight.js/styles/solarized-light.css";
 
-	user-select: all;
+	user-select: auto;
 
 	h1,
 	h2,

--- a/webpack.config.dll.js
+++ b/webpack.config.dll.js
@@ -12,7 +12,6 @@ module.exports = {
 			'draft-js',
 			'highlight.js',
 			'lodash',
-			'marked',
 			'moment',
 			'promise',
 			'react',
@@ -23,6 +22,7 @@ module.exports = {
 			'redux-localstorage',
 			'redux-thunk',
 			'react-virtualized',
+			'showdown',
 			'simperium',
 			'sockjs-client'
 		]


### PR DESCRIPTION
Markdown: Add ability to copy rendered note HTML

When viewing a note's Markdown preview and with no selection, if you
press the copy shortcut then the rendered HTML for the note will fill
the clipboard buffer. If there is some selected text then the copy will
behave as normal.

**Testing**

Open a note preview and hit <kbd>⌘</kbd>+<kbd>C</kbd> or <kbd>Ctrl</kbd>+<kbd>C</kbd>. When pasting you should see HTML generated from the note. If you select some of the rendered content before copying you should find that when you paste it will be some kind of text view of the contents.