### PR TITLE
Refactor icon buttons in SearchBar and NoteToolbar

### DIFF
--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -4,7 +4,10 @@
 
   &.is-focus-mode.is-note-open {
     .app-layout__source-column {
-      display: none;
+      overflow: hidden;
+      opacity: $fade-alpha;
+      width: 0;
+      transition: width .2s ease-in-out, opacity .2s ease-in-out;
     }
   }
 
@@ -34,6 +37,10 @@
   }
 
   &.is-note-open {
+    .app-layout__source-column {
+      transition: opacity .2s ease-in-out;
+    }
+
     @media only screen and (max-width: $single-column) {
       .app-layout__source-column {
         opacity: 0;
@@ -50,14 +57,12 @@
 
 .app-layout__source-column {
   width: 328px;
-  min-width: 328px;
   display: flex;
   flex-direction: column;
   transition: transform 200ms ease-in-out;
 
   @media only screen and (max-width: $medium) {
     width: 300px;
-    min-width: 300px;
   }
 
   @media only screen and (max-width: $single-column) {

--- a/lib/icon-button/index.js
+++ b/lib/icon-button/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const IconButton = ({ icon, ...props }) => (
+  <button className="icon-button" type="button" {...props}>
+    {icon}
+  </button>
+);
+
+IconButton.propTypes = {
+  icon: PropTypes.element.isRequired,
+};
+
+export default IconButton;

--- a/lib/icon-button/style.scss
+++ b/lib/icon-button/style.scss
@@ -7,7 +7,11 @@
     transition: $anim-fast;
   }
 
-  &:active {
+  &:disabled {
+    opacity: .4;
+  }
+
+  &:active:not(:disabled) {
     svg {
       fill: darken($blue, 20%);
     }

--- a/lib/icon-button/style.scss
+++ b/lib/icon-button/style.scss
@@ -1,0 +1,15 @@
+.icon-button {
+  width: 32px;
+  height: 32px;
+  color: $blue;
+
+  svg {
+    transition: $anim-fast;
+  }
+
+  &:active {
+    svg {
+      fill: darken($blue, 20%);
+    }
+  }
+}

--- a/lib/icons/sidebar.jsx
+++ b/lib/icons/sidebar.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function SidebarIcon() {
+  return (
+    <svg
+      className="icon-sidebar"
+      xmlns="http://www.w3.org/2000/svg"
+      width="22"
+      height="22"
+      viewBox="0 0 22 22"
+    >
+      <path d="M19,3H3C1.895,3,1,3.895,1,5v12c0,1.105,0.895,2,2,2h16c1.105,0,2-0.895,2-2V5C21,3.895,20.105,3,19,3z M3,5h3v12H3V5z
+        M19,17H8V5h11V17z" />
+    </svg>
+  );
+}

--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import analytics from './analytics';
 import appState from './flux/app-state';
+import { toggleFocusMode } from './state/settings/actions';
 import filterNotes from './utils/filter-notes';
 
 export class NoteToolbarContainer extends Component {
@@ -19,6 +20,7 @@ export class NoteToolbarContainer extends Component {
     setIsViewingRevisions: PropTypes.func.isRequired,
     shareNote: PropTypes.func.isRequired,
     stateForFilterNotes: PropTypes.object.isRequired,
+    toggleFocusMode: PropTypes.func.isRequired,
     toggleNoteInfo: PropTypes.func.isRequired,
     toolbar: PropTypes.element.isRequired,
     trashNote: PropTypes.func.isRequired,
@@ -79,6 +81,7 @@ export class NoteToolbarContainer extends Component {
       onShareNote: this.props.shareNote,
       onTrashNote: this.onTrashNote,
       setIsViewingRevisions: this.props.setIsViewingRevisions,
+      toggleFocusMode: this.props.toggleFocusMode,
     };
     const { editorMode, markdownEnabled } = this.props;
 
@@ -124,6 +127,7 @@ const mapDispatchToProps = dispatch => ({
         dialog: { type: 'Share', modal: true },
       })
     ),
+  toggleFocusMode: () => dispatch(toggleFocusMode()),
   toggleNoteInfo: () => dispatch(toggleNoteInfo()),
   trashNote: args => dispatch(trashNote(args)),
 });

--- a/lib/note-toolbar/index.jsx
+++ b/lib/note-toolbar/index.jsx
@@ -10,6 +10,7 @@ import PreviewStopIcon from '../icons/preview-stop';
 import RevisionsIcon from '../icons/revisions';
 import TrashIcon from '../icons/trash';
 import ShareIcon from '../icons/share';
+import SidebarIcon from '../icons/sidebar';
 
 export class NoteToolbar extends Component {
   static displayName = 'NoteToolbar';
@@ -24,6 +25,7 @@ export class NoteToolbar extends Component {
     onCloseNote: PropTypes.func,
     onShowNoteInfo: PropTypes.func,
     setIsViewingRevisions: PropTypes.func,
+    toggleFocusMode: PropTypes.func.isRequired,
     onSetEditorMode: PropTypes.func,
     editorMode: PropTypes.string,
     markdownEnabled: PropTypes.bool,
@@ -72,49 +74,60 @@ export class NoteToolbar extends Component {
       <div className="note-toolbar-placeholder theme-color-border" />
     ) : (
       <div className="note-toolbar">
-        <div className="note-toolbar__button note-toolbar-back">
-          <IconButton
-            icon={<BackIcon />}
-            onClick={this.props.onCloseNote}
-            title="Back"
-          />
-        </div>
-        {markdownEnabled && (
+        <div className="note-toolbar__column-left">
           <div className="note-toolbar__button">
             <IconButton
-              icon={isPreviewing ? <PreviewStopIcon /> : <PreviewIcon />}
-              onClick={this.setEditorMode}
-              title="Preview"
+              icon={<SidebarIcon />}
+              onClick={this.props.toggleFocusMode}
+              title="Toggle Sidebar"
             />
           </div>
-        )}
-        <div className="note-toolbar__button">
-          <IconButton
-            icon={<RevisionsIcon />}
-            onClick={this.showRevisions}
-            title="History"
-          />
         </div>
-        <div className="note-toolbar__button">
-          <IconButton
-            icon={<ShareIcon />}
-            onClick={this.props.onShareNote.bind(null)}
-            title="Share"
-          />
-        </div>
-        <div className="note-toolbar__button">
-          <IconButton
-            icon={<TrashIcon />}
-            onClick={this.props.onTrashNote.bind(null, note)}
-            title="Trash"
-          />
-        </div>
-        <div className="note-toolbar__button">
-          <IconButton
-            icon={<InfoIcon />}
-            onClick={this.props.onShowNoteInfo}
-            title="Info"
-          />
+        <div className="note-toolbar__column-right">
+          <div className="note-toolbar__button note-toolbar-back">
+            <IconButton
+              icon={<BackIcon />}
+              onClick={this.props.onCloseNote}
+              title="Back"
+            />
+          </div>
+          {markdownEnabled && (
+            <div className="note-toolbar__button">
+              <IconButton
+                icon={isPreviewing ? <PreviewStopIcon /> : <PreviewIcon />}
+                onClick={this.setEditorMode}
+                title="Preview"
+              />
+            </div>
+          )}
+          <div className="note-toolbar__button">
+            <IconButton
+              icon={<RevisionsIcon />}
+              onClick={this.showRevisions}
+              title="History"
+            />
+          </div>
+          <div className="note-toolbar__button">
+            <IconButton
+              icon={<ShareIcon />}
+              onClick={this.props.onShareNote.bind(null)}
+              title="Share"
+            />
+          </div>
+          <div className="note-toolbar__button">
+            <IconButton
+              icon={<TrashIcon />}
+              onClick={this.props.onTrashNote.bind(null, note)}
+              title="Trash"
+            />
+          </div>
+          <div className="note-toolbar__button">
+            <IconButton
+              icon={<InfoIcon />}
+              onClick={this.props.onShowNoteInfo}
+              title="Info"
+            />
+          </div>
         </div>
       </div>
     );

--- a/lib/note-toolbar/index.jsx
+++ b/lib/note-toolbar/index.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 
+import IconButton from '../icon-button';
 import BackIcon from '../icons/back';
 import InfoIcon from '../icons/info';
 import PreviewIcon from '../icons/preview';
@@ -71,67 +72,49 @@ export class NoteToolbar extends Component {
       <div className="note-toolbar-placeholder theme-color-border" />
     ) : (
       <div className="note-toolbar">
-        <div className="note-toolbar-icon note-toolbar-back">
-          <button
-            type="button"
-            title="Back"
-            className="button button-borderless"
+        <div className="note-toolbar__button note-toolbar-back">
+          <IconButton
+            icon={<BackIcon />}
             onClick={this.props.onCloseNote}
-          >
-            <BackIcon />
-          </button>
+            title="Back"
+          />
         </div>
         {markdownEnabled && (
-          <div className="note-toolbar-icon">
-            <button
-              type="button"
-              title="Preview"
-              className="button button-borderless"
+          <div className="note-toolbar__button">
+            <IconButton
+              icon={isPreviewing ? <PreviewStopIcon /> : <PreviewIcon />}
               onClick={this.setEditorMode}
-            >
-              {isPreviewing ? <PreviewStopIcon /> : <PreviewIcon />}
-            </button>
+              title="Preview"
+            />
           </div>
         )}
-        <div className="note-toolbar-icon">
-          <button
-            type="button"
-            title="History"
-            className="button button-borderless"
+        <div className="note-toolbar__button">
+          <IconButton
+            icon={<RevisionsIcon />}
             onClick={this.showRevisions}
-          >
-            <RevisionsIcon />
-          </button>
+            title="History"
+          />
         </div>
-        <div className="note-toolbar-icon">
-          <button
-            type="button"
-            title="Share"
-            className="button button-borderless"
+        <div className="note-toolbar__button">
+          <IconButton
+            icon={<ShareIcon />}
             onClick={this.props.onShareNote.bind(null)}
-          >
-            <ShareIcon />
-          </button>
+            title="Share"
+          />
         </div>
-        <div className="note-toolbar-icon">
-          <button
-            type="button"
-            title="Trash"
-            className="button button-borderless"
+        <div className="note-toolbar__button">
+          <IconButton
+            icon={<TrashIcon />}
             onClick={this.props.onTrashNote.bind(null, note)}
-          >
-            <TrashIcon />
-          </button>
+            title="Trash"
+          />
         </div>
-        <div className="note-toolbar-icon">
-          <button
-            type="button"
-            title="Info"
-            className="button button-borderless"
+        <div className="note-toolbar__button">
+          <IconButton
+            icon={<InfoIcon />}
             onClick={this.props.onShowNoteInfo}
-          >
-            <InfoIcon />
-          </button>
+            title="Info"
+          />
         </div>
       </div>
     );
@@ -142,7 +125,7 @@ export class NoteToolbar extends Component {
 
     return (
       <div className="note-toolbar-trashed">
-        <div className="note-toolbar-text">
+        <div className="note-toolbar__button">
           <button
             type="button"
             className="button button-compact button-danger"
@@ -151,7 +134,7 @@ export class NoteToolbar extends Component {
             Delete Forever
           </button>
         </div>
-        <div className="note-toolbar-text">
+        <div className="note-toolbar__button">
           <button
             type="button"
             className="button button-primary button-compact"

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -9,31 +9,43 @@
 
 .note-toolbar {
   display: flex;
-  align-items: center;
-  flex: none;
+  justify-content: space-between;
+  width: 100%;
   padding: 0 15px;
+}
 
-  @media only screen and (max-width: $single-column) {
+.note-toolbar__column-left,
+.note-toolbar__column-right {
+  display: flex;
+  align-items: center;
+}
+
+@media only screen and (max-width: $single-column) {
+  .note-toolbar__column-left {
+    display: none;
+  }
+
+  .note-toolbar__column-right {
     width: 100%;
     justify-content: space-between;
   }
+}
 
-  .note-toolbar__button {
-    flex: none;
-    margin-right: 14px;
-    text-align: center;
+.note-toolbar__button {
+  flex: none;
+  margin-right: 14px;
+  text-align: center;
 
-    &:last-child {
-      margin-right: 0;
-    }
+  &:last-child {
+    margin-right: 0;
   }
+}
 
-  .note-toolbar-back {
-    display: none;
+.note-toolbar-back {
+  display: none;
 
-    @media only screen and (max-width: $single-column) {
-      display: flex;
-    }
+  @media only screen and (max-width: $single-column) {
+    display: flex;
   }
 }
 

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -18,25 +18,13 @@
     justify-content: space-between;
   }
 
-  .note-toolbar-icon,
-  .note-toolbar-text {
+  .note-toolbar__button {
     flex: none;
     margin-right: 14px;
     text-align: center;
 
     &:last-child {
       margin-right: 0;
-    }
-  }
-
-  .note-toolbar-icon {
-    width: 32px;
-    height: 32px;
-
-    button {
-      width: 100%;
-      height: 100%;
-      padding: 0;
     }
   }
 
@@ -55,7 +43,7 @@
   padding: 10px 16px;
   justify-content: flex-end;
 
-  .note-toolbar-text {
+  .note-toolbar__button {
     margin: 0 0 0 16px;
   }
 

--- a/lib/search-bar/index.jsx
+++ b/lib/search-bar/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
  */
 import appState from '../flux/app-state';
 import { tracks } from '../analytics';
+import IconButton from '../icon-button';
 import NewNoteIcon from '../icons/new-note';
 import SearchField from '../search-field';
 import TagsIcon from '../icons/tags';
@@ -24,22 +25,14 @@ export const SearchBar = ({
   showTrash,
 }) => (
   <div className="search-bar theme-color-border">
-    <button
-      className="button button-borderless"
-      onClick={onToggleNavigation}
-      title="Tags"
-    >
-      <TagsIcon />
-    </button>
+    <IconButton icon={<TagsIcon />} onClick={onToggleNavigation} title="Tags" />
     <SearchField />
-    <button
-      className="button button-borderless"
+    <IconButton
       disabled={showTrash}
+      icon={<NewNoteIcon />}
       onClick={() => onNewNote(withoutTags(query))}
       title="New Note"
-    >
-      <NewNoteIcon />
-    </button>
+    />
   </div>
 );
 

--- a/lib/state/index.js
+++ b/lib/state/index.js
@@ -7,6 +7,7 @@
 import { compose, createStore, combineReducers, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import persistState from 'redux-localstorage';
+import { omit } from 'lodash';
 
 import appState from '../flux/app-state';
 
@@ -24,7 +25,13 @@ export const reducers = combineReducers({
 export const store = createStore(
   reducers,
   compose(
-    persistState('settings', { key: 'simpleNote' }),
+    persistState('settings', {
+      key: 'simpleNote',
+      slicer: path => state => ({
+        // Omit property from persisting
+        [path]: omit(state[path], 'focusModeEnabled'),
+      }),
+    }),
     applyMiddleware(thunk)
   )
 );

--- a/scss/_components.scss
+++ b/scss/_components.scss
@@ -9,6 +9,7 @@
 @import 'dialogs/settings/style';
 @import 'dialogs/share/style';
 @import 'editable-list/style';
+@import 'icon-button/style';
 @import 'icons/style';
 @import 'navigation-bar/style';
 @import 'navigation-bar/item/style';


### PR DESCRIPTION
This refactors the icon buttons used in SearchBar and NoteToolbar so they can be styled and managed in one place.

You can test this using the branch in #881, and just refer to this PR for code changes.