### PR TITLE
Limit protocols allowed for external links

### DIFF
--- a/lib/utils/url-utils.js
+++ b/lib/utils/url-utils.js
@@ -1,5 +1,7 @@
 import { has } from 'lodash';
 
+const allowedProtocols = ['http://', 'https://', 'mailto:'];
+
 let state = {
   isRunningElectron: null,
 };
@@ -19,4 +21,15 @@ function init() {
   state = { ...state, isRunningElectron, openExternalUrl };
 }
 
-export const viewExternalUrl = url => state.openExternalUrl(url);
+export const viewExternalUrl = url => {
+  const lowerCaseUrl = url.toLowerCase().trim();
+  const urlStartsWithProtocol = function(protocol) {
+    return this.startsWith(protocol);
+  };
+
+  if (!allowedProtocols.some(urlStartsWithProtocol, lowerCaseUrl)) {
+    return;
+  }
+
+  state.openExternalUrl(lowerCaseUrl);
+};

--- a/lib/utils/url-utils.js
+++ b/lib/utils/url-utils.js
@@ -1,6 +1,6 @@
 import { has } from 'lodash';
 
-const allowedProtocols = ['http://', 'https://', 'mailto:'];
+const allowedProtocols = ['http:', 'https:', 'mailto:'];
 
 let state = {
   isRunningElectron: null,
@@ -22,14 +22,20 @@ function init() {
 }
 
 export const viewExternalUrl = url => {
-  const lowerCaseUrl = url.toLowerCase().trim();
-  const urlStartsWithProtocol = function(protocol) {
-    return this.startsWith(protocol);
-  };
+  try {
+    const protocol = new URL(url).protocol;
 
-  if (!allowedProtocols.some(urlStartsWithProtocol, lowerCaseUrl)) {
+    const isAllowed = function(allowed) {
+      return this === allowed;
+    };
+
+    if (!allowedProtocols.some(isAllowed, protocol)) {
+      return;
+    }
+  } catch (e) {
+    // Invalid Url
     return;
   }
 
-  state.openExternalUrl(lowerCaseUrl);
+  state.openExternalUrl(url);
 };

--- a/lib/utils/url-utils.js
+++ b/lib/utils/url-utils.js
@@ -25,11 +25,7 @@ export const viewExternalUrl = url => {
   try {
     const protocol = new URL(url).protocol;
 
-    const isAllowed = function(allowed) {
-      return this === allowed;
-    };
-
-    if (!allowedProtocols.some(isAllowed, protocol)) {
+    if (!allowedProtocols.some(allowed => allowed === protocol)) {
       return;
     }
   } catch (e) {


### PR DESCRIPTION
We received a report that the app is happy to open any url provided to it in the markdown preview. This PR locks it down to only open `http`, `https`, and `mailto` links.

**To Test**
 * Create a markdown note with some links in it, some of them with http, https, mailto and some other naughty ones such as `file://`.
 * Only the allowed protocols should open when clicked.