### PR TITLE
Add/keyboard shortcuts

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -96,7 +96,7 @@ const isElectron = (() => {
   const foundElectron = has(window, 'process.type');
 
   if (foundElectron) {
-    fs = __non_webpack_require__('fs');
+    fs = __non_webpack_require__('fs'); // eslint-disable-line no-undef
   }
 
   return () => foundElectron;
@@ -212,7 +212,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
             })
           )
           .then(blob => fs.writeFile(command.filename, blob, 'base64'))
-          .catch(console.log);
+          .catch(console.log); // eslint-disable-line no-console
       }
 
       const canRun = overEvery(
@@ -291,7 +291,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
     },
 
     initializeElectron() {
-      const remote = __non_webpack_require__('electron').remote;
+      const remote = __non_webpack_require__('electron').remote; // eslint-disable-line no-undef
 
       this.setState({
         electron: {
@@ -495,7 +495,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
     renderDialog({ params, ...dialog }, key) {
       var DialogComponent = Dialogs[dialog.type];
 
-      if (DialogComponent == null) {
+      if (DialogComponent === null) {
         throw new Error('Unknown dialog type.');
       }
 

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -86,6 +86,8 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
     openTagList: () => dispatch(actionCreators.toggleNavigation()),
     resetAuth: () => dispatch(reduxActions.auth.reset()),
     setAuthorized: () => dispatch(reduxActions.auth.setAuthorized()),
+    setSearchFocus: () =>
+      dispatch(actionCreators.setSearchFocus({ searchFocus: true })),
   };
 }
 
@@ -180,6 +182,15 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       // open tag list
       if (cmdOrCtrl && 'T' === key && !this.state.showNavigation) {
         this.props.openTagList();
+
+        event.stopPropagation();
+        event.preventDefault();
+        return false;
+      }
+
+      // focus search field
+      if (cmdOrCtrl && 'F' === key) {
+        this.props.setSearchFocus();
 
         event.stopPropagation();
         event.preventDefault();

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -440,25 +440,27 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
                 <SearchBar noteBucket={noteBucket} />
                 <NoteList noteBucket={noteBucket} />
               </div>
-              <NoteEditor
-                allTags={state.tags}
-                editorMode={state.editorMode}
-                filter={state.filter}
-                note={selectedNote}
-                revisions={state.revisions}
-                onSetEditorMode={this.onSetEditorMode}
-                onUpdateContent={this.onUpdateContent}
-                onUpdateNoteTags={this.onUpdateNoteTags}
-                onTrashNote={this.onTrashNote}
-                onRestoreNote={this.onRestoreNote}
-                onShareNote={this.onShareNote}
-                onDeleteNoteForever={this.onDeleteNoteForever}
-                onRevisions={this.onRevisions}
-                onCloseNote={() => this.props.actions.closeNote()}
-                onNoteInfo={() => this.props.actions.toggleNoteInfo()}
-                shouldPrint={state.shouldPrint}
-                onNotePrinted={this.onNotePrinted}
-              />
+              {selectedNote && (
+                <NoteEditor
+                  allTags={state.tags}
+                  editorMode={state.editorMode}
+                  filter={state.filter}
+                  note={selectedNote}
+                  revisions={state.revisions}
+                  onSetEditorMode={this.onSetEditorMode}
+                  onUpdateContent={this.onUpdateContent}
+                  onUpdateNoteTags={this.onUpdateNoteTags}
+                  onTrashNote={this.onTrashNote}
+                  onRestoreNote={this.onRestoreNote}
+                  onShareNote={this.onShareNote}
+                  onDeleteNoteForever={this.onDeleteNoteForever}
+                  onRevisions={this.onRevisions}
+                  onCloseNote={() => this.props.actions.closeNote()}
+                  onNoteInfo={() => this.props.actions.toggleNoteInfo()}
+                  shouldPrint={state.shouldPrint}
+                  onNotePrinted={this.onNotePrinted}
+                />
+              )}
               {state.showNoteInfo && <NoteInfo noteBucket={noteBucket} />}
             </div>
           ) : (

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -261,7 +261,7 @@ export default class NoteContentEditor extends React.Component {
     return (
       this.editor &&
       document.activeElement ===
-        get(ReactDOM.findDOMNode(this.editor), 'children[0].children[0]')
+        get(ReactDOM.findDOMNode(this.editor), 'children[0].children[0]') // eslint-disable-line react/no-find-dom-node
     );
   };
 

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -87,6 +87,15 @@ export const NoteEditor = React.createClass({
       return false;
     }
 
+    // open note list - shift + [
+    if (cmdOrCtrl && '{' === key) {
+      this.props.onCloseNote();
+
+      event.stopPropagation();
+      event.preventDefault();
+      return false;
+    }
+
     // toggle between tag editor and note editor
     if (cmdOrCtrl && 't' === key && this.props.isEditorActive) {
       // prefer focusing the edit field first

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -43,6 +43,10 @@ export const NoteEditor = React.createClass({
     };
   },
 
+  componentDidMount() {
+    this.toggleShortcuts(true);
+  },
+
   componentWillReceiveProps: function() {
     this.setState({ revision: null });
   },
@@ -60,6 +64,30 @@ export const NoteEditor = React.createClass({
       window.print();
       this.props.onNotePrinted();
     }
+  },
+
+  componentWillUnmount() {
+    this.toggleShortcuts(false);
+  },
+
+  handleShortcut(event) {
+    const { ctrlKey, key, metaKey } = event;
+
+    const cmdOrCtrl = ctrlKey || metaKey;
+
+    // toggle editor mode
+    if (cmdOrCtrl && 'P' === key && this.props.markdownEnabled) {
+      const prevEditorMode = this.props.editorMode;
+      const nextEditorMode = prevEditorMode === 'edit' ? 'markdown' : 'edit';
+
+      this.props.onSetEditorMode(nextEditorMode);
+
+      event.stopPropagation();
+      event.preventDefault();
+      return false;
+    }
+
+    return true;
   },
 
   onViewRevision: function(revision) {
@@ -96,6 +124,14 @@ export const NoteEditor = React.createClass({
 
   setIsViewingRevisions: function(isViewing) {
     this.setState({ isViewingRevisions: isViewing });
+  },
+
+  toggleShortcuts(doEnable) {
+    if (doEnable) {
+      window.addEventListener('keydown', this.handleShortcut, true);
+    } else {
+      window.removeEventListener('keydown', this.handleShortcut, true);
+    }
   },
 
   render: function() {

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -87,8 +87,8 @@ export const NoteEditor = React.createClass({
       return false;
     }
 
-    // open note list - shift + [
-    if (cmdOrCtrl && '{' === key) {
+    // open note list - shift + n
+    if (cmdOrCtrl && 'N' === key) {
       this.props.onCloseNote();
 
       event.stopPropagation();

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -87,7 +87,29 @@ export const NoteEditor = React.createClass({
       return false;
     }
 
+    // toggle between tag editor and note editor
+    if (cmdOrCtrl && 't' === key && this.props.isEditorActive) {
+      // prefer focusing the edit field first
+      if (!this.editFieldHasFocus()) {
+        this.focusNoteEditor && this.focusNoteEditor();
+
+        event.stopPropagation();
+        event.preventDefault();
+        return false;
+      } else if (!this.tagFieldHasFocus()) {
+        this.focusTagField && this.focusTagField();
+
+        event.stopPropagation();
+        event.preventDefault();
+        return false;
+      }
+    }
+
     return true;
+  },
+
+  editFieldHasFocus() {
+    return this.editorHasFocus && this.editorHasFocus();
   },
 
   onViewRevision: function(revision) {
@@ -124,6 +146,26 @@ export const NoteEditor = React.createClass({
 
   setIsViewingRevisions: function(isViewing) {
     this.setState({ isViewingRevisions: isViewing });
+  },
+
+  storeEditorHasFocus(f) {
+    this.editorHasFocus = f;
+  },
+
+  storeFocusEditor(f) {
+    this.focusNoteEditor = f;
+  },
+
+  storeFocusTagField(f) {
+    this.focusTagField = f;
+  },
+
+  storeTagFieldHasFocus(f) {
+    this.tagFieldHasFocus = f;
+  },
+
+  tagFieldHasFocus() {
+    return this.tagFieldHasFocus && this.tagFieldHasFocus();
   },
 
   toggleShortcuts(doEnable) {
@@ -194,6 +236,8 @@ export const NoteEditor = React.createClass({
           {!!markdownEnabled && this.renderModeBar()}
           <div className="note-editor-detail">
             <NoteDetail
+              storeFocusEditor={this.storeFocusEditor}
+              storeHasFocus={this.storeEditorHasFocus}
               filter={this.props.filter}
               note={revision}
               previewingMarkdown={markdownEnabled && editorMode === 'markdown'}
@@ -211,6 +255,8 @@ export const NoteEditor = React.createClass({
         )}
         {!isTrashed && (
           <TagField
+            storeFocusTagField={this.storeFocusTagField}
+            storeHasFocus={this.storeTagFieldHasFocus}
             allTags={this.props.allTags.map(property('data.name'))}
             note={this.props.note}
             tags={tags}
@@ -255,8 +301,9 @@ export const NoteEditor = React.createClass({
   },
 });
 
-const mapStateToProps = ({ settings }) => ({
+const mapStateToProps = ({ appState: state, settings }) => ({
   fontSize: settings.fontSize,
+  isEditorActive: !state.showNavigation,
   markdownEnabled: settings.markdownEnabled,
 });
 

--- a/lib/tag-field.jsx
+++ b/lib/tag-field.jsx
@@ -6,7 +6,14 @@ import TagChip from './components/tag-chip';
 import TagInput from './tag-input';
 import classNames from 'classnames';
 import analytics from './analytics';
-import { differenceBy, intersectionBy, invoke, negate, noop, union } from 'lodash';
+import {
+  differenceBy,
+  intersectionBy,
+  invoke,
+  negate,
+  noop,
+  union,
+} from 'lodash';
 
 export default React.createClass({
   propTypes: {
@@ -151,7 +158,7 @@ export default React.createClass({
   onKeyDown: function(e) {
     if (this.state.showEmailTooltip) {
       this.hideEmailTooltip();
-  },
+    }
 
     return this.interceptKeys(e);
   },

--- a/lib/tag-field.jsx
+++ b/lib/tag-field.jsx
@@ -6,10 +6,12 @@ import TagChip from './components/tag-chip';
 import TagInput from './tag-input';
 import classNames from 'classnames';
 import analytics from './analytics';
-import { differenceBy, intersectionBy, invoke, negate, union } from 'lodash';
+import { differenceBy, intersectionBy, invoke, negate, noop, union } from 'lodash';
 
 export default React.createClass({
   propTypes: {
+    storeFocusTagField: PropTypes.func,
+    storeHasFocus: PropTypes.func,
     unusedTags: PropTypes.arrayOf(PropTypes.string),
     usedTags: PropTypes.arrayOf(PropTypes.string),
     onUpdateNoteTags: PropTypes.func.isRequired,
@@ -17,6 +19,8 @@ export default React.createClass({
 
   getDefaultProps: function() {
     return {
+      storeFocusTagField: noop,
+      storeHasFocus: noop,
       tags: [],
     };
   },
@@ -29,6 +33,9 @@ export default React.createClass({
   },
 
   componentDidMount() {
+    this.props.storeFocusTagField(this.focusTagField);
+    this.props.storeHasFocus(this.hasFocus);
+
     document.addEventListener('click', this.unselect, true);
   },
 
@@ -94,6 +101,14 @@ export default React.createClass({
     this.setState({ showEmailTooltip: false });
   },
 
+  hasFocus() {
+    return this.inputHasFocus && this.inputHasFocus();
+  },
+
+  focusTagField() {
+    this.focusInput && this.focusInput();
+  },
+
   interceptKeys(e) {
     // only handle backspace
     if (8 !== e.which) {
@@ -136,9 +151,17 @@ export default React.createClass({
   onKeyDown: function(e) {
     if (this.state.showEmailTooltip) {
       this.hideEmailTooltip();
-    }
+  },
 
     return this.interceptKeys(e);
+  },
+
+  storeFocusInput(f) {
+    this.focusInput = f;
+  },
+
+  storeHasFocus(f) {
+    this.inputHasFocus = f;
   },
 
   storeHiddenTag(r) {
@@ -202,6 +225,8 @@ export default React.createClass({
             value={tagInput}
             onChange={this.storeTagInput}
             onSelect={this.addTag}
+            storeFocusInput={this.storeFocusInput}
+            storeHasFocus={this.storeHasFocus}
             tagNames={differenceBy(allTags, tags, s => s.toLocaleLowerCase())}
           />
           <Overlay

--- a/lib/tag-input.jsx
+++ b/lib/tag-input.jsx
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { identity, invoke } from 'lodash';
+import { identity, invoke, noop } from 'lodash';
 
 const KEY_TAB = 9;
 const KEY_ENTER = 13;
@@ -16,6 +16,8 @@ export class TagInput extends Component {
     inputRef: PropTypes.func,
     onChange: PropTypes.func,
     onSelect: PropTypes.func,
+    storeFocusInput: PropTypes.func,
+    storeHasFocus: PropTypes.func,
     tagNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     value: PropTypes.string.isRequired,
   };
@@ -24,7 +26,14 @@ export class TagInput extends Component {
     inputRef: identity,
     onChange: identity,
     onSelect: identity,
+    storeFocusInput: noop,
+    storeHasFocus: noop,
   };
+
+  componentDidMount() {
+    this.props.storeFocusInput(this.focusInput);
+    this.props.storeHasFocus(this.hasFocus);
+  }
 
   componentWillUnmount() {
     invoke(
@@ -67,6 +76,10 @@ export class TagInput extends Component {
     const selection = window.getSelection();
     selection.removeAllRanges();
     selection.addRange(range);
+  };
+
+  hasFocus = () => {
+    return document.activeElement === this.inputField;
   };
 
   interceptKeys = event =>

--- a/lib/tag-input.jsx
+++ b/lib/tag-input.jsx
@@ -78,9 +78,7 @@ export class TagInput extends Component {
     selection.addRange(range);
   };
 
-  hasFocus = () => {
-    return document.activeElement === this.inputField;
-  };
+  hasFocus = () => document.activeElement === this.inputField;
 
   interceptKeys = event =>
     invoke(


### PR DESCRIPTION
Resolves #37 

Adds several global keyboard shortcuts for navigating around Simplenote

There's a pattern here :wink: - we're adopting <kbd>CmdOrCtrl</kbd> + <kbd>Shift</kbd> as the sort of global escape sequence. It was already being used for exporting a note, with <kbd>CmdOrCtrl</kbd> + <kbd>Shift</kbd> + <kbd>e</kbd>. The one exception is toggling between the editor and tag editor and that one should only work when the editor area is focused.

- [x] Navigate and select a note - <kbd>CmdOrCtrl</kbd> + <kbd>Shift</kbd> + <kbd>Up</kbd>/<kbd>Down</kbd>/<kbd>j</kbd>/<kbd>k</kbd>
- [x] Open and navigate tag menu - <kbd>CmdOrCtrl</kbd> + <kbd>Shift</kbd> + <kbd>t</kbd>
- [x] Global binding to focus search field - <kbd>CmdOrCtrl</kbd> + <kbd>Shift</kbd> + <kbd>f</kbd>
- [x] Toggle markdown preview - <kbd>CmdOrCtrl</kbd> + <kbd>Shift</kbd> + <kbd>p</kbd>
- [x] Open/focus list view - <kbd>CmdOrCtrl</kbd> + <kbd>Shift</kbd> + <kbd>n</kbd>
- [x] Toggle between editor and tag editor - <kbd>CmdOrCtrl</kbd> + <kbd>t</kbd>

There are some oddities in these: because we don't track whether or not the different window panes are open (they are always open and hidden through crafty CSS) it is hard to selectively enable the hotkeys. That means interactions like selecting the prev/next note work regardless of app state; if you open the list view and navigate to the next note, for example, it will jump back to the note detail view instead of merely highlighting the next note in the list. Similarly, the markdown toggler will always work even if no note is selected or if a note without Markdown support is selected.

**Implementation Note**
You'll notice that this is a fairly "brute-force" PR where I've just gone in imperatively and used global state (window listeners) to trap the hotkeys on individual components and that I have similarly passed up focus functions through reverse-prop-passing. While _dirty_ in most senses of the word the solution I chose was a tradeoff between rewriting the entire way the app works and doing something we could manage. To that end I have tried to be _consistent_ in how the implementations in the various components are done. This should make it reasonably easy to do a search and find all places implementing hotkeys.

**Testing**

I would appreciate considerable manual testing of these shortcuts to see if they make sense and feel right, also that nothing is broken or too strange with the way they work. Did it not work when you expected it to? Did the action seem broken to you? etc…

**Futher work**

This needs a corresponding update in the application documentation and a nice modal overlay showing the shortcuts would be essential in my opinion. Stay tuned!