### PR TITLE
Fix tag drawer closing unexpectedly

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -429,7 +429,6 @@ export const actionMap = new ActionMap({
 
     selectNote(state, { noteId }) {
       return update(state, {
-        showNavigation: { $set: false },
         editingTags: { $set: false },
         selectedNoteId: { $set: noteId },
         revisions: { $set: null },


### PR DESCRIPTION
Closes #823 

This fixes the issue of the tag drawer closing unexpectedly if the note saves while it is open.

## Details
Updating a note's content was triggering `selectNote`, which was hiding the tag drawer. I can't imagine a case where selecting a note should have to hide the tag drawer, especially since a user cannot actively select a note when the tag drawer is open. Let me know if you recall a case when this is necessary.