### PR TITLE
Use `cheap-module-eval-source-map` for sourcemaps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const spawnSync = require('child_process').spawnSync;
 
 module.exports = {
   context: __dirname + '/lib',
-  devtool: 'sourcemap',
+  devtool: 'cheap-module-eval-source-map',
   entry: ['./boot'],
   output: {
     path: __dirname + '/dist',


### PR DESCRIPTION
This was a major cause of the excruciating slow builds.

We were using a very slow [sourcemap style](https://webpack.js.org/configuration/devtool/), and it was also enabled in production builds.

This fix should make every kind of build faster, but most of all HMR should feel a lot more snappier.