### PR TITLE
Updates babel, adds async/await

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,7 @@
 
   },
   "presets": [
-    [ "env", { "targets": { "electron": "1.7" } } ],
+    [ "env", { "targets": { "electron": "1.7", "uglify": true } } ],
     "react"
   ],
   "plugins": [

--- a/.babelrc
+++ b/.babelrc
@@ -1,15 +1,14 @@
 {
   "env": {
-    "test": {
-      "presets": [ "es2015", "react" ]
-    }
+
   },
   "presets": [
-    [ "es2015", { "modules": false } ],
+    [ "env", { "targets": { "electron": "1.7" } } ],
     "react"
   ],
   "plugins": [
     "babel-plugin-transform-class-properties",
-    "babel-plugin-transform-object-rest-spread"
+    "babel-plugin-transform-object-rest-spread",
+    "babel-plugin-transform-async-to-generator"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel-eslint": "7.2.3",
     "babel-jest": "20.0.3",
     "babel-loader": "7.1.2",
+    "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-object-rest-spread": "6.26.0",
     "babel-preset-env": "1.6.0",


### PR DESCRIPTION
Uses `babel-preset-env` in the `.babelrc` config and targets electron browser.

Also adds `async/await` via `babel-plugin-transform-async-to-generator` and shows example use in  settings dialog.

While this is perfectly good:

```js
const noteHasSynced = note =>
  new Promise((resolve, reject) =>
  getVersion(note.id, (e, v) => (e || v === 0 ? reject() : resolve()))
);

Promise.all(notes.map(noteHasSynced)).then(
  () => onSignOut(), // All good, sign out now!
  () => this.showUnsyncedWarning() // Show a warning to the user
);
```

Using `async/await` allows for a more straight forward approach:

```js
for (const note of notes) {
  if ((await getVersion(note)) === 0) {
    // Show a warning to the user
    this.showUnsyncedWarning();
    return;
  }
}
onSignOut();
```

Also, simperium/node-simperium#56 adds a `Promise` based interface to all bucket methods so it could potentially improve code readability by changing callback code to `async/await` code.