### PR TITLE
Fix: Stop jumping to the tag entry

### DIFF
--- a/lib/tag-input.jsx
+++ b/lib/tag-input.jsx
@@ -99,7 +99,7 @@ export class TagInput extends Component {
 	onChange = ( { target: { textContent: value } } ) =>
 		value.endsWith( ',' ) && value.trim().length // commas should automatically insert non-zero tags
 			? this.props.onSelect( value.slice( 0, -1 ).trim() )
-			: this.props.onChange( value.trim() );
+			: this.props.onChange( value.trim(), this.focusInput );
 
 	removePastedFormatting = event => {
 		document.execCommand(
@@ -127,10 +127,6 @@ export class TagInput extends Component {
 		invoke( event, 'preventDefault' );
 		invoke( event, 'stopPropagation' );
 	};
-
-	componentDidUpdate() {
-		this.focusInput();
-	}
 
 	render() {
 		const {


### PR DESCRIPTION
In #549 we accidentally introduced a bug where the tag input field would
steal input basically after every app re-render. This patch fixes that
by only jumping back into the input field after changes to that field.

**Testing**

In **master** it should be easy to replicate the problem: type somewhere
and wait for the cursor to jump into the tag field.

In this branch it should behave normally.

Watch out for this specific case though: when typing in a new tag does it
reverse the characters? I saw this behavior when I took out the focus
jump but in this branch it appears to be working fine. I think that means
it's safe and good :+1: