### PR TITLE
Send app version with Tracks events

### DIFF
--- a/lib/analytics/index.js
+++ b/lib/analytics/index.js
@@ -30,7 +30,10 @@ const analytics = {
         return;
       }
 
-      eventProperties = eventProperties || {};
+      eventProperties = {
+        ...eventProperties,
+        device_info_app_version: config.version, // eslint-disable-line no-undef
+      };
 
       if (!prefix) {
         prefix = analytics.getPlatformPrefix();

--- a/lib/analytics/index.js
+++ b/lib/analytics/index.js
@@ -26,7 +26,7 @@ const analytics = {
 
   tracks: {
     recordEvent: function(eventName, eventProperties) {
-      if (!window.analyticsEnabled) {
+      if (!window.analyticsEnabled || process.env.NODE_ENV === 'development') {
         return;
       }
 

--- a/lib/analytics/test.js
+++ b/lib/analytics/test.js
@@ -4,20 +4,57 @@ describe('Analytics', () => {
   describe('Tracks', () => {
     beforeEach(() => {
       global._tkq.push = jest.fn();
+      global.process.env.NODE_ENV = 'test';
+      global.analyticsEnabled = true;
+      global.config.version = '1.0.0';
+      analytics.getPlatformPrefix = jest.fn().mockReturnValue('spwindows_');
     });
 
     it('should track usage when analytics sharing is enabled', () => {
-      global.analyticsEnabled = true;
-
-      analytics.tracks.recordEvent('splinux_test_event');
+      analytics.tracks.recordEvent('test_event');
       expect(global._tkq.push).toHaveBeenCalled();
     });
 
     it('should not track usage when analytics sharing is disabled', () => {
       global.analyticsEnabled = false;
 
-      analytics.tracks.recordEvent('splinux_test_event');
+      analytics.tracks.recordEvent('test_event');
       expect(global._tkq.push).toHaveBeenCalledTimes(0);
+    });
+
+    it('should not track usage when NODE_ENV is development', () => {
+      global.process.env.NODE_ENV = 'development';
+      analytics.tracks.recordEvent('test_event');
+      expect(global._tkq.push).toHaveBeenCalledTimes(0);
+    });
+
+    it('should prefix the event name with the result of getPlatformPrefix', () => {
+      analytics.tracks.recordEvent('test_event');
+      const sentEventName = global._tkq.push.mock.calls[0][0][1];
+
+      expect(sentEventName).toBe('spwindows_test_event');
+    });
+
+    it('should send a basic set of properties with each event', () => {
+      analytics.tracks.recordEvent('test_event');
+      const sentEventProperties = global._tkq.push.mock.calls[0][0][2];
+
+      expect(sentEventProperties).toStrictEqual({
+        device_info_app_version: '1.0.0',
+      });
+    });
+
+    it('should passthru properties sent with the event', () => {
+      analytics.tracks.recordEvent('test_event', {
+        device_info_app_version: '2.0.0', // this should NOT overwrite
+        my_property: 'test_property', // this should passthru
+      });
+      const sentEventProperties1 = global._tkq.push.mock.calls[0][0][2];
+
+      expect(sentEventProperties1).toStrictEqual({
+        device_info_app_version: '1.0.0',
+        my_property: 'test_property',
+      });
     });
   });
 });


### PR DESCRIPTION
Our Tracks events weren't sending the app version with them, which is necessary for analyzing the data accurately.

I sent one test event to check that it is being received in Tracks:

<img width="507" alt="screen shot 2018-10-12 at 3 24 41" src="https://user-images.githubusercontent.com/555336/46825981-d2998180-cdcf-11e8-958d-13df2cb9c5c6.png">

Also, I've added some logic to disable event sending when in development.