### PR TITLE
adjusted menu to display zoom at view root level

### DIFF
--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -106,12 +106,12 @@ const buildViewMenu = settings => {
         type: 'separator',
       },
       {
-        label: '&Zoom In',
+        label: 'Zoom &In',
         accelerator: 'CommandOrControl+Plus',
         click: appCommandSender({ action: 'increaseFontSize' }),
       },
       {
-        label: '&Zoom Out',
+        label: 'Zoom &Out',
         accelerator: 'CommandOrControl+-',
         click: appCommandSender({ action: 'decreaseFontSize' }),
       },
@@ -124,7 +124,7 @@ const buildViewMenu = settings => {
         type: 'separator',
       },
       {
-        label: 'T&oggle Full Screen',
+        label: 'Toggle &Full Screen',
         accelerator: (function() {
           if (process.platform === 'darwin') {
             return 'Ctrl+Command+F';

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -7,75 +7,6 @@ const buildViewMenu = settings => {
     label: '&View',
     submenu: [
       {
-        label: '&Note Display',
-        submenu: [
-          {
-            label: '&Comfy',
-            id: 'comfy',
-          },
-          {
-            label: 'C&ondensed',
-            id: 'condensed',
-          },
-          {
-            label: '&Expanded',
-            id: 'expanded',
-          },
-        ].map(
-          buildRadioGroup({
-            action: 'setNoteDisplay',
-            propName: 'noteDisplay',
-            settings,
-          })
-        ),
-      },
-      {
-        label: 'Note &Editor',
-        submenu: [
-          {
-            label: '&Font Size',
-            submenu: [
-              // For the oddity with "Command" vs "Cmd"
-              // Cite: https://github.com/atom/electron/issues/1507
-              {
-                label: '&Bigger',
-                accelerator: 'CommandOrControl+=',
-                click: appCommandSender({ action: 'increaseFontSize' }),
-              },
-              {
-                label: '&Smaller',
-                accelerator: 'CommandOrControl+-',
-                click: appCommandSender({ action: 'decreaseFontSize' }),
-              },
-              {
-                label: '&Reset',
-                accelerator: 'CommandOrControl+0',
-                click: appCommandSender({ action: 'resetFontSize' }),
-              },
-            ],
-          },
-          {
-            label: '&Line Length',
-            submenu: [
-              {
-                label: '&Narrow',
-                id: 'narrow',
-              },
-              {
-                label: '&Full',
-                id: 'full',
-              },
-            ].map(
-              buildRadioGroup({
-                action: 'setLineLength',
-                propName: 'lineLength',
-                settings,
-              })
-            ),
-          },
-        ],
-      },
-      {
         label: '&Sort Type',
         submenu: [
           {
@@ -111,6 +42,48 @@ const buildViewMenu = settings => {
           ]),
       },
       {
+        label: '&Note Display',
+        submenu: [
+          {
+            label: '&Comfy',
+            id: 'comfy',
+          },
+          {
+            label: 'C&ondensed',
+            id: 'condensed',
+          },
+          {
+            label: '&Expanded',
+            id: 'expanded',
+          },
+        ].map(
+          buildRadioGroup({
+            action: 'setNoteDisplay',
+            propName: 'noteDisplay',
+            settings,
+          })
+        ),
+      },
+      {
+        label: '&Line Length',
+        submenu: [
+          {
+            label: '&Narrow',
+            id: 'narrow',
+          },
+          {
+            label: '&Full',
+            id: 'full',
+          },
+        ].map(
+          buildRadioGroup({
+            action: 'setLineLength',
+            propName: 'lineLength',
+            settings,
+          })
+        ),
+      },
+      {
         label: '&Theme',
         submenu: [
           {
@@ -128,6 +101,24 @@ const buildViewMenu = settings => {
             settings,
           })
         ),
+      },
+      {
+        type: 'separator',
+      },
+      {
+        label: '&Zoom In',
+        accelerator: 'CommandOrControl+Plus',
+        click: appCommandSender({ action: 'increaseFontSize' }),
+      },
+      {
+        label: '&Zoom Out',
+        accelerator: 'CommandOrControl+-',
+        click: appCommandSender({ action: 'decreaseFontSize' }),
+      },
+      {
+        label: '&Actual Size',
+        accelerator: 'CommandOrControl+0',
+        click: appCommandSender({ action: 'resetFontSize' }),
       },
       {
         type: 'separator',


### PR DESCRIPTION
Based on #818 

- I changed Font Size Bigger, Smaller, to be Zoom In and Zoom Out and moved it to view root level. 
- Changed the short key for Zoom in from ⌘= to ⌘+