### PR TITLE
Move and restyle WordPress.com login button

### DIFF
--- a/lib/auth/index.jsx
+++ b/lib/auth/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
@@ -59,18 +59,6 @@ export class Auth extends Component {
           <div className="login-logo">
             <SimplenoteLogo />
           </div>
-          {isElectron && (
-            <div className="wpcom-connect">
-              <div
-                className="button button-primary wpcom-connect-button"
-                onClick={this.onWPLogin}
-              >
-                <WordPressLogo />
-                Sign in with WordPress.com
-              </div>
-              <div className="wpcom-connect-or">or:</div>
-            </div>
-          )}
           <div className="login-fields theme-color-border theme-color-fg">
             <label
               className="login-field theme-color-border"
@@ -160,6 +148,22 @@ export class Auth extends Component {
               </a>
             </p>
           </div>
+          {isElectron && (
+            <Fragment>
+              <div className="login__or">or:</div>
+              <div className="login__btn-wpcom">
+                <button
+                  className="button button-borderless"
+                  onClick={this.onWPLogin}
+                >
+                  <span className="login__btn-wpcom-icon">
+                    <WordPressLogo />
+                  </span>
+                  Log in with WordPress.com
+                </button>
+              </div>
+            </Fragment>
+          )}
         </form>
       </div>
     );

--- a/lib/auth/index.jsx
+++ b/lib/auth/index.jsx
@@ -54,21 +54,21 @@ export class Auth extends Component {
 
     return (
       <div className="login">
-        {isMacApp && <div className="login-draggable-area" />}
-        <form className="login-form" onSubmit={this.onLogin}>
-          <div className="login-logo">
+        {isMacApp && <div className="login__draggable-area" />}
+        <form className="login__form" onSubmit={this.onLogin}>
+          <div className="login__logo">
             <SimplenoteLogo />
           </div>
-          <div className="login-fields theme-color-border theme-color-fg">
+          <div className="login__fields theme-color-border theme-color-fg">
             <label
-              className="login-field theme-color-border"
-              htmlFor="login-field-username"
+              className="login__field theme-color-border"
+              htmlFor="login__field-username"
             >
-              <span className="login-field-label">Email</span>
-              <span className="login-field-control">
+              <span className="login__field-label">Email</span>
+              <span className="login__field-control">
                 <input
                   ref={ref => (this.usernameInput = ref)}
-                  id="login-field-username"
+                  id="login__field-username"
                   type="email"
                   onKeyDown={this.onLogin}
                   spellCheck={false}
@@ -76,14 +76,14 @@ export class Auth extends Component {
               </span>
             </label>
             <label
-              className="login-field theme-color-border"
-              htmlFor="login-field-password"
+              className="login__field theme-color-border"
+              htmlFor="login__field-password"
             >
-              <span className="login-field-label">Password</span>
-              <span className="login-field-control">
+              <span className="login__field-label">Password</span>
+              <span className="login__field-control">
                 <input
                   ref={ref => (this.passwordInput = ref)}
-                  id="login-field-password"
+                  id="login__field-password"
                   type="password"
                   onKeyDown={this.onLogin}
                   spellCheck={false}
@@ -92,14 +92,14 @@ export class Auth extends Component {
             </label>
             {isCreatingAccount && (
               <label
-                className="login-field theme-color-border"
-                htmlFor="login-field-password-confirm"
+                className="login__field theme-color-border"
+                htmlFor="login__field-password-confirm"
               >
-                <span className="login-field-label">Confirm Password</span>
-                <span className="login-field-control">
+                <span className="login__field-label">Confirm Password</span>
+                <span className="login__field-control">
                   <input
                     ref={ref => (this.passwordConfirmInput = ref)}
-                    id="login-field-password-confirm"
+                    id="login__field-password-confirm"
                     type="password"
                     onKeyDown={this.onSignUp}
                     spellCheck={false}
@@ -109,21 +109,21 @@ export class Auth extends Component {
             )}
           </div>
           {this.props.hasInvalidCredentials && (
-            <p className="login-auth-message login-auth-failure">
+            <p className="login__auth-message login__auth-failure">
               The credentials you entered don&apos;t match
             </p>
           )}
           {this.props.hasLoginError && (
-            <p className="login-auth-message login-auth-failure">
+            <p className="login__auth-message login__auth-failure">
               {errorMessage}
             </p>
           )}
           {passwordErrorMessage && (
-            <p className="login-auth-message login-auth-failure">
+            <p className="login__auth-message login__auth-failure">
               {passwordErrorMessage}
             </p>
           )}
-          <div className="login-actions">
+          <div className="login__actions">
             <div
               className={submitClasses}
               onClick={isCreatingAccount ? this.onSignUp : this.onLogin}
@@ -131,7 +131,7 @@ export class Auth extends Component {
             >
               {this.props.authPending ? <Spinner /> : buttonLabel}
             </div>
-            <p className="login-forgot">
+            <p className="login__forgot">
               <a
                 href="https://app.simplenote.com/forgot/"
                 target="_blank"
@@ -141,7 +141,7 @@ export class Auth extends Component {
                 Forgot your password?
               </a>
             </p>
-            <p className="login-signup">
+            <p className="login__signup">
               {helpMessage}{' '}
               <a href="#" onClick={this.toggleSignUp}>
                 {helpLinkLabel}

--- a/lib/auth/index.jsx
+++ b/lib/auth/index.jsx
@@ -109,17 +109,15 @@ export class Auth extends Component {
             )}
           </div>
           {this.props.hasInvalidCredentials && (
-            <p className="login__auth-message login__auth-failure">
+            <p className="login__auth-message is-error">
               The credentials you entered don&apos;t match
             </p>
           )}
           {this.props.hasLoginError && (
-            <p className="login__auth-message login__auth-failure">
-              {errorMessage}
-            </p>
+            <p className="login__auth-message is-error">{errorMessage}</p>
           )}
           {passwordErrorMessage && (
-            <p className="login__auth-message login__auth-failure">
+            <p className="login__auth-message is-error">
               {passwordErrorMessage}
             </p>
           )}

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -118,17 +118,29 @@
       font-weight: $bold;
     }
   }
+}
 
-  .wpcom-connect-or {
-    text-align: center;
-    margin: 20px 0;
+.login__or {
+  text-align: center;
+  margin: 20px 0 12px;
+}
+
+.login__btn-wpcom {
+  button {
+    color: $gray;
+    width: 100%;
   }
+}
 
-  .logo-wordpress {
-    fill: #FFFFFF;
+.login__btn-wpcom-icon {
+  svg {
     margin-right: 6px;
     width: 32px;
     height: 32px;
+
+    path {
+      fill: $blue;
+    }
   }
 }
 

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -6,7 +6,7 @@
   overflow: auto;
   -webkit-overflow-scrolling: touch;
 
-  .login-draggable-area {
+  .login__draggable-area {
     -webkit-app-region: drag;
     width: 100%;
     height: 40px;
@@ -15,13 +15,13 @@
     position: absolute;
   }
 
-  .login-form {
+  .login__form {
     max-width: 320px;
     margin: auto;
     padding: 10px;
   }
 
-  .login-logo {
+  .login__logo {
     margin-bottom: 50px;
     text-align: center;
 
@@ -31,12 +31,12 @@
     }
   }
 
-  .login-fields {
+  .login__fields {
     border: 1px solid lighten($gray, 25%);
     border-radius: $border-radius;
   }
 
-  .login-field {
+  .login__field {
     display: flex;
     align-items: center;
     padding: 1px;
@@ -46,7 +46,7 @@
       border-bottom: none;
     }
 
-    .login-field-label {
+    .login__field-label {
       flex: none;
       width: 7.5em;
       padding: 8px 12px;
@@ -56,7 +56,7 @@
       color: $gray;
     }
 
-    .login-field-control {
+    .login__field-control {
       flex: 1 1 auto;
     }
 
@@ -77,12 +77,12 @@
     }
   }
 
-  .login-auth-message {
+  .login__auth-message {
     opacity: 0;
     margin-top: 8px;
     margin-bottom: 0;
 
-    &.login-auth-failure {
+    &.login__auth-failure {
       color: $red;
       text-align: center;
       opacity: 1;
@@ -90,7 +90,7 @@
     }
   }
 
-  .login-actions {
+  .login__actions {
     margin-top: 22px;
     text-align: center;
     color: $gray;
@@ -104,14 +104,14 @@
     align-items: center;
   }
 
-  .login-forgot {
+  .login__forgot {
     a {
       color: inherit;
       text-decoration: none;
     }
   }
 
-  .login-signup {
+  .login__signup {
     margin-top: 1em;
 
     a {
@@ -144,7 +144,7 @@
   }
 }
 
-.theme-dark .login-logo svg {
+.theme-dark .login__logo svg {
   border-radius: 0;
   border: none;
 }

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -82,7 +82,7 @@
     margin-top: 8px;
     margin-bottom: 0;
 
-    &.login__auth-failure {
+    &.is-error {
       color: $red;
       text-align: center;
       opacity: 1;


### PR DESCRIPTION
This moves the WordPress.com login button to the bottom of the login screen, and restyles it so it's not a primary button. I also changed the wording from "Sign in" to "Log in", for consistency across our products.

Janitorial changes:
- Rename CSS classes to match convention
- Change the `.login__auth-failure` class to a modifier

## Before
<img width="387" alt="screen shot 2018-09-18 at 3 18 28" src="https://user-images.githubusercontent.com/555336/45641939-db10dc00-baf1-11e8-8cfa-38f58b2383a8.png">

## After
<img width="378" alt="screen shot 2018-09-18 at 3 14 10" src="https://user-images.githubusercontent.com/555336/45642015-0267a900-baf2-11e8-9390-87ee2b637cc6.png">