### PR TITLE
Add welcome note when creating a new account

### DIFF
--- a/lib/boot.js
+++ b/lib/boot.js
@@ -18,6 +18,11 @@ import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { some } from 'lodash';
 
+import { content as welcomeMessage } from './welcome-message';
+
+import appState from './flux/app-state';
+const { newNote } = appState.actionCreators;
+
 const config = getConfig();
 
 const cookie = parse(document.cookie);
@@ -151,6 +156,14 @@ let props = {
         client.setUser(user);
         analytics.tracks.recordEvent('user_signed_in');
       })
+      .then(() =>
+        store.dispatch(
+          newNote({
+            noteBucket: client.bucket('note'),
+            content: welcomeMessage,
+          })
+        )
+      )
       .catch(() => {
         store.dispatch(setLoginError());
       });

--- a/lib/welcome-message.js
+++ b/lib/welcome-message.js
@@ -1,17 +1,15 @@
-export const content = `
-Welcome to Simplenote for Windows and Linux!
-
+export const content = `Welcome to Simplenote!
+ 
 To create a new note, click on the new note button.
-
+ 
 To search your notes, type in the search bar and enter any text. Simplenote will show you matching results instantly.
-
-Got a really important note? Press the pin button while viewing a note to pin it to the top of the list.
-
-Use tags to help organize your notes.
-
+ 
+Got a really important note? Open the note info bar and press the 'Pin to top' button to pin it to the top of the list.
+ 
+Use tags to help organize your notes. Look for the tag bar at the bottom of the note editor.
+ 
 Deleted notes go in the trash. You can restore them if you want, or empty the trash to get rid of them forever.
-
-You can access your notes on the web and your other devices. Go to http://simplenote.com to get started.
-
-We hope you enjoy using Simplenote!
-`;
+ 
+You can access your notes on the web and your other devices. Go to https://app.simplenote.com to get started.
+ 
+We hope you enjoy using Simplenote!`;

--- a/lib/welcome-message.js
+++ b/lib/welcome-message.js
@@ -1,0 +1,17 @@
+export const content = `
+Welcome to Simplenote for Windows and Linux!
+
+To create a new note, click on the new note button.
+
+To search your notes, type in the search bar and enter any text. Simplenote will show you matching results instantly.
+
+Got a really important note? Press the pin button while viewing a note to pin it to the top of the list.
+
+Use tags to help organize your notes.
+
+Deleted notes go in the trash. You can restore them if you want, or empty the trash to get rid of them forever.
+
+You can access your notes on the web and your other devices. Go to http://simplenote.com to get started.
+
+We hope you enjoy using Simplenote!
+`;


### PR DESCRIPTION
In the other Simplenote platforms, when someone creates a new account a
welcome message appears in the note list. The Electron app has been
missing this.

This change adds that new message in on account creation.

Addresses #633 because new accounts don't start with an empty note list

Could use some review over the welcome message text.

Eventually it would be cool if instead we had a Redux action with username and password for new account creation and let middleware do all the work to make that account. For the time being, I'm adding this into `boot.js` where it has been handled so far - an attempt at making a limited and pointed PR.