### PR TITLE
Make sure that ⌃⌘F doesn't trigger Search Notes (Mac)

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -183,7 +183,8 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
     handleShortcut = event => {
       const { ctrlKey, key, metaKey } = event;
 
-      const cmdOrCtrl = ctrlKey || metaKey;
+      // Is either cmd or ctrl pressed? (But not both)
+      const cmdOrCtrl = (ctrlKey || metaKey) && ctrlKey !== metaKey;
 
       // open tag list
       if (cmdOrCtrl && 'T' === key && !this.state.showNavigation) {


### PR DESCRIPTION
As discovered by @arunsathiya, <kbd>⌃⌘F</kbd> was triggering Search Notes instead of Toggle Full Screen.

The Search Notes shortcut handler was overtaking the Toggle Full Screen shortcut due to some missing logic. This fix adds stricter modifier logic to the keydown handler so that only <kbd>⌘F</kbd> and  <kbd>⌃F</kbd> will trigger Search Notes.

(In the near future I'm hoping to add a library like [React HotKeys](https://github.com/greena13/react-hotkeys) to cut down on the boilerplate and whatnot)

#### Test

- <kbd>⌘F</kbd> and  <kbd>⌃F</kbd> triggers Search Notes
- <kbd>⌃⌘F</kbd> triggers Toggle Full Screen (Mac only. <kbd>F11</kbd> on other platforms)