### PR TITLE
Final fix for checklist rendering problem 

### DIFF
--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -3,19 +3,19 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import highlight from 'highlight.js';
 import showdown from 'showdown';
-import xssFilter from 'showdown-xss-filter';
 import { get, debounce, invoke, noop } from 'lodash';
 import analytics from './analytics';
 import { viewExternalUrl } from './utils/url-utils';
 import NoteContentEditor from './note-content-editor';
+import filterXSS from 'xss';
 
 const saveDelay = 2000;
 
-const markdownConverter = new showdown.Converter({ extensions: [xssFilter] });
+const markdownConverter = new showdown.Converter();
 markdownConverter.setFlavor('github');
 
 const renderToNode = (node, content) => {
-  node.innerHTML = markdownConverter.makeHtml(content);
+  node.innerHTML = markdownConverter.makeHtml(filterXSS(content));
   node.querySelectorAll('pre code').forEach(highlight.highlightBlock);
 };
 

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import showdown from 'showdown';
-import xssFilter from 'showdown-xss-filter';
 import NoteDetail from './note-detail';
 import TagField from './tag-field';
 import NoteToolbar from './note-toolbar';
 import RevisionSelector from './revision-selector';
 import { get, property } from 'lodash';
+import filterXSS from 'xss';
 
-const markdownConverter = new showdown.Converter({ extensions: [xssFilter] });
+const markdownConverter = new showdown.Converter();
 markdownConverter.setFlavor('github');
 
 export class NoteEditor extends Component {
@@ -184,7 +184,7 @@ export class NoteEditor extends Component {
     if (shouldPrint) {
       const content = get(revision, 'data.content', '');
       noteContent = markdownEnabled
-        ? markdownConverter.makeHtml(content)
+        ? markdownConverter.makeHtml(filterXSS(content))
         : content;
     }
 

--- a/package.json
+++ b/package.json
@@ -99,8 +99,8 @@
     "sanitize-filename": "1.6.1",
     "serve-favicon": "2.4.5",
     "showdown": "1.8.6",
-    "showdown-xss-filter": "0.2.0",
-    "simperium": "0.3.1"
+    "simperium": "0.3.1",
+    "xss": "^0.3.7"
   },
   "optionalDependencies": {
     "appdmg": "0.5.2"


### PR DESCRIPTION
Hello @roundhill, @dmsnell 
Still trying to address https://github.com/Automattic/simplenote-electron/issues/694, https://github.com/Automattic/simplenote-electron/issues/314, https://github.com/Automattic/simplenote-electron/issues/681

After some thought about the concerns emerged in #714 , I think this is the best solution. This PR simply change the filtering pipeline that sanitize the input.
From:
Potentially malicious input -> ```showdown``` --(```showdown-extension```)--> ```js-xss``` -> Renderable HTML (without any input tags)
To:
Potentially malicious input -> ```js-xss``` -> ```showdown``` -> Renderable HTML (with trustworthy input tags generated by showdown)

For testing:

```
Test1

- [ ] Test
- [ ] Test
- [ ]Test
- [x] Test

<input type="checkbox"> test
<input type="checkbox">
<input xtype="checkbox" type='text'> test

[ ] Test
[x] Test

[ ]
[x]

<script>alert('xss!')</script>
```

that render:

| Before | With #714 | Now |
| -- | -- | -- |
| <img width="335" alt="final3" src="https://user-images.githubusercontent.com/6209647/37153568-6b992c76-22dd-11e8-898e-b8847ef29955.png"> | <img width="311" alt="final1" src="https://user-images.githubusercontent.com/6209647/37153566-6b4112b6-22dd-11e8-9d51-7384655ccd3b.png"> | <img width="361" alt="final2" src="https://user-images.githubusercontent.com/6209647/37153567-6b70b610-22dd-11e8-9adc-3a5ccc141289.png"> |

The last one being the more desirable.