### PR TITLE
Fix unsemantic buttons

### DIFF
--- a/lib/auth/index.jsx
+++ b/lib/auth/index.jsx
@@ -122,13 +122,13 @@ export class Auth extends Component {
             </p>
           )}
           <div className="login__actions">
-            <div
+            <button
               className={submitClasses}
               onClick={isCreatingAccount ? this.onSignUp : this.onLogin}
               type="submit"
             >
               {this.props.authPending ? <Spinner /> : buttonLabel}
-            </div>
+            </button>
             <p className="login__forgot">
               <a
                 href="https://app.simplenote.com/forgot/"

--- a/lib/revision-selector/index.jsx
+++ b/lib/revision-selector/index.jsx
@@ -132,19 +132,19 @@ export class RevisionSelector extends Component {
           />
         </div>
         <div className="revision-buttons">
-          <div
+          <button
             className="button button-secondary button-compact"
             onClick={this.onCancelRevision}
           >
             Cancel
-          </div>
-          <div
+          </button>
+          <button
             style={revisionButtonStyle}
             className="button button-primary button-compact"
             onClick={this.onAcceptRevision}
           >
             Restore Note
-          </div>
+          </button>
         </div>
       </div>
     );

--- a/lib/search-field/index.jsx
+++ b/lib/search-field/index.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
 import SmallCrossIcon from '../icons/cross-small';
 import appState from '../flux/app-state';
 import { tracks } from '../analytics';
@@ -42,13 +41,10 @@ export class SearchField extends Component {
 
   render() {
     const { placeholder, query } = this.props;
-
-    const classes = classNames('search-field', {
-      'has-query': query && query.length > 0,
-    });
+    const hasQuery = query && query.length > 0;
 
     return (
-      <div className={classes}>
+      <div className="search-field">
         <input
           ref={this.storeInput}
           type="text"
@@ -58,9 +54,13 @@ export class SearchField extends Component {
           value={query}
           spellCheck={false}
         />
-        <div onClick={this.clearQuery}>
+        <button
+          aria-label="Clear search"
+          hidden={!hasQuery}
+          onClick={this.clearQuery}
+        >
           <SmallCrossIcon />
-        </div>
+        </button>
       </div>
     );
   }

--- a/lib/search-field/style.scss
+++ b/lib/search-field/style.scss
@@ -22,11 +22,6 @@
 
   .icon-cross-small {
     transition: $anim-transition;
-    opacity: 0;
     fill: $gray;
-  }
-
-  &.has-query .icon-cross-small {
-    opacity: 1;
   }
 }


### PR DESCRIPTION
Closes #820 

This fixes several buttons that were inaccessible due to them being `div`s.

- Log In button
- Buttons in RevisionSelector
- "Clear search" button in SearchField