### PR TITLE
Fixing .deb release for Ubuntu 18

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -55,7 +55,7 @@
     "maintainer": "Automattic, Inc."
   },
   "deb": {
-    "depends": []
+    "depends": ["gconf2"]
   }
 }
 


### PR DESCRIPTION
Ubuntu 18 requires that we add a dependency on `gconf2`. Ref: https://github.com/Automattic/simplenote-electron/issues/727#issuecomment-382528636

**To Test**
* run `make package-linux`
* Install and run the app on Ubuntu 18 using the deb installer. It should open without issue.