### PR TITLE
Fix XSS in Print View

### DIFF
--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -183,6 +183,11 @@ export class NoteEditor extends Component {
       fontSize: fontSize + 'px',
     };
 
+    const printAttrs = {
+      style: printStyle,
+      class: 'note-print note-detail-markdown',
+    };
+
     return (
       <div className={classes}>
         <RevisionSelector
@@ -220,15 +225,17 @@ export class NoteEditor extends Component {
             />
           </div>
         </div>
-        {shouldPrint && (
-          <div
-            style={printStyle}
-            className="note-print note-detail-markdown"
-            dangerouslySetInnerHTML={{
-              __html: markdownEnabled ? renderNoteToHtml(content) : content,
-            }}
-          />
-        )}
+        {shouldPrint &&
+          markdownEnabled && (
+            <div
+              {...printAttrs}
+              dangerouslySetInnerHTML={{
+                __html: renderNoteToHtml(content),
+              }}
+            />
+          )}
+        {shouldPrint &&
+          !markdownEnabled && <div {...printAttrs}>{content}</div>}
         {!isTrashed && (
           <TagField
             storeFocusTagField={this.storeFocusTagField}


### PR DESCRIPTION
Fixing an issue where scripts could be executed when printing a note. Originally discovered here: https://github.com/Automattic/simplenote-electron/pull/724#discussion_r174950892

It didn't seem easy to me to do a conditional attribute for `dangerouslySetInnerHtml`, so I've ended up rendering different divs depending on if the note has markdown enabled or not.

**To Test**
* Create a note with something scripty in it, like:
```
">'><details/open/ontoggle=confirm('💩')>
```
* Print the note with both markdown enabled and disabled (you can also save to PDF to see same results if you don't have a printer)
* No scripts should execute and markdown notes should contain proper formatting.