### PR TITLE
Show Preview button according to note settings

### DIFF
--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -1,6 +1,7 @@
 import { Component, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { get, includes } from 'lodash';
 
 import analytics from './analytics';
 import appState from './flux/app-state';
@@ -12,10 +13,10 @@ export class NoteToolbarContainer extends Component {
     closeNote: PropTypes.func.isRequired,
     deleteNoteForever: PropTypes.func.isRequired,
     editorMode: PropTypes.oneOf(['edit', 'markdown']),
-    markdownEnabled: PropTypes.bool.isRequired,
     noteBucket: PropTypes.object.isRequired,
     noteRevisions: PropTypes.func.isRequired,
     restoreNote: PropTypes.func.isRequired,
+    revisionOrNote: PropTypes.object,
     setEditorMode: PropTypes.func.isRequired,
     setIsViewingRevisions: PropTypes.func.isRequired,
     shareNote: PropTypes.func.isRequired,
@@ -83,15 +84,18 @@ export class NoteToolbarContainer extends Component {
       setIsViewingRevisions: this.props.setIsViewingRevisions,
       toggleFocusMode: this.props.toggleFocusMode,
     };
-    const { editorMode, markdownEnabled } = this.props;
+    const { editorMode, revisionOrNote } = this.props;
+
+    const systemTags = get(revisionOrNote, 'data.systemTags', []);
+    const markdownEnabled = includes(systemTags, 'markdown');
 
     return cloneElement(toolbar, { ...handlers, editorMode, markdownEnabled });
   }
 }
 
-const mapStateToProps = ({ appState: state, settings }) => ({
+const mapStateToProps = ({ appState: state }) => ({
   editorMode: state.editorMode,
-  markdownEnabled: settings.markdownEnabled,
+  revisionOrNote: state.revision || state.note,
   stateForFilterNotes: {
     filter: state.filter,
     notes: state.notes,

--- a/lib/note-toolbar/index.jsx
+++ b/lib/note-toolbar/index.jsx
@@ -42,6 +42,7 @@ export class NoteToolbar extends Component {
     onShareNote: noop,
     onTrashNote: noop,
     setIsViewingRevisions: noop,
+    toggleFocusMode: noop,
   };
 
   showRevisions = () => {


### PR DESCRIPTION
Closes #899 

This fixes a regression introduced in 8a7f191, where the Preview button appears according to the app-wide markdown setting and not the note-specific setting.

#### To test
1. Create note and enable markdown in the info pane
2. Create another note and disable markdown in the info pane
3. Confirm that the first note shows the Preview button, and the second note hides the Preview button.