### PR TITLE
Fix offline/reconnect note sync with active note in the editor 

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -1,4 +1,4 @@
-import { partition } from 'lodash';
+import { get, partition } from 'lodash';
 import update from 'react-addons-update';
 import ActionMap from './action-map';
 import isEmailTag from '../utils/is-email-tag';
@@ -456,21 +456,33 @@ export const actionMap = new ActionMap({
 
           // diff of working and original will produce the modifications the client has currently made
           let working_diff = simperiumUtil.change.diff(original, working);
-          // generate a patch that composes both the working changes and upstream changes
-          patch = simperiumUtil.change.transform(working_diff, patch, original);
-          // apply the new patch to the upstream data
-          let rebased = simperiumUtil.change.apply(patch, data);
 
-          // TODO: determine where the cursor is and put it in the correct place
-          // when applying the rebased content
+          // Check for equal diffs so we don't duplicate changes
+          const diffsAreEqual =
+            get(working_diff, 'content.v', '') === get(patch, 'content.v', '');
 
-          state.note.data = rebased;
+          if (!diffsAreEqual) {
+            // generate a patch that composes both the working changes and upstream changes
+            patch = simperiumUtil.change.transform(
+              working_diff,
+              patch,
+              original
+            );
+            // apply the new patch to the upstream data
+            let rebased = simperiumUtil.change.apply(patch, data);
 
-          // update the bucket and sync
-          noteBucket.update(noteId, rebased);
+            // TODO: determine where the cursor is and put it in the correct place
+            // when applying the rebased content
+
+            state.note.data = rebased;
+
+            // update the bucket and sync
+            noteBucket.update(noteId, rebased);
+          }
 
           dispatch(
-            this.action('selectNote', {
+            this.action('loadAndSelectNote', {
+              noteBucket,
               noteId,
             })
           );


### PR DESCRIPTION
I believe I've discovered some bugs that can help with #602, but only for notes that are currently active in the editor.

**Bugs fixed**
 * We were applying duplicate changes when the app came online again. I added a check for an equal diff, and we don't do any patching if so. You can reproduce in `master` by going offline, making a change in electron, then going online again. You'll see the change apply twice.
 * We weren't updating the editor content properly when the note updated after coming online again. You can reproduce this in `master` by applying a change in another app while electron is offline. When you reconnect, you'll see the content update in the notes list but not in the editor! This could be why a lot of users lost content. I fixed this by using the `loadAndSelectNote` action vs. the `selectNote` action.

You can test this in general by taking the app offline and making changes. Also try making changes to a note from different clients at the exact same time. The diffs should merge properly (as best as it can).