### PR TITLE
Disable drag and drop on all created windows

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -122,6 +122,18 @@ module.exports = function main() {
     }
   });
 
+  app.on('browser-window-created', function(event, window) {
+    window.webContents.on('did-finish-load', () => {
+      // Disable drag and drop operations on the window
+      window.webContents.executeJavaScript(
+        "document.addEventListener('dragover', event => event.preventDefault());"
+      );
+      window.webContents.executeJavaScript(
+        "document.addEventListener('drop', event => event.preventDefault());"
+      );
+    });
+  });
+
   // This method will be called when Electron has finished
   // initialization and is ready to create browser windows.
   app.on('ready', activateWindow);

--- a/lib/auth.jsx
+++ b/lib/auth.jsx
@@ -202,7 +202,9 @@ export class Auth extends Component {
       width: 640,
       height: 640,
       show: false,
-      'node-integration': false,
+      webPreferences: {
+        nodeIntegration: false,
+      },
     });
 
     // Register simplenote:// protocol


### PR DESCRIPTION
Better solution than what I attempted in #770. We want to disable drag and drop on all windows created in the app.

**To Test**
* Click on sign in with wp.com sign in. 
* Attempt to drag and drop something into the window. Nothing should happen.
* Click 'Sign in with Google'. Dragging and dropping on this new window should also do nothing.