### PR TITLE
Fix: "Add tag" description

### DIFF
--- a/lib/tag-input.jsx
+++ b/lib/tag-input.jsx
@@ -146,7 +146,7 @@ export class TagInput extends Component {
 					contentEditable="true"
 					onInput={ this.onChange }
 					onKeyDown={ this.interceptKeys }
-					placeholder="Enter a tag name…"
+					placeholder="Add a tag…"
 					suppressContentEditableWarning
 				>
 					{ value }


### PR DESCRIPTION
Resolves #490
See also Automattic/Simplenote-United#1

In #389 I changed the description for the placeholder on the tag input
field. I think this was accidental and inadvertent.

This patch changes the text back to (close to) what it was but makes a
small change to make it unify closer with the other apps.

Previously it read `Add tags &hellip;`
Now it reads `Add a tag&hellip;`