### PR TITLE
Fix Appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ before_build:
   - openssl aes-256-cbc -d -in .\resources\secrets\config.json.enc -out .\config.json -k "%CSC_ENC_KEY%"
 
 build_script:
+  - make build
   - make package-win32
 
 artifacts:


### PR DESCRIPTION
In #841, the make target to create platform installers (e.g. `make package-win32`) was modified that `make build` isn't any longer part of this routine. 

This change however was not reflected in the appveyor config and resulted in a "white screen of death" as the binary did not had the web app bundled. Thanks @mirka for pointing out this issue. https://github.com/Automattic/simplenote-electron/pull/869#issuecomment-424364441 

This PR is required to finish testing for #869 

### How to test
Check the appveyor build here:
https://ci.appveyor.com/project/adlk/simplenote-electron/build/1.0.192/artifacts