### PR TITLE
Add noop as callback for fs.writeFile

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -215,7 +215,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
               type: 'base64',
             })
           )
-          .then(blob => fs.writeFile(command.filename, blob, 'base64'))
+          .then(blob => fs.writeFile(command.filename, blob, 'base64', noop))
           .catch(console.log); // eslint-disable-line no-console
       }
 


### PR DESCRIPTION
Without it, it throws a deprecation warning in the console:

```
[DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
```

To test, use the "Export Notes" feature from the app menu and save the zip file.