### PR TITLE
Add web app detection to analytics

### DIFF
--- a/lib/analytics/index.js
+++ b/lib/analytics/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-var user, prefix;
+var user;
 require('./tracks');
 
 const analytics = {
@@ -12,12 +12,12 @@ const analytics = {
 
   getPlatformPrefix: function() {
     if (navigator.appVersion.indexOf('Win') !== -1) {
-      return 'spwindows_';
+      return 'spwindows';
     } else if (navigator.appVersion.indexOf('Linux') !== -1) {
-      return 'splinux_';
+      return 'splinux';
     }
 
-    return 'unknown_';
+    return null;
   },
 
   setUser: function(newUser) {
@@ -30,26 +30,17 @@ const analytics = {
         return;
       }
 
-      eventProperties = {
+      const prefix = analytics.getPlatformPrefix();
+
+      if (!prefix) return;
+
+      const fullEventName = `${prefix}_${eventName}`;
+      const fullEventProperties = {
         ...eventProperties,
         device_info_app_version: config.version, // eslint-disable-line no-undef
       };
 
-      if (!prefix) {
-        prefix = analytics.getPlatformPrefix();
-      }
-
-      eventName = prefix + eventName;
-
-      //console.log( 'Record event "%s" called with props %s', eventName, JSON.stringify( eventProperties ) );
-      if (
-        !eventName.includes('splinux_') &&
-        !eventName.includes('spwindows_')
-      ) {
-        return;
-      }
-
-      window._tkq.push(['recordEvent', eventName, eventProperties]);
+      window._tkq.push(['recordEvent', fullEventName, fullEventProperties]);
     },
   },
 

--- a/lib/analytics/index.js
+++ b/lib/analytics/index.js
@@ -10,14 +10,20 @@ const analytics = {
     analytics.identifyUser();
   },
 
+  // Return a valid platform prefix when on a platform that should be tracked
   getPlatformPrefix: function() {
-    if (navigator.appVersion.indexOf('Win') !== -1) {
-      return 'spwindows';
-    } else if (navigator.appVersion.indexOf('Linux') !== -1) {
-      return 'splinux';
+    if (!navigator.appVersion.includes('Electron')) {
+      return 'spweb';
     }
 
-    return null;
+    switch (true) {
+      case navigator.appVersion.includes('Win'):
+        return 'spwindows';
+      case navigator.appVersion.includes('Linux'):
+        return 'splinux';
+      default:
+        return null;
+    }
   },
 
   setUser: function(newUser) {

--- a/lib/analytics/index.js
+++ b/lib/analytics/index.js
@@ -16,14 +16,14 @@ const analytics = {
       return 'spweb';
     }
 
-    switch (true) {
-      case navigator.appVersion.includes('Win'):
-        return 'spwindows';
-      case navigator.appVersion.includes('Linux'):
-        return 'splinux';
-      default:
-        return null;
+    if (navigator.appVersion.includes('Win')) {
+      return 'spwindows';
     }
+    if (navigator.appVersion.includes('Linux')) {
+      return 'splinux';
+    }
+
+    return null;
   },
 
   setUser: function(newUser) {
@@ -38,7 +38,9 @@ const analytics = {
 
       const prefix = analytics.getPlatformPrefix();
 
-      if (!prefix) return;
+      if (!prefix) {
+        return;
+      }
 
       const fullEventName = `${prefix}_${eventName}`;
       const fullEventProperties = {

--- a/lib/analytics/test.js
+++ b/lib/analytics/test.js
@@ -1,7 +1,29 @@
 import analytics from './';
 
 describe('Analytics', () => {
-  describe('Tracks', () => {
+  describe('getPlatformPrefix', () => {
+    Object.defineProperty(global.navigator, 'appVersion', {
+      configurable: true,
+    });
+
+    it('should return "spweb" if not Electron', () => {
+      Object.defineProperty(global.navigator, 'appVersion', {
+        get: () =>
+          '5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36',
+      });
+      expect(analytics.getPlatformPrefix()).toBe('spweb');
+    });
+
+    it('should return null if Electron on Mac', () => {
+      Object.defineProperty(global.navigator, 'appVersion', {
+        get: () =>
+          '5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Simplenote/1.2.1 Chrome/61.0.3163.100 Electron/2.0.8 Safari/537.36',
+      });
+      expect(analytics.getPlatformPrefix()).toBe(null);
+    });
+  });
+
+  describe('tracks', () => {
     beforeEach(() => {
       global._tkq.push = jest.fn();
       global.process.env.NODE_ENV = 'test';
@@ -26,6 +48,16 @@ describe('Analytics', () => {
       global.process.env.NODE_ENV = 'development';
       analytics.tracks.recordEvent('test_event');
       expect(global._tkq.push).toHaveBeenCalledTimes(0);
+    });
+
+    it('should only send when platform prefix is supplied', () => {
+      analytics.getPlatformPrefix.mockReturnValue('my_prefix');
+      analytics.tracks.recordEvent('test_event');
+
+      analytics.getPlatformPrefix.mockReturnValue(null);
+      analytics.tracks.recordEvent('test_event');
+
+      expect(global._tkq.push).toHaveBeenCalledTimes(1);
     });
 
     it('should prefix the event name with the result of getPlatformPrefix', () => {

--- a/lib/analytics/test.js
+++ b/lib/analytics/test.js
@@ -7,7 +7,7 @@ describe('Analytics', () => {
       global.process.env.NODE_ENV = 'test';
       global.analyticsEnabled = true;
       global.config.version = '1.0.0';
-      analytics.getPlatformPrefix = jest.fn().mockReturnValue('spwindows_');
+      analytics.getPlatformPrefix = jest.fn().mockReturnValue('spwindows');
     });
 
     it('should track usage when analytics sharing is enabled', () => {


### PR DESCRIPTION
Closes #908

This sets the prefix `spweb` to Tracks events when the app is [not running in Electron](https://github.com/electron/electron/issues/2288#issuecomment-337858978).