### PR TITLE
Simperium update 0.3.2

### DIFF
--- a/lib/dialogs/settings/index.jsx
+++ b/lib/dialogs/settings/index.jsx
@@ -50,7 +50,10 @@ export class SettingsDialog extends Component {
       // Also check persisted store for any notes with version 0
       const noteHasSynced = note =>
         new Promise((resolve, reject) =>
-          getVersion(note.id, (e, v) => (e || v === 0 ? reject() : resolve()))
+          noteBucket.getVersion(
+            note.id,
+            (e, v) => (e || v === 0 ? reject() : resolve())
+          )
         );
 
       Promise.all(notes.map(noteHasSynced)).then(

--- a/lib/dialogs/settings/index.jsx
+++ b/lib/dialogs/settings/index.jsx
@@ -39,7 +39,6 @@ export class SettingsDialog extends Component {
     // Safety first! Check for any unsynced notes before signing out.
     const { noteBucket } = this.props;
     const { notes } = this.props.appState;
-    const { getVersion } = noteBucket;
 
     noteBucket.hasLocalChanges((error, hasChanges) => {
       if (hasChanges) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13461,11 +13461,6 @@
         }
       }
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
     "nomnom": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
@@ -18724,11 +18719,11 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simperium": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/simperium/-/simperium-0.3.1.tgz",
-      "integrity": "sha1-kmWUmJrPniro2awMmT0hDe/ao7M=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/simperium/-/simperium-0.3.2.tgz",
+      "integrity": "sha512-4cr+dEApxsgBmvv356gt8lBLohMQrCJ/NStKLW7P0d5rFdpuuc9CmtN4xr5aQi2Yqtseu8P4h6eP8KBinrwxaw==",
       "requires": {
-        "node-uuid": "^1.4.7",
+        "uuid": "^3.2.1",
         "websocket": "^1.0.22"
       }
     },
@@ -19879,9 +19874,9 @@
       "dev": true
     },
     "typedarray-to-buffer": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.2.tgz",
-      "integrity": "sha1-EBezLZhP9VbroQD1AViauhrOLgQ=",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "requires": {
         "is-typedarray": "^1.0.0"
       }
@@ -20287,8 +20282,7 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8-compile-cache": {
       "version": "1.1.2",
@@ -21324,14 +21318,21 @@
       }
     },
     "websocket": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.25.tgz",
-      "integrity": "sha512-M58njvi6ZxVb5k7kpnHh2BvNKuBWiwIYvsToErBzWhvBZYwlEiLcyLrG41T1jRcrY9ettqPYEqduLI7ul54CVQ==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.28.tgz",
+      "integrity": "sha512-00y/20/80P7H4bCYkzuuvvfDvh+dgtXi5kzDf3UcZwN6boTYaKvsrtZ5lIYm1Gsg48siMErd9M4zjSYfYFHTrA==",
       "requires": {
         "debug": "^2.2.0",
-        "nan": "^2.3.3",
-        "typedarray-to-buffer": "^3.1.2",
+        "nan": "^2.11.0",
+        "typedarray-to-buffer": "^3.1.5",
         "yaeti": "^0.0.6"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+        }
       }
     },
     "websocket-driver": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "redux-thunk": "2.2.0",
     "sanitize-filename": "1.6.1",
     "showdown": "1.8.6",
-    "simperium": "0.3.1",
+    "simperium": "0.3.2",
     "valid-url": "1.0.9"
   },
   "optionalDependencies": {


### PR DESCRIPTION
For #827 
Update to package and lock files to pull in updated Simperium and remove node-uuid dependency.