### PR TITLE
Code splitting (Part 1): Drop locale support in moment.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,6 +99,7 @@ module.exports = () => {
       new webpack.DefinePlugin({
         config: JSON.stringify(config()),
       }),
+      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     ],
   };
 };


### PR DESCRIPTION
A majority chunk of moment.js can be removed by [dropping locale support](https://github.com/moment/moment/issues/2416#issuecomment-344840418), which we are not using at the moment.

### To test

Check that the two places we're using moment.js are not broken:
- Revisions selector
    <img width="229" alt="screen shot 2018-10-20 at 4 06 37" src="https://user-images.githubusercontent.com/555336/47239789-3dc30380-d421-11e8-8f9f-4c8dc0368de7.png">
- Info pane
    <img width="255" alt="screen shot 2018-10-20 at 4 06 46" src="https://user-images.githubusercontent.com/555336/47239799-43b8e480-d421-11e8-9d35-c40760d8b56a.png">