### PR TITLE
XSS Refactor: Replace `showdown-xss` with in-house sanitizer

### DIFF
--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -2,20 +2,17 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import highlight from 'highlight.js';
-import showdown from 'showdown';
-import xssFilter from 'showdown-xss-filter';
 import { get, debounce, invoke, noop } from 'lodash';
 import analytics from './analytics';
 import { viewExternalUrl } from './utils/url-utils';
 import NoteContentEditor from './note-content-editor';
 
+import { renderNoteToHtml } from './utils/render-note-to-html';
+
 const saveDelay = 2000;
 
-const markdownConverter = new showdown.Converter({ extensions: [xssFilter] });
-markdownConverter.setFlavor('github');
-
 const renderToNode = (node, content) => {
-  node.innerHTML = markdownConverter.makeHtml(content);
+  node.innerHTML = renderNoteToHtml(content);
   node.querySelectorAll('pre code').forEach(highlight.highlightBlock);
 };
 

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -2,16 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import showdown from 'showdown';
-import xssFilter from 'showdown-xss-filter';
 import NoteDetail from './note-detail';
 import TagField from './tag-field';
 import NoteToolbar from './note-toolbar';
 import RevisionSelector from './revision-selector';
 import { get, property } from 'lodash';
 
-const markdownConverter = new showdown.Converter({ extensions: [xssFilter] });
-markdownConverter.setFlavor('github');
+import { renderNoteToHtml } from './utils/render-note-to-html';
 
 export class NoteEditor extends Component {
   static propTypes = {
@@ -158,7 +155,6 @@ export class NoteEditor extends Component {
   };
 
   render() {
-    let noteContent = '';
     const { editorMode, note, revisions, fontSize, shouldPrint } = this.props;
     const revision = this.state.revision || note;
     const isViewingRevisions = this.state.isViewingRevisions;
@@ -181,12 +177,7 @@ export class NoteEditor extends Component {
       }
     );
 
-    if (shouldPrint) {
-      const content = get(revision, 'data.content', '');
-      noteContent = markdownEnabled
-        ? markdownConverter.makeHtml(content)
-        : content;
-    }
+    const content = get(revision, 'data.content', '');
 
     const printStyle = {
       fontSize: fontSize + 'px',
@@ -233,7 +224,9 @@ export class NoteEditor extends Component {
           <div
             style={printStyle}
             className="note-print note-detail-markdown"
-            dangerouslySetInnerHTML={{ __html: noteContent }}
+            dangerouslySetInnerHTML={{
+              __html: markdownEnabled ? renderNoteToHtml(content) : content,
+            }}
           />
         )}
         {!isTrashed && (

--- a/lib/utils/render-note-to-html.js
+++ b/lib/utils/render-note-to-html.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import showdown from 'showdown';
+
+/**
+ * Internal dependencies
+ */
+import { sanitizeHtml } from './sanitize-html';
+
+const markdownConverter = new showdown.Converter();
+markdownConverter.setFlavor('github');
+
+export const renderNoteToHtml = content =>
+  sanitizeHtml(markdownConverter.makeHtml(content));

--- a/lib/utils/sanitize-html.js
+++ b/lib/utils/sanitize-html.js
@@ -1,0 +1,246 @@
+import validUrl from 'valid-url';
+import { filter } from 'lodash';
+
+/**
+ * Determine if a given tag is allowed
+ *
+ * @param {Node} node node being examined
+ * @returns {Boolean} whether the tag is allowed
+ */
+const isAllowedTag = node => {
+  const tagName = node.nodeName.toLowerCase();
+
+  if ('input' === tagName) {
+    return 'checkbox' === node.getAttribute('type');
+  }
+
+  switch (tagName) {
+    case '#text':
+    case 'a':
+    case 'article':
+    case 'b':
+    case 'br':
+    case 'blockquote':
+    case 'cite':
+    case 'code':
+    case 'dd':
+    case 'del':
+    case 'div':
+    case 'dt':
+    case 'em':
+    case 'h1':
+    case 'h2':
+    case 'h3':
+    case 'h4':
+    case 'h5':
+    case 'h6':
+    case 'hr':
+    case 'i':
+    case 'img':
+    case 'ins':
+    case 'li':
+    case 'ol':
+    case 'p':
+    case 'pre':
+    case 's':
+    case 'span':
+    case 'strong':
+    case 'sub':
+    case 'sup':
+    case 'table':
+    case 'tbody':
+    case 'td':
+    case 'th':
+    case 'thead':
+    case 'tr':
+    case 'tt':
+    case 'ul':
+      return true;
+    default:
+      return false;
+  }
+};
+
+/**
+ * Determine if a given attribute is allowed
+ *
+ * Note! Before adding more attributes here
+ *       make sure that we don't open up an
+ *       attribute which could allow for a
+ *       snippet of code to execute, such
+ *       as `onclick` or `onmouseover`
+ *
+ * @param {String} tagName name of tag on which attribute is found
+ * @param {String} attrName name of attribute under inspection
+ * @returns {Boolean} whether the attribute is allowed
+ */
+const isAllowedAttr = (tagName, attrName) => {
+  switch (tagName) {
+    case 'a':
+      switch (attrName) {
+        case 'alt':
+        case 'href':
+        case 'rel':
+        case 'title':
+          return true;
+        default:
+          return false;
+      }
+
+    case 'img':
+      switch (attrName) {
+        case 'alt':
+        case 'src':
+        case 'title':
+          return true;
+        default:
+          return false;
+      }
+
+    case 'input':
+      switch (attrName) {
+        case 'checked':
+        case 'type':
+          return true;
+        default:
+          return false;
+      }
+
+    default:
+      return false;
+  }
+};
+
+/**
+ * Determine if the given tag and its children
+ * should be removed entirely from the DOM tree
+ *
+ * @param {Node} node node being examined
+ * @return {boolean} whether the node is forbidden
+ */
+const isForbidden = node => {
+  const tagName = node.nodeName.toLowerCase();
+
+  switch (tagName) {
+    case 'head':
+    case 'html':
+    case 'iframe':
+    case 'link':
+    case 'meta':
+    case 'object':
+    case 'script':
+    case 'style':
+      return true;
+    default:
+      return false;
+  }
+};
+
+/**
+ * Sanitizes input HTML for security and styling
+ *
+ * @param {String} content unverified HTML
+ * @returns {string} sanitized HTML
+ */
+export const sanitizeHtml = content => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(content, 'text/html');
+
+  // this will let us visit every single DOM node programmatically
+  const walker = doc.createTreeWalker(doc.body);
+
+  /**
+   * we don't want to remove nodes while walking the tree
+   * or we'll invite data-race bugs. instead, we'll track
+   * which ones we want to remove then drop them at the end
+   *
+   * @type {Array<Node>} List of nodes to remove
+   */
+  const removeList = [];
+
+  /**
+   * unlike the remove list, these should be entirely
+   * eliminated and none of their children should be
+   * inserted into the final document
+   *
+   * @type {Array<Node>} List of nodes to eliminate
+   */
+  const forbiddenList = [];
+
+  // walk over every DOM node
+  while (walker.nextNode()) {
+    const node = walker.currentNode;
+
+    if (isForbidden(node)) {
+      forbiddenList.push(node);
+      continue;
+    }
+
+    if (!isAllowedTag(node)) {
+      removeList.push(node);
+      continue;
+    }
+
+    const tagName = node.nodeName.toLowerCase();
+
+    // strip out anything not explicitly allowed
+    //
+    // Node.attributes is a NamedNodeMap, not an Array
+    // so it has no Array methods and the Attr nodes' indexes may differ
+    //
+    // Note that we must iterate twice because Node.attributes is
+    // a live collection and we will introduce bugs if we remove
+    // as we go on the first pass.
+    //
+    // @see https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes
+    filter(
+      node.attributes,
+      ({ name, value }) =>
+        !isAllowedAttr(tagName, name) ||
+        // only valid http(s) URLs are allowed
+        (('href' === name || 'src' === name) && !validUrl.isWebUri(value))
+    ).forEach(({ name }) => node.removeAttribute(name));
+
+    // of course, all links need to be normalized since
+    // they now exist inside of our new context
+    if ('a' === tagName && node.getAttribute('href')) {
+      node.setAttribute('target', '_blank');
+      node.setAttribute('rel', 'external noopener noreferrer');
+    }
+  }
+
+  // eliminate the forbidden tags and drop their children
+  forbiddenList.forEach(node => {
+    try {
+      node.parentNode.removeChild(node);
+    } catch (e) {
+      // this one could have existed
+      // under a node that we already removed,
+      // which would lead to a failure right now
+      // this is fine, just continue along
+    }
+  });
+
+  // remove the unwanted tags and transfer
+  // their children up a level in their place
+  removeList.forEach(node => {
+    const parent = node.parentNode;
+    let child;
+
+    try {
+      // eslint-disable-next-line no-cond-assign
+      while ((child = node.firstChild)) {
+        parent.insertBefore(child, node);
+      }
+
+      parent.removeChild(node);
+    } catch (e) {
+      // this one could have originally existed
+      // under a node that we already removed,
+      // which would lead to a failure right now
+      // this is fine, just continue along
+    }
+  });
+
+  return doc.body.innerHTML;
+};

--- a/lib/utils/sanitize-html.js
+++ b/lib/utils/sanitize-html.js
@@ -1,3 +1,4 @@
+import isemail from 'isemail';
 import validUrl from 'valid-url';
 import { filter } from 'lodash';
 
@@ -193,17 +194,36 @@ export const sanitizeHtml = content => {
     // as we go on the first pass.
     //
     // @see https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes
-    filter(
-      node.attributes,
-      ({ name, value }) =>
-        !isAllowedAttr(tagName, name) ||
-        // only valid http(s) URLs are allowed
-        (('href' === name || 'src' === name) && !validUrl.isWebUri(value))
-    ).forEach(({ name }) => node.removeAttribute(name));
+    filter(node.attributes, ({ name, value }) => {
+      if (isAllowedAttr(tagName, name)) {
+        return false;
+      }
+
+      // only valid http(s) URLs are allowed
+      if (('href' === name || 'src' === name) && validUrl.isWebUri(value)) {
+        return false;
+      }
+
+      // emails must be reasonably-verifiable email addresses
+      if (
+        'href' === name &&
+        value.startsWith('mailto:') &&
+        isemail.validate(value.slice(7))
+      ) {
+        return false;
+      }
+
+      return true;
+    }).forEach(({ name }) => node.removeAttribute(name));
 
     // of course, all links need to be normalized since
     // they now exist inside of our new context
-    if ('a' === tagName && node.getAttribute('href')) {
+    const hrefAttribute = 'a' === tagName && node.getAttribute('href');
+    if (
+      'a' === tagName &&
+      'string' === typeof hrefAttribute &&
+      !hrefAttribute.startsWith('mailto:')
+    ) {
       node.setAttribute('target', '_blank');
       node.setAttribute('rel', 'external noopener noreferrer');
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7373,6 +7373,21 @@
       "integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE=",
       "dev": true
     },
+    "isemail": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.1.tgz",
+      "integrity": "sha512-mVjAjvdPkpwXW61agT2E9AkGoegZO7SdJGCezWwxnETL58f5KwJ4vSVAMBUL5idL6rTlYAIGkX3n4suiviMLNw==",
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        }
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2421,7 +2421,8 @@
     "commander": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -2648,16 +2649,6 @@
         "sha.js": "2.4.10"
       }
     },
-    "create-react-class": {
-      "version": "15.6.3",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
-    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -2875,11 +2866,6 @@
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
       "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
       "dev": true
-    },
-    "cssfilter": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.8.tgz",
-      "integrity": "sha1-ZWTKzLqKdt2bS5IGaLn7f9pQ5Uw="
     },
     "cssnano": {
       "version": "3.10.0",
@@ -4052,7 +4038,7 @@
         "object.assign": "4.1.0",
         "object.entries": "1.0.4",
         "object.values": "1.0.4",
-        "prop-types": "15.6.1",
+        "prop-types": "15.6.0",
         "uuid": "3.2.1"
       },
       "dependencies": {
@@ -4368,7 +4354,7 @@
         "doctrine": "2.1.0",
         "has": "1.0.1",
         "jsx-ast-utils": "2.0.1",
-        "prop-types": "15.6.1"
+        "prop-types": "15.6.0"
       }
     },
     "eslint-scope": {
@@ -12507,9 +12493,9 @@
       }
     },
     "prop-types": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -12752,15 +12738,14 @@
       "dev": true
     },
     "react": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
-      "integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
       "requires": {
-        "create-react-class": "15.6.3",
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.1"
+        "prop-types": "15.6.0"
       }
     },
     "react-addons-shallow-compare": {
@@ -12788,21 +12773,21 @@
       }
     },
     "react-dom": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
-      "integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
       "dev": true,
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.1"
+        "prop-types": "15.6.0"
       }
     },
     "react-onclickoutside": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-4.5.0.tgz",
-      "integrity": "sha1-CFPbLQS1Py0MjwuhMxaTLSTCcMg=",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz",
+      "integrity": "sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg==",
       "dev": true
     },
     "react-overlays": {
@@ -12812,7 +12797,7 @@
       "requires": {
         "classnames": "2.2.5",
         "dom-helpers": "3.3.1",
-        "prop-types": "15.6.1",
+        "prop-types": "15.6.0",
         "prop-types-extra": "1.0.1",
         "react-transition-group": "2.2.1",
         "warning": "3.0.0"
@@ -12828,17 +12813,18 @@
         "lodash": "4.17.5",
         "lodash-es": "4.17.5",
         "loose-envify": "1.3.1",
-        "prop-types": "15.6.1"
+        "prop-types": "15.6.0"
       }
     },
     "react-test-renderer": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.6.1.tgz",
-      "integrity": "sha1-Am9KW7VVJmH9LMS7zQ1LyKNev34=",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.2.0.tgz",
+      "integrity": "sha512-Kd4gJFtpNziR9ElOE/C23LeflKLZPRpNQYWP3nQBY43SJ5a+xyEGSeMrm2zxNKXcnCbBS/q1UpD9gqd5Dv+rew==",
       "dev": true,
       "requires": {
         "fbjs": "0.8.16",
-        "object-assign": "4.1.1"
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
       }
     },
     "react-transition-group": {
@@ -12850,7 +12836,7 @@
         "classnames": "2.2.5",
         "dom-helpers": "3.3.1",
         "loose-envify": "1.3.1",
-        "prop-types": "15.6.1",
+        "prop-types": "15.6.0",
         "warning": "3.0.0"
       }
     },
@@ -12863,7 +12849,7 @@
         "classnames": "2.2.5",
         "dom-helpers": "3.3.1",
         "loose-envify": "1.3.1",
-        "prop-types": "15.6.1"
+        "prop-types": "15.6.0"
       }
     },
     "read-config-file": {
@@ -12997,7 +12983,7 @@
       "requires": {
         "error-stack-parser": "1.3.6",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.1",
+        "prop-types": "15.6.0",
         "sourcemapped-stacktrace": "1.1.8"
       }
     },
@@ -13961,14 +13947,6 @@
       "integrity": "sha1-kepO47elRIqspoIKTifmkMatdxw=",
       "requires": {
         "yargs": "10.1.2"
-      }
-    },
-    "showdown-xss-filter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/showdown-xss-filter/-/showdown-xss-filter-0.2.0.tgz",
-      "integrity": "sha1-OYV7rlbWGEl58mh2sYe7h+n08Ew=",
-      "requires": {
-        "xss": "0.2.18"
       }
     },
     "signal-exit": {
@@ -15711,6 +15689,11 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
+    },
     "validate-npm-package-license": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
@@ -16832,15 +16815,6 @@
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
       "dev": true
-    },
-    "xss": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-0.2.18.tgz",
-      "integrity": "sha1-bfX7XKKL3FHnhiT/Y/GeE+vXO6s=",
-      "requires": {
-        "commander": "2.14.1",
-        "cssfilter": "0.0.8"
-      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -103,8 +103,8 @@
     "sanitize-filename": "1.6.1",
     "serve-favicon": "2.4.5",
     "showdown": "1.8.6",
-    "showdown-xss-filter": "0.2.0",
-    "simperium": "0.3.1"
+    "simperium": "0.3.1",
+    "valid-url": "1.0.9"
   },
   "optionalDependencies": {
     "appdmg": "0.5.2"

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "draft-js-simpledecorator": "1.0.2",
     "electron-window-state": "4.1.1",
     "highlight.js": "9.12.0",
+    "isemail": "3.1.1",
     "jszip": "3.1.5",
     "lodash": "4.17.5",
     "moment": "2.20.1",


### PR DESCRIPTION
See #681
See #694
See #721

The `showdown-xss` library wasn't really doing for us what we wanted.
It was transforming our checkbox inputs and making them display as plain
text instead of as actual HTML.

In this patch I've removed `showdown-xss` and created a new centralized
function to render HTML which calls our custom sanitization.

Why do it ourselves? We don't need the kind of sanitiation which only
removes the malicious code and leaves as much as it can untouched.
Instead we are free here to strip out basically everything except for
a few white-listed tags and attributes since we ourselves are the ones
producing the output; we don't have to support full HTML in the notes.

This patch should guard against everything on the OWASP list of XSS
attacks. It will remove significant styling and custom HTML but when a
tag is removed it will usually just take out the tag itself and leave
the inner content as plain text. Some tags are "forbidden" and all their
children are removed with them.

cc: @Jackymancs4 

With the contributions and discussion about the checkboxes I really wanted
to get that bug fixed but I was also uneasy about the proposed solutions in
#721 and #714. I was uneasy because our XSS libraries were already opaque
and less-maintained than we would want. Digging into libraries also revealed
custom HTML parsing code that I wasn't sure I trusted.

In this proposal we're relying on the browser to parse the HTML and walk
through it node-by-node giving us the best possible parse with the protection
the browser already has coded into it against attacks that target the parser…

```html
<
script
>…<
/script>
```

…since we're generating markup and we don't promise "everything Markdown
can do is available here" then we can produce whatever subset of Markdown
we want to support. I have chosen to try and mimic the allowed tags and attributes
as is currently supported in the web version of Simplenote. We can add more
tags such as `<abbr>` and `<acronym>` and I think if we wanted to we could
open up some styling or class attributes but for now I'm reaching for harmony
across the platforms more than one being better than others.

**Testing**

Try to break rendering with malicious attacks and also verify that checkboxes
and expected output appears.