### PR TITLE
Update Electron to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "babel-preset-react": "6.24.1",
     "classnames": "2.2.5",
     "css-loader": "0.28.9",
-    "electron": "1.7.11",
+    "electron": "1.8.4",
     "electron-builder": "20.2.0",
     "electron-packager": "9.1.0",
     "enzyme": "2.9.1",


### PR DESCRIPTION
The current version of electron has a vulnerability, although from the report I think Simplenote is safe from it: https://www.electronjs.org/blog/webview-fix. But, better safe than sorry.

**To Test**
* `npm install`
* `electron .`
* Verify electron-y things work correctly (app menus, printing, etc)

