### PR TITLE
Search: Add tag search, multiple term search

### DIFF
--- a/lib/editor/matching-text-decorator.js
+++ b/lib/editor/matching-text-decorator.js
@@ -1,5 +1,4 @@
 import SimpleDecorator from 'draft-js-simpledecorator';
-import { escapeRegExp } from 'lodash';
 
 import CssClassWrapper from './css-class-wrapper';
 
@@ -38,9 +37,7 @@ export const matchingTextDecorator = search => {
 		return null;
 	}
 
-	const matcher = new RegExp( escapeRegExp( search ), 'gi' );
-
-	return new SimpleDecorator( findMatchingText( matcher ), CssClassWrapper );
+	return new SimpleDecorator( findMatchingText( search ), CssClassWrapper );
 };
 
 export default matchingTextDecorator;

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -7,6 +7,7 @@ import {
 } from 'draft-js';
 import { includes, invoke, noop } from 'lodash';
 
+import { filterHasText, searchPattern } from './utils/filter-notes';
 import { LF_ONLY_NEWLINES } from './utils/export';
 import matchingTextDecorator from './editor/matching-text-decorator';
 
@@ -152,7 +153,7 @@ export default class NoteContentEditor extends React.Component {
 	state = {
 		editorState: EditorState.createWithContent(
 			ContentState.createFromText( this.props.content, '\n' ),
-			matchingTextDecorator( this.props.filter ),
+			filterHasText( this.props.filter ) && matchingTextDecorator( searchPattern( this.props.filter ) ),
 		)
 	}
 
@@ -208,7 +209,7 @@ export default class NoteContentEditor extends React.Component {
 
 		let newEditorState = EditorState.createWithContent(
 			ContentState.createFromText( newContent, '\n' ),
-			matchingTextDecorator( nextFilter ),
+			filterHasText( nextFilter ) && matchingTextDecorator( searchPattern( nextFilter ) ),
 		)
 
 		// avoids weird caret position if content is changed

--- a/lib/utils/filter-notes.js
+++ b/lib/utils/filter-notes.js
@@ -1,18 +1,104 @@
 /**
  * External dependencies
  */
-import { escapeRegExp, get, includes, overEvery } from 'lodash';
-
-const includesSearch = ( text, search ) => ( new RegExp( escapeRegExp( search ), 'gi' ) ).test( text || '' );
+import { difference, escapeRegExp, get, overEvery } from 'lodash';
 
 const matchesTrashView = isViewingTrash => note =>
 	isViewingTrash === !! get( note, 'data.deleted', false );
 
-const matchesTag = tag => note =>
-	! tag || includes( get( note, 'data.tags', [] ), get( tag, 'data.name', '' ) );
+const tagPattern = () => /(?:\btag:)([\w-]+)(?!\B)/g;
 
-const matchesSearch = query => note =>
-	! query || includesSearch( get( note, 'data.content' ), query );
+const matchesTag = ( tag, filter = '' ) => note => {
+	let filterTags = [];
+	let match;
+	const matcher = tagPattern();
+
+	while ( ( match = matcher.exec( filter ) ) !== null ) {
+		filterTags.push( match[ 1 ] );
+
+		if ( filterTags.length > 100 ) {
+			debugger;
+			break;
+		}
+	}
+
+	const givenTag = tag
+		? [ get( tag, 'data.name', '' ) ]
+		: [];
+
+	const noteTags = get( note, 'data.tags', [] );
+
+	const missingTags = difference( [...filterTags, ...givenTag ], noteTags );
+
+	return missingTags.length === 0;
+};
+
+export const filterHasText = filter => !! filter.replace( tagPattern(), '' ).trim();
+
+const getTerms = filter => {
+	if ( ! filter ) {
+		return [];
+	}
+
+	const withoutTags = filter.replace( tagPattern(), '' ).trim();
+
+	const literalsPattern = /(?:\")((?:\\"|[^"])+)(?:\")/g;
+	const boundaryPattern = /[\b\s]/g;
+
+	let match;
+	let withoutLiterals = '';
+
+	const literals = [];
+	while ( ( match = literalsPattern.exec( withoutTags ) ) !== null ) {
+		literals.push( match[ 0 ].slice( 1, -1 ) );
+
+		withoutLiterals += filter.slice( literalsPattern.lastIndex, match.index );
+	}
+
+	if (
+		( literalsPattern.lastIndex > 0 || literals.length === 0 ) &&
+		literalsPattern.lastIndex < withoutTags.length
+	) {
+		withoutLiterals += withoutTags.slice( literalsPattern.lastIndex );
+	}
+
+	const terms = withoutLiterals
+		.split( boundaryPattern )
+		.map( a => a.trim() )
+		.filter( a => a );
+
+	return [ ...literals, ...terms ];
+};
+
+export const searchPattern = filter => {
+	const withoutTags = filter.replace( tagPattern(), '' ).trim();
+
+	if ( ! withoutTags ) {
+		return new RegExp( '.+', 'g' );
+	}
+
+	const terms = getTerms( withoutTags );
+
+	if ( ! terms.length ) {
+		return new RegExp( '', 'g' );
+	}
+
+	return new RegExp( `(?:${ terms.map( word => `(?:${ escapeRegExp( word ) })` ).join( '|' ) })`, 'gi' );
+};
+
+const matchesSearch = ( filter = '' ) => note => {
+	if ( ! filter ) {
+		return true;
+	}
+
+	const content = get( note, 'data.content' );
+
+	if ( ! content ) {
+		return false;
+	}
+
+	return getTerms( filter ).every( term => ( new RegExp( escapeRegExp( term ), 'gi' ) ).test( content ) );
+};
 
 export default function filterNotes( state ) {
 	const {
@@ -25,7 +111,7 @@ export default function filterNotes( state ) {
 	return notes
 		.filter( overEvery( [
 			matchesTrashView( showTrash ),
-			matchesTag( tag ),
+			matchesTag( tag, filter ),
 			matchesSearch( filter ),
 		] ) );
 }

--- a/lib/utils/filter-notes.js
+++ b/lib/utils/filter-notes.js
@@ -3,35 +3,7 @@
  */
 import { difference, escapeRegExp, get, overEvery } from 'lodash';
 
-const matchesTrashView = isViewingTrash => note =>
-	isViewingTrash === !! get( note, 'data.deleted', false );
-
 const tagPattern = () => /(?:\btag:)([\w-]+)(?!\B)/g;
-
-const matchesTag = ( tag, filter = '' ) => note => {
-	let filterTags = [];
-	let match;
-	const matcher = tagPattern();
-
-	while ( ( match = matcher.exec( filter ) ) !== null ) {
-		filterTags.push( match[ 1 ] );
-
-		if ( filterTags.length > 100 ) {
-			debugger;
-			break;
-		}
-	}
-
-	const givenTag = tag
-		? [ get( tag, 'data.name', '' ) ]
-		: [];
-
-	const noteTags = get( note, 'data.tags', [] );
-
-	const missingTags = difference( [...filterTags, ...givenTag ], noteTags );
-
-	return missingTags.length === 0;
-};
 
 export const filterHasText = filter => !! filter.replace( tagPattern(), '' ).trim();
 
@@ -84,6 +56,34 @@ export const searchPattern = filter => {
 	}
 
 	return new RegExp( `(?:${ terms.map( word => `(?:${ escapeRegExp( word ) })` ).join( '|' ) })`, 'gi' );
+};
+
+const matchesTrashView = isViewingTrash => note =>
+	isViewingTrash === !! get( note, 'data.deleted', false );
+
+const matchesTag = ( tag, filter = '' ) => note => {
+	let filterTags = [];
+	let match;
+	const matcher = tagPattern();
+
+	while ( ( match = matcher.exec( filter ) ) !== null ) {
+		filterTags.push( match[ 1 ] );
+
+		if ( filterTags.length > 100 ) {
+			debugger;
+			break;
+		}
+	}
+
+	const givenTag = tag
+		? [ get( tag, 'data.name', '' ) ]
+		: [];
+
+	const noteTags = get( note, 'data.tags', [] );
+
+	const missingTags = difference( [...filterTags, ...givenTag ], noteTags );
+
+	return missingTags.length === 0;
 };
 
 const matchesSearch = ( filter = '' ) => note => {


### PR DESCRIPTION
Resolves #596

The search has been limited by a couple factors:
 - one could only search for a single tag by
   clicking on it in the tag list
 - one could only search for a full phrase

In this patch the `filter-notes` module gets additional
code to extend the search behavior: namely it allows for
searching by one or more tags and it treats each separate
term in the search input field as part of the query.

What does that mean?

`tag:fruit fresh farm` - searches through notes with the "fruit" tag
which also have the words "fresh" and "farm" in them

This means that each term is joined in an `AND` like expression.

Because someone may want to search for text with spaces in it which
would normally be treated as separate terms, one may surround a text
with double-quotes to search for that as a single piece or phrase.

`"2 + j3"` would search for a note having the exact string `2 + j3` in
it instead of the three terms `2`, `+`, and `j3`.