### PR TITLE
Add maintainer email address for Linux

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -94,7 +94,7 @@
       "Categories": "Utility"
     },
     "vendor": "Automattic, Inc.",
-    "maintainer": "Automattic, Inc."
+    "maintainer": "Automattic, Inc. <support@simplenote.com>"
   },
   "deb": {
     "depends": ["gconf2"]


### PR DESCRIPTION
Closes #781 

This fixes the Lintian error [`maintainer-address-missing`](https://lintian.debian.org/tags/maintainer-address-missing.html) which was causing a bad quality error in Ubuntu.