### PR TITLE
Fixes '0' from displaying near the tags edit button

### DIFF
--- a/lib/tag-list.jsx
+++ b/lib/tag-list.jsx
@@ -64,7 +64,7 @@ export class TagList extends Component {
       <div className={classes}>
         <div className="tag-list-title">
           <h2 className="panel-title theme-color-fg-dim">Tags</h2>
-          {tags.length && (
+          {0 !== tags.length && (
             <button
               className="tag-list-edit-toggle button button-borderless"
               tabIndex="0"

--- a/lib/tag-list.jsx
+++ b/lib/tag-list.jsx
@@ -64,7 +64,7 @@ export class TagList extends Component {
       <div className={classes}>
         <div className="tag-list-title">
           <h2 className="panel-title theme-color-fg-dim">Tags</h2>
-          {0 !== tags.length && (
+          {tags.length > 0 && (
             <button
               className="tag-list-edit-toggle button button-borderless"
               tabIndex="0"


### PR DESCRIPTION
I noticed that a `0` was being displayed for the tags edit button after you signed out/in again:

<img width="199" alt="screen shot 2017-11-06 at 3 37 13 pm" src="https://user-images.githubusercontent.com/789137/32469684-a04e7dd4-c308-11e7-8b74-bd64e2d1c4d7.png">

This fixes that by checking for a zero `tags` array length. Note: The `tags` array is always created in the state so I don't think we need to worry about it being `undefined` here.
