### PR TITLE
Add displayNames to unnamed React components

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -109,6 +109,8 @@ const isElectronMac = () =>
 
 export const App = connect(mapStateToProps, mapDispatchToProps)(
   class extends Component {
+    static displayName = 'App';
+
     static propTypes = {
       actions: PropTypes.object.isRequired,
       appState: PropTypes.object.isRequired,

--- a/lib/browser-shell.jsx
+++ b/lib/browser-shell.jsx
@@ -28,6 +28,8 @@ const getState = () => {
  */
 export const browserShell = Wrapped =>
   class extends Component {
+    static displayName = 'BrowserShell';
+
     state = getState();
 
     componentDidMount() {

--- a/lib/components/tag-chip/index.jsx
+++ b/lib/components/tag-chip/index.jsx
@@ -12,4 +12,6 @@ export const TagChip = ({ onSelect = noop, selected, tag: tagName }) => (
   </div>
 );
 
+TagChip.displayName = 'TagChip';
+
 export default TagChip;

--- a/lib/editable-list.jsx
+++ b/lib/editable-list.jsx
@@ -5,6 +5,8 @@ import SmallCrossOutlineIcon from './icons/cross-outline-small';
 import ReorderIcon from './icons/reorder';
 
 export class EditableList extends Component {
+  static displayName = 'EditableList';
+
   static propTypes = {
     editing: PropTypes.bool.isRequired,
     items: PropTypes.array.isRequired,

--- a/lib/navigation-bar.jsx
+++ b/lib/navigation-bar.jsx
@@ -17,6 +17,8 @@ const {
 } = appState.actionCreators;
 
 export class NavigationBar extends Component {
+  static displayName = 'NavigationBar';
+
   static defaultProps = {
     onSelectAllNotes: function() {},
     onSelectTrash: function() {},

--- a/lib/note-detail.jsx
+++ b/lib/note-detail.jsx
@@ -17,6 +17,8 @@ const renderToNode = (node, content) => {
 };
 
 export class NoteDetail extends Component {
+  static displayName = 'NoteDetail';
+
   static propTypes = {
     dialogs: PropTypes.array.isRequired,
     filter: PropTypes.string.isRequired,

--- a/lib/note-editor.jsx
+++ b/lib/note-editor.jsx
@@ -11,6 +11,8 @@ import { get, property } from 'lodash';
 import { renderNoteToHtml } from './utils/render-note-to-html';
 
 export class NoteEditor extends Component {
+  static displayName = 'NoteEditor';
+
   static propTypes = {
     editorMode: PropTypes.oneOf(['edit', 'markdown']),
     note: PropTypes.object,

--- a/lib/note-list.jsx
+++ b/lib/note-list.jsx
@@ -24,6 +24,9 @@ import { tracks } from './analytics';
 import filterNotes from './utils/filter-notes';
 import noteTitle from './utils/note-utils';
 
+AutoSizer.displayName = 'AutoSizer';
+List.displayName = 'List';
+
 /**
  * Delay for preventing row height calculation thrashing
  *
@@ -309,6 +312,8 @@ const renderNote = (
 };
 
 export class NoteList extends Component {
+  static displayName = 'NoteList';
+
   static propTypes = {
     notes: PropTypes.array.isRequired,
     selectedNoteId: PropTypes.any,

--- a/lib/note-toolbar.jsx
+++ b/lib/note-toolbar.jsx
@@ -9,6 +9,8 @@ import TrashIcon from './icons/trash';
 import ShareIcon from './icons/share';
 
 export class NoteToolbar extends Component {
+  static displayName = 'NoteToolbar';
+
   static propTypes = {
     note: PropTypes.object,
     onTrashNote: PropTypes.func.isRequired,

--- a/lib/search-bar.jsx
+++ b/lib/search-bar.jsx
@@ -57,4 +57,6 @@ const mapDispatchToProps = (dispatch, { noteBucket }) => ({
   onToggleNavigation: () => dispatch(toggleNavigation()),
 });
 
+SearchBar.displayName = 'SearchBar';
+
 export default connect(mapStateToProps, mapDispatchToProps)(SearchBar);

--- a/lib/search-field.jsx
+++ b/lib/search-field.jsx
@@ -11,6 +11,8 @@ const { recordEvent } = tracks;
 const KEY_ESC = 27;
 
 export class SearchField extends Component {
+  static displayName = 'SearchField';
+
   static propTypes = {
     placeholder: PropTypes.string.isRequired,
     query: PropTypes.string.isRequired,

--- a/lib/tag-field.jsx
+++ b/lib/tag-field.jsx
@@ -17,6 +17,8 @@ import {
 } from 'lodash';
 
 export class TagField extends Component {
+  static displayName = 'TagField';
+
   static propTypes = {
     storeFocusTagField: PropTypes.func,
     storeHasFocus: PropTypes.func,

--- a/lib/tag-input.jsx
+++ b/lib/tag-input.jsx
@@ -13,6 +13,8 @@ const startsWith = prefix => text =>
     .startsWith(prefix.trim().toLowerCase());
 
 export class TagInput extends Component {
+  static displayName = 'TagInput';
+
   static propTypes = {
     inputRef: PropTypes.func,
     onChange: PropTypes.func,

--- a/lib/tag-list.jsx
+++ b/lib/tag-list.jsx
@@ -17,6 +17,8 @@ const {
 const { recordEvent } = tracks;
 
 export class TagList extends Component {
+  static displayName = 'TagList';
+
   static propTypes = {
     onSelectTag: PropTypes.func.isRequired,
     onEditTags: PropTypes.func.isRequired,


### PR DESCRIPTION
Many of the wrapped components were missing [displayNames](https://reactjs.org/docs/react-component.html#displayname), making it difficult to debug in the React dev tools.

This adds displayNames to the components that were not showing names in the dev tools.

### Before
<img width="461" alt="screen shot 2018-09-01 at 0 27 09" src="https://user-images.githubusercontent.com/555336/44921606-fce23300-ad7d-11e8-916c-48b5c692d2f6.png">

### After
<img width="355" alt="screen shot 2018-09-01 at 0 25 16" src="https://user-images.githubusercontent.com/555336/44921609-023f7d80-ad7e-11e8-92d4-500ab1e8904d.png">
