### PR TITLE
Code splitting (Part 2): Dynamically load highlight.js and JSZip

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,6 +10,7 @@
   ],
   "plugins": [
     "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-proposal-object-rest-spread"
+    "@babel/plugin-proposal-object-rest-spread",
+    "@babel/plugin-syntax-dynamic-import"
   ]
 }

--- a/lib/note-detail/index.jsx
+++ b/lib/note-detail/index.jsx
@@ -1,22 +1,16 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import highlight from 'highlight.js';
 import { get, debounce, invoke, noop } from 'lodash';
 import classNames from 'classnames';
+
 import analytics from '../analytics';
 import { viewExternalUrl } from '../utils/url-utils';
 import NoteContentEditor from '../note-content-editor';
 import SimplenoteCompactLogo from '../icons/simplenote-compact';
-
-import { renderNoteToHtml } from '../utils/render-note-to-html';
+import renderToNode from './render-to-node';
 
 const saveDelay = 2000;
-
-const renderToNode = (node, content) => {
-  node.innerHTML = renderNoteToHtml(content);
-  node.querySelectorAll('pre code').forEach(highlight.highlightBlock);
-};
 
 export class NoteDetail extends Component {
   static displayName = 'NoteDetail';

--- a/lib/note-detail/render-to-node.js
+++ b/lib/note-detail/render-to-node.js
@@ -1,0 +1,18 @@
+import { renderNoteToHtml } from '../utils/render-note-to-html';
+
+export const renderToNode = (node, content) => {
+  node.innerHTML = renderNoteToHtml(content);
+
+  const codeElements = node.querySelectorAll('pre code');
+
+  // Only load syntax highlighter if code blocks exist
+  if (codeElements.length) {
+    import(/* webpackChunkName: 'highlight' */ 'highlight.js')
+      .then(({ default: highlight }) => {
+        codeElements.forEach(highlight.highlightBlock);
+      })
+      .catch(console.log);
+  }
+};
+
+export default renderToNode;

--- a/lib/utils/export/to-zip.js
+++ b/lib/utils/export/to-zip.js
@@ -1,4 +1,3 @@
-import JSZip from 'jszip';
 import sanitize from 'sanitize-filename';
 import { identity, update } from 'lodash';
 
@@ -99,34 +98,40 @@ const toUniqueNames = ([notes, nameCounts], note) => {
 };
 
 export const noteExportToZip = notes => {
-  const zip = new JSZip();
+  return import(/* webpackChunkName: 'jszip' */ 'jszip')
+    .then(({ default: JSZip }) => {
+      const zip = new JSZip();
 
-  zip.file(
-    'source/notes.json',
-    JSON.stringify(notes, null, 2).replace(LF_ONLY_NEWLINES, '\r\n')
-  );
+      zip.file(
+        'source/notes.json',
+        JSON.stringify(notes, null, 2).replace(LF_ONLY_NEWLINES, '\r\n')
+      );
 
-  notes.activeNotes
-    .map(appendTags) // add tags to end of content
-    .map(addFilename) // generate filename from content
-    .reduce(toUniqueNames, [[], {}]) // add `(n)` if there are duplicates
-    .shift() // the list of notes is the first item in the pair returned from above
-    .forEach(({ content, fileName, lastModified }) => {
-      zip.file(`${fileName}.txt`, content, { date: new Date(lastModified) });
-    }); // add the note as a file in the zip
+      notes.activeNotes
+        .map(appendTags) // add tags to end of content
+        .map(addFilename) // generate filename from content
+        .reduce(toUniqueNames, [[], {}]) // add `(n)` if there are duplicates
+        .shift() // the list of notes is the first item in the pair returned from above
+        .forEach(({ content, fileName, lastModified }) => {
+          zip.file(`${fileName}.txt`, content, {
+            date: new Date(lastModified),
+          });
+        }); // add the note as a file in the zip
 
-  notes.trashedNotes
-    .map(appendTags) // add tags to end of content
-    .map(addFilename) // generate filename from content
-    .reduce(toUniqueNames, [[], {}]) // add `(n)` if there are duplicates
-    .shift() // the list of notes is the first item in the pair returned from above
-    .forEach(({ content, fileName, lastModified }) => {
-      zip.file(`trash/${fileName}.txt`, content, {
-        date: new Date(lastModified),
-      });
-    }); // add the note as a file in the zip
+      notes.trashedNotes
+        .map(appendTags) // add tags to end of content
+        .map(addFilename) // generate filename from content
+        .reduce(toUniqueNames, [[], {}]) // add `(n)` if there are duplicates
+        .shift() // the list of notes is the first item in the pair returned from above
+        .forEach(({ content, fileName, lastModified }) => {
+          zip.file(`trash/${fileName}.txt`, content, {
+            date: new Date(lastModified),
+          });
+        }); // add the note as a file in the zip
 
-  return zip;
+      return zip;
+    })
+    .catch(console.log); // eslint-disable-line no-console
 };
 
 export default noteExportToZip;

--- a/package-lock.json
+++ b/package-lock.json
@@ -583,6 +583,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
+      "integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@babel/core": "7.0.0",
     "@babel/plugin-proposal-class-properties": "7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0",
+    "@babel/plugin-syntax-dynamic-import": "7.0.0",
     "@babel/preset-env": "7.0.0",
     "@babel/preset-react": "7.0.0",
     "ajv": "6.5.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = () => {
     output: {
       path: __dirname + '/dist',
       filename: 'app.js',
+      chunkFilename: '[name].js',
     },
     module: {
       rules: [


### PR DESCRIPTION
This takes two of our relatively big dependencies and changes them to load dynamically, since they are not needed by most users.

### highlight.js

- highlight.js: 753.16 KB (15.2%)
- Only used for syntax highlighting code blocks. Therefore, it only has to load when a user previews a Markdown note that has a code block in it.
- This chunk is currently 578 KB minified and loading the full library, which contains syntax rules for 176 languages and 82 styles. Core library is only 62 KB. Might be nicer if we just choose the common languages, and maybe add back more if we get requests... (Future TODO)

### JSZip

- jszip: 140.69 KB (2.84%)
- Only used for zipping the export files.

### To test

Open the network tab in devtools, and see that:

- `vendors~highlight.js` is only loaded when previewing a Markdown note with a code block
- `vendors~JSZip.js` is only loaded when exporting notes