### PR TITLE
Close sidebar when Settings dialog is opened

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -112,10 +112,16 @@ export const actionMap = new ActionMap({
         }
       }
 
-      return update(state, {
+      const updateCommands = {
         dialogs: { $push: [{ ...dialog, params, key: state.nextDialogKey }] },
         nextDialogKey: { $set: state.nextDialogKey + 1 },
-      });
+      };
+
+      if (type === 'Settings') {
+        updateCommands.showNavigation = { $set: false };
+      }
+
+      return update(state, updateCommands);
     },
 
     closeDialog(state, { key }) {


### PR DESCRIPTION
Closes #146 

This is a small enhancement to close the tag drawer when the Settings dialog is opened. It fixes two usability issues in the web version:

- Logging out and logging back in would result in an initial screen where the tag drawer was open.
- The tag drawer had to be closed manually after accessing the Settings dialog.