### PR TITLE
Restore :focus outlines

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import 'focus-visible/dist/focus-visible.js';
 import appState from './flux/app-state';
 import reduxActions from './state/actions';
 import selectors from './state/selectors';

--- a/lib/controls/checkbox/style.scss
+++ b/lib/controls/checkbox/style.scss
@@ -8,6 +8,10 @@
   vertical-align: middle;
   overflow: hidden;
 
+  &:focus-within {
+    outline: $focus-outline;
+  }
+
   input {
     position: absolute;
     top: 0;

--- a/lib/controls/toggle/style.scss
+++ b/lib/controls/toggle/style.scss
@@ -14,6 +14,10 @@ $toggle-control-knob-size: $toggle-control-height - $toggle-control-knob-margin 
   vertical-align: middle;
   overflow: hidden;
 
+  &:focus-within {
+    outline: $focus-outline;
+  }
+
   input {
     position: absolute;
     top: 0;
@@ -26,7 +30,6 @@ $toggle-control-knob-size: $toggle-control-height - $toggle-control-knob-margin 
     padding: 0;
     opacity: 0;
     border: none;
-    outline: none;
     background: none;
     appearance: none;
   }

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -20,6 +20,14 @@
   .revision-buttons {
     display: flex;
     justify-content: center;
+
+    button {
+      @extend %smart-focus-outline;
+
+      &:focus {
+        outline-color: lighten($blue, 20%);
+      }
+    }
   }
 
   .button-primary {
@@ -51,13 +59,18 @@
   }
 
   input[type='range'] {
+    @extend %smart-focus-outline;
+
     width: 100%;
     max-width: $max-content-width;
     -webkit-appearance: none;
     background: $white;
     height: 2px;
     border-radius: 5px;
-    outline: 0;
+
+    &:focus {
+      outline-color: lighten($blue, 20%);
+    }
   }
 
   input[type='range']::-webkit-slider-thumb {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8177,6 +8177,11 @@
         "imul": "^1.0.0"
       }
     },
+    "focus-visible": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-4.1.5.tgz",
+      "integrity": "sha512-yo/njtk/BB4Z2euzaZe3CZrg4u5s5uEi7ZwbHBJS2quHx51N0mmcx9nTIiImUGlgy+vf26d0CcQluahBBBL/Fw=="
+    },
     "follow-redirects": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.5.tgz",
@@ -11501,7 +11506,7 @@
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "draft-js-simpledecorator": "1.0.2",
     "electron-spellchecker": "^1.1.2",
     "electron-window-state": "4.1.1",
+    "focus-visible": "^4.1.5",
     "highlight.js": "9.12.0",
     "isemail": "3.1.1",
     "jszip": "3.1.5",

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -5,6 +5,10 @@
   box-sizing: border-box;
 }
 
+a {
+  @extend %smart-focus-outline;
+}
+
 a[href^='http://'],
 a[href^='https://'] {
   cursor: pointer; // Make all web links use pointer cursor

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -1,0 +1,11 @@
+// Hide focus outlines when interacting with mouse
+// https://github.com/WICG/focus-visible
+%smart-focus-outline {
+  &:focus {
+    outline: $focus-outline;
+  }
+
+  @at-root .js-focus-visible &:focus:not(.focus-visible) {
+    outline: 0;
+  }
+}

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -41,6 +41,8 @@ $fade-alpha: 0.25;
 
 $border-radius: 3px;
 
+$focus-outline: 4px auto lighten($blue, 15%);
+
 // Global Measurements
 $navigation-bar-width: 216px;
 $note-info-width: 268px;

--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -1,8 +1,9 @@
 // Resets button styles
 button {
+  @extend %smart-focus-outline;
+
   background: transparent;
   border: none;
-  outline: 0;
   padding: 0;
   cursor: default;
   font-size: 14px;
@@ -17,7 +18,6 @@ button {
   white-space: nowrap;
   text-overflow: ellipsis;
   margin: 0;
-  outline: 0;
   overflow: hidden;
   text-decoration: none;
   vertical-align: top;

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -4,6 +4,7 @@
 
 // Internal
 @import 'variables';
+@import 'mixins';
 @import 'general';
 @import 'scrollbar';
 @import 'components';


### PR DESCRIPTION
Closes #953 

This restores :focus outlines for buttons, radio buttons, checkbox toggles, and sliders.

Thanks to a [handy polyfill](https://github.com/WICG/focus-visible), they will only be shown when the user is interacting with a keyboard. (Normal mouse clicks will not show them)

![outlines](https://user-images.githubusercontent.com/555336/47678645-a4a4a180-dc05-11e8-98ef-214b55bbea15.gif)

There are several buttons that will not show a focus outline due to incorrect semantics (Will be fixed in a separate PR #961 for easier review):

- Log In button
- Buttons in RevisionSelector
- "Clear search" button in SearchField