### PR TITLE
Redux: Introduce state.ui.visiblePanes (lean approach)

### DIFF
--- a/lib/state/action-types.js
+++ b/lib/state/action-types.js
@@ -1,1 +1,2 @@
 export const AUTH_SET = Symbol();
+export const TAG_DRAWER_TOGGLE = 'TAG_DRAWER_TOGGLE';

--- a/lib/state/index.js
+++ b/lib/state/index.js
@@ -12,11 +12,13 @@ import appState from '../flux/app-state';
 
 import auth from './auth/reducer';
 import settings from './settings/reducer';
+import ui from './ui/reducer';
 
 export const reducers = combineReducers( {
 	appState: appState.reducer.bind( appState ),
 	auth,
 	settings,
+	ui,
 } );
 
 export const store = createStore( reducers, compose(

--- a/lib/state/ui/actions.js
+++ b/lib/state/ui/actions.js
@@ -1,0 +1,6 @@
+import { TAG_DRAWER_TOGGLE } from '../action-types';
+
+export const toggleTagDrawer = show => ( {
+	type: TAG_DRAWER_TOGGLE,
+	show,
+} );

--- a/lib/state/ui/reducer.js
+++ b/lib/state/ui/reducer.js
@@ -1,0 +1,17 @@
+import { difference, union } from 'lodash';
+import { combineReducers } from 'redux';
+import { TAG_DRAWER_TOGGLE } from '../action-types';
+
+const defaultVisiblePanes = [ 'editor', 'noteList' ];
+
+const visiblePanes = ( state = defaultVisiblePanes, { type, show } ) => {
+	if ( TAG_DRAWER_TOGGLE === type ) {
+		return show
+			? union( state, [ 'tagDrawer' ] )
+			: difference( state, [ 'tagDrawer' ] );
+	}
+
+	return state;
+};
+
+export default combineReducers( { visiblePanes } );


### PR DESCRIPTION
Replaces #620 

Groundwork for the refactor of the panes into independent entities.

Introduce a new Redux state tree, `ui`, with a new property `visiblePanes`.
`visiblePanes` contains an array of currently visible panes.

The available panes are:
- `editor`
- `noteList`
- `tagDrawer`
