### PR TITLE
Fix new user signups to create a web account

### DIFF
--- a/lib/boot.js
+++ b/lib/boot.js
@@ -27,6 +27,7 @@ const config = getConfig();
 
 const cookie = parse(document.cookie);
 const auth = new Auth(config.app_id, config.app_key);
+const appProvider = 'simplenote.com';
 
 require('../scss/app.scss');
 
@@ -144,7 +145,7 @@ let props = {
 
     store.dispatch(setPendingAuth());
     auth
-      .create(username, password)
+      .create(username, password, appProvider)
       .then(user => {
         if (!user.access_token) {
           return store.dispatch(resetAuth);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "simplenote",
   "productName": "Simplenote",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Simplenote for desktop.",
   "author": "Automattic, Inc. (https://automattic.com)",
   "main": "desktop/index.js",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "serve-favicon": "2.4.3",
     "showdown": "1.7.2",
     "showdown-xss-filter": "0.2.0",
-    "simperium": "0.2.8"
+    "simperium": "0.2.9"
   },
   "optionalDependencies": {
     "appdmg": "0.4.5"


### PR DESCRIPTION
Note: Depends on https://github.com/Simperium/node-simperium/pull/52

We need to pass along an extra 'provider' parameter when signing up so that a web account will be created for the user.

**To Test**
 * Point simperium in `package.json` to a local checkout of https://github.com/Simperium/node-simperium/tree/update/signup-protocol
 * `npm install`
 * Run the app, and sign up for an account. You should receive an email after signing up, and be able to sign in to the web app at https://app.simplenote.com

If all looks good, I'll merge and release the node-simperium PR and bump the version in package.json here.

