### PR TITLE
[macOS] Put “Bring All to Front” in proper menu

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -22,7 +22,7 @@ module.exports = function main() {
 
   // Keep a global reference of the window object, if you don't, the window will
   // be closed automatically when the JavaScript object is GCed.
-  var mainWindow = null;
+  let mainWindow = null;
 
   const activateWindow = function() {
     // Only allow a single window
@@ -37,7 +37,7 @@ module.exports = function main() {
     });
 
     // Create the browser window.
-    var iconPath = path.join(
+    const iconPath = path.join(
       __dirname,
       '../lib/icons/app-icon/icon_256x256.png'
     );
@@ -198,7 +198,7 @@ function createMenuTemplate(settings) {
     },
   };
 
-  var helpMenu = {
+  const helpMenu = {
     label: '&Help',
     submenu: [
       {
@@ -210,7 +210,7 @@ function createMenuTemplate(settings) {
     ],
   };
 
-  var fileMenu = {
+  const fileMenu = {
     label: '&File',
     submenu: [
       {
@@ -332,7 +332,7 @@ function createMenuTemplate(settings) {
     });
   }
 
-  var menuTemplate = [
+  const menuTemplate = [
     fileMenu,
     {
       label: '&Edit',

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -259,6 +259,23 @@ function createMenuTemplate(settings) {
     ],
   };
 
+  const windowMenu = {
+    label: '&Window',
+    role: 'window',
+    submenu: [
+      {
+        label: '&Minimize',
+        accelerator: 'CommandOrControl+M',
+        role: 'minimize',
+      },
+      {
+        label: '&Close',
+        accelerator: 'CommandOrControl+W',
+        role: 'close',
+      },
+    ],
+  };
+
   // linux menu item adjustments
   if (process.platform === 'linux') {
     // add about menu item to Help
@@ -370,22 +387,7 @@ function createMenuTemplate(settings) {
       ],
     },
     buildViewMenu(settings),
-    {
-      label: '&Window',
-      role: 'window',
-      submenu: [
-        {
-          label: '&Minimize',
-          accelerator: 'CommandOrControl+M',
-          role: 'minimize',
-        },
-        {
-          label: '&Close',
-          accelerator: 'CommandOrControl+W',
-          role: 'close',
-        },
-      ],
-    },
+    windowMenu,
     helpMenu,
   ];
 
@@ -437,8 +439,7 @@ function createMenuTemplate(settings) {
       ],
     });
 
-    // Window menu.
-    menuTemplate[3].submenu.push(
+    windowMenu.submenu.push(
       {
         type: 'separator',
       },


### PR DESCRIPTION
There was an off-by-one error causing the “Bring All to Front” menu item to be in the wrong menu.

This fixes the misplacement, and removes the usage of array indices to avoid similar bugs.

### Before:
<img height="150" alt="screen shot 2018-08-30 at 22 22 14" src="https://user-images.githubusercontent.com/555336/44857078-fe422b80-aca9-11e8-9950-ef70ccd023e7.png"> <img height="150" alt="screen shot 2018-08-30 at 22 22 18" src="https://user-images.githubusercontent.com/555336/44857082-01d5b280-acaa-11e8-8b01-87b1dfdd2e33.png">

### After:

<img height="150" alt="screen shot 2018-08-30 at 22 21 32" src="https://user-images.githubusercontent.com/555336/44857210-42cdc700-acaa-11e8-8b96-5d09f7977efb.png"> <img height="150" alt="screen shot 2018-08-30 at 22 21 40" src="https://user-images.githubusercontent.com/555336/44857215-45c8b780-acaa-11e8-9f6b-cce651b6b41f.png">
