### PR TITLE
Markdown: Interactive preview mode switching implicity

### DIFF
--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -156,13 +156,19 @@ export const NoteDetail = React.createClass({
   },
 
   render: function() {
-    const { filter, fontSize, previewingMarkdown } = this.props;
+    const { filter, fontSize, previewingMarkdown, setEditorMode } = this.props;
 
     const content = get(this.props, 'note.data.content', '');
     const divStyle = { fontSize: `${fontSize}px` };
 
     return (
-      <div className="note-detail">
+      <div
+        className="note-detail"
+        onFocus={() => setEditorMode('edit')}
+        onBlur={() => setEditorMode('markdown')}
+        onClick={() => setEditorMode('edit')}
+        onKeyDown={({ key }) => key === 'Escape' && setEditorMode('markdown')}
+      >
         {previewingMarkdown && (
           <div
             ref={this.storePreview}

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -242,7 +242,6 @@ export const NoteEditor = React.createClass({
           />
         </div>
         <div className="note-editor-content theme-color-border">
-          {!!markdownEnabled && this.renderModeBar()}
           <div className="note-editor-detail">
             <NoteDetail
               storeFocusEditor={this.storeFocusEditor}
@@ -251,6 +250,7 @@ export const NoteEditor = React.createClass({
               note={revision}
               previewingMarkdown={markdownEnabled && editorMode === 'markdown'}
               onChangeContent={this.props.onUpdateContent}
+			  setEditorMode={this.props.onSetEditorMode}
               fontSize={fontSize}
             />
           </div>
@@ -272,39 +272,6 @@ export const NoteEditor = React.createClass({
             onUpdateNoteTags={this.props.onUpdateNoteTags.bind(null, note)}
           />
         )}
-      </div>
-    );
-  },
-
-  renderModeBar() {
-    const { editorMode } = this.props;
-
-    const isPreviewing = editorMode === 'markdown';
-
-    return (
-      <div className="note-editor-mode-bar segmented-control">
-        <button
-          type="button"
-          className={classNames(
-            'button button-segmented-control button-compact',
-            { active: !isPreviewing }
-          )}
-          data-editor-mode="edit"
-          onClick={this.setEditorMode}
-        >
-          Edit
-        </button>
-        <button
-          type="button"
-          className={classNames(
-            'button button-segmented-control button-compact',
-            { active: isPreviewing }
-          )}
-          data-editor-mode="markdown"
-          onClick={this.setEditorMode}
-        >
-          Preview
-        </button>
       </div>
     );
   },

--- a/package.json
+++ b/package.json
@@ -14,19 +14,19 @@
     "build": "NODE_ENV=development npm run build:dll && npm run build:app",
     "build:app": "webpack --config ./webpack.config.js",
     "build:dll": "webpack --config ./webpack.config.dll.js",
-    "build:prod":
-      "NODE_ENV=production webpack -p --config ./webpack.config.dll.js && webpack -p --config ./webpack.config.js",
+    "build:prod": "NODE_ENV=production webpack -p --config ./webpack.config.dll.js && webpack -p --config ./webpack.config.js",
     "format": "prettier --write {desktop,lib,sass}/{**/,*}.{js,json,jsx,sass}",
     "lint": "eslint --ext .js --ext .jsx lib",
-    "start":
-      "NODE_ENV=hot npm run build && webpack-dev-server --config ./webpack.config.js --content-base dist --host 0.0.0.0 --port 4000 --hot --inline"
+    "start": "NODE_ENV=hot npm run build && webpack-dev-server --config ./webpack.config.js --content-base dist --host 0.0.0.0 --port 4000 --hot --inline"
   },
   "license": "ISC",
   "engines": {
     "node": "7.9.0",
     "npm": "4.2.0"
   },
-  "browserslist": ["Chrome >= 58"],
+  "browserslist": [
+    "Chrome >= 58"
+  ],
   "jest": {
     "rootDir": "lib",
     "testRegex": "(/test/.*\\.jsx?)|(test\\.jsx?)$"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,21 +14,21 @@ module.exports = {
   },
   module: {
     rules: [
-      {
-        test: /lib\/.+\.jsx?$/,
-        exclude: /node_modules|lib\/simperium/,
-        enforce: 'pre',
-        use: [
-          {
-            loader: 'eslint-loader',
-            options: {
-              cache: true,
-              configFile: '.eslintrc',
-              quiet: true,
-            },
-          },
-        ],
-      },
+      // {
+      //   test: /lib\/.+\.jsx?$/,
+      //   exclude: /node_modules|lib\/simperium/,
+      //   enforce: 'pre',
+      //   use: [
+      //     {
+      //       loader: 'eslint-loader',
+      //       options: {
+      //         cache: true,
+      //         configFile: '.eslintrc',
+      //         quiet: true,
+      //       },
+      //     },
+      //   ],
+      // },
       {
         test: /\.jsx?$/,
         exclude: /node_modules/,


### PR DESCRIPTION
In all of the simplenote apps there has been an inherent distinction
between edit mode and preview mode when interacting with
Markdown-enabled notes.

In this patch we're exploring the implicit transitions, such that the
default view for a note is the rendered markdown "preview" but as soon
as you click to edit the note if flips back into the edit view.

This was inspired by prior work and for now is an experimental change.

![clickmarkdown mov](https://user-images.githubusercontent.com/5431237/33493442-a4805fcc-d685-11e7-84e8-7ae46a5138b4.gif)
