### PR TITLE
Decompose app.jsx and NoteEditor (Part 5)

### DIFF
--- a/lib/app-layout/index.js
+++ b/lib/app-layout/index.js
@@ -4,6 +4,7 @@ import RevisionSelector from '../revision-selector';
 
 export const AppLayout = ({
   note,
+  noteBucket,
   revisions,
   onUpdateContent,
   searchBar,
@@ -21,13 +22,14 @@ export const AppLayout = ({
         revisions={revisions || []}
         onUpdateContent={onUpdateContent}
       />
-      {cloneElement(noteEditor, { note, onUpdateContent })}
+      {cloneElement(noteEditor, { note, noteBucket, onUpdateContent })}
     </Fragment>
   );
 };
 
 AppLayout.propTypes = {
   note: PropTypes.object,
+  noteBucket: PropTypes.object.isRequired,
   revisions: PropTypes.array,
   onUpdateContent: PropTypes.func.isRequired,
   searchBar: PropTypes.element.isRequired,

--- a/lib/app-layout/index.js
+++ b/lib/app-layout/index.js
@@ -1,5 +1,7 @@
 import React, { Fragment, cloneElement } from 'react';
 import PropTypes from 'prop-types';
+import NoteToolbarContainer from '../note-toolbar-container';
+import NoteToolbar from '../note-toolbar';
 import RevisionSelector from '../revision-selector';
 
 export const AppLayout = ({
@@ -21,6 +23,10 @@ export const AppLayout = ({
         note={note}
         revisions={revisions || []}
         onUpdateContent={onUpdateContent}
+      />
+      <NoteToolbarContainer
+        noteBucket={noteBucket}
+        toolbar={<NoteToolbar note={note} />}
       />
       {cloneElement(noteEditor, { note, noteBucket, onUpdateContent })}
     </Fragment>

--- a/lib/app-layout/index.js
+++ b/lib/app-layout/index.js
@@ -1,10 +1,14 @@
-import React, { Fragment, cloneElement } from 'react';
+import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import NoteToolbarContainer from '../note-toolbar-container';
 import NoteToolbar from '../note-toolbar';
 import RevisionSelector from '../revision-selector';
 
 export const AppLayout = ({
+  isNavigationOpen,
+  isNoteInfoOpen,
+  isNoteOpen,
   note,
   noteBucket,
   revisions,
@@ -13,27 +17,38 @@ export const AppLayout = ({
   noteList,
   noteEditor,
 }) => {
+  const mainClasses = classNames('app-layout', {
+    'is-navigation-open': isNavigationOpen,
+    'is-note-open': isNoteOpen,
+    'is-showing-note-info': isNoteInfoOpen,
+  });
+
   return (
-    <Fragment>
-      <div className="app-layout-source-list theme-color-bg theme-color-fg">
+    <div className={mainClasses}>
+      <div className="app-layout__source-column theme-color-bg theme-color-fg">
         {searchBar}
         {noteList}
       </div>
-      <RevisionSelector
-        note={note}
-        revisions={revisions || []}
-        onUpdateContent={onUpdateContent}
-      />
-      <NoteToolbarContainer
-        noteBucket={noteBucket}
-        toolbar={<NoteToolbar note={note} />}
-      />
-      {cloneElement(noteEditor, { note, noteBucket, onUpdateContent })}
-    </Fragment>
+      <div className="app-layout__note-column theme-color-bg theme-color-fg">
+        <RevisionSelector
+          note={note}
+          revisions={revisions || []}
+          onUpdateContent={onUpdateContent}
+        />
+        <NoteToolbarContainer
+          noteBucket={noteBucket}
+          toolbar={<NoteToolbar note={note} />}
+        />
+        {cloneElement(noteEditor, { note, noteBucket, onUpdateContent })}
+      </div>
+    </div>
   );
 };
 
 AppLayout.propTypes = {
+  isNavigationOpen: PropTypes.bool.isRequired,
+  isNoteInfoOpen: PropTypes.bool.isRequired,
+  isNoteOpen: PropTypes.bool.isRequired,
   note: PropTypes.object,
   noteBucket: PropTypes.object.isRequired,
   revisions: PropTypes.array,

--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -1,7 +1,50 @@
-.app-layout-source-list {
+.app-layout {
+  display: flex;
+  flex: 1 0 auto;
+
+  &.is-navigation-open {
+    opacity: $fade-alpha;
+    transition: $anim;
+    pointer-events: none;
+
+    @media only screen and (max-width: $single-column) {
+      .app-layout__note-column {
+        opacity: 0;
+      }
+    }
+  }
+
+  // Fade content when toolbars are visible
+  &.is-showing-note-info {
+    opacity: $fade-alpha;
+    transition: $anim;
+    pointer-events: none;
+
+    @media only screen and (max-width: $single-column) {
+      .app-layout__note-column {
+        opacity: $fade-alpha;
+      }
+    }
+  }
+
+  &.is-note-open {
+    @media only screen and (max-width: $single-column) {
+      .app-layout__source-column {
+        opacity: 0;
+        pointer-events: none;
+      }
+
+      .app-layout__note-column {
+        opacity: 1;
+        z-index: auto;
+      }
+    }
+  }
+}
+
+.app-layout__source-column {
   width: 328px;
   min-width: 328px;
-  background: $white;
   display: flex;
   flex-direction: column;
   transition: transform 200ms ease-in-out;
@@ -21,10 +64,23 @@
     transition: $anim-transition;
     opacity: 1;
     pointer-events: auto;
+  }
+}
 
-    .note-open & {
-      opacity: 0;
-      pointer-events: none;
-    }
+.app-layout__note-column {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+
+  @media only screen and (max-width: $single-column) {
+    position: absolute;
+    flex: none;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    opacity: 0;
+    z-index: -1;
+    transition: $anim-transition;
   }
 }

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -318,14 +318,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       return Math.max(filteredNotes.findIndex(noteIndex) - 1, 0);
     };
 
-    onRevisions = note => {
-      this.props.actions.noteRevisions({
-        noteBucket: this.props.noteBucket,
-        note,
-      });
-      analytics.tracks.recordEvent('editor_versions_accessed');
-    };
-
     toggleShortcuts = doEnable => {
       if (doEnable) {
         window.addEventListener('keydown', this.handleShortcut, true);
@@ -403,7 +395,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
                     filter={state.filter}
                     onSetEditorMode={this.onSetEditorMode}
                     onUpdateNoteTags={this.onUpdateNoteTags}
-                    onRevisions={this.onRevisions}
                     onCloseNote={() => this.props.actions.closeNote()}
                     onNoteInfo={() => this.props.actions.toggleNoteInfo()}
                     shouldPrint={state.shouldPrint}

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -307,14 +307,14 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
         tags,
       });
 
-    onTrashNote = note => {
+    onRestoreNote = note => {
       const previousIndex = this.getPreviousNoteIndex(note);
-      this.props.actions.trashNote({
+      this.props.actions.restoreNote({
         noteBucket: this.props.noteBucket,
         note,
         previousIndex,
       });
-      analytics.tracks.recordEvent('editor_note_deleted');
+      analytics.tracks.recordEvent('editor_note_restored');
     };
 
     // gets the index of the note located before the currently selected one
@@ -326,16 +326,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       };
 
       return Math.max(filteredNotes.findIndex(noteIndex) - 1, 0);
-    };
-
-    onRestoreNote = note => {
-      const previousIndex = this.getPreviousNoteIndex(note);
-      this.props.actions.restoreNote({
-        noteBucket: this.props.noteBucket,
-        note,
-        previousIndex,
-      });
-      analytics.tracks.recordEvent('editor_note_restored');
     };
 
     onShareNote = () =>
@@ -423,6 +413,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
               )}
               <AppLayout
                 note={selectedNote}
+                noteBucket={noteBucket}
                 revisions={state.revisions}
                 onUpdateContent={this.onUpdateContent}
                 searchBar={<SearchBar noteBucket={noteBucket} />}
@@ -439,7 +430,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
                     filter={state.filter}
                     onSetEditorMode={this.onSetEditorMode}
                     onUpdateNoteTags={this.onUpdateNoteTags}
-                    onTrashNote={this.onTrashNote}
                     onRestoreNote={this.onRestoreNote}
                     onShareNote={this.onShareNote}
                     onDeleteNoteForever={this.onDeleteNoteForever}

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -290,8 +290,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       });
     };
 
-    onSetEditorMode = mode => this.props.actions.setEditorMode({ mode });
-
     onUpdateContent = (note, content) =>
       this.props.actions.updateNoteContent({
         noteBucket: this.props.noteBucket,
@@ -393,7 +391,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
                     allTags={state.tags}
                     editorMode={state.editorMode}
                     filter={state.filter}
-                    onSetEditorMode={this.onSetEditorMode}
                     onUpdateNoteTags={this.onUpdateNoteTags}
                     shouldPrint={state.shouldPrint}
                     onNotePrinted={this.onNotePrinted}

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -395,7 +395,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
                     filter={state.filter}
                     onSetEditorMode={this.onSetEditorMode}
                     onUpdateNoteTags={this.onUpdateNoteTags}
-                    onCloseNote={() => this.props.actions.closeNote()}
                     onNoteInfo={() => this.props.actions.toggleNoteInfo()}
                     shouldPrint={state.shouldPrint}
                     onNotePrinted={this.onNotePrinted}

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -338,9 +338,11 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       const isMacApp = isElectronMac();
       const filteredNotes = filterNotes(state);
       const hasNotes = filteredNotes.length > 0;
-
       const selectedNote =
         state.note || (!isSmallScreen && hasNotes ? filteredNotes[0] : null);
+      const isNoteOpen = Boolean(
+        (isSmallScreen && state.note) || (!isSmallScreen && selectedNote)
+      );
 
       const appClasses = classNames('app', `theme-${settings.theme}`, {
         'is-line-length-full': settings.lineLength === 'full',
@@ -348,8 +350,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       });
 
       const mainClasses = classNames('simplenote-app', {
-        'note-open':
-          (isSmallScreen && state.note) || (!isSmallScreen && selectedNote),
         'note-info-open': state.showNoteInfo,
         'navigation-open': state.showNavigation,
         'is-electron': isElectron(),
@@ -375,6 +375,9 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
                 <NavigationBar noteBucket={noteBucket} tagBucket={tagBucket} />
               )}
               <AppLayout
+                isNavigationOpen={state.showNavigation}
+                isNoteOpen={isNoteOpen}
+                isNoteInfoOpen={state.showNoteInfo}
                 note={selectedNote}
                 noteBucket={noteBucket}
                 revisions={state.revisions}

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -318,14 +318,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       return Math.max(filteredNotes.findIndex(noteIndex) - 1, 0);
     };
 
-    onShareNote = () =>
-      this.props.actions.showDialog({
-        dialog: {
-          type: 'Share',
-          modal: true,
-        },
-      });
-
     onDeleteNoteForever = note => {
       const previousIndex = this.getPreviousNoteIndex(note);
       this.props.actions.deleteNoteForever({
@@ -420,7 +412,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
                     filter={state.filter}
                     onSetEditorMode={this.onSetEditorMode}
                     onUpdateNoteTags={this.onUpdateNoteTags}
-                    onShareNote={this.onShareNote}
                     onDeleteNoteForever={this.onDeleteNoteForever}
                     onRevisions={this.onRevisions}
                     onCloseNote={() => this.props.actions.closeNote()}

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -395,7 +395,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
                     filter={state.filter}
                     onSetEditorMode={this.onSetEditorMode}
                     onUpdateNoteTags={this.onUpdateNoteTags}
-                    onNoteInfo={() => this.props.actions.toggleNoteInfo()}
                     shouldPrint={state.shouldPrint}
                     onNotePrinted={this.onNotePrinted}
                   />

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -307,16 +307,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
         tags,
       });
 
-    onRestoreNote = note => {
-      const previousIndex = this.getPreviousNoteIndex(note);
-      this.props.actions.restoreNote({
-        noteBucket: this.props.noteBucket,
-        note,
-        previousIndex,
-      });
-      analytics.tracks.recordEvent('editor_note_restored');
-    };
-
     // gets the index of the note located before the currently selected one
     getPreviousNoteIndex = note => {
       const filteredNotes = filterNotes(this.props.appState);
@@ -430,7 +420,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
                     filter={state.filter}
                     onSetEditorMode={this.onSetEditorMode}
                     onUpdateNoteTags={this.onUpdateNoteTags}
-                    onRestoreNote={this.onRestoreNote}
                     onShareNote={this.onShareNote}
                     onDeleteNoteForever={this.onDeleteNoteForever}
                     onRevisions={this.onRevisions}

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -318,15 +318,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       return Math.max(filteredNotes.findIndex(noteIndex) - 1, 0);
     };
 
-    onDeleteNoteForever = note => {
-      const previousIndex = this.getPreviousNoteIndex(note);
-      this.props.actions.deleteNoteForever({
-        noteBucket: this.props.noteBucket,
-        note,
-        previousIndex,
-      });
-    };
-
     onRevisions = note => {
       this.props.actions.noteRevisions({
         noteBucket: this.props.noteBucket,
@@ -412,7 +403,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
                     filter={state.filter}
                     onSetEditorMode={this.onSetEditorMode}
                     onUpdateNoteTags={this.onUpdateNoteTags}
-                    onDeleteNoteForever={this.onDeleteNoteForever}
                     onRevisions={this.onRevisions}
                     onCloseNote={() => this.props.actions.closeNote()}
                     onNoteInfo={() => this.props.actions.toggleNoteInfo()}

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -389,7 +389,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
                 noteEditor={
                   <NoteEditor
                     allTags={state.tags}
-                    editorMode={state.editorMode}
                     filter={state.filter}
                     onUpdateNoteTags={this.onUpdateNoteTags}
                     shouldPrint={state.shouldPrint}

--- a/lib/navigation-bar/index.jsx
+++ b/lib/navigation-bar/index.jsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import onClickOutside from 'react-onclickoutside';
+import NavigationBarItem from './item';
 import TagList from '../tag-list';
 import NotesIcon from '../icons/notes';
 import TrashIcon from '../icons/trash';
 import SettingsIcon from '../icons/settings';
 import { viewExternalUrl } from '../utils/url-utils';
-import classNames from 'classnames';
 import appState from '../flux/app-state';
 
 const {
@@ -40,62 +40,41 @@ export class NavigationBar extends Component {
   onHelpClicked = () => viewExternalUrl('http://simplenote.com/help');
 
   // Determine if the selected class should be applied for the 'all notes' or 'trash' rows
-  getNavigationItemClass = isTrashRow => {
+  isSelected = ({ isTrashRow }) => {
     const { showTrash, selectedTag } = this.props;
     const isItemSelected = isTrashRow === showTrash;
 
-    return isItemSelected && !selectedTag
-      ? 'navigation-folders-item-selected'
-      : 'navigation-folders-item';
+    return isItemSelected && !selectedTag;
   };
 
   render() {
     const { noteBucket, tagBucket } = this.props;
-    const classes = classNames('button', 'button-borderless', 'theme-color-fg');
-    const allNotesClasses = classNames(
-      this.getNavigationItemClass(false),
-      classes
-    );
-    const trashClasses = classNames(this.getNavigationItemClass(true), classes);
 
     return (
       <div className="navigation theme-color-bg theme-color-fg theme-color-border">
         <div className="navigation-folders">
-          <button
-            type="button"
-            className={allNotesClasses}
+          <NavigationBarItem
+            icon={<NotesIcon />}
+            isSelected={this.isSelected({ isTrashRow: false })}
+            label="All Notes"
             onClick={this.props.onSelectAllNotes}
-          >
-            <span className="navigation-icon">
-              <NotesIcon />
-            </span>
-            All Notes
-          </button>
-          <button
-            type="button"
-            className={trashClasses}
+          />
+          <NavigationBarItem
+            icon={<TrashIcon />}
+            isSelected={this.isSelected({ isTrashRow: true })}
+            label="Trash"
             onClick={this.props.onSelectTrash}
-          >
-            <span className="navigation-icon">
-              <TrashIcon />
-            </span>
-            Trash
-          </button>
+          />
         </div>
         <div className="navigation-tags theme-color-border">
           <TagList noteBucket={noteBucket} tagBucket={tagBucket} />
         </div>
         <div className="navigation-tools theme-color-border">
-          <button
-            type="button"
-            className="navigation-tools-item button button-borderless theme-color-fg"
+          <NavigationBarItem
+            icon={<SettingsIcon />}
+            label="Settings"
             onClick={this.props.onSettings}
-          >
-            <span className="navigation-icon">
-              <SettingsIcon />
-            </span>
-            Settings
-          </button>
+          />
         </div>
         <div className="navigation-footer">
           <button

--- a/lib/navigation-bar/item/index.jsx
+++ b/lib/navigation-bar/item/index.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export const NavigationBarItem = ({
+  icon,
+  isSelected = false,
+  label,
+  onClick,
+}) => {
+  const classes = classNames('navigation-bar-item', {
+    'is-selected': isSelected,
+  });
+  const buttonClasses = classNames(
+    'button',
+    'button-borderless',
+    'theme-color-fg'
+  );
+
+  return (
+    <div className={classes}>
+      <button type="button" className={buttonClasses} onClick={onClick}>
+        <span className="navigation-bar-item__icon">{icon}</span>
+        {label}
+      </button>
+    </div>
+  );
+};
+
+NavigationBarItem.propTypes = {
+  icon: PropTypes.element.isRequired,
+  isSelected: PropTypes.bool,
+  label: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+export default NavigationBarItem;

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -1,0 +1,32 @@
+.navigation-bar-item {
+  width: 100%;
+  padding: 4px 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+
+  svg {
+    fill: $gray;
+  }
+
+  &.is-selected {
+    color: $blue;
+
+    svg[class^='icon-'] {
+      fill: $blue;
+    }
+  }
+}
+
+.navigation-bar-item__icon {
+  display: inline-block;
+  margin-right: .5em;
+  vertical-align: middle;
+
+  svg {
+    vertical-align: middle;
+    position: relative;
+    top: -.2em;
+  }
+}

--- a/lib/navigation-bar/style.scss
+++ b/lib/navigation-bar/style.scss
@@ -16,47 +16,6 @@
   padding: 10px 0;
 }
 
-.navigation-folders-item,
-.navigation-tools-item,
-.navigation-folders-item-selected {
-  width: 100%;
-  line-height: 2em;
-  padding: 8px 20px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-align: left;
-
-  svg {
-    fill: $gray;
-  }
-}
-
-.navigation-folders-item-selected {
-  span {
-    color: $blue;
-  }
-
-  svg[class^='icon-'] {
-    fill: $blue;
-  }
-}
-
-.theme-light,
-.theme-dark {
-  .navigation-folders-item,
-  .navigation-tools-item {
-    &:active,
-    &.active {
-      color: $blue;
-
-      svg[class^='icon-'] {
-        fill: $blue;
-      }
-    }
-  }
-}
-
 .navigation-tags {
   display: flex;
   height: 100%;
@@ -103,17 +62,5 @@
 
   &:last-child {
     margin-right: 0;
-  }
-}
-
-.navigation-icon {
-  display: inline-block;
-  margin-right: 0.5em;
-  vertical-align: middle;
-
-  svg {
-    vertical-align: middle;
-    position: relative;
-    top: -0.2em;
   }
 }

--- a/lib/note-detail/index.jsx
+++ b/lib/note-detail/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import highlight from 'highlight.js';
 import { get, debounce, invoke, noop } from 'lodash';
+import classNames from 'classnames';
 import analytics from '../analytics';
 import { viewExternalUrl } from '../utils/url-utils';
 import NoteContentEditor from '../note-content-editor';
@@ -24,6 +25,7 @@ export class NoteDetail extends Component {
     dialogs: PropTypes.array.isRequired,
     filter: PropTypes.string.isRequired,
     fontSize: PropTypes.number,
+    isViewingRevisions: PropTypes.bool.isRequired,
     onChangeContent: PropTypes.func.isRequired,
     note: PropTypes.object,
     previewingMarkdown: PropTypes.bool,
@@ -154,10 +156,20 @@ export class NoteDetail extends Component {
   };
 
   render() {
-    const { note, filter, fontSize, previewingMarkdown } = this.props;
+    const {
+      note,
+      filter,
+      fontSize,
+      isViewingRevisions,
+      previewingMarkdown,
+    } = this.props;
 
     const content = get(this.props, 'note.data.content', '');
     const divStyle = { fontSize: `${fontSize}px` };
+
+    const mainClasses = classNames('note-detail', {
+      'is-viewing-revisions': isViewingRevisions,
+    });
 
     return (
       <div className="note-detail-wrapper theme-color-border">
@@ -166,7 +178,7 @@ export class NoteDetail extends Component {
             <SimplenoteCompactLogo />
           </div>
         ) : (
-          <div className="note-detail">
+          <div className={mainClasses}>
             {previewingMarkdown && (
               <div
                 ref={this.storePreview}
@@ -201,6 +213,7 @@ export class NoteDetail extends Component {
 const mapStateToProps = ({ appState: state }) => ({
   dialogs: state.dialogs,
   filter: state.filter,
+  isViewingRevisions: state.isViewingRevisions,
   showNoteInfo: state.showNoteInfo,
 });
 

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -18,7 +18,11 @@
   display: flex;
   flex-direction: row;
   justify-content: center;
-  transition: all 0.3s ease-in-out;
+  transition: all .3s ease-in-out;
+
+  &.is-viewing-revisions {
+    padding-top: 51px;
+  }
 
   div[data-contents] {
     padding-bottom: 20px;
@@ -35,11 +39,15 @@
   .logo {
     width: 140px;
     height: 140px;
-    opacity: 0.2;
+    opacity: .2;
 
     path {
       fill: $gray;
     }
+  }
+
+  @media only screen and (max-width: $single-column) {
+    display: none; // prevents flicker when closing note
   }
 }
 
@@ -50,7 +58,7 @@
   height: 100%;
   max-width: 780px;
   padding: 24px;
-  border: none;
+  border: 0;
   line-height: 1.5em;
   font-size: 16px;
   color: darken($gray, 20%);
@@ -151,7 +159,7 @@
     background: transparent;
   }
   table {
-    border-collapse:collapse;
+    border-collapse: collapse;
     border-spacing: 0;
     display: block;
     width: 100%;

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -22,7 +22,6 @@ export class NoteEditor extends Component {
     onSetEditorMode: PropTypes.func.isRequired,
     onUpdateContent: PropTypes.func.isRequired,
     onUpdateNoteTags: PropTypes.func.isRequired,
-    onRestoreNote: PropTypes.func.isRequired,
     onShareNote: PropTypes.func.isRequired,
     onDeleteNoteForever: PropTypes.func.isRequired,
     onRevisions: PropTypes.func.isRequired,
@@ -170,7 +169,6 @@ export class NoteEditor extends Component {
           toolbar={
             <NoteToolbar
               note={note}
-              onRestoreNote={this.props.onRestoreNote}
               onShareNote={this.props.onShareNote}
               onDeleteNoteForever={this.props.onDeleteNoteForever}
               onRevisions={this.props.onRevisions}

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
 import appState from '../flux/app-state';
 import NoteDetail from '../note-detail';
 import TagField from '../tag-field';
@@ -15,7 +14,6 @@ export class NoteEditor extends Component {
   static propTypes = {
     closeNote: PropTypes.func.isRequired,
     editorMode: PropTypes.oneOf(['edit', 'markdown']),
-    isViewingRevisions: PropTypes.bool.isRequired,
     markdownEnabled: PropTypes.bool.isRequired,
     note: PropTypes.object,
     fontSize: PropTypes.number,
@@ -120,13 +118,7 @@ export class NoteEditor extends Component {
   };
 
   render() {
-    const {
-      editorMode,
-      isViewingRevisions,
-      note,
-      fontSize,
-      shouldPrint,
-    } = this.props;
+    const { editorMode, note, fontSize, shouldPrint } = this.props;
     const revision = this.props.revision || note;
     const tags = (revision && revision.data && revision.data.tags) || [];
     const isTrashed = !!(note && note.data.deleted);
@@ -136,16 +128,6 @@ export class NoteEditor extends Component {
       revision.data &&
       revision.data.systemTags &&
       revision.data.systemTags.indexOf('markdown') !== -1;
-
-    const classes = classNames(
-      'note-editor',
-      'theme-color-bg',
-      'theme-color-fg',
-      {
-        revisions: isViewingRevisions,
-        markdown: markdownEnabled,
-      }
-    );
 
     const content = get(revision, 'data.content', '');
 
@@ -159,7 +141,7 @@ export class NoteEditor extends Component {
     };
 
     return (
-      <div className={classes}>
+      <div className="note-editor theme-color-bg theme-color-fg">
         <NoteDetail
           storeFocusEditor={this.storeFocusEditor}
           storeHasFocus={this.storeEditorHasFocus}
@@ -200,7 +182,6 @@ const mapStateToProps = ({ appState: state, settings }) => ({
   fontSize: settings.fontSize,
   editorMode: state.editorMode,
   isEditorActive: !state.showNavigation,
-  isViewingRevisions: state.isViewingRevisions,
   markdownEnabled: settings.markdownEnabled,
   revision: state.revision,
 });

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -18,6 +18,7 @@ export class NoteEditor extends Component {
     closeNote: PropTypes.func.isRequired,
     editorMode: PropTypes.oneOf(['edit', 'markdown']),
     isViewingRevisions: PropTypes.bool.isRequired,
+    markdownEnabled: PropTypes.bool.isRequired,
     note: PropTypes.object,
     fontSize: PropTypes.number,
     shouldPrint: PropTypes.bool,
@@ -163,9 +164,7 @@ export class NoteEditor extends Component {
       <div className={classes}>
         <NoteToolbarContainer
           noteBucket={this.props.noteBucket}
-          toolbar={
-            <NoteToolbar note={note} markdownEnabled={markdownEnabled} />
-          }
+          toolbar={<NoteToolbar note={note} />}
         />
         <NoteDetail
           storeFocusEditor={this.storeFocusEditor}

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -22,7 +22,6 @@ export class NoteEditor extends Component {
     onSetEditorMode: PropTypes.func.isRequired,
     onUpdateContent: PropTypes.func.isRequired,
     onUpdateNoteTags: PropTypes.func.isRequired,
-    onDeleteNoteForever: PropTypes.func.isRequired,
     onRevisions: PropTypes.func.isRequired,
     onCloseNote: PropTypes.func.isRequired,
     onNoteInfo: PropTypes.func.isRequired,
@@ -168,7 +167,6 @@ export class NoteEditor extends Component {
           toolbar={
             <NoteToolbar
               note={note}
-              onDeleteNoteForever={this.props.onDeleteNoteForever}
               onRevisions={this.props.onRevisions}
               onCloseNote={this.props.onCloseNote}
               onNoteInfo={this.props.onNoteInfo}

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -24,7 +24,6 @@ export class NoteEditor extends Component {
     onSetEditorMode: PropTypes.func.isRequired,
     onUpdateContent: PropTypes.func.isRequired,
     onUpdateNoteTags: PropTypes.func.isRequired,
-    onNoteInfo: PropTypes.func.isRequired,
     onPrintNote: PropTypes.func,
     revision: PropTypes.object,
   };
@@ -167,7 +166,6 @@ export class NoteEditor extends Component {
           toolbar={
             <NoteToolbar
               note={note}
-              onNoteInfo={this.props.onNoteInfo}
               onSetEditorMode={this.props.onSetEditorMode}
               editorMode={editorMode}
               markdownEnabled={markdownEnabled}

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -164,11 +164,7 @@ export class NoteEditor extends Component {
         <NoteToolbarContainer
           noteBucket={this.props.noteBucket}
           toolbar={
-            <NoteToolbar
-              note={note}
-              editorMode={editorMode}
-              markdownEnabled={markdownEnabled}
-            />
+            <NoteToolbar note={note} markdownEnabled={markdownEnabled} />
           }
         />
         <NoteDetail
@@ -209,6 +205,7 @@ export class NoteEditor extends Component {
 
 const mapStateToProps = ({ appState: state, settings }) => ({
   fontSize: settings.fontSize,
+  editorMode: state.editorMode,
   isEditorActive: !state.showNavigation,
   isViewingRevisions: state.isViewingRevisions,
   markdownEnabled: settings.markdownEnabled,

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -3,10 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import appState from '../flux/app-state';
-import NoteToolbarContainer from '../note-toolbar-container';
 import NoteDetail from '../note-detail';
 import TagField from '../tag-field';
-import NoteToolbar from '../note-toolbar';
 import { get, property } from 'lodash';
 
 import { renderNoteToHtml } from '../utils/render-note-to-html';
@@ -162,10 +160,6 @@ export class NoteEditor extends Component {
 
     return (
       <div className={classes}>
-        <NoteToolbarContainer
-          noteBucket={this.props.noteBucket}
-          toolbar={<NoteToolbar note={note} />}
-        />
         <NoteDetail
           storeFocusEditor={this.storeFocusEditor}
           storeHasFocus={this.storeEditorHasFocus}

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -6,7 +6,6 @@ import NoteToolbarContainer from '../note-toolbar-container';
 import NoteDetail from '../note-detail';
 import TagField from '../tag-field';
 import NoteToolbar from '../note-toolbar';
-import appState from '../flux/app-state';
 import { get, property } from 'lodash';
 
 import { renderNoteToHtml } from '../utils/render-note-to-html';
@@ -19,7 +18,6 @@ export class NoteEditor extends Component {
     isViewingRevisions: PropTypes.bool.isRequired,
     note: PropTypes.object,
     fontSize: PropTypes.number,
-    setIsViewingRevisions: PropTypes.func.isRequired,
     shouldPrint: PropTypes.bool,
     onSetEditorMode: PropTypes.func.isRequired,
     onUpdateContent: PropTypes.func.isRequired,
@@ -176,7 +174,6 @@ export class NoteEditor extends Component {
               onShareNote={this.props.onShareNote}
               onDeleteNoteForever={this.props.onDeleteNoteForever}
               onRevisions={this.props.onRevisions}
-              setIsViewingRevisions={this.props.setIsViewingRevisions}
               onCloseNote={this.props.onCloseNote}
               onNoteInfo={this.props.onNoteInfo}
               onSetEditorMode={this.props.onSetEditorMode}
@@ -229,12 +226,4 @@ const mapStateToProps = ({ appState: state, settings }) => ({
   revision: state.revision,
 });
 
-const { setIsViewingRevisions } = appState.actionCreators;
-
-const mapDispatchToProps = dispatch => ({
-  setIsViewingRevisions: isViewingRevisions => {
-    dispatch(setIsViewingRevisions({ isViewingRevisions }));
-  },
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(NoteEditor);
+export default connect(mapStateToProps)(NoteEditor);

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import appState from '../flux/app-state';
 import NoteToolbarContainer from '../note-toolbar-container';
 import NoteDetail from '../note-detail';
 import TagField from '../tag-field';
@@ -14,6 +15,7 @@ export class NoteEditor extends Component {
   static displayName = 'NoteEditor';
 
   static propTypes = {
+    closeNote: PropTypes.func.isRequired,
     editorMode: PropTypes.oneOf(['edit', 'markdown']),
     isViewingRevisions: PropTypes.bool.isRequired,
     note: PropTypes.object,
@@ -22,7 +24,6 @@ export class NoteEditor extends Component {
     onSetEditorMode: PropTypes.func.isRequired,
     onUpdateContent: PropTypes.func.isRequired,
     onUpdateNoteTags: PropTypes.func.isRequired,
-    onCloseNote: PropTypes.func.isRequired,
     onNoteInfo: PropTypes.func.isRequired,
     onPrintNote: PropTypes.func,
     revision: PropTypes.object,
@@ -72,7 +73,7 @@ export class NoteEditor extends Component {
 
     // open note list - shift + n
     if (cmdOrCtrl && 'N' === key) {
-      this.props.onCloseNote();
+      this.props.closeNote();
 
       event.stopPropagation();
       event.preventDefault();
@@ -166,7 +167,6 @@ export class NoteEditor extends Component {
           toolbar={
             <NoteToolbar
               note={note}
-              onCloseNote={this.props.onCloseNote}
               onNoteInfo={this.props.onNoteInfo}
               onSetEditorMode={this.props.onSetEditorMode}
               editorMode={editorMode}
@@ -218,4 +218,10 @@ const mapStateToProps = ({ appState: state, settings }) => ({
   revision: state.revision,
 });
 
-export default connect(mapStateToProps)(NoteEditor);
+const { closeNote } = appState.actionCreators;
+
+const mapDispatchToProps = dispatch => ({
+  closeNote: () => dispatch(closeNote()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(NoteEditor);

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -21,11 +21,11 @@ export class NoteEditor extends Component {
     note: PropTypes.object,
     fontSize: PropTypes.number,
     shouldPrint: PropTypes.bool,
-    onSetEditorMode: PropTypes.func.isRequired,
     onUpdateContent: PropTypes.func.isRequired,
     onUpdateNoteTags: PropTypes.func.isRequired,
     onPrintNote: PropTypes.func,
     revision: PropTypes.object,
+    setEditorMode: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -63,7 +63,7 @@ export class NoteEditor extends Component {
       const prevEditorMode = this.props.editorMode;
       const nextEditorMode = prevEditorMode === 'edit' ? 'markdown' : 'edit';
 
-      this.props.onSetEditorMode(nextEditorMode);
+      this.props.setEditorMode({ mode: nextEditorMode });
 
       event.stopPropagation();
       event.preventDefault();
@@ -166,7 +166,6 @@ export class NoteEditor extends Component {
           toolbar={
             <NoteToolbar
               note={note}
-              onSetEditorMode={this.props.onSetEditorMode}
               editorMode={editorMode}
               markdownEnabled={markdownEnabled}
             />
@@ -216,10 +215,11 @@ const mapStateToProps = ({ appState: state, settings }) => ({
   revision: state.revision,
 });
 
-const { closeNote } = appState.actionCreators;
+const { closeNote, setEditorMode } = appState.actionCreators;
 
 const mapDispatchToProps = dispatch => ({
   closeNote: () => dispatch(closeNote()),
+  setEditorMode: args => dispatch(setEditorMode(args)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteEditor);

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -22,7 +22,6 @@ export class NoteEditor extends Component {
     onSetEditorMode: PropTypes.func.isRequired,
     onUpdateContent: PropTypes.func.isRequired,
     onUpdateNoteTags: PropTypes.func.isRequired,
-    onShareNote: PropTypes.func.isRequired,
     onDeleteNoteForever: PropTypes.func.isRequired,
     onRevisions: PropTypes.func.isRequired,
     onCloseNote: PropTypes.func.isRequired,
@@ -169,7 +168,6 @@ export class NoteEditor extends Component {
           toolbar={
             <NoteToolbar
               note={note}
-              onShareNote={this.props.onShareNote}
               onDeleteNoteForever={this.props.onDeleteNoteForever}
               onRevisions={this.props.onRevisions}
               onCloseNote={this.props.onCloseNote}

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -22,7 +22,6 @@ export class NoteEditor extends Component {
     onSetEditorMode: PropTypes.func.isRequired,
     onUpdateContent: PropTypes.func.isRequired,
     onUpdateNoteTags: PropTypes.func.isRequired,
-    onRevisions: PropTypes.func.isRequired,
     onCloseNote: PropTypes.func.isRequired,
     onNoteInfo: PropTypes.func.isRequired,
     onPrintNote: PropTypes.func,
@@ -167,7 +166,6 @@ export class NoteEditor extends Component {
           toolbar={
             <NoteToolbar
               note={note}
-              onRevisions={this.props.onRevisions}
               onCloseNote={this.props.onCloseNote}
               onNoteInfo={this.props.onNoteInfo}
               onSetEditorMode={this.props.onSetEditorMode}

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import NoteToolbarContainer from '../note-toolbar-container';
 import NoteDetail from '../note-detail';
 import TagField from '../tag-field';
 import NoteToolbar from '../note-toolbar';
@@ -23,7 +24,6 @@ export class NoteEditor extends Component {
     onSetEditorMode: PropTypes.func.isRequired,
     onUpdateContent: PropTypes.func.isRequired,
     onUpdateNoteTags: PropTypes.func.isRequired,
-    onTrashNote: PropTypes.func.isRequired,
     onRestoreNote: PropTypes.func.isRequired,
     onShareNote: PropTypes.func.isRequired,
     onDeleteNoteForever: PropTypes.func.isRequired,
@@ -167,19 +167,23 @@ export class NoteEditor extends Component {
 
     return (
       <div className={classes}>
-        <NoteToolbar
-          note={note}
-          onTrashNote={this.props.onTrashNote}
-          onRestoreNote={this.props.onRestoreNote}
-          onShareNote={this.props.onShareNote}
-          onDeleteNoteForever={this.props.onDeleteNoteForever}
-          onRevisions={this.props.onRevisions}
-          setIsViewingRevisions={this.props.setIsViewingRevisions}
-          onCloseNote={this.props.onCloseNote}
-          onNoteInfo={this.props.onNoteInfo}
-          onSetEditorMode={this.props.onSetEditorMode}
-          editorMode={editorMode}
-          markdownEnabled={markdownEnabled}
+        <NoteToolbarContainer
+          noteBucket={this.props.noteBucket}
+          toolbar={
+            <NoteToolbar
+              note={note}
+              onRestoreNote={this.props.onRestoreNote}
+              onShareNote={this.props.onShareNote}
+              onDeleteNoteForever={this.props.onDeleteNoteForever}
+              onRevisions={this.props.onRevisions}
+              setIsViewingRevisions={this.props.setIsViewingRevisions}
+              onCloseNote={this.props.onCloseNote}
+              onNoteInfo={this.props.onNoteInfo}
+              onSetEditorMode={this.props.onSetEditorMode}
+              editorMode={editorMode}
+              markdownEnabled={markdownEnabled}
+            />
+          }
         />
         <NoteDetail
           storeFocusEditor={this.storeFocusEditor}

--- a/lib/note-editor/style.scss
+++ b/lib/note-editor/style.scss
@@ -1,16 +1,5 @@
 .note-editor {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  background: $white;
-}
-
-.revisions {
-  .revision-selector {
-    top: 0 !important;
-  }
-
-  .note-detail {
-    padding-top: 51px !important;
-  }
+  flex: 1 0 auto;
 }

--- a/lib/note-list/index.jsx
+++ b/lib/note-list/index.jsx
@@ -12,7 +12,7 @@
  * row height calculations should be double-checked
  * against performance regressions.
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { AutoSizer, List } from 'react-virtualized';
 import PublishIcon from '../icons/feed';
@@ -432,32 +432,34 @@ export class NoteList extends Component {
         {isEmptyList ? (
           <span className="note-list-placeholder">No Notes</span>
         ) : (
-          <div className={listItemsClasses}>
-            <AutoSizer>
-              {({ height, width }) => (
-                <List
-                  ref={this.refList}
-                  estimatedRowSize={
-                    ROW_HEIGHT_BASE +
-                    ROW_HEIGHT_LINE * maxPreviewLines[noteDisplay]
-                  }
-                  height={height}
-                  noteDisplay={noteDisplay}
-                  notes={this.props.notes}
-                  rowCount={this.props.notes.length}
-                  rowHeight={
-                    'condensed' === noteDisplay
-                      ? ROW_HEIGHT_BASE
-                      : getRowHeight(this.props.notes, { noteDisplay, width })
-                  }
-                  rowRenderer={renderNoteRow}
-                  width={width}
-                />
-              )}
-            </AutoSizer>
-          </div>
+          <Fragment>
+            <div className={listItemsClasses}>
+              <AutoSizer>
+                {({ height, width }) => (
+                  <List
+                    ref={this.refList}
+                    estimatedRowSize={
+                      ROW_HEIGHT_BASE +
+                      ROW_HEIGHT_LINE * maxPreviewLines[noteDisplay]
+                    }
+                    height={height}
+                    noteDisplay={noteDisplay}
+                    notes={this.props.notes}
+                    rowCount={this.props.notes.length}
+                    rowHeight={
+                      'condensed' === noteDisplay
+                        ? ROW_HEIGHT_BASE
+                        : getRowHeight(this.props.notes, { noteDisplay, width })
+                    }
+                    rowRenderer={renderNoteRow}
+                    width={width}
+                  />
+                )}
+              </AutoSizer>
+            </div>
+            {!!showTrash && emptyTrashButton}
+          </Fragment>
         )}
-        {!!showTrash && emptyTrashButton}
       </div>
     );
   }

--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -8,6 +8,7 @@ import filterNotes from './utils/filter-notes';
 
 export class NoteToolbarContainer extends Component {
   static propTypes = {
+    deleteNoteForever: PropTypes.func.isRequired,
     noteBucket: PropTypes.object.isRequired,
     restoreNote: PropTypes.func.isRequired,
     setIsViewingRevisions: PropTypes.func.isRequired,
@@ -35,6 +36,12 @@ export class NoteToolbarContainer extends Component {
     analytics.tracks.recordEvent('editor_note_deleted');
   };
 
+  onDeleteNoteForever = note => {
+    const { noteBucket } = this.props;
+    const previousIndex = this.getPreviousNoteIndex(note);
+    this.props.deleteNoteForever({ noteBucket, note, previousIndex });
+  };
+
   onRestoreNote = note => {
     const { noteBucket } = this.props;
     const previousIndex = this.getPreviousNoteIndex(note);
@@ -45,6 +52,7 @@ export class NoteToolbarContainer extends Component {
   render() {
     const { toolbar } = this.props;
     const handlers = {
+      onDeleteNoteForever: this.onDeleteNoteForever,
       onRestoreNote: this.onRestoreNote,
       onShareNote: this.props.shareNote,
       onTrashNote: this.onTrashNote,
@@ -65,6 +73,7 @@ const mapStateToProps = ({ appState: state }) => ({
 });
 
 const {
+  deleteNoteForever,
   restoreNote,
   setIsViewingRevisions,
   showDialog,
@@ -72,6 +81,7 @@ const {
 } = appState.actionCreators;
 
 const mapDispatchToProps = dispatch => ({
+  deleteNoteForever: args => dispatch(deleteNoteForever(args)),
   restoreNote: args => dispatch(restoreNote(args)),
   setIsViewingRevisions: isViewingRevisions => {
     dispatch(setIsViewingRevisions({ isViewingRevisions }));

--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -16,6 +16,7 @@ export class NoteToolbarContainer extends Component {
     setIsViewingRevisions: PropTypes.func.isRequired,
     shareNote: PropTypes.func.isRequired,
     stateForFilterNotes: PropTypes.object.isRequired,
+    toggleNoteInfo: PropTypes.func.isRequired,
     toolbar: PropTypes.element.isRequired,
     trashNote: PropTypes.func.isRequired,
   };
@@ -63,6 +64,7 @@ export class NoteToolbarContainer extends Component {
       onCloseNote: this.props.closeNote,
       onDeleteNoteForever: this.onDeleteNoteForever,
       onRestoreNote: this.onRestoreNote,
+      onShowNoteInfo: this.props.toggleNoteInfo,
       onShowRevisions: this.onShowRevisions,
       onShareNote: this.props.shareNote,
       onTrashNote: this.onTrashNote,
@@ -89,6 +91,7 @@ const {
   restoreNote,
   setIsViewingRevisions,
   showDialog,
+  toggleNoteInfo,
   trashNote,
 } = appState.actionCreators;
 
@@ -106,6 +109,7 @@ const mapDispatchToProps = dispatch => ({
         dialog: { type: 'Share', modal: true },
       })
     ),
+  toggleNoteInfo: () => dispatch(toggleNoteInfo()),
   trashNote: args => dispatch(trashNote(args)),
 });
 

--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -8,6 +8,7 @@ import filterNotes from './utils/filter-notes';
 
 export class NoteToolbarContainer extends Component {
   static propTypes = {
+    closeNote: PropTypes.func.isRequired,
     deleteNoteForever: PropTypes.func.isRequired,
     noteBucket: PropTypes.object.isRequired,
     noteRevisions: PropTypes.func.isRequired,
@@ -59,6 +60,7 @@ export class NoteToolbarContainer extends Component {
   render() {
     const { toolbar } = this.props;
     const handlers = {
+      onCloseNote: this.props.closeNote,
       onDeleteNoteForever: this.onDeleteNoteForever,
       onRestoreNote: this.onRestoreNote,
       onShowRevisions: this.onShowRevisions,
@@ -81,6 +83,7 @@ const mapStateToProps = ({ appState: state }) => ({
 });
 
 const {
+  closeNote,
   deleteNoteForever,
   noteRevisions,
   restoreNote,
@@ -90,6 +93,7 @@ const {
 } = appState.actionCreators;
 
 const mapDispatchToProps = dispatch => ({
+  closeNote: () => dispatch(closeNote()),
   deleteNoteForever: args => dispatch(deleteNoteForever(args)),
   noteRevisions: args => dispatch(noteRevisions(args)),
   restoreNote: args => dispatch(restoreNote(args)),

--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -9,6 +9,7 @@ import filterNotes from './utils/filter-notes';
 export class NoteToolbarContainer extends Component {
   static propTypes = {
     noteBucket: PropTypes.object.isRequired,
+    restoreNote: PropTypes.func.isRequired,
     setIsViewingRevisions: PropTypes.func.isRequired,
     stateForFilterNotes: PropTypes.object.isRequired,
     toolbar: PropTypes.element.isRequired,
@@ -33,9 +34,17 @@ export class NoteToolbarContainer extends Component {
     analytics.tracks.recordEvent('editor_note_deleted');
   };
 
+  onRestoreNote = note => {
+    const { noteBucket } = this.props;
+    const previousIndex = this.getPreviousNoteIndex(note);
+    this.props.restoreNote({ noteBucket, note, previousIndex });
+    analytics.tracks.recordEvent('editor_note_restored');
+  };
+
   render() {
     const { toolbar } = this.props;
     const handlers = {
+      onRestoreNote: this.onRestoreNote,
       onTrashNote: this.onTrashNote,
       setIsViewingRevisions: this.props.setIsViewingRevisions,
     };
@@ -53,15 +62,18 @@ const mapStateToProps = ({ appState: state }) => ({
   },
 });
 
-const { setIsViewingRevisions, trashNote } = appState.actionCreators;
+const {
+  restoreNote,
+  setIsViewingRevisions,
+  trashNote,
+} = appState.actionCreators;
 
 const mapDispatchToProps = dispatch => ({
+  restoreNote: args => dispatch(restoreNote(args)),
   setIsViewingRevisions: isViewingRevisions => {
     dispatch(setIsViewingRevisions({ isViewingRevisions }));
   },
-  trashNote: args => {
-    dispatch(trashNote(args));
-  },
+  trashNote: args => dispatch(trashNote(args)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(

--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -11,6 +11,7 @@ export class NoteToolbarContainer extends Component {
     closeNote: PropTypes.func.isRequired,
     deleteNoteForever: PropTypes.func.isRequired,
     editorMode: PropTypes.oneOf(['edit', 'markdown']),
+    markdownEnabled: PropTypes.bool.isRequired,
     noteBucket: PropTypes.object.isRequired,
     noteRevisions: PropTypes.func.isRequired,
     restoreNote: PropTypes.func.isRequired,
@@ -79,14 +80,15 @@ export class NoteToolbarContainer extends Component {
       onTrashNote: this.onTrashNote,
       setIsViewingRevisions: this.props.setIsViewingRevisions,
     };
-    const { editorMode } = this.props;
+    const { editorMode, markdownEnabled } = this.props;
 
-    return cloneElement(toolbar, { ...handlers, editorMode });
+    return cloneElement(toolbar, { ...handlers, editorMode, markdownEnabled });
   }
 }
 
-const mapStateToProps = ({ appState: state }) => ({
+const mapStateToProps = ({ appState: state, settings }) => ({
   editorMode: state.editorMode,
+  markdownEnabled: settings.markdownEnabled,
   stateForFilterNotes: {
     filter: state.filter,
     notes: state.notes,

--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -10,6 +10,7 @@ export class NoteToolbarContainer extends Component {
   static propTypes = {
     deleteNoteForever: PropTypes.func.isRequired,
     noteBucket: PropTypes.object.isRequired,
+    noteRevisions: PropTypes.func.isRequired,
     restoreNote: PropTypes.func.isRequired,
     setIsViewingRevisions: PropTypes.func.isRequired,
     shareNote: PropTypes.func.isRequired,
@@ -49,11 +50,18 @@ export class NoteToolbarContainer extends Component {
     analytics.tracks.recordEvent('editor_note_restored');
   };
 
+  onShowRevisions = note => {
+    const { noteBucket } = this.props;
+    this.props.noteRevisions({ noteBucket, note });
+    analytics.tracks.recordEvent('editor_versions_accessed');
+  };
+
   render() {
     const { toolbar } = this.props;
     const handlers = {
       onDeleteNoteForever: this.onDeleteNoteForever,
       onRestoreNote: this.onRestoreNote,
+      onShowRevisions: this.onShowRevisions,
       onShareNote: this.props.shareNote,
       onTrashNote: this.onTrashNote,
       setIsViewingRevisions: this.props.setIsViewingRevisions,
@@ -74,6 +82,7 @@ const mapStateToProps = ({ appState: state }) => ({
 
 const {
   deleteNoteForever,
+  noteRevisions,
   restoreNote,
   setIsViewingRevisions,
   showDialog,
@@ -82,6 +91,7 @@ const {
 
 const mapDispatchToProps = dispatch => ({
   deleteNoteForever: args => dispatch(deleteNoteForever(args)),
+  noteRevisions: args => dispatch(noteRevisions(args)),
   restoreNote: args => dispatch(restoreNote(args)),
   setIsViewingRevisions: isViewingRevisions => {
     dispatch(setIsViewingRevisions({ isViewingRevisions }));

--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -13,6 +13,7 @@ export class NoteToolbarContainer extends Component {
     noteBucket: PropTypes.object.isRequired,
     noteRevisions: PropTypes.func.isRequired,
     restoreNote: PropTypes.func.isRequired,
+    setEditorMode: PropTypes.func.isRequired,
     setIsViewingRevisions: PropTypes.func.isRequired,
     shareNote: PropTypes.func.isRequired,
     stateForFilterNotes: PropTypes.object.isRequired,
@@ -58,12 +59,15 @@ export class NoteToolbarContainer extends Component {
     analytics.tracks.recordEvent('editor_versions_accessed');
   };
 
+  onSetEditorMode = mode => this.props.setEditorMode({ mode });
+
   render() {
     const { toolbar } = this.props;
     const handlers = {
       onCloseNote: this.props.closeNote,
       onDeleteNoteForever: this.onDeleteNoteForever,
       onRestoreNote: this.onRestoreNote,
+      onSetEditorMode: this.onSetEditorMode,
       onShowNoteInfo: this.props.toggleNoteInfo,
       onShowRevisions: this.onShowRevisions,
       onShareNote: this.props.shareNote,
@@ -89,6 +93,7 @@ const {
   deleteNoteForever,
   noteRevisions,
   restoreNote,
+  setEditorMode,
   setIsViewingRevisions,
   showDialog,
   toggleNoteInfo,
@@ -100,6 +105,7 @@ const mapDispatchToProps = dispatch => ({
   deleteNoteForever: args => dispatch(deleteNoteForever(args)),
   noteRevisions: args => dispatch(noteRevisions(args)),
   restoreNote: args => dispatch(restoreNote(args)),
+  setEditorMode: args => dispatch(setEditorMode(args)),
   setIsViewingRevisions: isViewingRevisions => {
     dispatch(setIsViewingRevisions({ isViewingRevisions }));
   },

--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -11,6 +11,7 @@ export class NoteToolbarContainer extends Component {
     noteBucket: PropTypes.object.isRequired,
     restoreNote: PropTypes.func.isRequired,
     setIsViewingRevisions: PropTypes.func.isRequired,
+    shareNote: PropTypes.func.isRequired,
     stateForFilterNotes: PropTypes.object.isRequired,
     toolbar: PropTypes.element.isRequired,
     trashNote: PropTypes.func.isRequired,
@@ -45,6 +46,7 @@ export class NoteToolbarContainer extends Component {
     const { toolbar } = this.props;
     const handlers = {
       onRestoreNote: this.onRestoreNote,
+      onShareNote: this.props.shareNote,
       onTrashNote: this.onTrashNote,
       setIsViewingRevisions: this.props.setIsViewingRevisions,
     };
@@ -65,6 +67,7 @@ const mapStateToProps = ({ appState: state }) => ({
 const {
   restoreNote,
   setIsViewingRevisions,
+  showDialog,
   trashNote,
 } = appState.actionCreators;
 
@@ -73,6 +76,12 @@ const mapDispatchToProps = dispatch => ({
   setIsViewingRevisions: isViewingRevisions => {
     dispatch(setIsViewingRevisions({ isViewingRevisions }));
   },
+  shareNote: () =>
+    dispatch(
+      showDialog({
+        dialog: { type: 'Share', modal: true },
+      })
+    ),
   trashNote: args => dispatch(trashNote(args)),
 });
 

--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -9,6 +9,7 @@ import filterNotes from './utils/filter-notes';
 export class NoteToolbarContainer extends Component {
   static propTypes = {
     noteBucket: PropTypes.object.isRequired,
+    setIsViewingRevisions: PropTypes.func.isRequired,
     stateForFilterNotes: PropTypes.object.isRequired,
     toolbar: PropTypes.element.isRequired,
     trashNote: PropTypes.func.isRequired,
@@ -36,6 +37,7 @@ export class NoteToolbarContainer extends Component {
     const { toolbar } = this.props;
     const handlers = {
       onTrashNote: this.onTrashNote,
+      setIsViewingRevisions: this.props.setIsViewingRevisions,
     };
 
     return cloneElement(toolbar, handlers);
@@ -51,9 +53,12 @@ const mapStateToProps = ({ appState: state }) => ({
   },
 });
 
-const { trashNote } = appState.actionCreators;
+const { setIsViewingRevisions, trashNote } = appState.actionCreators;
 
 const mapDispatchToProps = dispatch => ({
+  setIsViewingRevisions: isViewingRevisions => {
+    dispatch(setIsViewingRevisions({ isViewingRevisions }));
+  },
   trashNote: args => {
     dispatch(trashNote(args));
   },

--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -10,6 +10,7 @@ export class NoteToolbarContainer extends Component {
   static propTypes = {
     closeNote: PropTypes.func.isRequired,
     deleteNoteForever: PropTypes.func.isRequired,
+    editorMode: PropTypes.oneOf(['edit', 'markdown']),
     noteBucket: PropTypes.object.isRequired,
     noteRevisions: PropTypes.func.isRequired,
     restoreNote: PropTypes.func.isRequired,
@@ -20,6 +21,10 @@ export class NoteToolbarContainer extends Component {
     toggleNoteInfo: PropTypes.func.isRequired,
     toolbar: PropTypes.element.isRequired,
     trashNote: PropTypes.func.isRequired,
+  };
+
+  static defaultProps = {
+    editorMode: 'edit',
   };
 
   // Gets the index of the note located before the currently selected one
@@ -74,12 +79,14 @@ export class NoteToolbarContainer extends Component {
       onTrashNote: this.onTrashNote,
       setIsViewingRevisions: this.props.setIsViewingRevisions,
     };
+    const { editorMode } = this.props;
 
-    return cloneElement(toolbar, handlers);
+    return cloneElement(toolbar, { ...handlers, editorMode });
   }
 }
 
 const mapStateToProps = ({ appState: state }) => ({
+  editorMode: state.editorMode,
   stateForFilterNotes: {
     filter: state.filter,
     notes: state.notes,

--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -1,0 +1,64 @@
+import { Component, cloneElement } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import analytics from './analytics';
+import appState from './flux/app-state';
+import filterNotes from './utils/filter-notes';
+
+export class NoteToolbarContainer extends Component {
+  static propTypes = {
+    noteBucket: PropTypes.object.isRequired,
+    stateForFilterNotes: PropTypes.object.isRequired,
+    toolbar: PropTypes.element.isRequired,
+    trashNote: PropTypes.func.isRequired,
+  };
+
+  // Gets the index of the note located before the currently selected one
+  getPreviousNoteIndex = note => {
+    const filteredNotes = filterNotes(this.props.stateForFilterNotes);
+
+    const noteIndex = function(filteredNote) {
+      return note.id === filteredNote.id;
+    };
+
+    return Math.max(filteredNotes.findIndex(noteIndex) - 1, 0);
+  };
+
+  onTrashNote = note => {
+    const { noteBucket } = this.props;
+    const previousIndex = this.getPreviousNoteIndex(note);
+    this.props.trashNote({ noteBucket, note, previousIndex });
+    analytics.tracks.recordEvent('editor_note_deleted');
+  };
+
+  render() {
+    const { toolbar } = this.props;
+    const handlers = {
+      onTrashNote: this.onTrashNote,
+    };
+
+    return cloneElement(toolbar, handlers);
+  }
+}
+
+const mapStateToProps = ({ appState: state }) => ({
+  stateForFilterNotes: {
+    filter: state.filter,
+    notes: state.notes,
+    showTrash: state.showTrash,
+    tag: state.tag,
+  },
+});
+
+const { trashNote } = appState.actionCreators;
+
+const mapDispatchToProps = dispatch => ({
+  trashNote: args => {
+    dispatch(trashNote(args));
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(
+  NoteToolbarContainer
+);

--- a/lib/note-toolbar/index.jsx
+++ b/lib/note-toolbar/index.jsx
@@ -23,7 +23,7 @@ export class NoteToolbar extends Component {
     onCloseNote: PropTypes.func,
     onShowNoteInfo: PropTypes.func,
     setIsViewingRevisions: PropTypes.func,
-    onSetEditorMode: PropTypes.func.isRequired,
+    onSetEditorMode: PropTypes.func,
     editorMode: PropTypes.string.isRequired,
     markdownEnabled: PropTypes.bool,
   };
@@ -32,6 +32,7 @@ export class NoteToolbar extends Component {
     onCloseNote: noop,
     onDeleteNoteForever: noop,
     onRestoreNote: noop,
+    onSetEditorMode: noop,
     onShowNoteInfo: noop,
     onShowRevisions: noop,
     onShareNote: noop,

--- a/lib/note-toolbar/index.jsx
+++ b/lib/note-toolbar/index.jsx
@@ -19,7 +19,7 @@ export class NoteToolbar extends Component {
     onTrashNote: PropTypes.func,
     onDeleteNoteForever: PropTypes.func.isRequired,
     onRevisions: PropTypes.func.isRequired,
-    onShareNote: PropTypes.func.isRequired,
+    onShareNote: PropTypes.func,
     onCloseNote: PropTypes.func.isRequired,
     onNoteInfo: PropTypes.func.isRequired,
     setIsViewingRevisions: PropTypes.func,
@@ -30,6 +30,7 @@ export class NoteToolbar extends Component {
 
   static defaultProps = {
     onRestoreNote: noop,
+    onShareNote: noop,
     onTrashNote: noop,
     setIsViewingRevisions: noop,
   };

--- a/lib/note-toolbar/index.jsx
+++ b/lib/note-toolbar/index.jsx
@@ -24,11 +24,12 @@ export class NoteToolbar extends Component {
     onShowNoteInfo: PropTypes.func,
     setIsViewingRevisions: PropTypes.func,
     onSetEditorMode: PropTypes.func,
-    editorMode: PropTypes.string.isRequired,
+    editorMode: PropTypes.string,
     markdownEnabled: PropTypes.bool,
   };
 
   static defaultProps = {
+    editorMode: 'edit',
     onCloseNote: noop,
     onDeleteNoteForever: noop,
     onRestoreNote: noop,

--- a/lib/note-toolbar/index.jsx
+++ b/lib/note-toolbar/index.jsx
@@ -17,7 +17,7 @@ export class NoteToolbar extends Component {
     note: PropTypes.object,
     onRestoreNote: PropTypes.func,
     onTrashNote: PropTypes.func,
-    onDeleteNoteForever: PropTypes.func.isRequired,
+    onDeleteNoteForever: PropTypes.func,
     onRevisions: PropTypes.func.isRequired,
     onShareNote: PropTypes.func,
     onCloseNote: PropTypes.func.isRequired,
@@ -29,6 +29,7 @@ export class NoteToolbar extends Component {
   };
 
   static defaultProps = {
+    onDeleteNoteForever: noop,
     onRestoreNote: noop,
     onShareNote: noop,
     onTrashNote: noop,

--- a/lib/note-toolbar/index.jsx
+++ b/lib/note-toolbar/index.jsx
@@ -15,8 +15,8 @@ export class NoteToolbar extends Component {
 
   static propTypes = {
     note: PropTypes.object,
+    onRestoreNote: PropTypes.func,
     onTrashNote: PropTypes.func,
-    onRestoreNote: PropTypes.func.isRequired,
     onDeleteNoteForever: PropTypes.func.isRequired,
     onRevisions: PropTypes.func.isRequired,
     onShareNote: PropTypes.func.isRequired,
@@ -29,6 +29,7 @@ export class NoteToolbar extends Component {
   };
 
   static defaultProps = {
+    onRestoreNote: noop,
     onTrashNote: noop,
     setIsViewingRevisions: noop,
   };

--- a/lib/note-toolbar/index.jsx
+++ b/lib/note-toolbar/index.jsx
@@ -22,7 +22,7 @@ export class NoteToolbar extends Component {
     onShareNote: PropTypes.func.isRequired,
     onCloseNote: PropTypes.func.isRequired,
     onNoteInfo: PropTypes.func.isRequired,
-    setIsViewingRevisions: PropTypes.func.isRequired,
+    setIsViewingRevisions: PropTypes.func,
     onSetEditorMode: PropTypes.func.isRequired,
     editorMode: PropTypes.string.isRequired,
     markdownEnabled: PropTypes.bool,
@@ -30,6 +30,7 @@ export class NoteToolbar extends Component {
 
   static defaultProps = {
     onTrashNote: noop,
+    setIsViewingRevisions: noop,
   };
 
   showRevisions = () => {

--- a/lib/note-toolbar/index.jsx
+++ b/lib/note-toolbar/index.jsx
@@ -20,7 +20,7 @@ export class NoteToolbar extends Component {
     onDeleteNoteForever: PropTypes.func,
     onShowRevisions: PropTypes.func,
     onShareNote: PropTypes.func,
-    onCloseNote: PropTypes.func.isRequired,
+    onCloseNote: PropTypes.func,
     onNoteInfo: PropTypes.func.isRequired,
     setIsViewingRevisions: PropTypes.func,
     onSetEditorMode: PropTypes.func.isRequired,
@@ -29,6 +29,7 @@ export class NoteToolbar extends Component {
   };
 
   static defaultProps = {
+    onCloseNote: noop,
     onDeleteNoteForever: noop,
     onRestoreNote: noop,
     onShowRevisions: noop,

--- a/lib/note-toolbar/index.jsx
+++ b/lib/note-toolbar/index.jsx
@@ -18,7 +18,7 @@ export class NoteToolbar extends Component {
     onRestoreNote: PropTypes.func,
     onTrashNote: PropTypes.func,
     onDeleteNoteForever: PropTypes.func,
-    onRevisions: PropTypes.func.isRequired,
+    onShowRevisions: PropTypes.func,
     onShareNote: PropTypes.func,
     onCloseNote: PropTypes.func.isRequired,
     onNoteInfo: PropTypes.func.isRequired,
@@ -31,6 +31,7 @@ export class NoteToolbar extends Component {
   static defaultProps = {
     onDeleteNoteForever: noop,
     onRestoreNote: noop,
+    onShowRevisions: noop,
     onShareNote: noop,
     onTrashNote: noop,
     setIsViewingRevisions: noop,
@@ -38,7 +39,7 @@ export class NoteToolbar extends Component {
 
   showRevisions = () => {
     this.props.setIsViewingRevisions(true);
-    this.props.onRevisions(this.props.note);
+    this.props.onShowRevisions(this.props.note);
   };
 
   render() {

--- a/lib/note-toolbar/index.jsx
+++ b/lib/note-toolbar/index.jsx
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { noop } from 'lodash';
+
 import BackIcon from '../icons/back';
 import InfoIcon from '../icons/info';
 import PreviewIcon from '../icons/preview';
@@ -13,7 +15,7 @@ export class NoteToolbar extends Component {
 
   static propTypes = {
     note: PropTypes.object,
-    onTrashNote: PropTypes.func.isRequired,
+    onTrashNote: PropTypes.func,
     onRestoreNote: PropTypes.func.isRequired,
     onDeleteNoteForever: PropTypes.func.isRequired,
     onRevisions: PropTypes.func.isRequired,
@@ -24,6 +26,10 @@ export class NoteToolbar extends Component {
     onSetEditorMode: PropTypes.func.isRequired,
     editorMode: PropTypes.string.isRequired,
     markdownEnabled: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    onTrashNote: noop,
   };
 
   showRevisions = () => {

--- a/lib/note-toolbar/index.jsx
+++ b/lib/note-toolbar/index.jsx
@@ -21,7 +21,7 @@ export class NoteToolbar extends Component {
     onShowRevisions: PropTypes.func,
     onShareNote: PropTypes.func,
     onCloseNote: PropTypes.func,
-    onNoteInfo: PropTypes.func.isRequired,
+    onShowNoteInfo: PropTypes.func,
     setIsViewingRevisions: PropTypes.func,
     onSetEditorMode: PropTypes.func.isRequired,
     editorMode: PropTypes.string.isRequired,
@@ -32,6 +32,7 @@ export class NoteToolbar extends Component {
     onCloseNote: noop,
     onDeleteNoteForever: noop,
     onRestoreNote: noop,
+    onShowNoteInfo: noop,
     onShowRevisions: noop,
     onShareNote: noop,
     onTrashNote: noop,
@@ -125,7 +126,7 @@ export class NoteToolbar extends Component {
             type="button"
             title="Info"
             className="button button-borderless"
-            onClick={this.props.onNoteInfo}
+            onClick={this.props.onShowNoteInfo}
           >
             <InfoIcon />
           </button>

--- a/lib/revision-selector/index.jsx
+++ b/lib/revision-selector/index.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import onClickOutside from 'react-onclickoutside';
 import moment from 'moment';
 import { orderBy } from 'lodash';
+import classNames from 'classnames';
 import appState from '../flux/app-state';
 
 const sortedRevisions = revisions =>
@@ -11,6 +12,7 @@ const sortedRevisions = revisions =>
 
 export class RevisionSelector extends Component {
   static propTypes = {
+    isViewingRevisions: PropTypes.bool.isRequired,
     note: PropTypes.object,
     revisions: PropTypes.array.isRequired,
     onUpdateContent: PropTypes.func.isRequired,
@@ -96,6 +98,7 @@ export class RevisionSelector extends Component {
   };
 
   render() {
+    const { isViewingRevisions } = this.props;
     const { revisions, selection: rawSelection } = this.state;
 
     const min = 0;
@@ -112,8 +115,12 @@ export class RevisionSelector extends Component {
     const revisionButtonStyle =
       selection === max ? { opacity: '0.5', pointerEvents: 'none' } : {};
 
+    const mainClasses = classNames('revision-selector', {
+      'is-visible': isViewingRevisions,
+    });
+
     return (
-      <div className="revision-selector">
+      <div className={mainClasses}>
         <div className="revision-date">{revisionDate}</div>
         <div className="revision-slider">
           <input
@@ -144,6 +151,10 @@ export class RevisionSelector extends Component {
   }
 }
 
+const mapStateToProps = ({ appState: state }) => ({
+  isViewingRevisions: state.isViewingRevisions,
+});
+
 const { setRevision, setIsViewingRevisions } = appState.actionCreators;
 
 const mapDispatchToProps = dispatch => ({
@@ -157,6 +168,6 @@ const mapDispatchToProps = dispatch => ({
   },
 });
 
-export default connect(null, mapDispatchToProps)(
+export default connect(mapStateToProps, mapDispatchToProps)(
   onClickOutside(RevisionSelector)
 );

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -9,6 +9,10 @@
   top: -114px;
   transition: all 0.3s ease-in-out;
 
+  &.is-visible {
+    top: 0;
+  }
+
   @media only screen and (max-width: $single-column) {
     width: 100%;
   }

--- a/scss/_components.scss
+++ b/scss/_components.scss
@@ -11,6 +11,7 @@
 @import 'editable-list/style';
 @import 'icons/style';
 @import 'navigation-bar/style';
+@import 'navigation-bar/item/style';
 @import 'note-detail/style';
 @import 'note-editor/style';
 @import 'note-info/style';

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -62,40 +62,6 @@ optgroup {
   &.navigation-open {
     transform: translateX($navigation-bar-width);
   }
-
-  .note-editor {
-    flex: 1 1 auto;
-  }
-
-  @media only screen and (max-width: $single-column) {
-    .note-editor {
-      position: absolute;
-      flex: none;
-      width: 100%;
-      height: 100%;
-      top: 0;
-      left: 0;
-      opacity: 0;
-      z-index: -1;
-      transition: $anim-transition;
-    }
-
-    &.note-open .note-editor {
-      opacity: 1;
-    }
-
-    &.note-info-open {
-      .note-editor {
-        opacity: $fade-alpha;
-      }
-    }
-
-    &.navigation-open {
-      .note-editor {
-        opacity: 0;
-      }
-    }
-  }
 }
 
 .panel-title {
@@ -103,25 +69,6 @@ optgroup {
   text-transform: uppercase;
   font-size: 86%;
   color: darken($gray, 20%);
-}
-
-/* Fade content when toolbars are visible */
-.note-info-open {
-  .note-editor,
-  .app-layout-source-list {
-    opacity: $fade-alpha;
-    transition: $anim;
-    pointer-events: none;
-  }
-}
-
-.navigation-open {
-  .note-editor,
-  .app-layout-source-list {
-    opacity: $fade-alpha;
-    transition: $anim;
-    pointer-events: none;
-  }
 }
 
 .is-macos {

--- a/scss/print.scss
+++ b/scss/print.scss
@@ -1,20 +1,20 @@
 @media print {
   html,
   body,
-  .note-editor {
+  .app-layout__note-column {
     overflow: visible;
     height: auto;
   }
 
   .app,
   .simplenote-app,
-  .simplenote-app .note-editor {
+  .app-layout__note-column {
     display: block;
     height: auto;
   }
 
   .navigation,
-  .app-layout-source-list,
+  .app-layout__source-column,
   .revision-selector,
   .note-toolbar-wrapper,
   .note-detail-wrapper,


### PR DESCRIPTION
Wraps NoteToolbar in a redux-connected container, and extracts the whole thing out of NoteEditor and into AppLayout. (CSS for it is broken at this point — will fix at the end)