### PR TITLE
Add PUBLISH option to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ PORT ?= 4000
 # Access dev server or locally built web app files
 DEV_SERVER ?= false
 
+# Port for dev server
+PUBLISH ?= onTag
+
 
 # Main targets
 .PHONY: start
@@ -118,19 +121,19 @@ package: build-if-changed
 package-win32:
 ifeq ($(IS_WINDOWS),true)
 	@echo Building .appx as well
-	@npx electron-builder --win --config=./electron-builder-appx.json
+	@npx electron-builder --win -p $(PUBLISH) --config=./electron-builder-appx.json
 else
 	@echo Skipping .appx as we are not on a Windows host
-	@npx electron-builder --win
+	@npx electron-builder --win -p $(PUBLISH)
 endif
 
 .PHONY: package-osx 
 package-osx: build-if-changed
-	@npx electron-builder --mac
+	@npx electron-builder --mac -p $(PUBLISH)
 
 .PHONY: package-linux
 package-linux: build-if-changed
-	@npx electron-builder --linux
+	@npx electron-builder --linux -p $(PUBLISH)
 
 
 # NPM


### PR DESCRIPTION
This PR adds the option to modify the publish flag for electron-builder which previously defaulted to `onTagOrDraft`. The new default is `onTag`.

**How to use the new option:**

```
PUBLISH=always|onTag|onTagOrDraft|never make package
```