### PR TITLE
Update secrets for new appveyor org

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [{
+    "name": "Debug Main Process",
+    "type": "node",
+    "request": "launch",
+    "cwd": "${workspaceRoot}",
+    "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+    "windows": {
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+    },
+    "args": ["."]
+  }]
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,11 @@
 environment:
   CSC_ENC_KEY: 
-    secure: qjH2ZaCgr2sQSdAsBKT7n+o7jSBUHo5j8vyUFarUIKt55MvPVIgBave3kY7SO2Kmk/KS8+T4PA7Y5OmJBaV8NyqijCoMByDcP9pehu5rkdA=
+    secure: ef2yQX3A9dZPQzS6r7oY7pUtzK/ICiUUDZZsh/K7eT59a4BVdxqCfIZU812MmqQHK/iC4cYLdTW+tWHrq9bJquzQgHGjgB0cTBwS9KUjyOg=
   CSC_KEY_PASSWORD:
-    secure: LIl7Fkr/mxpbjj/eD4EDgA==
+    secure: Sz53shy7P4kPzBKa9shHTw==
   CSC_LINK: .\resources\certificates\win.p12
   GH_TOKEN:
-    secure: 9sXk2TIAMx817wesBs0aUJE4l37eTOzUKh6EKNvsfd+1X4FeKUeIRtbqy00SgGNA
+    secure: m2UKPC/0BUlPZ63dLNIbuoFRNW448BzVrlW6TnjtoLtXCqY+lz9+aKTP4miCwQEy
 
 image: Visual Studio 2017
 

--- a/dev-app-update.yml
+++ b/dev-app-update.yml
@@ -1,0 +1,3 @@
+owner: adlk
+repo: simplenote-test
+provider: github

--- a/dev-app-update.yml
+++ b/dev-app-update.yml
@@ -1,3 +1,0 @@
-owner: adlk
-repo: simplenote-test
-provider: github


### PR DESCRIPTION
We are currently moving to the official A8C appveyor organization. Therefore, the secrets need to be re-encrypted for the new account. 