### PR TITLE
Disable app window drag and drop

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -81,6 +81,11 @@ module.exports = function main() {
       shell.openExternal(linkUrl);
     });
 
+    // Disables navigation for app window drag and drop
+    mainWindow.webContents.on('will-navigate', function(event) {
+      event.preventDefault();
+    });
+
     // Emitted when the window is closed.
     mainWindow.on('closed', function() {
       // Dereference the window object, usually you would store windows

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -82,9 +82,7 @@ module.exports = function main() {
     });
 
     // Disables navigation for app window drag and drop
-    mainWindow.webContents.on('will-navigate', function(event) {
-      event.preventDefault();
-    });
+    mainWindow.webContents.on('will-navigate', event => event.preventDefault());
 
     // Emitted when the window is closed.
     mainWindow.on('closed', function() {


### PR DESCRIPTION
Electron doesn't disable drag and drop by default, so we'll explicitly stop navigating when the `will-navigate` event fires.

See: https://discuss.atom.io/t/prevent-window-navigation-when-dropping-a-link/24365

**To Test**
* Try and drag anything into the app. The only thing that should work is when you drag text into the editor.
* Click on external links, they should still open in an external browser.