### PR TITLE
add modification timestamp to zip

### DIFF
--- a/lib/utils/export/to-zip.js
+++ b/lib/utils/export/to-zip.js
@@ -30,6 +30,17 @@ const addFilename = note => ({
 });
 
 /**
+ * Add the modification date
+ *
+ * @param {Object} note object
+ * @returns {Object} augmented note object with modification date
+ */
+const addModified = note => ({
+  ...note,
+  modified: note.lastModified,
+});
+
+/**
  * Appends associated tags as a list at end of note content if available
  *
  * This lines up the tags in an indented block separated by commas.
@@ -109,9 +120,12 @@ export const noteExportToZip = notes => {
   notes.activeNotes
     .map(appendTags) // add tags to end of content
     .map(addFilename) // generate filename from content
+    .map(addModified) // grab the modification date
     .reduce(toUniqueNames, [[], {}]) // add `(n)` if there are duplicates
     .shift() // the list of notes is the first item in the pair returned from above
-    .forEach(({ content, fileName }) => zip.file(`${fileName}.txt`, content)); // add the note as a file in the zip
+    .forEach(({ content, fileName, modified }) => {
+      zip.file(`${fileName}.txt`, content, { date: new Date(modified) });
+    }); // add the note as a file in the zip
 
   notes.trashedNotes
     .map(appendTags) // add tags to end of content

--- a/lib/utils/export/to-zip.js
+++ b/lib/utils/export/to-zip.js
@@ -30,17 +30,6 @@ const addFilename = note => ({
 });
 
 /**
- * Add the modification date
- *
- * @param {Object} note object
- * @returns {Object} augmented note object with modification date
- */
-const addModified = note => ({
-  ...note,
-  modified: note.lastModified,
-});
-
-/**
  * Appends associated tags as a list at end of note content if available
  *
  * This lines up the tags in an indented block separated by commas.
@@ -120,11 +109,10 @@ export const noteExportToZip = notes => {
   notes.activeNotes
     .map(appendTags) // add tags to end of content
     .map(addFilename) // generate filename from content
-    .map(addModified) // grab the modification date
     .reduce(toUniqueNames, [[], {}]) // add `(n)` if there are duplicates
     .shift() // the list of notes is the first item in the pair returned from above
-    .forEach(({ content, fileName, modified }) => {
-      zip.file(`${fileName}.txt`, content, { date: new Date(modified) });
+    .forEach(({ content, fileName, lastModified }) => {
+      zip.file(`${fileName}.txt`, content, { date: new Date(lastModified) });
     }); // add the note as a file in the zip
 
   notes.trashedNotes
@@ -132,9 +120,11 @@ export const noteExportToZip = notes => {
     .map(addFilename) // generate filename from content
     .reduce(toUniqueNames, [[], {}]) // add `(n)` if there are duplicates
     .shift() // the list of notes is the first item in the pair returned from above
-    .forEach(({ content, fileName }) =>
-      zip.file(`trash/${fileName}.txt`, content)
-    ); // add the note as a file in the zip
+    .forEach(({ content, fileName, lastModified }) => {
+      zip.file(`trash/${fileName}.txt`, content, {
+        date: new Date(lastModified),
+      });
+    }); // add the note as a file in the zip
 
   return zip;
 };


### PR DESCRIPTION
  grab the modification date from the note and use it in the options
  for JSZip so the zip file accurately reflects the note ordering