### PR TITLE
Fix for checklist rendering problem

### DIFF
--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import highlight from 'highlight.js';
 import showdown from 'showdown';
-import xssFilter from 'showdown-xss-filter';
+import xssfilter from 'showdown-xss-config';
 import { get, debounce, invoke, noop } from 'lodash';
 import analytics from './analytics';
 import { viewExternalUrl } from './utils/url-utils';
@@ -10,7 +10,23 @@ import NoteContentEditor from './note-content-editor';
 
 const saveDelay = 2000;
 
-const markdownConverter = new showdown.Converter({ extensions: [xssFilter] });
+// whitelist <input> (only checkbox type) and <li> tags
+const xssConfig = {
+  onTag(tag, html) {
+    if (tag === 'input') {
+      if (html.includes('type="checkbox"')) return html;
+    }
+    if (tag === 'li') {
+      return html;
+    }
+  },
+};
+
+console.log(xssfilter); // eslint-disable-line no-console
+
+const markdownConverter = new showdown.Converter({
+  extensions: [xssfilter(xssConfig)],
+});
 markdownConverter.setFlavor('github');
 
 const renderToNode = (node, content) => {

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -2,14 +2,28 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import showdown from 'showdown';
-import xssFilter from 'showdown-xss-filter';
+import xssfilter from 'showdown-xss-config';
 import NoteDetail from './note-detail';
 import TagField from './tag-field';
 import NoteToolbar from './note-toolbar';
 import RevisionSelector from './revision-selector';
 import { get, property } from 'lodash';
 
-const markdownConverter = new showdown.Converter({ extensions: [xssFilter] });
+// whitelist <input> (only checkbox type) and <li> tags
+const xssConfig = {
+  onTag(tag, html) {
+    if (tag === 'input') {
+      if (html.includes('type="checkbox"')) return html;
+    }
+    if (tag === 'li') {
+      return html;
+    }
+  },
+};
+
+const markdownConverter = new showdown.Converter({
+  extensions: [xssfilter(xssConfig)],
+});
 markdownConverter.setFlavor('github');
 
 export const NoteEditor = React.createClass({

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "sanitize-filename": "1.6.1",
     "serve-favicon": "2.4.3",
     "showdown": "1.7.2",
-    "showdown-xss-filter": "0.2.0",
+    "showdown-xss-config": "~1.0.x",
     "simperium": "0.3.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Trying to address https://github.com/Automattic/simplenote-electron/issues/694, https://github.com/Automattic/simplenote-electron/issues/314, https://github.com/Automattic/simplenote-electron/issues/681

Hello,
after some investigation I found that the problem was indeed the sanitization of html performed by https://github.com/leizongmin/js-xss through https://github.com/VisionistInc/showdown-xss-filter.

```js-xss``` provides powerful filtering API, but ```showdown-xss-filter``` forces only the default behavior that kills every type of input and form.

Since ```showdown-xss-filter``` has pretty old dependencies, I'm going to maintain (mainly for personal use) an updated [fork](https://github.com/jackymancs4/showdown-xss-config) that enables all of js-xss configurations.

This PR includes a whitelisting configuration that allows only checklist rendering, while performing xss validation on everything else.

## Test:

```
Test1

- [ ] Test
- [ ] Test
- [ ]Test
- [x] Test

[ ] Test
[x] Test

[ ]
[x]

<script>alert('xss!')</script>
```

| Before | After |
| -- | -- |
| <img width="734" alt="schermata 2018-02-22 alle 17 31 11 2" src="https://user-images.githubusercontent.com/6209647/36550816-7d8c0756-17f6-11e8-803d-7bc982597798.png"> | <img width="422" alt="schermata 2018-02-22 alle 17 24 48 2" src="https://user-images.githubusercontent.com/6209647/36550818-7dc3431a-17f6-11e8-807d-5f801f0d1f27.png"> |

