### PR TITLE
Remove autoHideMenuBar so we get the menu back on windows/linux.

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -48,7 +48,6 @@ module.exports = function main() {
       minWidth: 370,
       minHeight: 520,
       icon: iconPath,
-      autoHideMenuBar: true,
       titleBarStyle: 'hidden',
       show: false,
     });


### PR DESCRIPTION
The update to electron must have made `autoHideMenuBar` actually work :) I removed it so we get the menu back on Windows/Linux:

<img width="359" alt="screen shot 2017-11-08 at 11 18 33 am" src="https://user-images.githubusercontent.com/789137/32569739-d2965f4a-c476-11e7-9cf5-16a7b39399d1.png">

Fixes #659 
