### PR TITLE
Fix external links in Electron 

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -76,7 +76,7 @@ module.exports = function main() {
 
     mainWindowState.manage(mainWindow);
 
-    mainWindow.webContents.on('new-window', function(event, linkUrl){
+    mainWindow.webContents.on('new-window', function(event, linkUrl) {
       event.preventDefault();
       shell.openExternal(linkUrl);
     });

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -76,6 +76,11 @@ module.exports = function main() {
 
     mainWindowState.manage(mainWindow);
 
+    mainWindow.webContents.on('new-window', function(event, linkUrl){
+      event.preventDefault();
+      shell.openExternal(linkUrl);
+    });
+
     // Emitted when the window is closed.
     mainWindow.on('closed', function() {
       // Dereference the window object, usually you would store windows


### PR DESCRIPTION
Links with `window.open` and `target=_blank` weren't opening properly in Electron.

I found a solution at https://github.com/electron/electron/issues/1344#issuecomment-171516261 that will intercept the links and open them in an external browser.

We have some code in `url-utils.js` to open a link externally as well, but looks like we don't use it anywhere now.

**To Test**
* Click on the 'forgot password' link in the auth view, and links in the about screen. They should open in an external browser window when in electron (and in the browser as well)

Fixes #656