### PR TITLE
Remove orange outline from notes list in electron

### DIFF
--- a/scss/note-list.scss
+++ b/scss/note-list.scss
@@ -78,6 +78,10 @@
   overflow: auto;
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
+
+  div:focus {
+    outline: none;
+  }
 }
 
 .note-list-empty-trash {


### PR DESCRIPTION
Electron's internal browser was adding an outline around the notes list when it received focus.

Looks like @drw158 had encountered this before, I'm just adding the override to the divs within the notes list.

Fixes #658 