### PR TITLE
Fix: Prevent XSS opening with rendered Markdown

### DIFF
--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import highlight from 'highlight.js';
 import showdown from 'showdown';
+import xssFilter from 'showdown-xss-filter';
 import { get, debounce, invoke } from 'lodash';
 import analytics from './analytics';
 import { viewExternalUrl } from './utils/url-utils';
@@ -8,7 +9,7 @@ import NoteContentEditor from './note-content-editor';
 
 const saveDelay = 2000;
 
-const markdownConverter = new showdown.Converter();
+const markdownConverter = new showdown.Converter( { extensions: [ xssFilter ] } );
 markdownConverter.setFlavor( 'github' );
 
 const renderToNode = ( node, content ) => {

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -2,13 +2,14 @@ import React, { PropTypes } from 'react'
 import { connect } from 'react-redux';
 import classNames from 'classnames'
 import showdown from 'showdown';
+import xssFilter from 'showdown-xss-filter';
 import NoteDetail from './note-detail'
 import TagField from './tag-field'
 import NoteToolbar from './note-toolbar'
 import RevisionSelector from './revision-selector'
 import { get, property } from 'lodash'
 
-const markdownConverter = new showdown.Converter();
+const markdownConverter = new showdown.Converter( { extensions: [ xssFilter ] } );
 markdownConverter.setFlavor( 'github' );
 
 export const NoteEditor = React.createClass( {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "sanitize-filename": "1.6.1",
     "serve-favicon": "2.3.2",
     "showdown": "1.7.1",
+    "showdown-xss-filter": "0.2.0",
     "simperium": "0.2.6"
   }
 }


### PR DESCRIPTION
Resolves #487

Previously the markdown renderer would render _any_ HTML because all
HTML is also valid markdown. However, we don't want the nastier bits.
This patch introduces the `showdown-xss-filter` extension to the
rendered in an attempt to sanitize what gets rendered.

**Testing**

Paste this into a note: `<input type=text value=a onfocus=alert(JSON.stringify(document)) AUTOFOCUS>`

In **master** it will trash your app as soon as you render it because it will loop on an alert. You need to reset the app state and get back into the edit mode.

In this branch it should display as plain text as you see above and there should be no popups.