### PR TITLE
Purge unused react packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16381,12 +16381,6 @@
         "object-assign": "^4.1.0"
       }
     },
-    "react-addons-test-utils": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz",
-      "integrity": "sha1-wStu/cIkfBDae4dw0YUICnsEcVY=",
-      "dev": true
-    },
     "react-addons-update": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/react-addons-update/-/react-addons-update-15.6.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16372,15 +16372,6 @@
         "prop-types": "^15.6.0"
       }
     },
-    "react-addons-shallow-compare": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz",
-      "integrity": "sha1-GYoAuR/DdiPbZKKP0XtZa6NicC8=",
-      "requires": {
-        "fbjs": "^0.8.4",
-        "object-assign": "^4.1.0"
-      }
-    },
     "react-addons-update": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/react-addons-update/-/react-addons-update-15.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "promise": "7.1.1",
     "prop-types": "15.6.0",
     "react": "16.2.0",
-    "react-addons-shallow-compare": "15.6.2",
     "react-addons-update": "15.6.2",
     "react-overlays": "0.8.3",
     "react-redux": "5.0.7",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "node-sass": "^4.9.3",
     "postcss-loader": "2.1.0",
     "prettier": "1.10.2",
-    "react-addons-test-utils": "15.6.2",
     "react-dom": "16.2.0",
     "react-onclickoutside": "6.7.1",
     "react-test-renderer": "16.2.0",

--- a/webpack.config.dll.js
+++ b/webpack.config.dll.js
@@ -15,7 +15,6 @@ module.exports = {
       'moment',
       'promise',
       'react',
-      'react-addons-shallow-compare',
       'react-addons-update',
       'react-redux',
       'redux',


### PR DESCRIPTION
Removes two packages that were unused and deprecated:

## [react-addons-test-utils](https://www.npmjs.com/package/react-addons-test-utils)

This was probably [needed in the past](https://github.com/Automattic/simplenote-electron/pull/473#pullrequestreview-17549884) as a peer dependency of something, but not with the package versions we have now. Removing this will also remove a peer dependency warning (`react-addons-test-utils@15.6.2 requires a peer of react-dom@^15.4.2 but none is installed`).

## [react-addons-shallow-compare](https://www.npmjs.com/package/react-addons-shallow-compare)

This was [needed in the past](https://github.com/Automattic/simplenote-electron/pull/476#pullrequestreview-14551333) as a peer dependency of `react-virtualized`, but has been [unnecessary since v9.0](https://github.com/bvaughn/react-virtualized/pull/577).

