### PR TITLE
Fix: Unit tests were broken

### DIFF
--- a/lib/components/tag-chip/test.jsx
+++ b/lib/components/tag-chip/test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { mount, shallow } from 'enzyme';
 
-import TagChip from '../';
+import TagChip from './';
 
 describe( 'TagChip', () => {
 	it( 'should select tag when clicked', () => {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "autoprefixer": "6.5.4",
     "babel-core": "6.21.0",
     "babel-eslint": "7.1.1",
+    "babel-jest": "20.0.3",
     "babel-loader": "6.2.10",
     "babel-preset-es2015": "6.18.0",
     "babel-preset-react": "6.16.0",


### PR DESCRIPTION
Resolves #551

The unit tests were broken. `jest` was failing to run non-transformed
code and there was a broken import statement for the tag chip tests.

This pulls in `babel-jest` which automatically runs instead of `jest`
and the tests are passing.

**Testing**

Just run `npm test`. In **master** it should break and in this branch it should pass :smile:

cc: @gie3d 