### PR TITLE
Fix Focus Mode button malfunction on first launch

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -180,15 +180,20 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
     }
 
     componentDidUpdate(prevProps) {
-      const { settings, isSmallScreen, appState: state } = this.props;
+      const { settings, isSmallScreen, appState } = this.props;
 
       if (settings !== prevProps.settings) {
         ipc.send('settingsUpdate', settings);
       }
 
+      // If note has just been loaded
+      if (prevProps.appState.note === undefined && appState.note) {
+        this.setState({ isNoteOpen: true });
+      }
+
       if (isSmallScreen !== prevProps.isSmallScreen) {
         this.setState({
-          isNoteOpen: Boolean(!isSmallScreen && state.note),
+          isNoteOpen: Boolean(!isSmallScreen && appState.note),
         });
       }
     }


### PR DESCRIPTION
There was a bug where the Focus Mode toggle button would not work immediately after launching the app. This was happening because the `is-note-open` CSS class was not being set correctly.

### Steps to reproduce

1. Log in
1. Quit and relaunch app (or reload browser)
1. Click Focus Mode toggle button

→ Nothing happens

### To test

Try the above steps, and verify that the Focus Mode toggle button works as expected.