### PR TITLE
Clear all cookies upon app logout

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -7,6 +7,7 @@ const {
   ipcMain,
   shell,
   Menu,
+  session,
 } = require('electron');
 
 const path = require('path');
@@ -72,6 +73,24 @@ module.exports = function main() {
       Menu.setApplicationMenu(
         Menu.buildFromTemplate(createMenuTemplate(settings))
       );
+    });
+
+    ipcMain.on('clearCookies', function() {
+      session.defaultSession.cookies.get({}, (error, cookies) => {
+        cookies.forEach(cookie => {
+          let cookieUrl = '';
+          cookieUrl += cookie.secure ? 'https://' : 'http://';
+          cookieUrl += cookie.domain.charAt(0) === '.' ? 'www' : '';
+          cookieUrl += cookie.domain;
+          cookieUrl += cookie.path;
+
+          session.defaultSession.cookies.remove(
+            cookieUrl,
+            cookie.name,
+            () => {} // Ignore callback
+          );
+        });
+      });
     });
 
     mainWindowState.manage(mainWindow);

--- a/lib/dialogs/settings.jsx
+++ b/lib/dialogs/settings.jsx
@@ -51,12 +51,17 @@ export class SettingsDialog extends Component {
   };
 
   signOut = () => {
-    const { onSignOut, onSetWPToken } = this.props;
+    const { onSignOut, onSetWPToken, isElectron } = this.props;
 
     // Reset the WordPress Token
     onSetWPToken(null);
 
     onSignOut();
+
+    if (isElectron) {
+      const ipcRenderer = __non_webpack_require__('electron').ipcRenderer; // eslint-disable-line no-undef
+      ipcRenderer.send('clearCookies');
+    }
   };
 
   showUnsyncedWarning = () => {


### PR DESCRIPTION
The WordPress cookie was being stored by the app, so you'd always be signed in to WordPress.com even if you signed out of Simplenote. This PR ensures the WordPress.com account is signed out when the user signs out of the app by clearing the cookies.

**To Test**
* Sign in to the app with a WordPress.com account.
* Sign out of the app.
* Sign in with WordPress.com again, you should not be signed in to WordPress.com.