### PR TITLE
Fix incorrect `list_trash_viewed` event

### DIFF
--- a/lib/navigation-bar/index.jsx
+++ b/lib/navigation-bar/index.jsx
@@ -1,6 +1,9 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import onClickOutside from 'react-onclickoutside';
+
+import analytics from '../analytics';
 import NavigationBarItem from './item';
 import TagList from '../tag-list';
 import NotesIcon from '../icons/notes';
@@ -20,9 +23,12 @@ const {
 export class NavigationBar extends Component {
   static displayName = 'NavigationBar';
 
+  static propTypes = {
+    selectTrash: PropTypes.func.isRequired,
+  };
+
   static defaultProps = {
     onShowAllNotes: function() {},
-    onSelectTrash: function() {},
   };
 
   // Used by onClickOutside wrapper
@@ -39,6 +45,11 @@ export class NavigationBar extends Component {
   };
 
   onHelpClicked = () => viewExternalUrl('http://simplenote.com/help');
+
+  onSelectTrash = () => {
+    this.props.selectTrash();
+    analytics.tracks.recordEvent('list_trash_viewed');
+  };
 
   // Determine if the selected class should be applied for the 'all notes' or 'trash' rows
   isSelected = ({ isTrashRow }) => {
@@ -64,7 +75,7 @@ export class NavigationBar extends Component {
             icon={<TrashIcon />}
             isSelected={this.isSelected({ isTrashRow: true })}
             label="Trash"
-            onClick={this.props.onSelectTrash}
+            onClick={this.onSelectTrash}
           />
         </div>
         <div className="navigation-tags theme-color-border">
@@ -109,8 +120,8 @@ const mapDispatchToProps = dispatch => ({
   onAbout: () => dispatch(showDialog({ dialog: DialogTypes.ABOUT })),
   onOutsideClick: () => dispatch(toggleNavigation()),
   onShowAllNotes: () => dispatch(showAllNotesAndSelectFirst()),
-  onSelectTrash: () => dispatch(selectTrash()),
   onSettings: () => dispatch(showDialog({ dialog: DialogTypes.SETTINGS })),
+  selectTrash: () => dispatch(selectTrash()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(

--- a/lib/tag-list/index.jsx
+++ b/lib/tag-list/index.jsx
@@ -128,7 +128,7 @@ const mapDispatchToProps = (dispatch, { noteBucket, tagBucket }) => ({
         tagBucket,
       })
     );
-    recordEvent('list_trash_viewed');
+    recordEvent('list_tag_deleted');
   },
 });
 


### PR DESCRIPTION
Deleting tags from the Navigation Bar was firing an event named `list_trash_viewed`, instead of something like `list_tag_deleted`. This PR fixes this bug.

(Any `list_trash_viewed` events prior to this fix are invalid, and should be interpreted as `list_tag_deleted`.)

### To test

1. Replace the [`recordEvent` function](https://github.com/Automattic/simplenote-electron/blob/eb8e540c00dcb842f8cba61416b5b2b277fd7f05/lib/analytics/index.js#L28) in `lib/analytics/index.js` with a console logger:
    ```
    recordEvent: eventName => console.log(eventName),
    ```
1. Verify that the correct event name is logged when
    - opening the trash
    - deleting a tag from the sidebar