### PR TITLE
Packager: downgrades node engine requirements to LTS

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -24,7 +24,7 @@ var opts = {
 	author: config.author,
 	platform: builder.getPlatform( process.argv ),
 	arch: builder.getArch( process.argv ),
-	version: electronVersion,
+	electronVersion,
 	appVersion: config.version,
 	appSign: 'Developer ID Application: ' + config.author,
 	out: './release',
@@ -58,7 +58,8 @@ builder.beforeBuild( __dirname, opts, function( error ) {
 
 	packager( opts, function( err ) {
 		if ( err ) {
-			console.log( error );
+			console.log( 'Packager Error:' );
+			console.log( err );
 		} else {
 			builder.cleanUp( path.join( __dirname, 'release' ), opts );
 		}

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "author": "",
   "license": "ISC",
   "engines": {
-    "node": "8.4.0",
-    "npm": "5.3.0"
+    "node": "6.11.2",
+    "npm": "3.10.10"
   },
   "jest": {
     "rootDir": "lib"


### PR DESCRIPTION
 In order to prevent prune error when electron packager runs `npm prune --production` on npm versions `> 5.2`. This has been documented on https://github.com/npm/npm/issues/17781.

The PR also includes a small change in light of a packager deprecation warning and an error log fix.

To test, downgrade to node `6.11.2` and npm `3.10.10` and

```
> make package-linux
```

Packing should complete and the folder `release/Simplenote-linux-x64/resources/app/node_modules` should contain only production dependencies.