### PR TITLE
Add Tracks events for Share dialog view and collaborator add/remove

### DIFF
--- a/lib/dialogs/share/index.jsx
+++ b/lib/dialogs/share/index.jsx
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import createHash from 'create-hash/browser';
+import { includes, isEmpty } from 'lodash';
+
+import analytics from '../../analytics';
 import isEmailTag from '../../utils/is-email-tag';
 import TabbedDialog from '../../tabbed-dialog';
 import ToggleControl from '../../controls/toggle';
-import { includes, isEmpty } from 'lodash';
 
 const shareTabs = ['collaborate', 'publish'];
 
@@ -56,6 +58,7 @@ export class ShareDialog extends Component {
         note,
         tags: [...tags, collaborator],
       });
+      analytics.tracks.recordEvent('editor_note_collaborator_added');
     }
   };
 
@@ -71,6 +74,7 @@ export class ShareDialog extends Component {
       note,
       tags,
     });
+    analytics.tracks.recordEvent('editor_note_collaborator_removed');
   };
 
   collaborators = () => {

--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -74,6 +74,11 @@ export class NoteToolbarContainer extends Component {
     analytics.tracks.recordEvent('editor_versions_accessed');
   };
 
+  onShareNote = () => {
+    this.props.shareNote();
+    analytics.tracks.recordEvent('editor_share_dialog_viewed');
+  };
+
   onSetEditorMode = mode => this.props.setEditorMode({ mode });
 
   render() {
@@ -85,7 +90,7 @@ export class NoteToolbarContainer extends Component {
       onSetEditorMode: this.onSetEditorMode,
       onShowNoteInfo: this.props.toggleNoteInfo,
       onShowRevisions: this.onShowRevisions,
-      onShareNote: this.props.shareNote,
+      onShareNote: this.onShareNote,
       onTrashNote: this.onTrashNote,
       setIsViewingRevisions: this.props.setIsViewingRevisions,
       toggleFocusMode: this.props.toggleFocusMode,


### PR DESCRIPTION
This adds three new Tracks events:

- editor_share_dialog_viewed
- editor_note_collaborator_added
- editor_note_collaborator_removed

### To test

1. Replace the [`recordEvent` function](https://github.com/Automattic/simplenote-electron/blob/eb8e540c00dcb842f8cba61416b5b2b277fd7f05/lib/analytics/index.js#L28) in `lib/analytics/index.js` with a console logger:
    ```
    recordEvent: eventName => console.log(eventName),
    ```
1. Verify that it fires when
    - opening the Share dialog
    - adding/removing collaborators