### PR TITLE
Add missing tracks event

### DIFF
--- a/lib/boot.js
+++ b/lib/boot.js
@@ -156,6 +156,7 @@ let props = {
         store.dispatch(setAuthorized());
         localStorage.setItem('access_token', user.access_token);
         client.setUser(user);
+        analytics.tracks.recordEvent('user_account_created');
         analytics.tracks.recordEvent('user_signed_in');
       })
       .then(() =>


### PR DESCRIPTION
This app is missing the `user_account_created` tracks event that the other apps have.

**To Test**
* Create a new Simplenote account from the app.
* The event should be logged in Tracks.