### PR TITLE
Add Markdown Field to the export json

### DIFF
--- a/lib/utils/export/index.js
+++ b/lib/utils/export/index.js
@@ -28,6 +28,7 @@ const mapNote = note => {
       lastModified: new Date(note.data.modificationDate * 1000).toISOString(),
     },
     get(note, 'pinned', false) && { pinned: true },
+    get(note, 'data.systemTags', []).includes('markdown') && { markdown: true },
     tags.length && { tags },
     get(note, 'data.systemTags', []).includes('published') &&
       get(note, 'data.publishURL', '').length && {


### PR DESCRIPTION
For #922 it'd be nice if we could restore markdown formatted notes if a user imports a Simplenote export. Or perhaps another app export could also flag that the note is markdown formatted!

**To Test**
* Export your notes, ensure that some have markdown enabled and some don't. Notes that are markdown enabled will have a `markdown` property present, and notes that don't will have no `markdown` property:

```
{
  "activeNotes": [
    {
      "id": "d7703380-e5e9-4902-bc46-ae47f526c988",
      "content": "Not markdown...",
      "creationDate": "2018-10-18T23:51:58.258Z",
      "lastModified": "2018-10-18T23:52:08.000Z"
    },
    {
      "id": "02a8b0fc-bb35-48ec-8566-d06e550a8a07",
      "content": "Sweet.\r\n\r\nMarked up, yo.",
      "creationDate": "2018-10-18T23:48:33.568Z",
      "lastModified": "2018-10-18T23:48:41.000Z",
      "markdown": true
    }
  ],
  "trashedNotes": []
}
```