### PR TITLE
Fix Javascript Execution when pasting into tag field

### DIFF
--- a/lib/tag-input.jsx
+++ b/lib/tag-input.jsx
@@ -123,7 +123,7 @@ export class TagInput extends Component {
 
   removePastedFormatting = event => {
     document.execCommand(
-      'insertHTML',
+      'insertText',
       false, // don't show default UI - see execCommand docs for explanation
       event.clipboardData.getData('text/plain')
     );


### PR DESCRIPTION
We received a report that you could paste certain HTML into the tags field and it would execute Javascript. 

I've fixed this by using `insertText` instead of `insertHTML` when pasting into the tags field. @dmsnell you used this when adding autocomplete for tags, it appears to still work fine for me without `insertHTML` but perhaps you had a reason for using it?

**To Test**
* Open a note
* Paste `<img src=1 href=1 onerror="javascript:alert('🤯')"></img>` into the tags field.
* No js alert should appear, and the text should be inserted as plain text.
* Verify that tag autocomplete still works as expected.