### PR TITLE
Release: Require `appdmg` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,5 +100,8 @@
     "showdown": "1.7.2",
     "showdown-xss-filter": "0.2.0",
     "simperium": "0.2.6"
+  },
+  "optionalDependencies": {
+    "appdmg": "0.4.5"
   }
 }


### PR DESCRIPTION
In order to build the macOS bundle we need to be able to create the
`dmg` file. Unfortunately this package won't install properly on
non-macOS machines. This patch adds the dependency to
`optionalDependencies` which should not prevent the `npm install`
process from continuing if it fails. For macOS builds it should install
and for others it should skip without causing trouble.