### PR TITLE
Fix eslint errorUpdate filename in webpack config.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
             loader: 'eslint-loader',
             options: {
               cache: true,
-              configFile: '.eslintrc',
+              configFile: '.eslintrc.json',
               quiet: true,
             },
           },


### PR DESCRIPTION
I missed while reviewing #847 that we need to update the `eslintrc` filename in the webpack config.

**To Test**
* `npm start` should work :)