### PR TITLE
Fix Improper Tag Creation from Duplicating Tags

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -136,7 +136,8 @@ export const actionMap = new ActionMap({
     newTag: {
       creator({ tagBucket, name }) {
         return () => {
-          tagBucket.add({ name }, () => {
+          // tag.id should be a lower case version of the tag name
+          tagBucket.update(name.toLowerCase(), { name }, () => {
             // dispatch( this.action( 'loadTags', { tagBucket } ) );
           });
         };

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -136,8 +136,9 @@ export const actionMap = new ActionMap({
     newTag: {
       creator({ tagBucket, name }) {
         return () => {
-          // tag.id should be a lower case version of the tag name
-          tagBucket.update(name.toLowerCase(), { name }, () => {
+          // tag.id must be the tag name in lower case and percent escaped
+          const tagId = encodeURIComponent(name.toLowerCase());
+          tagBucket.update(tagId, { name }, () => {
             // dispatch( this.action( 'loadTags', { tagBucket } ) );
           });
         };

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -138,9 +138,7 @@ export const actionMap = new ActionMap({
         return () => {
           // tag.id must be the tag name in lower case and percent escaped
           const tagId = encodeURIComponent(name.toLowerCase());
-          tagBucket.update(tagId, { name }, () => {
-            // dispatch( this.action( 'loadTags', { tagBucket } ) );
-          });
+          tagBucket.update(tagId, { name });
         };
       },
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simplenote",
   "productName": "Simplenote",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Simplenote for desktop.",
   "author": "Automattic, Inc. (https://automattic.com)",
   "main": "desktop/index.js",


### PR DESCRIPTION
https://github.com/Automattic/simplenote-android/issues/474 led me back to an issue in this app.

Our tag model is a little funny, it has an `id` which _should be_ a lower-case and percent escaped version of the tag name the user enters. So a tag named `Woot` should have an id of `woot`, `W@@t` should have an id of `w%40%40t`, etc.

In this app we were letting Simperium [assign a random id](https://github.com/Simperium/node-simperium/blob/master/src/simperium/bucket.js#L18) whenever we added a new tag:
<img width="309" alt="screen shot 2017-12-06 at 3 22 07 pm" src="https://user-images.githubusercontent.com/789137/33690974-ce2c4c14-da9a-11e7-85f3-92a95b9c50b0.png">

This was causing the issue in other apps that were checking for an existing id before adding a new tag. I fixed it by using `bucket.update` instead of `bucket.add`, which allows a custom id to be passed and still creates a new object.

**To Test**
* Create a new tag in this app.
* Head over to another Simplenote client like iOS or android and add the new tag to another note.
* It should have added the same tag you originally created and not make a duplicate.

This PR does not attempt to fix existing tags in the app that were created improperly, as I couldn't quite wrap my head around how to do that :)