### PR TITLE
Add mode-based config in webpack

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
   "plugins": ["eslint-plugin-react", "jest", "prettier"],
   "rules": {
     "eqeqeq": ["error", "always"],
+    "no-console": "warn",
     "no-lonely-if": "error",
     "no-shadow": "warn",
     "no-spaced-func": "error",

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ dev:
 dev-server:
 	@$(MAKE) build NODE_ENV=$(NODE_ENV)
 
-	@NODE_ENV=$(NODE_ENV) npx webpack-dev-server --config ./webpack.config.js --content-base dist --host $(HOST) --port $(PORT) --hot --inline
+	@NODE_ENV=$(NODE_ENV) npx webpack-dev-server --config ./webpack.config.js --content-base dist --host $(HOST) --port $(PORT) --hot
 
 .PHONY: test
 test: 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ dev:
 dev-server:
 	@$(MAKE) build NODE_ENV=$(NODE_ENV)
 
-	@NODE_ENV=$(NODE_ENV) npx webpack-dev-server --mode=development --config ./webpack.config.js --content-base dist --host $(HOST) --port $(PORT) --hot
+	@NODE_ENV=$(NODE_ENV) npx webpack-dev-server --config ./webpack.config.js --content-base dist --host $(HOST) --port $(PORT) --hot
 
 .PHONY: test
 test: 
@@ -80,12 +80,12 @@ endif
 
 # Build utils
 .PHONY: build-app
-build-app:
-	@NODE_ENV=$(NODE_ENV) npx webpack $(if $(IS_PRODUCTION),-p --mode=production) --config ./webpack.config.js
+build-app: 
+	@NODE_ENV=$(NODE_ENV) npx webpack $(if $(IS_PRODUCTION),-p) --config ./webpack.config.js
 
 .PHONY: build-dll
-build-dll:
-	@NODE_ENV=$(NODE_ENV) npx webpack $(if $(IS_PRODUCTION),-p --mode=production) --config ./webpack.config.dll.js
+build-dll: 
+	@NODE_ENV=$(NODE_ENV) npx webpack $(if $(IS_PRODUCTION),-p) --config ./webpack.config.dll.js
 
 .PHONY: build-if-not-exists 
 build-if-not-exists: config.json

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ dev:
 dev-server:
 	@$(MAKE) build NODE_ENV=$(NODE_ENV)
 
-	@NODE_ENV=$(NODE_ENV) npx webpack-dev-server --config ./webpack.config.js --content-base dist --host $(HOST) --port $(PORT) --hot
+	@NODE_ENV=$(NODE_ENV) npx webpack-dev-server --mode=development --config ./webpack.config.js --content-base dist --host $(HOST) --port $(PORT) --hot
 
 .PHONY: test
 test: 
@@ -80,12 +80,12 @@ endif
 
 # Build utils
 .PHONY: build-app
-build-app: 
-	@NODE_ENV=$(NODE_ENV) npx webpack $(if $(IS_PRODUCTION),-p) --config ./webpack.config.js
+build-app:
+	@NODE_ENV=$(NODE_ENV) npx webpack $(if $(IS_PRODUCTION),-p --mode=production) --config ./webpack.config.js
 
 .PHONY: build-dll
-build-dll: 
-	@NODE_ENV=$(NODE_ENV) npx webpack $(if $(IS_PRODUCTION),-p) --config ./webpack.config.dll.js
+build-dll:
+	@NODE_ENV=$(NODE_ENV) npx webpack $(if $(IS_PRODUCTION),-p --mode=production) --config ./webpack.config.dll.js
 
 .PHONY: build-if-not-exists 
 build-if-not-exists: config.json

--- a/webpack.config.dll.js
+++ b/webpack.config.dll.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack');
 
-module.exports = (env, argv) => {
-  const isDevMode = argv.mode === 'development';
+module.exports = () => {
+  const isDevMode = process.env.NODE_ENV === 'development';
 
   return {
     context: process.cwd(),

--- a/webpack.config.dll.js
+++ b/webpack.config.dll.js
@@ -1,42 +1,46 @@
 const webpack = require('webpack');
 
-module.exports = {
-  context: process.cwd(),
+module.exports = (env, argv) => {
+  const isDevMode = argv.mode === 'development';
 
-  devtool: 'source-map',
+  return {
+    context: process.cwd(),
+    mode: isDevMode ? 'development' : 'production',
+    devtool: isDevMode && 'cheap-module-eval-source-map',
 
-  entry: {
-    vendor: [
-      'cookie',
-      'create-hash',
-      'draft-js',
-      'highlight.js',
-      'lodash',
-      'moment',
-      'promise',
-      'react',
-      'react-addons-update',
-      'react-redux',
-      'redux',
-      'redux-localstorage',
-      'redux-thunk',
-      'react-virtualized',
-      'showdown',
-      'simperium',
-      'sockjs-client',
+    entry: {
+      vendor: [
+        'cookie',
+        'create-hash',
+        'draft-js',
+        'highlight.js',
+        'lodash',
+        'moment',
+        'promise',
+        'react',
+        'react-addons-update',
+        'react-redux',
+        'redux',
+        'redux-localstorage',
+        'redux-thunk',
+        'react-virtualized',
+        'showdown',
+        'simperium',
+        'sockjs-client',
+      ],
+    },
+
+    output: {
+      filename: '[name].dll.js',
+      path: __dirname + '/dist/',
+      library: '[name]',
+    },
+
+    plugins: [
+      new webpack.DllPlugin({
+        name: '[name]',
+        path: __dirname + '/dist/[name].json',
+      }),
     ],
-  },
-
-  output: {
-    filename: '[name].dll.js',
-    path: __dirname + '/dist/',
-    library: '[name]',
-  },
-
-  plugins: [
-    new webpack.DllPlugin({
-      name: '[name]',
-      path: __dirname + '/dist/[name].json',
-    }),
-  ],
+  };
 };

--- a/webpack.config.dll.js
+++ b/webpack.config.dll.js
@@ -6,7 +6,8 @@ module.exports = () => {
   return {
     context: process.cwd(),
     mode: isDevMode ? 'development' : 'production',
-    devtool: isDevMode && 'cheap-module-eval-source-map',
+    devtool:
+      process.env.SOURCEMAP || (isDevMode && 'cheap-module-eval-source-map'),
 
     entry: {
       vendor: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,97 +5,98 @@ const config = require('./get-config');
 const spawnSync = require('child_process').spawnSync;
 const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
-module.exports = {
-  context: __dirname + '/lib',
-  devtool: 'cheap-module-eval-source-map',
-  devServer: { inline: true },
-  entry: ['./boot'],
-  output: {
-    path: __dirname + '/dist',
-    filename: 'app.js',
-  },
-  module: {
-    rules: [
-      {
-        test: /lib\/.+\.jsx?$/,
-        exclude: /node_modules|lib\/simperium/,
-        enforce: 'pre',
-        use: [
-          {
-            loader: 'eslint-loader',
-            options: {
-              cache: true,
-              configFile: '.eslintrc.json',
-              quiet: true,
+module.exports = (env, argv) => {
+  const isDevMode = argv.mode === 'development';
+
+  return {
+    context: __dirname + '/lib',
+    devtool: isDevMode && 'cheap-module-eval-source-map',
+    devServer: { inline: true },
+    entry: ['./boot'],
+    output: {
+      path: __dirname + '/dist',
+      filename: 'app.js',
+    },
+    module: {
+      rules: [
+        {
+          test: /lib\/.+\.jsx?$/,
+          exclude: /node_modules|lib\/simperium/,
+          enforce: 'pre',
+          use: [
+            {
+              loader: 'eslint-loader',
+              options: {
+                cache: true,
+                configFile: '.eslintrc.json',
+                quiet: true,
+              },
             },
-          },
-        ],
-      },
-      {
-        test: /\.jsx?$/,
-        exclude: /node_modules/,
-        use: [
-          {
-            loader: 'babel-loader',
-            options: {
-              cacheDirectory: true,
+          ],
+        },
+        {
+          test: /\.jsx?$/,
+          exclude: /node_modules/,
+          use: [
+            {
+              loader: 'babel-loader',
+              options: {
+                cacheDirectory: true,
+              },
             },
-          },
-        ],
-      },
-      {
-        test: /\.scss$/,
-        use: [
-          'style-loader',
-          {
-            loader: 'css-loader',
-            options: {
-              sourceMap: true,
+          ],
+        },
+        {
+          test: /\.scss$/,
+          use: [
+            'style-loader',
+            {
+              loader: 'css-loader',
+              options: {
+                sourceMap: isDevMode,
+              },
             },
-          },
-          {
-            loader: 'postcss-loader',
-            options: {
-              plugins: [autoprefixer()],
-              sourceMap: true,
+            {
+              loader: 'postcss-loader',
+              options: {
+                plugins: [autoprefixer()],
+                sourceMap: isDevMode,
+              },
             },
-          },
-          {
-            loader: 'sass-loader',
-            options: {
-              includePaths: [__dirname + '/lib'],
-              sourceMap: true,
+            {
+              loader: 'sass-loader',
+              options: {
+                includePaths: [__dirname + '/lib'],
+                sourceMap: isDevMode,
+              },
             },
-          },
-        ],
-      },
+          ],
+        },
+      ],
+    },
+    resolve: {
+      extensions: ['.js', '.jsx', '.json', '.scss', '.css'],
+      modules: ['node_modules'],
+    },
+    plugins: [
+      new webpack.DllReferencePlugin({
+        context: process.cwd(),
+        manifest: require(process.cwd() + '/dist/vendor.json'),
+      }),
+      new HardSourceWebpackPlugin(),
+      new HtmlWebpackPlugin({
+        'build-platform': process.platform,
+        'build-reference': spawnSync('git', ['describe', '--always', '--dirty'])
+          .stdout.toString('utf8')
+          .replace('\n', ''),
+        favicon: process.cwd() + '/public_html/favicon.ico',
+        'node-version': process.version,
+        template: 'index.ejs',
+        title: 'Simplenote',
+      }),
+      new webpack.DefinePlugin({
+        config: JSON.stringify(config()),
+      }),
     ],
-  },
-  resolve: {
-    extensions: ['.js', '.jsx', '.json', '.scss', '.css'],
-    modules: ['node_modules'],
-  },
-  plugins: [
-    new webpack.DllReferencePlugin({
-      context: process.cwd(),
-      manifest: require(process.cwd() + '/dist/vendor.json'),
-    }),
-    new HardSourceWebpackPlugin(),
-    new HtmlWebpackPlugin({
-      'build-platform': process.platform,
-      'build-reference': spawnSync('git', ['describe', '--always', '--dirty'])
-        .stdout.toString('utf8')
-        .replace('\n', ''),
-      favicon: process.cwd() + '/public_html/favicon.ico',
-      'node-version': process.version,
-      template: 'index.ejs',
-      title: 'Simplenote',
-    }),
-    new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify(
-        process.env.NODE_ENV || 'development'
-      ),
-      config: JSON.stringify(config()),
-    }),
-  ],
+  };
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,11 +5,12 @@ const config = require('./get-config');
 const spawnSync = require('child_process').spawnSync;
 const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
-module.exports = (env, argv) => {
-  const isDevMode = argv.mode === 'development';
+module.exports = () => {
+  const isDevMode = process.env.NODE_ENV === 'development';
 
   return {
     context: __dirname + '/lib',
+    mode: isDevMode ? 'development' : 'production',
     devtool: isDevMode && 'cheap-module-eval-source-map',
     devServer: { inline: true },
     entry: ['./boot'],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 module.exports = {
   context: __dirname + '/lib',
   devtool: 'cheap-module-eval-source-map',
+  devServer: { inline: true },
   entry: ['./boot'],
   output: {
     path: __dirname + '/dist',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,8 @@ module.exports = () => {
   return {
     context: __dirname + '/lib',
     mode: isDevMode ? 'development' : 'production',
-    devtool: isDevMode && 'cheap-module-eval-source-map',
+    devtool:
+      process.env.SOURCEMAP || (isDevMode && 'cheap-module-eval-source-map'),
     devServer: { inline: true },
     entry: ['./boot'],
     output: {


### PR DESCRIPTION
This adds conditional settings based on whether the `mode` is production or development, so we aren't doing sourcemaps, minification, etc. when unnecessary.

Developing in `webpack-dev-server` should feel a lot snappier. This will also fix the FOUC in production builds (closes #839).