### PR TITLE
Remove need to install global electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,10 @@ _Note: Simplenote API features such as sharing and publishing will not work with
 
 ## Electron
 
-Install electron globally `npm install -g electron --save-dev`, then:
-
 1. Run `npm run build`
-2. Run `electron .`
+2. Run `npm run electron`
 
-You can also pass along the `--devtools` option after `electron .` to open the developer tools
+You can also pass along the `--devtools` option (`npm run electron -- --devtools`) to open the developer tools.
 
 ## Coding Guidelines
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:app": "webpack --config ./webpack.config.js",
     "build:dll": "webpack --config ./webpack.config.dll.js",
     "build:prod": "NODE_ENV=production webpack -p --config ./webpack.config.dll.js && webpack -p --config ./webpack.config.js",
+    "electron": "electron .",
     "format": "prettier --write {desktop,lib,sass}/{**/,*}.{js,json,jsx,sass}",
     "lint": "eslint --ext .js --ext .jsx lib",
     "start": "NODE_ENV=hot npm run build && webpack-dev-server --config ./webpack.config.js --content-base dist --host 0.0.0.0 --port 4000 --hot --inline"


### PR DESCRIPTION
This removes the need to install Electron globally, and just use the one that's already in `node_modules`.

There doesn't seem to be anything (like in the [Makefile](https://github.com/Automattic/simplenote-electron/blob/remove-global-electron/Makefile)) depending on the global Electron, but I may be missing something.