### PR TITLE
Bump Electron version to 2.0.8

### DIFF
--- a/lib/context-menu.jsx
+++ b/lib/context-menu.jsx
@@ -56,7 +56,7 @@ export class ContextMenu extends Component {
       return;
     }
 
-    menu.popup(currentWindow);
+    menu.popup({ window: currentWindow });
   };
 
   buildMenu = children => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -635,22 +635,22 @@
       "dev": true
     },
     "app-builder-lib": {
-      "version": "20.28.2",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-20.28.2.tgz",
-      "integrity": "sha512-oSnjjcLWPyJDEm8SW1AAI1fpKixf+ptx/renfIRJYdkeRi0frZikqSjgSKKIPVNnmnDIhAtMbYdNk0Kwx41/sg==",
+      "version": "20.28.3",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-20.28.3.tgz",
+      "integrity": "sha512-oZqv3+oi5bfKbN5eFfEbNovSuMTXn3yu8yJbmqDCNXcI1caOF+hCNAUpgMFohNGO0uY80veAwQTysZ74/VFjCA==",
       "dev": true,
       "requires": {
         "7zip-bin": "~4.0.2",
         "app-builder-bin": "2.1.2",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.5",
-        "builder-util": "6.1.2",
+        "builder-util": "6.1.3",
         "builder-util-runtime": "4.4.1",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^3.1.0",
         "ejs": "^2.6.1",
         "electron-osx-sign": "0.4.10",
-        "electron-publish": "20.28.0",
+        "electron-publish": "20.28.3",
         "fs-extra-p": "^4.6.1",
         "hosted-git-info": "^2.7.1",
         "is-ci": "^1.2.0",
@@ -662,7 +662,7 @@
         "plist": "^3.0.1",
         "read-config-file": "3.1.2",
         "sanitize-filename": "^1.6.1",
-        "semver": "^5.5.0",
+        "semver": "^5.5.1",
         "temp-file": "^3.1.3"
       },
       "dependencies": {
@@ -701,42 +701,6 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
-          }
-        },
-        "electron-osx-sign": {
-          "version": "0.4.10",
-          "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.10.tgz",
-          "integrity": "sha1-vk87ibKnWh3F8eckkIGrKSnKOiY=",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.5.0",
-            "compare-version": "^0.1.2",
-            "debug": "^2.6.8",
-            "isbinaryfile": "^3.0.2",
-            "minimist": "^1.2.0",
-            "plist": "^2.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "plist": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
-              "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
-              "dev": true,
-              "requires": {
-                "base64-js": "1.2.0",
-                "xmlbuilder": "8.2.2",
-                "xmldom": "0.1.x"
-              }
-            }
           }
         },
         "esprima": {
@@ -779,30 +743,11 @@
             "esprima": "^4.0.0"
           }
         },
-        "plist": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-          "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.2.3",
-            "xmlbuilder": "^9.0.7",
-            "xmldom": "0.1.x"
-          },
-          "dependencies": {
-            "base64-js": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-              "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-              "dev": true
-            },
-            "xmlbuilder": {
-              "version": "9.0.7",
-              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-              "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-              "dev": true
-            }
-          }
+        "semver": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+          "dev": true
         }
       }
     },
@@ -2614,9 +2559,9 @@
       "dev": true
     },
     "builder-util": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-6.1.2.tgz",
-      "integrity": "sha512-ZtOOPnzKmdJSXTo2yEWatZrkftBwOIOzc4lvqSoGf6yz9SdLsjPLvh0E1sA0Xohrio+Mz7AVB0XT67GgfZ6/hw==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-6.1.3.tgz",
+      "integrity": "sha512-MXeARNff9KHlzJYGJcAhLI/tpE57PmUnleaYfL22IE+viRt192Yr3wQL444ztsA+LUHJ8d12moUoG00jh1hfLA==",
       "dev": true,
       "requires": {
         "7zip-bin": "~4.0.2",
@@ -2629,8 +2574,8 @@
         "is-ci": "^1.2.0",
         "js-yaml": "^3.12.0",
         "lazy-val": "^1.0.3",
-        "semver": "^5.5.0",
-        "source-map-support": "^0.5.8",
+        "semver": "^5.5.1",
+        "source-map-support": "^0.5.9",
         "stat-mode": "^0.2.2",
         "temp-file": "^3.1.3"
       },
@@ -2709,6 +2654,12 @@
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
           }
+        },
+        "semver": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+          "dev": true
         },
         "source-map-support": {
           "version": "0.5.9",
@@ -4367,9 +4318,9 @@
       }
     },
     "commander": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
       "dev": true
     },
     "commondir": {
@@ -5393,16 +5344,16 @@
       "dev": true
     },
     "dmg-builder": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-5.3.0.tgz",
-      "integrity": "sha512-vzjrc7UmPQ+rb4tH8wbQdMq6Fu9M5chFndzhK2831xIpRsRlNlGEIWMiFRZ/MlboVL0vWxG0/2JCd2YMAevEpA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-5.3.1.tgz",
+      "integrity": "sha512-/+vtqlgvTtha/4Gc76XIRKS2KzYO58sTWXhZ/kgfNr05ZXY6bIw26v7xDu8ZBpTYnfWI09JRZTMv1yIXT/vvfg==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "~20.28.0",
+        "app-builder-lib": "~20.28.3",
         "bluebird-lst": "^1.0.5",
-        "builder-util": "~6.1.0",
+        "builder-util": "~6.1.3",
         "fs-extra-p": "^4.6.1",
-        "iconv-lite": "^0.4.23",
+        "iconv-lite": "^0.4.24",
         "js-yaml": "^3.12.0",
         "parse-color": "^1.0.0",
         "sanitize-filename": "^1.6.1"
@@ -5647,9 +5598,9 @@
       "dev": true
     },
     "electron": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.8.4.tgz",
-      "integrity": "sha512-2f1cx0G3riMFODXFftF5AHXy+oHfhpntZHTDN66Hxtl09gmEr42B3piNEod9MEmw72f75LX2JfeYceqq1PF8cA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.8.tgz",
+      "integrity": "sha512-pbeGFbwijb5V3Xy/KMcwIp59eA9igg2br+7EHbbwQoa3HRDF5JjTrciX7OiscCA52+ze2n4q38S4lXPqRitgIA==",
       "dev": true,
       "requires": {
         "@types/node": "^8.0.24",
@@ -5658,17 +5609,17 @@
       }
     },
     "electron-builder": {
-      "version": "20.28.2",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-20.28.2.tgz",
-      "integrity": "sha512-HdHp4Gsod+E2hXAYu1/Jww+JeJrRSdp2HA4yr03RqH29Hdluuep7bzmIcTCiAcibdYBzTojY3jmqwQJRUX0DBQ==",
+      "version": "20.28.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-20.28.3.tgz",
+      "integrity": "sha512-Sbe7E18Fl88la642PpcMU4jxv/1/vI3PCT/+Szly3O97DtKwuuVmk5MhW+FDBKgNS2f0xJgA6vRRraDK6HYvrw==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "20.28.2",
+        "app-builder-lib": "20.28.3",
         "bluebird-lst": "^1.0.5",
-        "builder-util": "6.1.2",
+        "builder-util": "6.1.3",
         "builder-util-runtime": "4.4.1",
         "chalk": "^2.4.1",
-        "dmg-builder": "5.3.0",
+        "dmg-builder": "5.3.1",
         "fs-extra-p": "^4.6.1",
         "is-ci": "^1.2.0",
         "lazy-val": "^1.0.3",
@@ -5843,9 +5794,9 @@
       }
     },
     "electron-osx-sign": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.7.tgz",
-      "integrity": "sha1-HXVkeoJ0jqzUi+pwYW7IP/rePuU=",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.10.tgz",
+      "integrity": "sha1-vk87ibKnWh3F8eckkIGrKSnKOiY=",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.0",
@@ -5854,6 +5805,19 @@
         "isbinaryfile": "^3.0.2",
         "minimist": "^1.2.0",
         "plist": "^2.1.0"
+      },
+      "dependencies": {
+        "plist": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
+          "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+          "dev": true,
+          "requires": {
+            "base64-js": "1.2.0",
+            "xmlbuilder": "8.2.2",
+            "xmldom": "0.1.x"
+          }
+        }
       }
     },
     "electron-packager": {
@@ -5892,41 +5856,20 @@
           }
         },
         "electron-download": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-4.1.0.tgz",
-          "integrity": "sha1-v5MsdG8vh//MCdHdRy8v9rkYeEU=",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-4.1.1.tgz",
+          "integrity": "sha512-FjEWG9Jb/ppK/2zToP+U5dds114fM1ZOJqMAR4aXXL5CvyPE9fiqBK/9YcwC9poIFQTEJk/EM/zyRwziziRZrg==",
           "dev": true,
           "requires": {
-            "debug": "^2.2.0",
+            "debug": "^3.0.0",
             "env-paths": "^1.0.0",
-            "fs-extra": "^2.0.0",
+            "fs-extra": "^4.0.1",
             "minimist": "^1.2.0",
-            "nugget": "^2.0.0",
+            "nugget": "^2.0.1",
             "path-exists": "^3.0.0",
-            "rc": "^1.1.2",
-            "semver": "^5.3.0",
-            "sumchecker": "^2.0.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "fs-extra": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-              "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^2.1.0"
-              }
-            }
+            "rc": "^1.2.1",
+            "semver": "^5.4.1",
+            "sumchecker": "^2.0.2"
           }
         },
         "fs-extra": {
@@ -5938,17 +5881,15 @@
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
-          },
-          "dependencies": {
-            "jsonfile": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-              "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.6"
-              }
-            }
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
           }
         },
         "pify": {
@@ -5956,6 +5897,17 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
+        },
+        "plist": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
+          "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+          "dev": true,
+          "requires": {
+            "base64-js": "1.2.0",
+            "xmlbuilder": "8.2.2",
+            "xmldom": "0.1.x"
+          }
         },
         "sumchecker": {
           "version": "2.0.2",
@@ -5980,13 +5932,13 @@
       }
     },
     "electron-publish": {
-      "version": "20.28.0",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-20.28.0.tgz",
-      "integrity": "sha512-ZGwzXyWuEGIvaCCGD0tebhjYGf7lxjdmkFAW3oFjRXOBXsBl91elOzOwfRSs/7zUE9mvvE0MnyJeBlqO7SAUvA==",
+      "version": "20.28.3",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-20.28.3.tgz",
+      "integrity": "sha512-/2t5zk9EKgH7p7rFZ+ynTKLmpKGF9bktMP2UR6u4bbPz9w4r3WEUbPOeZ1TLqUCAqdfZECcj4ThjrlcAJTghCA==",
       "dev": true,
       "requires": {
         "bluebird-lst": "^1.0.5",
-        "builder-util": "~6.1.0",
+        "builder-util": "~6.1.3",
         "builder-util-runtime": "^4.4.1",
         "chalk": "^2.4.1",
         "fs-extra-p": "^4.6.1",
@@ -6774,30 +6726,33 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
-      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.2",
         "debug": "2.6.9",
-        "mkdirp": "0.5.0",
+        "mkdirp": "0.5.1",
         "yauzl": "2.4.1"
       },
       "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+        "buffer-from": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
           "dev": true
         },
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         }
       }
@@ -13732,14 +13687,28 @@
       }
     },
     "plist": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
-      "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
+      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.0",
-        "xmlbuilder": "8.2.2",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^9.0.7",
         "xmldom": "0.1.x"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+          "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+          "dev": true
+        },
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+          "dev": true
+        }
       }
     },
     "pluralize": {
@@ -17381,9 +17350,9 @@
       }
     },
     "run-series": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
-      "integrity": "sha1-iac93F51ye+KtjIMChYA1qQRebk=",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.8.tgz",
+      "integrity": "sha512-+GztYEPRpIsQoCSraWHDBs9WVy4eVME16zhOtDB4H9J4xN0XRhknnmLOl+4gRgZtu8dpp9N/utSPjKH/xmDzXg==",
       "dev": true
     },
     "rx-lite": {
@@ -19620,9 +19589,9 @@
       }
     },
     "universalify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "unorm": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "babel-preset-react": "6.24.1",
     "classnames": "2.2.5",
     "css-loader": "0.28.9",
-    "electron": "1.8.4",
+    "electron": "2.0.8",
     "electron-builder": "^20.28.2",
     "electron-packager": "9.1.0",
     "enzyme": "3.5.0",


### PR DESCRIPTION
I checked that we are not affected by [breaking API changes](https://electronjs.org/blog/electron-2-0), except for a minor signature change to `menu.popup`.