### PR TITLE
Fix javascript execution in print view on Linux

### DIFF
--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -232,6 +232,7 @@ export class NoteEditor extends Component {
               dangerouslySetInnerHTML={{
                 __html: renderNoteToHtml(content),
               }}
+              onClick={event => event.preventDefault()}
             />
           )}
         {shouldPrint &&

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -232,7 +232,6 @@ export class NoteEditor extends Component {
               dangerouslySetInnerHTML={{
                 __html: renderNoteToHtml(content),
               }}
-              onClick={event => event.preventDefault()}
             />
           )}
         {shouldPrint &&

--- a/lib/utils/sanitize-html.js
+++ b/lib/utils/sanitize-html.js
@@ -195,6 +195,16 @@ export const sanitizeHtml = content => {
     //
     // @see https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes
     filter(node.attributes, ({ name, value }) => {
+      // No javascript Uris allowed
+      if (
+        value
+          .toLowerCase()
+          .trim()
+          .startsWith('javascript')
+      ) {
+        return true;
+      }
+
       if (isAllowedAttr(tagName, name)) {
         return false;
       }

--- a/lib/utils/sanitize-html.js
+++ b/lib/utils/sanitize-html.js
@@ -75,12 +75,23 @@ const isAllowedTag = node => {
  * @param {String} attrName name of attribute under inspection
  * @returns {Boolean} whether the attribute is allowed
  */
-const isAllowedAttr = (tagName, attrName) => {
+const isAllowedAttr = (tagName, attrName, value) => {
   switch (tagName) {
     case 'a':
       switch (attrName) {
-        case 'alt':
         case 'href':
+          // No javascript Uris allowed
+          if (
+            value
+              .toLowerCase()
+              .trim()
+              .startsWith('javascript')
+          ) {
+            return false;
+          }
+
+          return true;
+        case 'alt':
         case 'rel':
         case 'title':
           return true;
@@ -195,17 +206,7 @@ export const sanitizeHtml = content => {
     //
     // @see https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes
     filter(node.attributes, ({ name, value }) => {
-      // No javascript Uris allowed
-      if (
-        value
-          .toLowerCase()
-          .trim()
-          .startsWith('javascript')
-      ) {
-        return true;
-      }
-
-      if (isAllowedAttr(tagName, name)) {
+      if (isAllowedAttr(tagName, name, value)) {
         return false;
       }
 


### PR DESCRIPTION
A HackerOne report stated that you could execute code in the print view, but only on linux and if you used a `javascript:` uri in a link. I've fixed this by adding an early check in our HTML sanitizer for the javascript uri. And for additional safety I've disabled clicks on the print div.

**To Test**
* You must test this on Linux, as macOS and Windows don't allow you to click outside of a print dialog.
* Add something like `<a href=" javasCript:alert('awesome');">CLICK ME</a>` to a note, and enable markdown and turn the preview on.
* Print the note, and attempt to click outside of the print dialog on the link. Nothing should happen. 