### PR TITLE
About View: Add new row about Simperium

### DIFF
--- a/lib/dialogs/about.jsx
+++ b/lib/dialogs/about.jsx
@@ -54,17 +54,6 @@ export class AboutDialog extends Component {
           <li>
             <a
               target="_blank"
-              href="https://simplenote.com/"
-              rel="noopener noreferrer"
-            >
-              <span className="about-links-title">Apps</span>
-              <br />simplenote.com
-            </a>
-            <TopRightArrowIcon />
-          </li>
-          <li>
-            <a
-              target="_blank"
               href="https://simperium.com"
               rel="noopener noreferrer"
             >

--- a/lib/dialogs/about.jsx
+++ b/lib/dialogs/about.jsx
@@ -32,7 +32,7 @@ export class AboutDialog extends Component {
           <li>
             <a
               target="_blank"
-              href="http://simplenote.com/blog/"
+              href="https://simplenote.com/blog/"
               rel="noopener noreferrer"
             >
               <span className="about-links-title">Blog</span>
@@ -54,11 +54,22 @@ export class AboutDialog extends Component {
           <li>
             <a
               target="_blank"
-              href="http://simplenote.com/"
+              href="https://simplenote.com/"
               rel="noopener noreferrer"
             >
               <span className="about-links-title">Apps</span>
               <br />simplenote.com
+            </a>
+            <TopRightArrowIcon />
+          </li>
+          <li>
+            <a
+              target="_blank"
+              href="https://simperium.com"
+              rel="noopener noreferrer"
+            >
+              <span className="about-links-title">Simperium</span>
+              <br />Add data sync to your app
             </a>
             <TopRightArrowIcon />
           </li>
@@ -90,7 +101,7 @@ export class AboutDialog extends Component {
           <p>
             <a
               target="_blank"
-              href="http://simplenote.com/privacy/"
+              href="https://simplenote.com/privacy/"
               rel="noopener noreferrer"
             >
               Privacy Policy
@@ -98,7 +109,7 @@ export class AboutDialog extends Component {
             &nbsp;&bull;&nbsp;{' '}
             <a
               target="_blank"
-              href="http://simplenote.com/terms/"
+              href="https://simplenote.com/terms/"
               rel="noopener noreferrer"
             >
               Terms of Service


### PR DESCRIPTION
We're adding a blurb to all of the apps in the about screen for Simperium to help promote the service.

<img width="471" alt="screen shot 2018-07-12 at 10 04 16 am" src="https://user-images.githubusercontent.com/789137/42648772-b1c4ac24-85bc-11e8-834e-023ec5286d04.png">

I'm wondering if this is too many rows now 🤔. If the reviewer agrees we can maybe replace the `Apps` row with this new Simperium one.