### PR TITLE
Importer: Add core Simplenote format support

### DIFF
--- a/lib/utils/import/README.MD
+++ b/lib/utils/import/README.MD
@@ -2,13 +2,12 @@
 
 This is the core importer for Simplenote. It expects a JSON object of notes in the same format as the `import` module. It is aggressive about only allowing certain properties, and converts dates into timestamps where appropriate. Importing specific export files (Such as Evernote .enex) should use a separate conversion script and then pass the resulting JSON object to `importNotes()`.
 
-Example JSON:
+Example JSON with allowed properties:
 
 ```
 {
   "activeNotes": [
     {
-      "id": "279d0a2a9cbf4107830175fd6b562f62",
       "content": "Random thought: How much wood could a woodchuck chuck if a woodchuck could chuck wood?",
       "creationDate": "2013-10-16T20:17:41.760Z",
       "lastModified": "2018-10-10T22:07:54.128Z",
@@ -20,8 +19,7 @@ Example JSON:
   ],
   "trashedNotes": [
     {
-      "id": "80461f52-2c63-4f3f-825e-69a0236da327",
-      "content": "Hello?",
+      "content": "Hello, world!",
       "creationDate": "2016-02-29T23:01:03.115Z",
       "lastModified": "2016-02-29T23:01:08.000Z"
     }

--- a/lib/utils/import/README.MD
+++ b/lib/utils/import/README.MD
@@ -1,0 +1,30 @@
+# Simplenote Import
+
+This is the core importer for Simplenote. It expects a JSON object of notes in the same format as the `import` module. It is aggressive about only allowing certain properties, and converts dates into timestamps where appropriate. Importing specific export files (Such as Evernote .enex) should use a separate conversion script and then pass the resulting JSON object to `importNotes()`.
+
+Example JSON:
+
+```
+{
+  "activeNotes": [
+    {
+      "id": "279d0a2a9cbf4107830175fd6b562f62",
+      "content": "Random thought: How much wood could a woodchuck chuck if a woodchuck could chuck wood?",
+      "creationDate": "2013-10-16T20:17:41.760Z",
+      "lastModified": "2018-10-10T22:07:54.128Z",
+      "pinned": true,
+      "tags": [
+        "Reminders"
+      ]
+    },
+  ],
+  "trashedNotes": [
+    {
+      "id": "80461f52-2c63-4f3f-825e-69a0236da327",
+      "content": "Hello?",
+      "creationDate": "2016-02-29T23:01:03.115Z",
+      "lastModified": "2016-02-29T23:01:08.000Z"
+    }
+  ]
+}
+```

--- a/lib/utils/import/README.MD
+++ b/lib/utils/import/README.MD
@@ -1,8 +1,8 @@
 # Simplenote Import
 
-This is the core importer for Simplenote. It expects a JSON object of notes in the same format as the `import` module. It is aggressive about only allowing certain properties, and converts dates into timestamps where appropriate. Importing specific export files (Such as Evernote .enex) should use a separate conversion script and then pass the resulting JSON object to `importNotes()`.
+This is the core importer for Simplenote. It expects an object of notes in the same format as the `import` module. It is aggressive about only allowing certain properties, and converts dates into timestamps where appropriate. Importing specific export files (Such as Evernote .enex) should use a separate conversion script and then pass the resulting object to `importNotes()`.
 
-Example JSON with allowed properties:
+Example object with allowed properties:
 
 ```
 {

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -19,7 +19,7 @@ class CoreImporter extends EventEmitter {
     this.tagBucket = tagBucket;
   }
 
-  importNote = (note, { isTrashed = false, isMarkdown = false }) => {
+  importNote = (note, { isTrashed = false, isMarkdown = false } = {}) => {
     const importedNote = pick(note, propertyWhitelist);
     // We don't want to allow these properties to be imported, but they need to be set
     importedNote.publishURL = '';

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -19,13 +19,13 @@ class CoreImporter extends EventEmitter {
     this.tagBucket = tagBucket;
   }
 
-  importNote = (note, isTrashedNotes = false) => {
+  importNote = (note, { isTrashed = false, isMarkdown = false }) => {
     const importedNote = pick(note, propertyWhitelist);
     // We don't want to allow these properties to be imported, but they need to be set
     importedNote.publishURL = '';
     importedNote.shareURL = '';
 
-    importedNote.deleted = isTrashedNotes;
+    importedNote.deleted = isTrashed;
 
     importedNote.tags = get(importedNote, 'tags', []);
     importedNote.systemTags = get(importedNote, 'systemTags', []);
@@ -34,7 +34,7 @@ class CoreImporter extends EventEmitter {
       delete importedNote.pinned;
     }
 
-    if (importedNote.markdown) {
+    if (importedNote.markdown || isMarkdown) {
       importedNote.systemTags.push('markdown');
       delete importedNote.markdown;
     }
@@ -81,7 +81,9 @@ class CoreImporter extends EventEmitter {
     }
 
     get(notes, 'activeNotes', []).map(note => this.importNote(note));
-    get(notes, 'trashedNotes', []).map(note => this.importNote(note, true));
+    get(notes, 'trashedNotes', []).map(note =>
+      this.importNote(note, { isTrashed: true })
+    );
   };
 }
 

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -19,7 +19,7 @@ const importNotes = (notes = {}, noteBucket, tagBucket) => {
     throw new Error('Invalid import format: No active or trashed notes found.');
   }
 
-  const importNote = note => {
+  const importNote = (note, isTrashedNotes = false) => {
     const importedNote = pick(note, propertyWhitelist);
 
     // We don't want to allow these properties to be imported, but they need to be set
@@ -27,7 +27,7 @@ const importNotes = (notes = {}, noteBucket, tagBucket) => {
     importedNote.shareURL = '';
     importedNote.systemTags = get(importedNote, 'systemTags', []);
 
-    importedNote.deleted = get(importedNote, 'deleted', false);
+    importedNote.deleted = isTrashedNotes;
 
     // Accout for Simplenote's exported `lastModified` date. Convert to timestamp
     if (importedNote.lastModified) {
@@ -53,8 +53,8 @@ const importNotes = (notes = {}, noteBucket, tagBucket) => {
     noteBucket.add(importedNote);
   };
 
-  get(notes, 'activeNotes', []).map(importNote);
-  get(notes, 'trashedNotes', []).map(importNote);
+  get(notes, 'activeNotes', []).map(note => importNote(note));
+  get(notes, 'trashedNotes', []).map(note => importNote(note, true));
 };
 
 export default importNotes;

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -3,11 +3,12 @@ import { isEmpty, get, pick } from 'lodash';
 const propertyWhitelist = [
   'content',
   'creationDate',
+  'deleted',
   'lastModified',
+  'markdown',
   'modificationDate',
   'pinned',
   'tags',
-  'deleted',
 ];
 
 const importNotes = (notes = {}, noteBucket, tagBucket) => {
@@ -26,17 +27,29 @@ const importNotes = (notes = {}, noteBucket, tagBucket) => {
     importedNote.publishURL = '';
     importedNote.shareURL = '';
 
-    importedNote.systemTags = get(importedNote, 'systemTags', []);
     importedNote.deleted = isTrashedNotes;
+
+    importedNote.systemTags = get(importedNote, 'systemTags', []);
+    if (importedNote.pinned) {
+      importedNote.systemTags.push('pinned');
+      delete importedNote.pinned;
+    }
+
+    if (importedNote.markdown) {
+      importedNote.systemTags.push('markdown');
+      delete importedNote.markdown;
+    }
 
     // Accout for Simplenote's exported `lastModified` date. Convert to timestamp
     if (importedNote.lastModified && isNaN(importedNote.lastModified)) {
-      importedNote.modificationDate = Date.parse(importedNote.lastModified);
+      importedNote.modificationDate =
+        new Date(importedNote.lastModified).getTime() / 1000;
       delete importedNote.lastModified;
     }
 
     if (importedNote.creationDate && isNaN(importedNote.creationDate)) {
-      importedNote.creationDate = Date.parse(importedNote.creationDate);
+      importedNote.creationDate =
+        new Date(importedNote.creationDate).getTime() / 1000;
     }
 
     // Add the tags to the tag bucket

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -10,7 +10,7 @@ const propertyWhitelist = [
   'deleted',
 ];
 
-const importNotes = (notes = {}, noteBucket, tagBucket) => {
+const importNotes = (notes = {}, noteBucket, tagBucket, importedFrom) => {
   if (isEmpty(notes)) {
     throw new Error('No notes to import.');
   }
@@ -19,13 +19,22 @@ const importNotes = (notes = {}, noteBucket, tagBucket) => {
     throw new Error('Invalid import format: No active or trashed notes found.');
   }
 
+  const importDate = new Date();
+
   const importNote = (note, isTrashedNotes = false) => {
     const importedNote = pick(note, propertyWhitelist);
 
     // We don't want to allow these properties to be imported, but they need to be set
     importedNote.publishURL = '';
     importedNote.shareURL = '';
+
     importedNote.systemTags = get(importedNote, 'systemTags', []);
+
+    if (importedFrom) {
+      importedNote.systemTags.push({
+        importedFrom: [importedFrom, importDate.toISOString()],
+      });
+    }
 
     importedNote.deleted = isTrashedNotes;
 

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -27,6 +27,7 @@ class CoreImporter extends EventEmitter {
 
     importedNote.deleted = isTrashedNotes;
 
+    importedNote.tags = get(importedNote, 'tags', []);
     importedNote.systemTags = get(importedNote, 'systemTags', []);
     if (importedNote.pinned) {
       importedNote.systemTags.push('pinned');

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -10,7 +10,7 @@ const propertyWhitelist = [
   'deleted',
 ];
 
-const importNotes = (notes = {}, noteBucket, tagBucket, importedFrom) => {
+const importNotes = (notes = {}, noteBucket, tagBucket) => {
   if (isEmpty(notes)) {
     throw new Error('No notes to import.');
   }
@@ -18,8 +18,6 @@ const importNotes = (notes = {}, noteBucket, tagBucket, importedFrom) => {
   if (!notes.activeNotes && !notes.trashedNotes) {
     throw new Error('Invalid import format: No active or trashed notes found.');
   }
-
-  const importDate = new Date();
 
   const importNote = (note, isTrashedNotes = false) => {
     const importedNote = pick(note, propertyWhitelist);
@@ -29,22 +27,15 @@ const importNotes = (notes = {}, noteBucket, tagBucket, importedFrom) => {
     importedNote.shareURL = '';
 
     importedNote.systemTags = get(importedNote, 'systemTags', []);
-
-    if (importedFrom) {
-      importedNote.systemTags.push({
-        importedFrom: [importedFrom, importDate.toISOString()],
-      });
-    }
-
     importedNote.deleted = isTrashedNotes;
 
     // Accout for Simplenote's exported `lastModified` date. Convert to timestamp
-    if (importedNote.lastModified) {
+    if (importedNote.lastModified && isNaN(importedNote.lastModified)) {
       importedNote.modificationDate = Date.parse(importedNote.lastModified);
       delete importedNote.lastModified;
     }
 
-    if (importedNote.creationDate) {
+    if (importedNote.creationDate && isNaN(importedNote.creationDate)) {
       importedNote.creationDate = Date.parse(importedNote.creationDate);
     }
 

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -13,7 +13,7 @@ const propertyWhitelist = [
 ];
 
 class CoreImporter extends EventEmitter {
-  constructor(noteBucket, tagBucket) {
+  constructor({ noteBucket, tagBucket }) {
     super();
     this.noteBucket = noteBucket;
     this.tagBucket = tagBucket;

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events';
 import { isEmpty, get, pick } from 'lodash';
 
 const propertyWhitelist = [
@@ -11,18 +12,15 @@ const propertyWhitelist = [
   'tags',
 ];
 
-const importNotes = (notes = {}, noteBucket, tagBucket) => {
-  if (isEmpty(notes)) {
-    throw new Error('No notes to import.');
+class CoreImporter extends EventEmitter {
+  constructor(noteBucket, tagBucket) {
+    super();
+    this.noteBucket = noteBucket;
+    this.tagBucket = tagBucket;
   }
 
-  if (!notes.activeNotes && !notes.trashedNotes) {
-    throw new Error('Invalid import format: No active or trashed notes found.');
-  }
-
-  const importNote = (note, isTrashedNotes = false) => {
+  importNote = (note, isTrashedNotes = false) => {
     const importedNote = pick(note, propertyWhitelist);
-
     // We don't want to allow these properties to be imported, but they need to be set
     importedNote.publishURL = '';
     importedNote.shareURL = '';
@@ -59,15 +57,31 @@ const importNotes = (notes = {}, noteBucket, tagBucket) => {
           return;
         }
         // We use update() to set the id of the tag (as well as the name prop)
-        tagBucket.update(tagName, { name: tagName });
+        this.tagBucket.update(tagName, { name: tagName });
       });
     }
 
-    noteBucket.add(importedNote);
+    this.noteBucket.add(importedNote);
   };
 
-  get(notes, 'activeNotes', []).map(note => importNote(note));
-  get(notes, 'trashedNotes', []).map(note => importNote(note, true));
-};
+  importNotes = (notes = {}) => {
+    if (isEmpty(notes)) {
+      this.emit('status', 'error', 'No notes to import.');
+      return;
+    }
 
-export default importNotes;
+    if (!notes.activeNotes && !notes.trashedNotes) {
+      this.emit(
+        'status',
+        'error',
+        'Invalid import format: No active or trashed notes found.'
+      );
+      return;
+    }
+
+    get(notes, 'activeNotes', []).map(note => this.importNote(note));
+    get(notes, 'trashedNotes', []).map(note => this.importNote(note, true));
+  };
+}
+
+export default CoreImporter;

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -1,0 +1,48 @@
+import { isEmpty, get, pick } from 'lodash';
+
+const propertyWhitelist = [
+  'content',
+  'creationDate',
+  'lastModified',
+  'modificationDate',
+  'pinned',
+  'tags',
+  'deleted',
+];
+
+const importNotes = (notes = {}, noteBucket) => {
+  if (isEmpty(notes)) {
+    throw new Error('No notes to import.');
+  }
+
+  if (!get(notes, 'activeNotes') || !get(notes, 'trashedNotes')) {
+    throw new Error('Invalid import format: No active or trashed notes found.');
+  }
+
+  const importNote = note => {
+    const importedNote = pick(note, propertyWhitelist);
+
+    // We don't want to allow these properties to be imported, but they need to be set
+    importedNote.publishURL = '';
+    importedNote.shareURL = '';
+    importedNote.systemTags = [];
+
+    importedNote.deleted = get(importedNote, 'deleted', false);
+
+    // Accout for Simplenote's exported `lastModified` date. Convert to timestamp
+    if (importedNote.lastModified) {
+      importedNote.modificationDate = Date.parse(importedNote.lastModified);
+      delete importedNote.lastModified;
+    }
+
+    if (importedNote.creationDate) {
+      importedNote.creationDate = Date.parse(importedNote.creationDate);
+    }
+
+    noteBucket.add(importedNote);
+  };
+
+  get(notes, 'activeNotes', []).map(note => importNote(note));
+};
+
+export default importNotes;

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -43,6 +43,7 @@ const importNotes = (notes = {}, noteBucket) => {
   };
 
   get(notes, 'activeNotes', []).map(note => importNote(note));
+  get(notes, 'trashedNotes', []).map(note => importNote(note));
 };
 
 export default importNotes;

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -15,7 +15,7 @@ const importNotes = (notes = {}, noteBucket) => {
     throw new Error('No notes to import.');
   }
 
-  if (!get(notes, 'activeNotes') || !get(notes, 'trashedNotes')) {
+  if (!notes.activeNotes && !notes.trashedNotes) {
     throw new Error('Invalid import format: No active or trashed notes found.');
   }
 
@@ -25,7 +25,7 @@ const importNotes = (notes = {}, noteBucket) => {
     // We don't want to allow these properties to be imported, but they need to be set
     importedNote.publishURL = '';
     importedNote.shareURL = '';
-    importedNote.systemTags = [];
+    importedNote.systemTags = get(importedNote, 'systemTags', []);
 
     importedNote.deleted = get(importedNote, 'deleted', false);
 

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -10,7 +10,7 @@ const propertyWhitelist = [
   'deleted',
 ];
 
-const importNotes = (notes = {}, noteBucket) => {
+const importNotes = (notes = {}, noteBucket, tagBucket) => {
   if (isEmpty(notes)) {
     throw new Error('No notes to import.');
   }
@@ -39,11 +39,22 @@ const importNotes = (notes = {}, noteBucket) => {
       importedNote.creationDate = Date.parse(importedNote.creationDate);
     }
 
+    // Add the tags to the tag bucket
+    if (importedNote.tags) {
+      importedNote.tags.map(tagName => {
+        if (isEmpty(tagName)) {
+          return;
+        }
+        // We use update() to set the id of the tag (as well as the name prop)
+        tagBucket.update(tagName, { name: tagName });
+      });
+    }
+
     noteBucket.add(importedNote);
   };
 
-  get(notes, 'activeNotes', []).map(note => importNote(note));
-  get(notes, 'trashedNotes', []).map(note => importNote(note));
+  get(notes, 'activeNotes', []).map(importNote);
+  get(notes, 'trashedNotes', []).map(importNote);
 };
 
 export default importNotes;

--- a/lib/utils/import/test.js
+++ b/lib/utils/import/test.js
@@ -1,14 +1,29 @@
-import importNotes from './';
+import CoreImporter from './';
 
 describe('Importer', () => {
-  it('should throw when no notes are passed', () => {
-    expect(() => importNotes(null)).toThrow(/No notes to import./);
+  let importer;
+
+  beforeEach(() => {
+    importer = new CoreImporter({ noteBucket: {}, tagBucket: {} });
+    importer.emit = jest.fn();
   });
 
-  it('should throw when invalid json is passed', () => {
+  it('should emit error when no notes are passed', () => {
+    importer.importNotes();
+    expect(importer.emit).toBeCalledWith(
+      'status',
+      'error',
+      'No notes to import.'
+    );
+  });
+
+  it('should emit error when invalid object is passed', () => {
     const bogusNotes = { actveNotes: [] };
-    expect(() => importNotes(bogusNotes)).toThrow(
-      /Invalid import format: No active or trashed notes found./
+    importer.importNotes(bogusNotes);
+    expect(importer.emit).toBeCalledWith(
+      'status',
+      'error',
+      'Invalid import format: No active or trashed notes found.'
     );
   });
 });

--- a/lib/utils/import/test.js
+++ b/lib/utils/import/test.js
@@ -1,0 +1,14 @@
+import importNotes from './';
+
+describe('Importer', () => {
+  it('should throw when no notes are passed', () => {
+    expect(importNotes.bind(importNotes, null)).toThrow(/No notes to import./);
+  });
+
+  it('should throw when invalid json is passed', () => {
+    const bogusNotes = { actveNotes: [] };
+    expect(importNotes.bind(importNotes, bogusNotes)).toThrow(
+      /Invalid import format: No active or trashed notes found./
+    );
+  });
+});

--- a/lib/utils/import/test.js
+++ b/lib/utils/import/test.js
@@ -2,12 +2,12 @@ import importNotes from './';
 
 describe('Importer', () => {
   it('should throw when no notes are passed', () => {
-    expect(importNotes.bind(importNotes, null)).toThrow(/No notes to import./);
+    expect(() => importNotes(null)).toThrow(/No notes to import./);
   });
 
   it('should throw when invalid json is passed', () => {
     const bogusNotes = { actveNotes: [] };
-    expect(importNotes.bind(importNotes, bogusNotes)).toThrow(
+    expect(() => importNotes(bogusNotes)).toThrow(
       /Invalid import format: No active or trashed notes found./
     );
   });


### PR DESCRIPTION
Here's the first step towards getting an importer going. This module expects to receive a JSON object that contains note data in the same format as when you export your notes from the app (the `notes.json` file).

I'm slightly concerned about performance here with large imports, perhaps we could use a [web worker](https://www.w3schools.com/html/html5_webworkers.asp)? The exporter is crazy fast with thousands of notes, however, so maybe we don't need to worry about it.

**To Test**
* Verify `npm run test` passes (I added some very basic tests)
* Export some notes from the app, and grab the `notes.json` file and put it in the source code in the same folder as `app.jsx`.
* Add `import exportedJSON from './notes.json'` and `import importNotes from './utils/import';` to the top of app.jsx.
* In `render()` of `app.jsx` (or anywhere you'd like) run `importNotes(exportedJSON, this.props.noteBucket);`
* The notes should import to the app and sync!

Refs: #916 

cc @dmsnell!