### PR TITLE
Fix Remote Code Execution in WordPress Auth Window

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -18,6 +18,7 @@ import NavigationBar from './navigation-bar';
 import Auth from './auth';
 import analytics from './analytics';
 import classNames from 'classnames';
+import { setWPToken } from './state/settings/actions';
 import {
   compact,
   concat,
@@ -84,12 +85,12 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
     ),
     setSortType: thenReloadNotes(settingsActions.setSortType),
     toggleSortOrder: thenReloadNotes(settingsActions.toggleSortOrder),
-
     openTagList: () => dispatch(actionCreators.toggleNavigation()),
     resetAuth: () => dispatch(reduxActions.auth.reset()),
     setAuthorized: () => dispatch(reduxActions.auth.setAuthorized()),
     setSearchFocus: () =>
       dispatch(actionCreators.setSearchFocus({ searchFocus: true })),
+    saveWPToken: token => dispatch(setWPToken(token)),
   };
 }
 
@@ -121,6 +122,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       onCreateUser: PropTypes.func.isRequired,
       onSignOut: PropTypes.func.isRequired,
       authorizeUserWithToken: PropTypes.func.isRequired,
+      saveWPToken: PropTypes.func.isRequired,
     };
 
     static defaultProps = {
@@ -214,6 +216,16 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
           )
           .then(blob => fs.writeFile(command.filename, blob, 'base64'))
           .catch(console.log); // eslint-disable-line no-console
+      }
+
+      if ('authorizeUserWithToken' === get(command, 'action')) {
+        if (command.wpToken) {
+          this.props.saveWPToken(command.wpToken);
+        }
+        return this.props.authorizeUserWithToken(
+          command.userEmail,
+          command.spToken
+        );
       }
 
       const canRun = overEvery(

--- a/lib/auth.jsx
+++ b/lib/auth.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { get } from 'lodash';
+import getConfig from '../get-config';
 import SimplenoteLogo from './icons/simplenote';
 import Spinner from './components/spinner';
 import WordPressLogo from './icons/wordpress';
@@ -181,7 +182,15 @@ export class Auth extends Component {
     ipcRenderer.on('wpAuthError', (event, payload) => {
       this.onAuthError(payload.message);
     });
-    ipcRenderer.send('startWPAuth');
+
+    const config = getConfig();
+    const redirectUrl = encodeURIComponent(config.wpcc_redirect_url);
+    const clientId = config.wpcc_client_id;
+
+    ipcRenderer.send('startWPAuth', {
+      redirectUrl,
+      clientId,
+    });
   };
 
   onAuthError = errorMessage => {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   "dependencies": {
     "cookie": "0.3.1",
     "create-hash": "1.1.3",
+    "crypto-random-string": "1.0.0",
     "draft-js": "0.10.5",
     "draft-js-simpledecorator": "1.0.2",
     "electron-window-state": "4.1.1",


### PR DESCRIPTION
I friendly hacker reported that the WordPress sign-in auth window allows remote code execution via drag and drop operations. We fixed a similar issue in the main app window a while back, but I didn't think about applying it to the new window used for the WP auth.

As I was looking into fixing this, I noticed that if a link with a "_blank" target was clicked it would open _another_ in app `BrowserWindow` and it would also be vulnerable to the same RCE. To fix this I've moved the code that creates the window and handles the auth operation to the main electron process in `app.js`  in order to utilize `preventDefault()` when the browser tries to open a new window. Details: https://github.com/electron/electron/issues/4473#issuecomment-184571997

**To Test**
* Follow the same instructions as #764, you should be able to sign in with WordPress.com and/or see appropriate error messages.
* Drag anything into the WP auth window, nothing should happen.