### PR TITLE
Add Line Length Setting (Part 2)

### DIFF
--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -54,6 +54,25 @@ const buildViewMenu = settings => {
               },
             ],
           },
+          {
+            label: '&Line Length',
+            submenu: [
+              {
+                label: '&Narrow',
+                id: 'narrow',
+              },
+              {
+                label: '&Full',
+                id: 'full',
+              },
+            ].map(
+              buildRadioGroup({
+                action: 'setLineLength',
+                propName: 'lineLength',
+                settings,
+              })
+            ),
+          },
         ],
       },
       {

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -76,6 +76,7 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
         'decreaseFontSize',
         'increaseFontSize',
         'resetFontSize',
+        'setLineLength',
         'setNoteDisplay',
         'setMarkdown',
         'setAccountName',
@@ -391,6 +392,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
         state.note || (!isSmallScreen && hasNotes ? filteredNotes[0] : null);
 
       const appClasses = classNames('app', `theme-${settings.theme}`, {
+        'is-line-length-full': settings.lineLength === 'full',
         'touch-enabled': 'ontouchstart' in document.body,
       });
 

--- a/lib/dialogs/settings.jsx
+++ b/lib/dialogs/settings.jsx
@@ -124,6 +124,7 @@ export class SettingsDialog extends Component {
   renderTabContent = tabName => {
     const {
       activateTheme,
+      setLineLength,
       setNoteDisplay,
       setSortType,
       toggleSortOrder,
@@ -132,6 +133,7 @@ export class SettingsDialog extends Component {
     const {
       settings: {
         theme: activeTheme,
+        lineLength,
         noteDisplay,
         sortType,
         sortReversed: sortIsReversed,
@@ -186,6 +188,17 @@ export class SettingsDialog extends Component {
               <Item title="Comfy" slug="comfy" />
               <Item title="Condensed" slug="condensed" />
               <Item title="Expanded" slug="expanded" />
+            </SettingsGroup>
+
+            <SettingsGroup
+              title="Line length"
+              slug="lineLength"
+              activeSlug={lineLength}
+              onChange={setLineLength}
+              renderer={RadioGroup}
+            >
+              <Item title="Narrow" slug="narrow" />
+              <Item title="Full" slug="full" />
             </SettingsGroup>
 
             <SettingsGroup

--- a/lib/dialogs/settings.jsx
+++ b/lib/dialogs/settings.jsx
@@ -177,6 +177,18 @@ export class SettingsDialog extends Component {
         return (
           <div className="dialog-column settings-display">
             <SettingsGroup
+              title="Note display"
+              slug="noteDisplay"
+              activeSlug={noteDisplay}
+              onChange={setNoteDisplay}
+              renderer={RadioGroup}
+            >
+              <Item title="Comfy" slug="comfy" />
+              <Item title="Condensed" slug="condensed" />
+              <Item title="Expanded" slug="expanded" />
+            </SettingsGroup>
+
+            <SettingsGroup
               title="Sort type"
               slug="sortType"
               activeSlug={sortType}
@@ -196,18 +208,6 @@ export class SettingsDialog extends Component {
               renderer={ToggleGroup}
             >
               <Item title="Reversed" slug="reversed" />
-            </SettingsGroup>
-
-            <SettingsGroup
-              title="Note display"
-              slug="noteDisplay"
-              activeSlug={noteDisplay}
-              onChange={setNoteDisplay}
-              renderer={RadioGroup}
-            >
-              <Item title="Comfy" slug="comfy" />
-              <Item title="Condensed" slug="condensed" />
-              <Item title="Expanded" slug="expanded" />
             </SettingsGroup>
 
             <SettingsGroup

--- a/lib/state/settings/actions.js
+++ b/lib/state/settings/actions.js
@@ -27,6 +27,11 @@ export const setNoteDisplay = noteDisplay => ({
   noteDisplay,
 });
 
+export const setLineLength = lineLength => ({
+  type: 'setLineLength',
+  lineLength,
+});
+
 export const setSortOrder = sortReversed => ({
   type: 'setSortReversed',
   sortReversed,

--- a/lib/state/settings/reducer.js
+++ b/lib/state/settings/reducer.js
@@ -41,6 +41,14 @@ const noteDisplay = (state = 'comfy', action) => {
   return action.noteDisplay;
 };
 
+const lineLength = (state = 'narrow', action) => {
+  if ('setLineLength' !== action.type) {
+    return state;
+  }
+
+  return action.lineLength;
+};
+
 const accountName = (state = null, action) => {
   if ('setAccountName' !== action.type) {
     return state;
@@ -68,6 +76,7 @@ const wpToken = (state = false, action) => {
 export default combineReducers({
   accountName,
   fontSize,
+  lineLength,
   markdownEnabled,
   noteDisplay,
   sortType,

--- a/scss/editor.scss
+++ b/scss/editor.scss
@@ -157,6 +157,13 @@
   }
 }
 
+.is-line-length-full {
+  .note-detail-textarea,
+  .note-detail-markdown {
+    max-width: none;
+  }
+}
+
 .note-detail-textarea {
   min-height: 100%;
   cursor: text;

--- a/scss/editor.scss
+++ b/scss/editor.scss
@@ -139,7 +139,7 @@
   width: 100%;
   height: 100%;
   max-width: 780px;
-  padding: 24px 48px;
+  padding: 24px;
   border: none;
   line-height: 1.5em;
   font-size: 16px;
@@ -150,10 +150,6 @@
 
   &:focus {
     outline: none;
-  }
-
-  @media only screen and (max-width: $medium) {
-    padding: 24px;
   }
 }
 


### PR DESCRIPTION
(Part 2 of a stacked pull request. Part 1: #814)

This implements the Line Length feature, adding controls to both the app menu and the settings dialog. The default setting is "Narrow". When set to "Full", the `max-width` rule on the note body is removed so that the text can wrap at window width.

![line-length](https://user-images.githubusercontent.com/555336/44909935-330ebb00-ad5c-11e8-996d-28afa653e75c.gif)

## Settings dialog
<img width="400" alt="screen shot 2018-08-31 at 20 21 33" src="https://user-images.githubusercontent.com/555336/44909761-846a7a80-ad5b-11e8-80a2-4dd2e9db8849.png">

