### PR TITLE
Decompose app.jsx and NoteEditor (Part 7)

### DIFF
--- a/lib/navigation-bar/index.jsx
+++ b/lib/navigation-bar/index.jsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import onClickOutside from 'react-onclickoutside';
+import NavigationBarItem from './item';
 import TagList from '../tag-list';
 import NotesIcon from '../icons/notes';
 import TrashIcon from '../icons/trash';
 import SettingsIcon from '../icons/settings';
 import { viewExternalUrl } from '../utils/url-utils';
-import classNames from 'classnames';
 import appState from '../flux/app-state';
 
 const {
@@ -40,67 +40,41 @@ export class NavigationBar extends Component {
   onHelpClicked = () => viewExternalUrl('http://simplenote.com/help');
 
   // Determine if the selected class should be applied for the 'all notes' or 'trash' rows
-  getNavigationItemClass = isTrashRow => {
+  isSelected = ({ isTrashRow }) => {
     const { showTrash, selectedTag } = this.props;
     const isItemSelected = isTrashRow === showTrash;
 
-    return isItemSelected && !selectedTag
-      ? 'navigation-folders-item-selected'
-      : 'navigation-folders-item';
+    return isItemSelected && !selectedTag;
   };
 
   render() {
     const { noteBucket, tagBucket } = this.props;
-    const buttonClasses = classNames(
-      'button',
-      'button-borderless',
-      'theme-color-fg'
-    );
 
     return (
       <div className="navigation theme-color-bg theme-color-fg theme-color-border">
         <div className="navigation-folders">
-          <div className={this.getNavigationItemClass(false)}>
-            <button
-              type="button"
-              className={buttonClasses}
-              onClick={this.props.onSelectAllNotes}
-            >
-              <span className="navigation-icon">
-                <NotesIcon />
-              </span>
-              All Notes
-            </button>
-          </div>
-          <div className={this.getNavigationItemClass(true)}>
-            <button
-              type="button"
-              className={buttonClasses}
-              onClick={this.props.onSelectTrash}
-            >
-              <span className="navigation-icon">
-                <TrashIcon />
-              </span>
-              Trash
-            </button>
-          </div>
+          <NavigationBarItem
+            icon={<NotesIcon />}
+            isSelected={this.isSelected({ isTrashRow: false })}
+            label="All Notes"
+            onClick={this.props.onSelectAllNotes}
+          />
+          <NavigationBarItem
+            icon={<TrashIcon />}
+            isSelected={this.isSelected({ isTrashRow: true })}
+            label="Trash"
+            onClick={this.props.onSelectTrash}
+          />
         </div>
         <div className="navigation-tags theme-color-border">
           <TagList noteBucket={noteBucket} tagBucket={tagBucket} />
         </div>
         <div className="navigation-tools theme-color-border">
-          <div className="navigation-tools-item">
-            <button
-              type="button"
-              className={buttonClasses}
-              onClick={this.props.onSettings}
-            >
-              <span className="navigation-icon">
-                <SettingsIcon />
-              </span>
-              Settings
-            </button>
-          </div>
+          <NavigationBarItem
+            icon={<SettingsIcon />}
+            label="Settings"
+            onClick={this.props.onSettings}
+          />
         </div>
         <div className="navigation-footer">
           <button

--- a/lib/navigation-bar/index.jsx
+++ b/lib/navigation-bar/index.jsx
@@ -51,51 +51,56 @@ export class NavigationBar extends Component {
 
   render() {
     const { noteBucket, tagBucket } = this.props;
-    const classes = classNames('button', 'button-borderless', 'theme-color-fg');
-    const allNotesClasses = classNames(
-      this.getNavigationItemClass(false),
-      classes
+    const buttonClasses = classNames(
+      'button',
+      'button-borderless',
+      'theme-color-fg'
     );
-    const trashClasses = classNames(this.getNavigationItemClass(true), classes);
 
     return (
       <div className="navigation theme-color-bg theme-color-fg theme-color-border">
         <div className="navigation-folders">
-          <button
-            type="button"
-            className={allNotesClasses}
-            onClick={this.props.onSelectAllNotes}
-          >
-            <span className="navigation-icon">
-              <NotesIcon />
-            </span>
-            All Notes
-          </button>
-          <button
-            type="button"
-            className={trashClasses}
-            onClick={this.props.onSelectTrash}
-          >
-            <span className="navigation-icon">
-              <TrashIcon />
-            </span>
-            Trash
-          </button>
+          <div className={this.getNavigationItemClass(false)}>
+            <button
+              type="button"
+              className={buttonClasses}
+              onClick={this.props.onSelectAllNotes}
+            >
+              <span className="navigation-icon">
+                <NotesIcon />
+              </span>
+              All Notes
+            </button>
+          </div>
+          <div className={this.getNavigationItemClass(true)}>
+            <button
+              type="button"
+              className={buttonClasses}
+              onClick={this.props.onSelectTrash}
+            >
+              <span className="navigation-icon">
+                <TrashIcon />
+              </span>
+              Trash
+            </button>
+          </div>
         </div>
         <div className="navigation-tags theme-color-border">
           <TagList noteBucket={noteBucket} tagBucket={tagBucket} />
         </div>
         <div className="navigation-tools theme-color-border">
-          <button
-            type="button"
-            className="navigation-tools-item button button-borderless theme-color-fg"
-            onClick={this.props.onSettings}
-          >
-            <span className="navigation-icon">
-              <SettingsIcon />
-            </span>
-            Settings
-          </button>
+          <div className="navigation-tools-item">
+            <button
+              type="button"
+              className={buttonClasses}
+              onClick={this.props.onSettings}
+            >
+              <span className="navigation-icon">
+                <SettingsIcon />
+              </span>
+              Settings
+            </button>
+          </div>
         </div>
         <div className="navigation-footer">
           <button

--- a/lib/navigation-bar/item/index.jsx
+++ b/lib/navigation-bar/item/index.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export const NavigationBarItem = ({
+  icon,
+  isSelected = false,
+  label,
+  onClick,
+}) => {
+  const classes = classNames('navigation-bar-item', {
+    'is-selected': isSelected,
+  });
+  const buttonClasses = classNames(
+    'button',
+    'button-borderless',
+    'theme-color-fg'
+  );
+
+  return (
+    <div className={classes}>
+      <button type="button" className={buttonClasses} onClick={onClick}>
+        <span className="navigation-bar-item__icon">{icon}</span>
+        {label}
+      </button>
+    </div>
+  );
+};
+
+NavigationBarItem.propTypes = {
+  icon: PropTypes.element.isRequired,
+  isSelected: PropTypes.bool,
+  label: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+export default NavigationBarItem;

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -1,0 +1,32 @@
+.navigation-bar-item {
+  width: 100%;
+  padding: 4px 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+
+  svg {
+    fill: $gray;
+  }
+
+  &.is-selected {
+    color: $blue;
+
+    svg[class^='icon-'] {
+      fill: $blue;
+    }
+  }
+}
+
+.navigation-bar-item__icon {
+  display: inline-block;
+  margin-right: .5em;
+  vertical-align: middle;
+
+  svg {
+    vertical-align: middle;
+    position: relative;
+    top: -.2em;
+  }
+}

--- a/lib/navigation-bar/style.scss
+++ b/lib/navigation-bar/style.scss
@@ -20,8 +20,7 @@
 .navigation-tools-item,
 .navigation-folders-item-selected {
   width: 100%;
-  line-height: 2em;
-  padding: 8px 20px;
+  padding: 4px 8px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/lib/navigation-bar/style.scss
+++ b/lib/navigation-bar/style.scss
@@ -16,46 +16,6 @@
   padding: 10px 0;
 }
 
-.navigation-folders-item,
-.navigation-tools-item,
-.navigation-folders-item-selected {
-  width: 100%;
-  padding: 4px 8px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-align: left;
-
-  svg {
-    fill: $gray;
-  }
-}
-
-.navigation-folders-item-selected {
-  span {
-    color: $blue;
-  }
-
-  svg[class^='icon-'] {
-    fill: $blue;
-  }
-}
-
-.theme-light,
-.theme-dark {
-  .navigation-folders-item,
-  .navigation-tools-item {
-    &:active,
-    &.active {
-      color: $blue;
-
-      svg[class^='icon-'] {
-        fill: $blue;
-      }
-    }
-  }
-}
-
 .navigation-tags {
   display: flex;
   height: 100%;
@@ -102,17 +62,5 @@
 
   &:last-child {
     margin-right: 0;
-  }
-}
-
-.navigation-icon {
-  display: inline-block;
-  margin-right: 0.5em;
-  vertical-align: middle;
-
-  svg {
-    vertical-align: middle;
-    position: relative;
-    top: -0.2em;
   }
 }

--- a/lib/note-detail/index.jsx
+++ b/lib/note-detail/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import highlight from 'highlight.js';
 import { get, debounce, invoke, noop } from 'lodash';
+import classNames from 'classnames';
 import analytics from '../analytics';
 import { viewExternalUrl } from '../utils/url-utils';
 import NoteContentEditor from '../note-content-editor';
@@ -24,6 +25,7 @@ export class NoteDetail extends Component {
     dialogs: PropTypes.array.isRequired,
     filter: PropTypes.string.isRequired,
     fontSize: PropTypes.number,
+    isViewingRevisions: PropTypes.bool.isRequired,
     onChangeContent: PropTypes.func.isRequired,
     note: PropTypes.object,
     previewingMarkdown: PropTypes.bool,
@@ -154,10 +156,20 @@ export class NoteDetail extends Component {
   };
 
   render() {
-    const { note, filter, fontSize, previewingMarkdown } = this.props;
+    const {
+      note,
+      filter,
+      fontSize,
+      isViewingRevisions,
+      previewingMarkdown,
+    } = this.props;
 
     const content = get(this.props, 'note.data.content', '');
     const divStyle = { fontSize: `${fontSize}px` };
+
+    const mainClasses = classNames('note-detail', {
+      'is-viewing-revisions': isViewingRevisions,
+    });
 
     return (
       <div className="note-detail-wrapper theme-color-border">
@@ -166,7 +178,7 @@ export class NoteDetail extends Component {
             <SimplenoteCompactLogo />
           </div>
         ) : (
-          <div className="note-detail">
+          <div className={mainClasses}>
             {previewingMarkdown && (
               <div
                 ref={this.storePreview}
@@ -201,6 +213,7 @@ export class NoteDetail extends Component {
 const mapStateToProps = ({ appState: state }) => ({
   dialogs: state.dialogs,
   filter: state.filter,
+  isViewingRevisions: state.isViewingRevisions,
   showNoteInfo: state.showNoteInfo,
 });
 

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -18,7 +18,11 @@
   display: flex;
   flex-direction: row;
   justify-content: center;
-  transition: all 0.3s ease-in-out;
+  transition: all .3s ease-in-out;
+
+  &.is-viewing-revisions {
+    padding-top: 51px;
+  }
 
   div[data-contents] {
     padding-bottom: 20px;
@@ -35,7 +39,7 @@
   .logo {
     width: 140px;
     height: 140px;
-    opacity: 0.2;
+    opacity: .2;
 
     path {
       fill: $gray;
@@ -54,7 +58,7 @@
   height: 100%;
   max-width: 780px;
   padding: 24px;
-  border: none;
+  border: 0;
   line-height: 1.5em;
   font-size: 16px;
   color: darken($gray, 20%);
@@ -155,7 +159,7 @@
     background: transparent;
   }
   table {
-    border-collapse:collapse;
+    border-collapse: collapse;
     border-spacing: 0;
     display: block;
     width: 100%;

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -143,7 +143,6 @@ export class NoteEditor extends Component {
       'theme-color-fg',
       {
         revisions: isViewingRevisions,
-        markdown: markdownEnabled,
       }
     );
 

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
 import appState from '../flux/app-state';
 import NoteDetail from '../note-detail';
 import TagField from '../tag-field';
@@ -15,7 +14,6 @@ export class NoteEditor extends Component {
   static propTypes = {
     closeNote: PropTypes.func.isRequired,
     editorMode: PropTypes.oneOf(['edit', 'markdown']),
-    isViewingRevisions: PropTypes.bool.isRequired,
     markdownEnabled: PropTypes.bool.isRequired,
     note: PropTypes.object,
     fontSize: PropTypes.number,
@@ -120,13 +118,7 @@ export class NoteEditor extends Component {
   };
 
   render() {
-    const {
-      editorMode,
-      isViewingRevisions,
-      note,
-      fontSize,
-      shouldPrint,
-    } = this.props;
+    const { editorMode, note, fontSize, shouldPrint } = this.props;
     const revision = this.props.revision || note;
     const tags = (revision && revision.data && revision.data.tags) || [];
     const isTrashed = !!(note && note.data.deleted);
@@ -136,15 +128,6 @@ export class NoteEditor extends Component {
       revision.data &&
       revision.data.systemTags &&
       revision.data.systemTags.indexOf('markdown') !== -1;
-
-    const classes = classNames(
-      'note-editor',
-      'theme-color-bg',
-      'theme-color-fg',
-      {
-        revisions: isViewingRevisions,
-      }
-    );
 
     const content = get(revision, 'data.content', '');
 
@@ -158,7 +141,7 @@ export class NoteEditor extends Component {
     };
 
     return (
-      <div className={classes}>
+      <div className="note-editor theme-color-bg theme-color-fg">
         <NoteDetail
           storeFocusEditor={this.storeFocusEditor}
           storeHasFocus={this.storeEditorHasFocus}
@@ -199,7 +182,6 @@ const mapStateToProps = ({ appState: state, settings }) => ({
   fontSize: settings.fontSize,
   editorMode: state.editorMode,
   isEditorActive: !state.showNavigation,
-  isViewingRevisions: state.isViewingRevisions,
   markdownEnabled: settings.markdownEnabled,
   revision: state.revision,
 });

--- a/lib/note-editor/style.scss
+++ b/lib/note-editor/style.scss
@@ -3,9 +3,3 @@
   flex-direction: column;
   flex: 1 0 auto;
 }
-
-.revisions {
-  .note-detail {
-    padding-top: 51px !important;
-  }
-}

--- a/lib/note-editor/style.scss
+++ b/lib/note-editor/style.scss
@@ -5,10 +5,6 @@
 }
 
 .revisions {
-  .revision-selector {
-    top: 0 !important;
-  }
-
   .note-detail {
     padding-top: 51px !important;
   }

--- a/lib/note-list/index.jsx
+++ b/lib/note-list/index.jsx
@@ -12,7 +12,7 @@
  * row height calculations should be double-checked
  * against performance regressions.
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { AutoSizer, List } from 'react-virtualized';
 import PublishIcon from '../icons/feed';
@@ -432,32 +432,34 @@ export class NoteList extends Component {
         {isEmptyList ? (
           <span className="note-list-placeholder">No Notes</span>
         ) : (
-          <div className={listItemsClasses}>
-            <AutoSizer>
-              {({ height, width }) => (
-                <List
-                  ref={this.refList}
-                  estimatedRowSize={
-                    ROW_HEIGHT_BASE +
-                    ROW_HEIGHT_LINE * maxPreviewLines[noteDisplay]
-                  }
-                  height={height}
-                  noteDisplay={noteDisplay}
-                  notes={this.props.notes}
-                  rowCount={this.props.notes.length}
-                  rowHeight={
-                    'condensed' === noteDisplay
-                      ? ROW_HEIGHT_BASE
-                      : getRowHeight(this.props.notes, { noteDisplay, width })
-                  }
-                  rowRenderer={renderNoteRow}
-                  width={width}
-                />
-              )}
-            </AutoSizer>
-          </div>
+          <Fragment>
+            <div className={listItemsClasses}>
+              <AutoSizer>
+                {({ height, width }) => (
+                  <List
+                    ref={this.refList}
+                    estimatedRowSize={
+                      ROW_HEIGHT_BASE +
+                      ROW_HEIGHT_LINE * maxPreviewLines[noteDisplay]
+                    }
+                    height={height}
+                    noteDisplay={noteDisplay}
+                    notes={this.props.notes}
+                    rowCount={this.props.notes.length}
+                    rowHeight={
+                      'condensed' === noteDisplay
+                        ? ROW_HEIGHT_BASE
+                        : getRowHeight(this.props.notes, { noteDisplay, width })
+                    }
+                    rowRenderer={renderNoteRow}
+                    width={width}
+                  />
+                )}
+              </AutoSizer>
+            </div>
+            {!!showTrash && emptyTrashButton}
+          </Fragment>
         )}
-        {!!showTrash && emptyTrashButton}
       </div>
     );
   }

--- a/lib/revision-selector/index.jsx
+++ b/lib/revision-selector/index.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import onClickOutside from 'react-onclickoutside';
 import moment from 'moment';
 import { orderBy } from 'lodash';
+import classNames from 'classnames';
 import appState from '../flux/app-state';
 
 const sortedRevisions = revisions =>
@@ -11,6 +12,7 @@ const sortedRevisions = revisions =>
 
 export class RevisionSelector extends Component {
   static propTypes = {
+    isViewingRevisions: PropTypes.bool.isRequired,
     note: PropTypes.object,
     revisions: PropTypes.array.isRequired,
     onUpdateContent: PropTypes.func.isRequired,
@@ -96,6 +98,7 @@ export class RevisionSelector extends Component {
   };
 
   render() {
+    const { isViewingRevisions } = this.props;
     const { revisions, selection: rawSelection } = this.state;
 
     const min = 0;
@@ -112,8 +115,12 @@ export class RevisionSelector extends Component {
     const revisionButtonStyle =
       selection === max ? { opacity: '0.5', pointerEvents: 'none' } : {};
 
+    const mainClasses = classNames('revision-selector', {
+      'is-visible': isViewingRevisions,
+    });
+
     return (
-      <div className="revision-selector">
+      <div className={mainClasses}>
         <div className="revision-date">{revisionDate}</div>
         <div className="revision-slider">
           <input
@@ -144,6 +151,10 @@ export class RevisionSelector extends Component {
   }
 }
 
+const mapStateToProps = ({ appState: state }) => ({
+  isViewingRevisions: state.isViewingRevisions,
+});
+
 const { setRevision, setIsViewingRevisions } = appState.actionCreators;
 
 const mapDispatchToProps = dispatch => ({
@@ -157,6 +168,6 @@ const mapDispatchToProps = dispatch => ({
   },
 });
 
-export default connect(null, mapDispatchToProps)(
+export default connect(mapStateToProps, mapDispatchToProps)(
   onClickOutside(RevisionSelector)
 );

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -9,6 +9,10 @@
   top: -114px;
   transition: all 0.3s ease-in-out;
 
+  &.is-visible {
+    top: 0;
+  }
+
   @media only screen and (max-width: $single-column) {
     width: 100%;
   }

--- a/scss/_components.scss
+++ b/scss/_components.scss
@@ -11,6 +11,7 @@
 @import 'editable-list/style';
 @import 'icons/style';
 @import 'navigation-bar/style';
+@import 'navigation-bar/item/style';
 @import 'note-detail/style';
 @import 'note-editor/style';
 @import 'note-info/style';


### PR DESCRIPTION
Turns state-dependent `.revisions` styles into clearly-scoped modifiers.

This is **the end** of the stacked PR. Everything should be working properly, including CSS.

Please use this branch for testing, and refer to the others for reviewing code changes in smaller, related chunks: #843 #846 #851 #852 #853 #856 