### PR TITLE
Adding table style

### DIFF
--- a/scss/markdown-preview.scss
+++ b/scss/markdown-preview.scss
@@ -45,4 +45,21 @@
     color: darken($gray, 10%);
     background: transparent;
   }
+  table {
+    border-collapse:collapse;
+    border-spacing: 0;
+    display: block;
+    width: 100%;
+    tr:nth-child(2n) {
+      background-color: lighten($gray, 40%)
+    }
+    th, td {
+      border: 1px solid lighten($gray, 20%);
+      padding: 6px 13px;
+    }
+    th {
+      font-weight: 600
+    }
+  }
+
 }

--- a/scss/markdown-preview.scss
+++ b/scss/markdown-preview.scss
@@ -51,14 +51,14 @@
     display: block;
     width: 100%;
     tr:nth-child(2n) {
-      background-color: lighten($gray, 40%)
+      background-color: lighten($gray, 40%);
     }
     th, td {
       border: 1px solid lighten($gray, 20%);
       padding: 6px 13px;
     }
     th {
-      font-weight: 600
+      font-weight: 600;
     }
   }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -146,6 +146,14 @@
       color: $gray;
       background: transparent;
     }
+    table {
+      th, td {
+        border-color: darken($gray, 20%);
+      }
+      tr:nth-child(2n) {
+        background-color: darken($gray, 33%)
+      }
+    }
   }
 }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -151,7 +151,7 @@
         border-color: darken($gray, 20%);
       }
       tr:nth-child(2n) {
-        background-color: darken($gray, 33%)
+        background-color: darken($gray, 33%);
       }
     }
   }


### PR DESCRIPTION
Trying to address #672 

Dark theme | Light theme
| -- | -- | 
<img width="293" alt="schermata 2017-12-04 alle 22 48 50 copia" src="https://user-images.githubusercontent.com/6209647/33607919-eb1bdb1a-d9c2-11e7-8855-91a24abfe1d7.png"> | <img width="298" alt="schermata 2017-12-04 alle 22 49 16 copia" src="https://user-images.githubusercontent.com/6209647/33607920-eb3a1472-d9c2-11e7-915d-598430fcc8b0.png">

For the screens I have used the very same example found in the issue. 
The style has been copied from the one used in the github comment editor.