### PR TITLE
Initialize analytics preference correctly

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -262,6 +262,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
 
       setAuthorized();
       analytics.initialize(accountName);
+      this.onLoadPreferences();
     };
 
     onNotePrinted = () =>


### PR DESCRIPTION
The Share analytics toggle switch was jammed for new and preexisting accounts that did not have the preferences object yet.

This was because of a failure to initialize the object after login.

#### To test

1. Log out if you are logged in.
1. Create a new test account. (If you have sudo access to the Simplenote Dev database in Simperium, you can also just Delete Data for your existing test account before logging in. Will wipe out your notes too though.)
1. Open the Settings dialog, and make sure the Share analytics toggle is toggleable.