### PR TITLE
Flip the direction of the arrow on the revision icon

### DIFF
--- a/lib/icons/revisions.jsx
+++ b/lib/icons/revisions.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 export default function RevisionsIcon() {
 	return (
 		<svg className="icon-revisions" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22">
-			<path d="M13.293 14.707L10 11.414V6h2v4.586l2.707 2.707-1.414 1.414zM11 2a9 9 0 0 0-9 9h2c0-3.86 3.14-7 7-7s7 3.14 7 7-3.14 7-7 7a6.99 6.99 0 0 1-5.736-3H9v-2H2v7h2v-3.35A8.98 8.98 0 0 0 11 20a9 9 0 0 0 0-18z"/>
+			<path d="M8.7,14.7l3.3-3.3V6h-2v4.6l-2.7,2.7L8.7,14.7z M11,2c5,0,9,4,9,9h-2c0-3.9-3.1-7-7-7s-7,3.1-7,7s3.1,7,7,7c2.4,0,4.5-1.2,5.7-3H13v-2h7v7h-2v-3.3c-1.6,2-4.2,3.3-7,3.3c-5,0-9-4-9-9S6,2,11,2z"/>
 		</svg>
 	);
 }


### PR DESCRIPTION
Resolves #584 

Formerly the arrow pointed forwards in time but since this is opening up
the history revisions we want it to point backwards in time.

<img width="54" alt="screen shot 2017-07-12 at 5 31 39 pm" src="https://user-images.githubusercontent.com/5431237/28125804-fe127c64-6727-11e7-8401-f8bdb4e4aec9.png">
