### PR TITLE
split non-osx menu item adjustments into distinct linux & win32 block

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -259,8 +259,39 @@ function createMenuTemplate(settings) {
     ],
   };
 
-  // non-osx menu item adjustments
-  if (process.platform !== 'darwin') {
+  // linux menu item adjustments
+  if (process.platform === 'linux') {
+    // add about menu item to Help
+    helpMenu['submenu'].push({
+      type: 'separator',
+    });
+    helpMenu['submenu'].push(aboutMenuItem);
+    helpMenu['submenu'].push({
+      label: 'Help',
+      accelerator: 'F1',
+      click: function() {
+        shell.openExternal('http://simplenote.com/help');
+      },
+    });
+    // add exit and settings items to File
+    fileMenu['submenu'].push({
+      type: 'separator',
+    });
+    fileMenu['submenu'].push(settingsMenuItem);
+    fileMenu['submenu'].push({
+      type: 'separator',
+    });
+    fileMenu['submenu'].push({
+      label: 'E&xit',
+      accelerator: 'Ctrl+Q',
+      click: function() {
+        app.quit();
+      },
+    });
+  }
+
+  // windows menu item adjustments
+  if (process.platform === 'win32') {
     // add about menu item to Help
     helpMenu['submenu'].push({
       type: 'separator',


### PR DESCRIPTION
Addresses #782 by splitting non-osx menu item adjustments into specific "linux" and "win32" blocks. 

"linux" block then modifies "File > Exit" keyboard shortcut (from Alt+F4 to Ctrl+Q) and adds "Help > Help & Support" keyboard shortcut (F1) following the HIG at https://developer.gnome.org/hig/stable/keyboard-input.html.en

Tested on Debian 9, should still be tested on OSX and Windows... 