### PR TITLE
Fix Windows Build for 32 Bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ package: build-if-changed
 	@cp -R $(THIS_DIR)/dist $(DESKTOP_BUILD_DIR)
 
 package-win32: win32
-	@$(PACKAGE_WIN32) ./release/Simplenote-win32-ia32 --platform=win --config=./resources/build-config/win32.json
+	@$(PACKAGE_WIN32) ./release/Simplenote-win32-ia32 --win --ia32 --config=./resources/build-config/win32.json
 	@node $(THIS_DIR)/resources/build-scripts/rename-with-version-win.js
 	@node $(THIS_DIR)/resources/build-scripts/code-sign-win.js --spc=$(CERT_SPC) --pvk=$(CERT_PVK)
 

--- a/resources/build-config/build.json
+++ b/resources/build-config/build.json
@@ -1,6 +1,7 @@
 {
   "bundleId": "com.automattic.simplenote",
   "name": "Simplenote",
+  "productName": "Simplenote",
   "author": "Automattic, Inc.",
   "copyright": "Copyright (C) Automattic, Inc.",
   "directories": {

--- a/resources/build-config/win32.json
+++ b/resources/build-config/win32.json
@@ -2,5 +2,14 @@
   "icon": "resources/images/simplenote.ico",
   "directories": {
     "output": "release"
+  },
+  "target": [
+    {
+      "target": "nsis",
+      "arch": ["ia32"]
+    }
+  ],
+  "nsis": {
+    "perMachine": true
   }
 }


### PR DESCRIPTION
The `electron-builder` update was building 64 bit by default and installing to a different directory than the app previously went.

Now we:
* Force 32 bit build only
* Use `perMachine` flag to install the app to the `program files (x86)` folder, so updates work.