### PR TITLE
Add option to disable app updater

### DIFF
--- a/desktop/config-updater.json
+++ b/desktop/config-updater.json
@@ -1,4 +1,5 @@
 {
+  "updaterEnabled": true,
   "forceUpdate": false,
   "updater": {
     "url":

--- a/desktop/updater/index.js
+++ b/desktop/updater/index.js
@@ -37,6 +37,10 @@ function urlBuilder(version) {
 
 module.exports = function() {
   app.on('will-finish-launching', function() {
+    if (!config.updaterEnabled) {
+      return;
+    }
+    
     let url = urlBuilder(app.getVersion());
 
     if (platform.isOSX()) {


### PR DESCRIPTION
In order to submit the app to the Windows Store, we need a way to disable the update checker since all updates will just come through the store.

I've added a config option to handle this, it defaults to having the updater enabled.

**To Test**
* Set the version in `package.json` to `1.1.2`.
* Build the linux app, and run it. You should see the update prompt.
* Rebuild the app, now with `updaterEnabled` set to false.
* The update prompt should now not show.

This could help for #707 as well.