### PR TITLE
Fixes issues when switching accounts (#634 and #641)

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -250,6 +250,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       actions.authChanged();
 
       if (!client.isAuthorized()) {
+        actions.closeNote();
         return resetAuth();
       }
 

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "serve-favicon": "2.4.3",
     "showdown": "1.7.2",
     "showdown-xss-filter": "0.2.0",
-    "simperium": "0.2.6"
+    "simperium": "0.2.7"
   },
   "optionalDependencies": {
     "appdmg": "0.4.5"


### PR DESCRIPTION
* Fixed an issue with the `isIndexing` flag in Simperium, fixes #641.
* Clear note editor upon unauthentication (fixes #634)

**To Test**
1. Sign in to the app, observe that your notes are loaded.
2. Sign out, and sign in with another account.
3. Your notes should load and everything should work as normal!

To test the fix for #634, you need to switch to an account that has *no notes at all* from an account that *has notes*. The editor should be blank after you switch.
