### PR TITLE
Add the ability to toggle menubar

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -70,6 +70,8 @@ module.exports = function main() {
     Menu.setApplicationMenu(appMenu);
 
     ipcMain.on('settingsUpdate', function(event, settings) {
+      mainWindow.setMenuBarVisibility(settings.menubarVisible);
+
       Menu.setApplicationMenu(
         Menu.buildFromTemplate(createMenuTemplate(settings))
       );

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -140,6 +140,15 @@ var buildViewMenu = function(settings) {
           }
         },
       },
+      {
+        label: 'T&oggle Menubar Visibility',
+        accelerator: 'Ctrl+Shift+M',
+        click(item, focusedWindow) {
+          focusedWindow.webContents.send('appCommand', {
+            action: 'toggleMenubarVisibility',
+          });
+        },
+      },
     ],
   };
 };

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -79,6 +79,7 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
         'setNoteDisplay',
         'setMarkdown',
         'setAccountName',
+        'toggleMenubarVisibility',
       ]),
       dispatch
     ),
@@ -386,6 +387,8 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       const isMacApp = isElectronMac();
       const filteredNotes = filterNotes(state);
       const hasNotes = filteredNotes.length > 0;
+
+      console.log('menubar: ', this.state.menubarVisible); // eslint-disable-line
 
       const selectedNote =
         state.note || (!isSmallScreen && hasNotes ? filteredNotes[0] : null);

--- a/lib/state/settings/actions.js
+++ b/lib/state/settings/actions.js
@@ -57,3 +57,7 @@ export const setWPToken = token => ({
   type: 'setWPToken',
   token,
 });
+
+export const toggleMenubarVisibility = () => ({
+  type: 'toggleMenubarVisibility',
+});

--- a/lib/state/settings/reducer.js
+++ b/lib/state/settings/reducer.js
@@ -65,6 +65,14 @@ const wpToken = (state = false, action) => {
   return action.token;
 };
 
+const menubarVisible = (state = true, action) => {
+  if ('toggleMenubarVisibility' !== action.type) {
+    return state;
+  }
+
+  return !state;
+};
+
 export default combineReducers({
   accountName,
   fontSize,
@@ -74,4 +82,5 @@ export default combineReducers({
   sortReversed,
   theme,
   wpToken,
+  menubarVisible,
 });


### PR DESCRIPTION
Hi, this PR adds the ability to toggle menubar, via the alt key. 

Closes #735.


**How to test**

_The following instructions apply to Windows and Linux users._

Launch the desktop app.
Menubar should be visible.
Hitting Alt key should hide it.