### PR TITLE
Add Line Length Setting (Part 1)

### DIFF
--- a/desktop/menus/test/utils.js
+++ b/desktop/menus/test/utils.js
@@ -1,0 +1,30 @@
+import { buildRadioGroup } from '../utils';
+
+describe('Menu Utils', () => {
+  describe('buildRadioGroup', () => {
+    const menuItems = [
+      {
+        id: 'myValue',
+        passThroughProp: 'passThroughValue',
+      },
+      {
+        id: 'myUnselectedValue',
+      },
+    ];
+    const args = {
+      action: 'myAction',
+      propName: 'myProp',
+      settings: { myProp: 'myValue' },
+    };
+    const result = menuItems.map(buildRadioGroup(args));
+
+    test('should pass through any props', () => {
+      expect(result[0].passThroughProp).toBe('passThroughValue');
+    });
+
+    test('should set the correct item as "checked"', () => {
+      expect(result[0].checked).toBe(true);
+      expect(result[1].checked).toBe(false);
+    });
+  });
+});

--- a/desktop/menus/utils.js
+++ b/desktop/menus/utils.js
@@ -1,0 +1,28 @@
+const buildRadioGroup = ({ action, propName, settings }) => {
+  return item => {
+    const { id, ...props } = item;
+
+    return {
+      type: 'radio',
+      checked: id === settings[propName],
+      click: appCommandSender({
+        action,
+        [propName]: id,
+      }),
+      ...props,
+    };
+  };
+};
+
+const appCommandSender = arg => {
+  return (item, focusedWindow) => {
+    if (focusedWindow) {
+      focusedWindow.webContents.send('appCommand', arg);
+    }
+  };
+};
+
+module.exports = {
+  buildRadioGroup,
+  appCommandSender,
+};

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -1,26 +1,4 @@
-const buildRadioGroup = ({ action, propName, settings }) => {
-  return item => {
-    const { id, ...props } = item;
-
-    return {
-      type: 'radio',
-      checked: id === settings[propName],
-      click: appCommandSender({
-        action,
-        [propName]: id,
-      }),
-      ...props,
-    };
-  };
-};
-
-const appCommandSender = arg => {
-  return (item, focusedWindow) => {
-    if (focusedWindow) {
-      focusedWindow.webContents.send('appCommand', arg);
-    }
-  };
-};
+const { buildRadioGroup, appCommandSender } = require('./utils');
 
 const buildViewMenu = settings => {
   settings = settings || {};

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -1,21 +1,16 @@
-var buildRadioGroup = function(activePredicate) {
-  return function(item) {
-    var label = item[0],
-      prop = item[1],
-      action = item[2];
+const buildRadioGroup = ({ action, propName, settings }) => {
+  return item => {
+    const { id, ...props } = item;
 
     return {
-      label: label,
       type: 'radio',
-      checked: activePredicate(prop),
-      click: appCommandSender(action),
+      checked: id === settings[propName],
+      click: appCommandSender({
+        action,
+        [propName]: id,
+      }),
+      ...props,
     };
-  };
-};
-
-var equalTo = function(a) {
-  return function(b) {
-    return a === b;
   };
 };
 
@@ -27,7 +22,7 @@ const appCommandSender = arg => {
   };
 };
 
-var buildViewMenu = function(settings) {
+const buildViewMenu = settings => {
   settings = settings || {};
 
   return {
@@ -36,22 +31,25 @@ var buildViewMenu = function(settings) {
       {
         label: '&Note Display',
         submenu: [
-          [
-            '&Comfy',
-            'comfy',
-            { action: 'setNoteDisplay', noteDisplay: 'comfy' },
-          ],
-          [
-            'C&ondensed',
-            'condensed',
-            { action: 'setNoteDisplay', noteDisplay: 'condensed' },
-          ],
-          [
-            '&Expanded',
-            'expanded',
-            { action: 'setNoteDisplay', noteDisplay: 'expanded' },
-          ],
-        ].map(buildRadioGroup(equalTo(settings.noteDisplay))),
+          {
+            label: '&Comfy',
+            id: 'comfy',
+          },
+          {
+            label: 'C&ondensed',
+            id: 'condensed',
+          },
+          {
+            label: '&Expanded',
+            id: 'expanded',
+          },
+        ].map(
+          buildRadioGroup({
+            action: 'setNoteDisplay',
+            propName: 'noteDisplay',
+            settings,
+          })
+        ),
       },
       {
         label: 'Note &Editor',
@@ -83,23 +81,26 @@ var buildViewMenu = function(settings) {
       {
         label: '&Sort Type',
         submenu: [
-          [
-            'Last &modified',
-            'modificationDate',
-            { action: 'setSortType', sortType: 'modificationDate' },
-          ],
-          [
-            'Last &created',
-            'creationDate',
-            { action: 'setSortType', sortType: 'creationDate' },
-          ],
-          [
-            '&Alphabetical',
-            'alphabetical',
-            { action: 'setSortType', sortType: 'alphabetical' },
-          ],
+          {
+            label: 'Last &modified',
+            id: 'modificationDate',
+          },
+          {
+            label: 'Last &created',
+            id: 'creationDate',
+          },
+          {
+            label: '&Alphabetical',
+            id: 'alphabetical',
+          },
         ]
-          .map(buildRadioGroup(equalTo(settings.sortType)))
+          .map(
+            buildRadioGroup({
+              action: 'setSortType',
+              propName: 'sortType',
+              settings,
+            })
+          )
           .concat([
             {
               type: 'separator',
@@ -115,9 +116,21 @@ var buildViewMenu = function(settings) {
       {
         label: '&Theme',
         submenu: [
-          ['&Light', 'light', { action: 'activateTheme', theme: 'light' }],
-          ['&Dark', 'dark', { action: 'activateTheme', theme: 'dark' }],
-        ].map(buildRadioGroup(equalTo(settings.theme))),
+          {
+            label: '&Light',
+            id: 'light',
+          },
+          {
+            label: '&Dark',
+            id: 'dark',
+          },
+        ].map(
+          buildRadioGroup({
+            action: 'activateTheme',
+            propName: 'theme',
+            settings,
+          })
+        ),
       },
       {
         type: 'separator',

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -13,18 +13,6 @@ var buildRadioGroup = function(activePredicate) {
   };
 };
 
-var buildFontGroup = function(item) {
-  var label = item[0],
-    accelerator = item[1],
-    action = item[2];
-
-  return {
-    label: label,
-    accelerator: accelerator,
-    click: appCommandSender({ action }),
-  };
-};
-
 var equalTo = function(a) {
   return function(b) {
     return a === b;
@@ -73,10 +61,22 @@ var buildViewMenu = function(settings) {
             submenu: [
               // For the oddity with "Command" vs "Cmd"
               // Cite: https://github.com/atom/electron/issues/1507
-              ['&Bigger', 'CommandOrControl+=', 'increaseFontSize'],
-              ['&Smaller', 'CommandOrControl+-', 'decreaseFontSize'],
-              ['&Reset', 'CommandOrControl+0', 'resetFontSize'],
-            ].map(buildFontGroup),
+              {
+                label: '&Bigger',
+                accelerator: 'CommandOrControl+=',
+                click: appCommandSender({ action: 'increaseFontSize' }),
+              },
+              {
+                label: '&Smaller',
+                accelerator: 'CommandOrControl+-',
+                click: appCommandSender({ action: 'decreaseFontSize' }),
+              },
+              {
+                label: '&Reset',
+                accelerator: 'CommandOrControl+0',
+                click: appCommandSender({ action: 'resetFontSize' }),
+              },
+            ],
           },
         ],
       },

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -54,6 +54,25 @@ const buildViewMenu = settings => {
               },
             ],
           },
+          {
+            label: '&Line Length',
+            submenu: [
+              {
+                label: '&Narrow',
+                id: 'narrow',
+              },
+              {
+                label: '&Full',
+                id: 'full',
+              },
+            ].map(
+              buildRadioGroup({
+                action: 'setLineLength',
+                propName: 'lineLength',
+                settings,
+              })
+            ),
+          },
         ],
       },
       {

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -50,14 +50,39 @@ var buildViewMenu = function(settings) {
     label: '&View',
     submenu: [
       {
-        label: '&Font Size',
+        label: '&Note Display',
         submenu: [
-          // For the oddity with "Command" vs "Cmd"
-          // Cite: https://github.com/atom/electron/issues/1507
-          ['&Bigger', 'CommandOrControl+=', 'increaseFontSize'],
-          ['&Smaller', 'CommandOrControl+-', 'decreaseFontSize'],
-          ['&Reset', 'CommandOrControl+0', 'resetFontSize'],
-        ].map(buildFontGroup),
+          [
+            '&Comfy',
+            'comfy',
+            { action: 'setNoteDisplay', noteDisplay: 'comfy' },
+          ],
+          [
+            'C&ondensed',
+            'condensed',
+            { action: 'setNoteDisplay', noteDisplay: 'condensed' },
+          ],
+          [
+            '&Expanded',
+            'expanded',
+            { action: 'setNoteDisplay', noteDisplay: 'expanded' },
+          ],
+        ].map(buildRadioGroup(equalTo(settings.noteDisplay))),
+      },
+      {
+        label: 'Note &Editor',
+        submenu: [
+          {
+            label: '&Font Size',
+            submenu: [
+              // For the oddity with "Command" vs "Cmd"
+              // Cite: https://github.com/atom/electron/issues/1507
+              ['&Bigger', 'CommandOrControl+=', 'increaseFontSize'],
+              ['&Smaller', 'CommandOrControl+-', 'decreaseFontSize'],
+              ['&Reset', 'CommandOrControl+0', 'resetFontSize'],
+            ].map(buildFontGroup),
+          },
+        ],
       },
       {
         label: '&Sort Type',
@@ -99,32 +124,15 @@ var buildViewMenu = function(settings) {
             },
           ]),
       },
-      {
-        label: '&Note Display',
-        submenu: [
-          [
-            '&Comfy',
-            'comfy',
-            { action: 'setNoteDisplay', noteDisplay: 'comfy' },
-          ],
-          [
-            'C&ondensed',
-            'condensed',
-            { action: 'setNoteDisplay', noteDisplay: 'condensed' },
-          ],
-          [
-            '&Expanded',
-            'expanded',
-            { action: 'setNoteDisplay', noteDisplay: 'expanded' },
-          ],
-        ].map(buildRadioGroup(equalTo(settings.noteDisplay))),
-      },
-      {
+            {
         label: '&Theme',
         submenu: [
           ['&Light', 'light', { action: 'activateTheme', theme: 'light' }],
           ['&Dark', 'dark', { action: 'activateTheme', theme: 'dark' }],
         ].map(buildRadioGroup(equalTo(settings.theme))),
+      },
+      {
+        type: 'separator',
       },
       {
         label: 'T&oggle Full Screen',

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -8,13 +8,7 @@ var buildRadioGroup = function(activePredicate) {
       label: label,
       type: 'radio',
       checked: activePredicate(prop),
-      click: function(item, focusedWindow) {
-        if (!focusedWindow) {
-          return;
-        }
-
-        focusedWindow.webContents.send('appCommand', action);
-      },
+      click: appCommandSender(action),
     };
   };
 };
@@ -27,19 +21,21 @@ var buildFontGroup = function(item) {
   return {
     label: label,
     accelerator: accelerator,
-    click: function(item, focusedWindow) {
-      if (!focusedWindow) {
-        return;
-      }
-
-      focusedWindow.webContents.send('appCommand', { action: action });
-    },
+    click: appCommandSender({ action }),
   };
 };
 
 var equalTo = function(a) {
   return function(b) {
     return a === b;
+  };
+};
+
+const appCommandSender = arg => {
+  return (item, focusedWindow) => {
+    if (focusedWindow) {
+      focusedWindow.webContents.send('appCommand', arg);
+    }
   };
 };
 
@@ -112,19 +108,11 @@ var buildViewMenu = function(settings) {
               label: '&Reversed',
               type: 'checkbox',
               checked: settings.sortReversed,
-              click: function(item, focusedWindow) {
-                if (!focusedWindow) {
-                  return;
-                }
-
-                focusedWindow.webContents.send('appCommand', {
-                  action: 'toggleSortOrder',
-                });
-              },
+              click: appCommandSender({ action: 'toggleSortOrder' }),
             },
           ]),
       },
-            {
+      {
         label: '&Theme',
         submenu: [
           ['&Light', 'light', { action: 'activateTheme', theme: 'light' }],

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -76,6 +76,7 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
         'decreaseFontSize',
         'increaseFontSize',
         'resetFontSize',
+        'setLineLength',
         'setNoteDisplay',
         'setMarkdown',
         'setAccountName',
@@ -391,6 +392,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
         state.note || (!isSmallScreen && hasNotes ? filteredNotes[0] : null);
 
       const appClasses = classNames('app', `theme-${settings.theme}`, {
+        'is-line-length-full': settings.lineLength === 'full',
         'touch-enabled': 'ontouchstart' in document.body,
       });
 

--- a/lib/dialogs/settings.jsx
+++ b/lib/dialogs/settings.jsx
@@ -124,6 +124,7 @@ export class SettingsDialog extends Component {
   renderTabContent = tabName => {
     const {
       activateTheme,
+      setLineLength,
       setNoteDisplay,
       setSortType,
       toggleSortOrder,
@@ -132,6 +133,7 @@ export class SettingsDialog extends Component {
     const {
       settings: {
         theme: activeTheme,
+        lineLength,
         noteDisplay,
         sortType,
         sortReversed: sortIsReversed,
@@ -177,6 +179,29 @@ export class SettingsDialog extends Component {
         return (
           <div className="dialog-column settings-display">
             <SettingsGroup
+              title="Note display"
+              slug="noteDisplay"
+              activeSlug={noteDisplay}
+              onChange={setNoteDisplay}
+              renderer={RadioGroup}
+            >
+              <Item title="Comfy" slug="comfy" />
+              <Item title="Condensed" slug="condensed" />
+              <Item title="Expanded" slug="expanded" />
+            </SettingsGroup>
+
+            <SettingsGroup
+              title="Line length"
+              slug="lineLength"
+              activeSlug={lineLength}
+              onChange={setLineLength}
+              renderer={RadioGroup}
+            >
+              <Item title="Narrow" slug="narrow" />
+              <Item title="Full" slug="full" />
+            </SettingsGroup>
+
+            <SettingsGroup
               title="Sort type"
               slug="sortType"
               activeSlug={sortType}
@@ -196,18 +221,6 @@ export class SettingsDialog extends Component {
               renderer={ToggleGroup}
             >
               <Item title="Reversed" slug="reversed" />
-            </SettingsGroup>
-
-            <SettingsGroup
-              title="Note display"
-              slug="noteDisplay"
-              activeSlug={noteDisplay}
-              onChange={setNoteDisplay}
-              renderer={RadioGroup}
-            >
-              <Item title="Comfy" slug="comfy" />
-              <Item title="Condensed" slug="condensed" />
-              <Item title="Expanded" slug="expanded" />
             </SettingsGroup>
 
             <SettingsGroup

--- a/lib/state/settings/actions.js
+++ b/lib/state/settings/actions.js
@@ -27,6 +27,11 @@ export const setNoteDisplay = noteDisplay => ({
   noteDisplay,
 });
 
+export const setLineLength = lineLength => ({
+  type: 'setLineLength',
+  lineLength,
+});
+
 export const setSortOrder = sortReversed => ({
   type: 'setSortReversed',
   sortReversed,

--- a/lib/state/settings/reducer.js
+++ b/lib/state/settings/reducer.js
@@ -41,6 +41,14 @@ const noteDisplay = (state = 'comfy', action) => {
   return action.noteDisplay;
 };
 
+const lineLength = (state = 'narrow', action) => {
+  if ('setLineLength' !== action.type) {
+    return state;
+  }
+
+  return action.lineLength;
+};
+
 const accountName = (state = null, action) => {
   if ('setAccountName' !== action.type) {
     return state;
@@ -68,6 +76,7 @@ const wpToken = (state = false, action) => {
 export default combineReducers({
   accountName,
   fontSize,
+  lineLength,
   markdownEnabled,
   noteDisplay,
   sortType,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,10 @@
     "Chrome >= 58"
   ],
   "jest": {
-    "rootDir": "lib",
+    "roots": [
+      "desktop",
+      "lib"
+    ],
     "testRegex": "(/test/.*\\.jsx?)|(test\\.jsx?)$"
   },
   "prettier": {

--- a/scss/editor.scss
+++ b/scss/editor.scss
@@ -139,7 +139,7 @@
   width: 100%;
   height: 100%;
   max-width: 780px;
-  padding: 24px 48px;
+  padding: 24px;
   border: none;
   line-height: 1.5em;
   font-size: 16px;
@@ -151,9 +151,12 @@
   &:focus {
     outline: none;
   }
+}
 
-  @media only screen and (max-width: $medium) {
-    padding: 24px;
+.is-line-length-full {
+  .note-detail-textarea,
+  .note-detail-markdown {
+    max-width: none;
   }
 }
 


### PR DESCRIPTION
Closes #797 

(Part 1 of a stacked pull request. Part 2: #815)

These changes require Electron v2+ (dependent on #812).

This first part focuses on refactoring and reordering the View menu to prepare for the addition of the Line Length feature.

### ToDo

- [x] Reorder app menu to match simplenote-macos
- [x] Refactor view-menu and add tests
- [x] Prepare CSS styles
- [x] Implement line length action
- [x] Add Line Length to Settings Dialog