### PR TITLE
Fix note tag add/remove re-render bug

### DIFF
--- a/lib/app-layout/index.js
+++ b/lib/app-layout/index.js
@@ -1,6 +1,7 @@
 import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { get } from 'lodash';
 import NoteToolbarContainer from '../note-toolbar-container';
 import NoteToolbar from '../note-toolbar';
 import RevisionSelector from '../revision-selector';
@@ -41,7 +42,14 @@ export const AppLayout = ({
           noteBucket={noteBucket}
           toolbar={<NoteToolbar note={note} />}
         />
-        {cloneElement(noteEditor, { note, noteBucket, onUpdateContent })}
+        {cloneElement(noteEditor, {
+          note,
+          noteBucket,
+          onUpdateContent,
+          // Tags are flattened here as a separate prop to trigger a re-render
+          // in the tree when the tags are changed
+          tags: get(note, 'data.tags', []),
+        })}
       </div>
     </div>
   );

--- a/lib/tag-field/index.jsx
+++ b/lib/tag-field/index.jsx
@@ -20,8 +20,11 @@ export class TagField extends Component {
   static displayName = 'TagField';
 
   static propTypes = {
+    allTags: PropTypes.array.isRequired,
+    note: PropTypes.object.isRequired,
     storeFocusTagField: PropTypes.func,
     storeHasFocus: PropTypes.func,
+    tags: PropTypes.array.isRequired,
     unusedTags: PropTypes.arrayOf(PropTypes.string),
     usedTags: PropTypes.arrayOf(PropTypes.string),
     onUpdateNoteTags: PropTypes.func.isRequired,


### PR DESCRIPTION
#834 introduced a bug in which adding/removing a note tag would update the data, but the screen wouldn't re-render.

This fixes the issue.

![tag-update](https://user-images.githubusercontent.com/555336/46103250-5289ee00-c20b-11e8-9baa-e199b6f4fbed.gif)