### PR TITLE
Fix context menu for markdown preview

### DIFF
--- a/lib/context-menu.jsx
+++ b/lib/context-menu.jsx
@@ -47,7 +47,11 @@ export const ContextMenu = React.createClass({
 
     event.preventDefault();
 
-    if (!event.target.closest('textarea, input, [contenteditable="true"]')) {
+    if (
+      !event.target.closest(
+        'textarea, input, [contenteditable="true"], div.note-detail-markdown'
+      )
+    ) {
       return;
     }
 


### PR DESCRIPTION
@designsimply reported that the right-click menu was not working for the markdown preview.

This updates the `context-menu` code so that it will allow the menu to show from the markdown div:

<img width="230" alt="screen shot 2017-11-09 at 4 19 10 pm" src="https://user-images.githubusercontent.com/789137/32636585-57f56994-c56a-11e7-8419-f3236e00c3a8.png">

p.s. `prettier` wanted to format the code that way :)
