### PR TITLE
Search: Create new note contents from search field

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -228,7 +228,7 @@ var actionMap = new ActionMap( {
 		},
 
 		newNote: {
-			creator( { noteBucket } ) {
+			creator( { noteBucket, content = '' } ) {
 				return ( dispatch, getState ) => {
 					const state = getState().appState;
 					const settings = getState().settings;
@@ -244,7 +244,7 @@ var actionMap = new ActionMap( {
 
 					// insert a new note into the store and select it
 					noteBucket.add( {
-						content: '',
+						content,
 						deleted: false,
 						systemTags: settings.markdownEnabled ? [ 'markdown' ] : [],
 						creationDate: timestamp,

--- a/lib/search-bar.jsx
+++ b/lib/search-bar.jsx
@@ -15,6 +15,7 @@ import TagsIcon from './icons/tags';
 
 const {
 	newNote,
+	search,
 	toggleNavigation,
 } = appState.actionCreators;
 const { recordEvent } = tracks;
@@ -22,6 +23,7 @@ const { recordEvent } = tracks;
 export const SearchBar = ( {
 	onNewNote,
 	onToggleNavigation,
+	query,
 	showTrash,
 } ) => (
 	<div className="search-bar theme-color-border">
@@ -32,7 +34,7 @@ export const SearchBar = ( {
 		<button
 			className="button button-borderless"
 			disabled={ showTrash }
-			onClick={ onNewNote }
+			onClick={ () => onNewNote( query ) }
 			title="New Note"
 		>
 			<NewNoteIcon />
@@ -41,12 +43,14 @@ export const SearchBar = ( {
 );
 
 const mapStateToProps = ( { appState: state } ) => ( {
+	query: state.filter,
 	showTrash: state.showTrash,
 } );
 
 const mapDispatchToProps = ( dispatch, { noteBucket } ) => ( {
-	onNewNote: () => {
-		dispatch( newNote( { noteBucket } ) );
+	onNewNote: content => {
+		dispatch( search( { filter: '' } ) );
+		dispatch( newNote( { noteBucket, content } ) );
 		recordEvent( 'list_note_created' );
 	},
 	onToggleNavigation: () => dispatch( toggleNavigation() ),

--- a/lib/search-bar.jsx
+++ b/lib/search-bar.jsx
@@ -12,6 +12,7 @@ import { tracks } from './analytics';
 import NewNoteIcon from './icons/new-note';
 import SearchField from './search-field';
 import TagsIcon from './icons/tags';
+import { withoutTags } from './utils/filter-notes';
 
 const {
 	newNote,
@@ -34,7 +35,7 @@ export const SearchBar = ( {
 		<button
 			className="button button-borderless"
 			disabled={ showTrash }
-			onClick={ () => onNewNote( query ) }
+			onClick={ () => onNewNote( withoutTags( query ) ) }
 			title="New Note"
 		>
 			<NewNoteIcon />

--- a/lib/utils/filter-notes.js
+++ b/lib/utils/filter-notes.js
@@ -5,14 +5,13 @@ import { difference, escapeRegExp, get, overEvery } from 'lodash';
 
 const tagPattern = () => /(?:\btag:)([\w-]+)(?!\B)/g;
 
-export const filterHasText = filter => !! filter.replace( tagPattern(), '' ).trim();
+export const withoutTags = s => s.replace( tagPattern(), '' ).trim();
+export const filterHasText = filter => !! withoutTags( filter );
 
-const getTerms = filter => {
-	if ( ! filter ) {
+const getTerms = filterText => {
+	if ( ! filterText ) {
 		return [];
 	}
-
-	const withoutTags = filter.replace( tagPattern(), '' ).trim();
 
 	const literalsPattern = /(?:\")((?:\\"|[^"])+)(?:\")/g;
 	const boundaryPattern = /[\b\s]/g;
@@ -20,8 +19,10 @@ const getTerms = filter => {
 	let match;
 	let withoutLiterals = '';
 
+	const filter = withoutTags( filterText );
+
 	const literals = [];
-	while ( ( match = literalsPattern.exec( withoutTags ) ) !== null ) {
+	while ( ( match = literalsPattern.exec( filter ) ) !== null ) {
 		literals.push( match[ 0 ].slice( 1, -1 ) );
 
 		withoutLiterals += filter.slice( literalsPattern.lastIndex, match.index );
@@ -29,9 +30,9 @@ const getTerms = filter => {
 
 	if (
 		( literalsPattern.lastIndex > 0 || literals.length === 0 ) &&
-		literalsPattern.lastIndex < withoutTags.length
+		literalsPattern.lastIndex < filter.length
 	) {
-		withoutLiterals += withoutTags.slice( literalsPattern.lastIndex );
+		withoutLiterals += filter.slice( literalsPattern.lastIndex );
 	}
 
 	const terms = withoutLiterals
@@ -43,16 +44,10 @@ const getTerms = filter => {
 };
 
 export const searchPattern = filter => {
-	const withoutTags = filter.replace( tagPattern(), '' ).trim();
-
-	if ( ! withoutTags ) {
-		return new RegExp( '.+', 'g' );
-	}
-
-	const terms = getTerms( withoutTags );
+	const terms = getTerms( withoutTags( filter ) );
 
 	if ( ! terms.length ) {
-		return new RegExp( '', 'g' );
+		return new RegExp( '.+', 'g' );
 	}
 
 	return new RegExp( `(?:${ terms.map( word => `(?:${ escapeRegExp( word ) })` ).join( '|' ) })`, 'gi' );


### PR DESCRIPTION
Resolves #581

Previously when searching and clicking on the new note icon a blank note
would be inserted. Now the contents of the search field will be inserted
into the new note and the search field will clear.

**Testing**

Create new notes. Play around with the search field before doing so.