### PR TITLE
#555 Remove # from title on left panel

### DIFF
--- a/lib/note-list.jsx
+++ b/lib/note-list.jsx
@@ -22,7 +22,7 @@ import { connect } from 'react-redux';
 import appState from './flux/app-state';
 import { tracks } from './analytics';
 import filterNotes from './utils/filter-notes';
-import noteTitle from './utils/note-title';
+import noteTitle from './utils/note-utils';
 
 /**
  * Delay for preventing row height calculation thrashing

--- a/lib/utils/note-title.js
+++ b/lib/utils/note-title.js
@@ -28,7 +28,7 @@ const noteTitleAndPreviewMdRegExp = /[# ]*(\S[^\n]*)\s*(\S[^\n]*)?/;
 export const noteTitleAndPreview = note => {
   const content = note && note.data && note.data.content;
   const isMarkdown =
-    note && note.data && note.data.systemTags.some(x => x === 'markdown');
+    note && note.data && note.data.systemTags.some(tag => tag === 'markdown');
 
   const match = isMarkdown
     ? noteTitleAndPreviewMdRegExp.exec(content || '')

--- a/lib/utils/note-title.js
+++ b/lib/utils/note-title.js
@@ -10,6 +10,16 @@
 const noteTitleAndPreviewRegExp = /(\S[^\n]*)\s*(\S[^\n]*)?/;
 
 /**
+ * Matches the title and excerpt in a note's content skipping opening # from title
+ *
+ * Both the title and the excerpt are determined as
+ * content starting with something that isn't
+ * whitespace and leads up to a newline or line end
+ * @type {RegExp} matches a title and excerpt in note content skipping opening # from title
+ */
+const noteTitleAndPreviewMdRegExp = /[# ]*(\S[^\n]*)\s*(\S[^\n]*)?/;
+
+/**
  * Returns the title and excerpt for a given note
  *
  * @param {Object} note a note object
@@ -17,7 +27,12 @@ const noteTitleAndPreviewRegExp = /(\S[^\n]*)\s*(\S[^\n]*)?/;
  */
 export const noteTitleAndPreview = note => {
   const content = note && note.data && note.data.content;
-  const match = noteTitleAndPreviewRegExp.exec(content || '');
+  const isMarkdown =
+    note && note.data && note.data.systemTags.some(x => x === 'markdown');
+
+  const match = isMarkdown
+    ? noteTitleAndPreviewMdRegExp.exec(content || '')
+    : noteTitleAndPreviewRegExp.exec(content || '');
 
   const title = (match && match[1] && match[1].slice(0, 200)) || 'New note...';
   const preview = (match && match[2]) || '';

--- a/lib/utils/note-utils.js
+++ b/lib/utils/note-utils.js
@@ -7,8 +7,7 @@
  *
  * @type {RegExp} matches a title and excerpt in note content
  */
-//empty group at the beginning is intended to match group indexes with regex for Markdown notes
-const noteTitleAndPreviewRegExp = /()(\S[^\n]*)(\s*)(\S[^\n]*)?/;
+const noteTitleAndPreviewRegExp = /\s*(\S[^\n]*)\s*(\S[^\n]*)?/;
 
 /**
  * Matches the title and excerpt in a note's content skipping opening # from title
@@ -16,9 +15,10 @@ const noteTitleAndPreviewRegExp = /()(\S[^\n]*)(\s*)(\S[^\n]*)?/;
  * Both the title and the excerpt are determined as
  * content starting with something that isn't
  * whitespace and leads up to a newline or line end
+ *
  * @type {RegExp} matches a title and excerpt in note content skipping opening #'s from title and preview
  */
-const noteTitleAndPreviewMdRegExp = /(#{1,6}\s+)?(\S[^\n]*)(#{1,6}\s*)?(\S[^\n]*)?/;
+const noteTitleAndPreviewMdRegExp = /(?:#{0,6}\s+)?(\S[^\n]*)\s*(?:#{0,6}\s+)?(\S[^\n]*)?/;
 
 /**
  * Returns the title and excerpt for a given note
@@ -33,10 +33,21 @@ export const noteTitleAndPreview = note => {
     ? noteTitleAndPreviewMdRegExp.exec(content || '')
     : noteTitleAndPreviewRegExp.exec(content || '');
 
-  const title = (match && match[2] && match[2].slice(0, 200)) || 'New note...';
-  const preview = (match && match[4]) || '';
+  const defaults = {
+    title: 'New Note...',
+    preview: '',
+  };
 
-  return { title, preview };
+  if (!match) {
+    return defaults;
+  }
+
+  const [, title, preview] = match;
+
+  return {
+    title: title.slice(0, 200) || defaults.title,
+    preview: preview || defaults.preview,
+  };
 };
 
 export const isMarkdown = note => {

--- a/lib/utils/note-utils.js
+++ b/lib/utils/note-utils.js
@@ -7,7 +7,7 @@
  *
  * @type {RegExp} matches a title and excerpt in note content
  */
-const noteTitleAndPreviewRegExp = /(\S[^\n]*)\s*(\S[^\n]*)?/;
+const noteTitleAndPreviewRegExp = /()(\S[^\n]*)\s*(\S[^\n]*)?/;
 
 /**
  * Matches the title and excerpt in a note's content skipping opening # from title
@@ -17,7 +17,7 @@ const noteTitleAndPreviewRegExp = /(\S[^\n]*)\s*(\S[^\n]*)?/;
  * whitespace and leads up to a newline or line end
  * @type {RegExp} matches a title and excerpt in note content skipping opening # from title
  */
-const noteTitleAndPreviewMdRegExp = /[# ]*(\S[^\n]*)\s*(\S[^\n]*)?/;
+const noteTitleAndPreviewMdRegExp = /(#+ +)?(\S[^\n]*)\s*(\S[^\n]*)?/;
 
 /**
  * Returns the title and excerpt for a given note
@@ -27,17 +27,23 @@ const noteTitleAndPreviewMdRegExp = /[# ]*(\S[^\n]*)\s*(\S[^\n]*)?/;
  */
 export const noteTitleAndPreview = note => {
   const content = note && note.data && note.data.content;
-  const isMarkdown =
-    note && note.data && note.data.systemTags.some(tag => tag === 'markdown');
 
-  const match = isMarkdown
+  const match = isMarkdown(note)
     ? noteTitleAndPreviewMdRegExp.exec(content || '')
     : noteTitleAndPreviewRegExp.exec(content || '');
 
-  const title = (match && match[1] && match[1].slice(0, 200)) || 'New note...';
-  const preview = (match && match[2]) || '';
+  const title = (match && match[2] && match[2].slice(0, 200)) || 'New note...';
+  const preview = (match && match[3]) || '';
 
   return { title, preview };
+};
+
+export const isMarkdown = note => {
+  return (
+    note &&
+    note.data &&
+    note.data.systemTags.includes(tag => tag === 'markdown')
+  );
 };
 
 export default noteTitleAndPreview;

--- a/lib/utils/note-utils.js
+++ b/lib/utils/note-utils.js
@@ -8,7 +8,7 @@
  * @type {RegExp} matches a title and excerpt in note content
  */
 //empty group at the beginning is intended to match group indexes with regex for Markdown notes
-const noteTitleAndPreviewRegExp = /()(\S[^\n]*)\s*(\S[^\n]*)?/;
+const noteTitleAndPreviewRegExp = /()(\S[^\n]*)(\s*)(\S[^\n]*)?/;
 
 /**
  * Matches the title and excerpt in a note's content skipping opening # from title
@@ -16,9 +16,9 @@ const noteTitleAndPreviewRegExp = /()(\S[^\n]*)\s*(\S[^\n]*)?/;
  * Both the title and the excerpt are determined as
  * content starting with something that isn't
  * whitespace and leads up to a newline or line end
- * @type {RegExp} matches a title and excerpt in note content skipping opening #'s from title
+ * @type {RegExp} matches a title and excerpt in note content skipping opening #'s from title and preview
  */
-const noteTitleAndPreviewMdRegExp = /(#{1,6}\s+)?(\S[^\n]*)\s*(\S[^\n]*)?/;
+const noteTitleAndPreviewMdRegExp = /(#{1,6}\s+)?(\S[^\n]*)(#{1,6}\s*)?(\S[^\n]*)?/;
 
 /**
  * Returns the title and excerpt for a given note
@@ -34,17 +34,13 @@ export const noteTitleAndPreview = note => {
     : noteTitleAndPreviewRegExp.exec(content || '');
 
   const title = (match && match[2] && match[2].slice(0, 200)) || 'New note...';
-  const preview = (match && match[3]) || '';
+  const preview = (match && match[4]) || '';
 
   return { title, preview };
 };
 
 export const isMarkdown = note => {
-  return (
-    note &&
-    note.data &&
-    note.data.systemTags.includes(tag => tag === 'markdown')
-  );
+  return note && note.data && note.data.systemTags.includes('markdown');
 };
 
 export default noteTitleAndPreview;

--- a/lib/utils/note-utils.js
+++ b/lib/utils/note-utils.js
@@ -7,6 +7,7 @@
  *
  * @type {RegExp} matches a title and excerpt in note content
  */
+//empty group at the beginning is intended to match group indexes with regex for Markdown notes
 const noteTitleAndPreviewRegExp = /()(\S[^\n]*)\s*(\S[^\n]*)?/;
 
 /**
@@ -15,9 +16,9 @@ const noteTitleAndPreviewRegExp = /()(\S[^\n]*)\s*(\S[^\n]*)?/;
  * Both the title and the excerpt are determined as
  * content starting with something that isn't
  * whitespace and leads up to a newline or line end
- * @type {RegExp} matches a title and excerpt in note content skipping opening # from title
+ * @type {RegExp} matches a title and excerpt in note content skipping opening #'s from title
  */
-const noteTitleAndPreviewMdRegExp = /(#+ +)?(\S[^\n]*)\s*(\S[^\n]*)?/;
+const noteTitleAndPreviewMdRegExp = /(#{1,6}\s+)?(\S[^\n]*)\s*(\S[^\n]*)?/;
 
 /**
  * Returns the title and excerpt for a given note


### PR DESCRIPTION
**Testing**

Add notes with a leading `#` in the title (the first line in the note)

Make sure there is a mixture of markdown-enabled notes and plain notes.
Make sure this works as expected when there is a single `#` as well as a string of them, such as `### header`

Make sure that it leaves _wanted_ `#` in there, such as `# # # # Page # # # #`

Note any cases not mentioned here that may be significant to pay attention to.