### PR TITLE
Simple tray icon implementation

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -7,6 +7,7 @@ const {
   ipcMain,
   shell,
   Menu,
+  Tray
 } = require('electron');
 
 const path = require('path');
@@ -51,6 +52,19 @@ module.exports = function main() {
       titleBarStyle: 'hidden',
       show: false,
     });
+
+    // Tray
+    const tray = new Tray(iconPath)
+
+    tray.on('click', () => {
+      mainWindow.isVisible() ? mainWindow.hide() : mainWindow.show()
+    })
+    mainWindow.on('show', () => {
+      tray.setHighlightMode('always')
+    })
+    mainWindow.on('hide', () => {
+      tray.setHighlightMode('never')
+    })
 
     // and load the index of the app.
     if (typeof mainWindow.loadURL === 'function') {

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -54,18 +54,18 @@ module.exports = function main() {
     });
 
     // Tray
-    const tray = new Tray(iconPath)
+    const tray = new Tray(iconPath);
 
     tray.on('click', () => {
-      mainWindow.isVisible() ? mainWindow.hide() : mainWindow.show()
+      mainWindow.isVisible() ? mainWindow.hide() : mainWindow.show();
     })
     // Visual effects for macos
     // https://github.com/electron/electron/blob/master/docs/api/tray.md#traysethighlightmodemode-macos
     mainWindow.on('show', () => {
-      tray.setHighlightMode('always')
+      tray.setHighlightMode('always');
     })
     mainWindow.on('hide', () => {
-      tray.setHighlightMode('never')
+      tray.setHighlightMode('never');
     })
 
     // and load the index of the app.
@@ -109,7 +109,15 @@ module.exports = function main() {
     });
 
     // wait until window is presentable
-    mainWindow.once('ready-to-show', mainWindow.show);
+    mainWindow.once('ready-to-show', function() {
+      // hide to tray on startup
+      if (process.argv.includes('--hide-to-tray')) {
+        mainWindow.hide();
+      }
+      else {
+        mainWindow.show();
+      }
+    });
   };
 
   const shouldQuit = app.makeSingleInstance(() => {

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -59,6 +59,8 @@ module.exports = function main() {
     tray.on('click', () => {
       mainWindow.isVisible() ? mainWindow.hide() : mainWindow.show()
     })
+    // Visual effects for macos
+    // https://github.com/electron/electron/blob/master/docs/api/tray.md#traysethighlightmodemode-macos
     mainWindow.on('show', () => {
       tray.setHighlightMode('always')
     })


### PR DESCRIPTION
- [x] Simple tray icon implementation following
https://github.com/electron/electron/blob/master/docs/api/tray.md
- [x] Command line argument to hide to tray on startup (`--hide-to-tray`)

Tested on Linux MInt 18.3, with awesome wm 4.2.2