### PR TITLE
Search: Highlight text when jumping to search field

### DIFF
--- a/lib/search-field.jsx
+++ b/lib/search-field.jsx
@@ -25,6 +25,7 @@ export class SearchField extends Component {
 		const { searchFocus, onSearchFocused } = this.props;
 
 		if ( searchFocus && this.inputField ) {
+			this.inputField.select();
 			this.inputField.focus();
 			onSearchFocused();
 		}


### PR DESCRIPTION
Resolves #520

Previously when using a keyboard hotkey to start searching for a term
when there was a previous search term, the cursor would jump to the end.

Now it highlights the previous search term to make for more intuitive UI
flow.

**Testing**

Open in Electron and use the shortcut to search: <kbd>CmdOrCtrl</kbd>+<kbd>f</kbd>
Type something in then click somewhere else, such as in a note.

Use the keyboard shortcut to again focus the search field.
In **master** you should see the cursor at the end of the field.
In this branch the previous term should now be selected.