### PR TITLE
About View: Added Dynamic Year

### DIFF
--- a/lib/dialogs/about.jsx
+++ b/lib/dialogs/about.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import moment from 'moment';
 import SimplenoteLogo from '../icons/simplenote';
 import CrossIcon from '../icons/cross';
 import TopRightArrowIcon from '../icons/arrow-top-right';
@@ -17,7 +18,8 @@ export default React.createClass({
   },
 
   render() {
-    var dialog = this.props.dialog;
+    const dialog = this.props.dialog;
+    const thisYear = moment().year();
 
     return (
       <Dialog className="about" {...dialog} onDone={this.onDone}>
@@ -110,7 +112,7 @@ export default React.createClass({
               href="https://automattic.com/"
               rel="noopener noreferrer"
             >
-              &copy; 2016 Automattic, Inc.
+              &copy; {thisYear} Automattic, Inc.
             </a>
           </p>
         </div>

--- a/lib/dialogs/about.jsx
+++ b/lib/dialogs/about.jsx
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import moment from 'moment';
 import SimplenoteLogo from '../icons/simplenote';
 import CrossIcon from '../icons/cross';
 import TopRightArrowIcon from '../icons/arrow-top-right';
@@ -19,7 +18,7 @@ export default React.createClass({
 
   render() {
     const dialog = this.props.dialog;
-    const thisYear = moment().year();
+    const thisYear = new Date().getFullYear();
 
     return (
       <Dialog className="about" {...dialog} onDone={this.onDone}>


### PR DESCRIPTION
A tester noticed that the copyright date was behind in the about screen. How about we make it dynamic?

<img width="316" alt="screen shot 2017-11-09 at 4 01 49 pm" src="https://user-images.githubusercontent.com/789137/32635979-8916fe78-c567-11e7-8a61-23eabe12eb71.png">