### PR TITLE
Focus Mode

### DIFF
--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -133,6 +133,16 @@ const buildViewMenu = settings => {
         type: 'separator',
       },
       {
+        label: 'Focus Mode',
+        accelerator: 'CommandOrControl+Shift+F',
+        type: 'checkbox',
+        checked: settings.focusModeEnabled,
+        click: appCommandSender({ action: 'toggleFocusMode' }),
+      },
+      {
+        type: 'separator',
+      },
+      {
         label: 'T&oggle Full Screen',
         accelerator: (function() {
           if (process.platform === 'darwin') {

--- a/lib/app-layout/index.js
+++ b/lib/app-layout/index.js
@@ -6,6 +6,7 @@ import NoteToolbar from '../note-toolbar';
 import RevisionSelector from '../revision-selector';
 
 export const AppLayout = ({
+  isFocusMode,
   isNavigationOpen,
   isNoteInfoOpen,
   isNoteOpen,
@@ -18,6 +19,7 @@ export const AppLayout = ({
   noteEditor,
 }) => {
   const mainClasses = classNames('app-layout', {
+    'is-focus-mode': isFocusMode,
     'is-navigation-open': isNavigationOpen,
     'is-note-open': isNoteOpen,
     'is-showing-note-info': isNoteInfoOpen,
@@ -46,6 +48,7 @@ export const AppLayout = ({
 };
 
 AppLayout.propTypes = {
+  isFocusMode: PropTypes.bool.isRequired,
   isNavigationOpen: PropTypes.bool.isRequired,
   isNoteInfoOpen: PropTypes.bool.isRequired,
   isNoteOpen: PropTypes.bool.isRequired,

--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -2,6 +2,12 @@
   display: flex;
   flex: 1 0 auto;
 
+  &.is-focus-mode {
+    .app-layout__source-column {
+      display: none;
+    }
+  }
+
   &.is-navigation-open {
     opacity: $fade-alpha;
     transition: $anim;

--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex: 1 0 auto;
 
-  &.is-focus-mode {
+  &.is-focus-mode.is-note-open {
     .app-layout__source-column {
       display: none;
     }

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -375,6 +375,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
                 <NavigationBar noteBucket={noteBucket} tagBucket={tagBucket} />
               )}
               <AppLayout
+                isFocusMode={settings.focusModeEnabled}
                 isNavigationOpen={state.showNavigation}
                 isNoteOpen={isNoteOpen}
                 isNoteInfoOpen={state.showNoteInfo}

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -189,7 +189,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       }
 
       // focus search field
-      if (cmdOrCtrl && 'F' === key) {
+      if (cmdOrCtrl && 'f' === key) {
         this.props.setSearchFocus();
 
         event.stopPropagation();

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -76,6 +76,7 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
         'setNoteDisplay',
         'setMarkdown',
         'setAccountName',
+        'toggleFocusMode',
       ]),
       dispatch
     ),

--- a/lib/state/settings/actions.js
+++ b/lib/state/settings/actions.js
@@ -62,3 +62,14 @@ export const setWPToken = token => ({
   type: 'setWPToken',
   token,
 });
+
+export const setFocusMode = focusModeEnabled => ({
+  type: 'setFocusMode',
+  focusModeEnabled,
+});
+
+export const toggleFocusMode = () => (dispatch, getState) => {
+  const { settings: { focusModeEnabled } } = getState();
+
+  dispatch(setFocusMode(!focusModeEnabled));
+};

--- a/lib/state/settings/reducer.js
+++ b/lib/state/settings/reducer.js
@@ -25,6 +25,14 @@ const theme = (state = 'light', action) => {
   return action.theme;
 };
 
+const focusModeEnabled = (state = false, action) => {
+  if ('setFocusMode' !== action.type) {
+    return state;
+  }
+
+  return action.focusModeEnabled;
+};
+
 const fontSize = (state = 16, { type, fontSize: size = 16 }) => {
   if ('setFontSize' !== type) {
     return state;
@@ -75,6 +83,7 @@ const wpToken = (state = false, action) => {
 
 export default combineReducers({
   accountName,
+  focusModeEnabled,
   fontSize,
   lineLength,
   markdownEnabled,


### PR DESCRIPTION
Depends on #857 
Closes #796 

This is a minimum viable Focus Mode. The feature can only be toggled from the app menu (or by shortcut).

![focus-mode](https://user-images.githubusercontent.com/555336/45498357-cf04e180-b7b4-11e8-8994-0ef0ca360ab1.gif)

There are a few possible ways we can enhance this later:
- Keep the Tags button in the top left corner, which will jump straight to the tag drawer
- Add a Sidebar button (something like [this](https://thenounproject.com/search/?q=sidebar&i=1926136)) in the left corner of the Note Toolbar, which will act as a Focus Mode toggle (related: #433)
- Add a nice transition