### PR TITLE
Add SimplenoteImporter

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,5 +12,10 @@
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-syntax-dynamic-import"
-  ]
+  ],
+  "env": {
+    "test": {
+      "plugins": ["dynamic-import-node"]
+    }
+  }
 }

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -65,7 +65,7 @@ class CoreImporter extends EventEmitter {
     this.noteBucket.add(importedNote);
   };
 
-  importNotes = (notes = {}) => {
+  importNotes = (notes = {}, options) => {
     if (isEmpty(notes)) {
       this.emit('status', 'error', 'No notes to import.');
       return;
@@ -80,9 +80,9 @@ class CoreImporter extends EventEmitter {
       return;
     }
 
-    get(notes, 'activeNotes', []).map(note => this.importNote(note));
+    get(notes, 'activeNotes', []).map(note => this.importNote(note, options));
     get(notes, 'trashedNotes', []).map(note =>
-      this.importNote(note, { isTrashed: true })
+      this.importNote(note, { ...options, isTrashed: true })
     );
   };
 }

--- a/lib/utils/import/simplenote/index.js
+++ b/lib/utils/import/simplenote/index.js
@@ -28,9 +28,9 @@ class SimplenoteImporter extends EventEmitter {
       return;
     }
 
-    // Limit file size we will read to 2mb
-    if (file.size > 2000000) {
-      this.emit('status', 'error', 'File should be less than 2 MB.');
+    // Limit file size we will read to 1mb
+    if (file.size > 1000000) {
+      this.emit('status', 'error', 'File should be less than 1 MB.');
       return;
     }
 

--- a/lib/utils/import/simplenote/index.js
+++ b/lib/utils/import/simplenote/index.js
@@ -1,0 +1,59 @@
+import { EventEmitter } from 'events';
+import CoreImporter from '../';
+import { endsWith, isEmpty } from 'lodash';
+
+class SimplenoteImporter extends EventEmitter {
+  constructor({ noteBucket, tagBucket, options }) {
+    super();
+    this.noteBucket = noteBucket;
+    this.tagBucket = tagBucket;
+    this.options = options;
+  }
+
+  importNotes = filesArray => {
+    const coreImporter = new CoreImporter({
+      noteBucket: this.noteBucket,
+      tagBucket: this.tagBucket,
+    });
+
+    if (isEmpty(filesArray)) {
+      this.emit('status', 'error', 'No file to import.');
+      return;
+    }
+
+    const file = filesArray[0];
+
+    if (!endsWith(file.name.toLowerCase(), '.json')) {
+      this.emit('status', 'error', 'File name does not end in ".json".');
+      return;
+    }
+
+    // Limit file size we will read to 2mb
+    if (file.size > 2000000) {
+      this.emit('status', 'error', 'File should be less than 2 MB.');
+      return;
+    }
+
+    const fileReader = new FileReader();
+
+    fileReader.onload = event => {
+      const fileContent = event.target.result;
+
+      if (!fileContent) {
+        this.emit('status', 'error', 'File was empty.');
+        return;
+      }
+
+      const dataObj = JSON.parse(fileContent);
+      const noteCount =
+        dataObj.activeNotes.length + dataObj.trashedNotes.length;
+
+      coreImporter.importNotes(dataObj, this.options);
+      this.emit('status', 'complete', noteCount);
+    };
+
+    fileReader.readAsText(file);
+  };
+}
+
+export default SimplenoteImporter;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2568,6 +2568,15 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz",
+      "integrity": "sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
       "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
@@ -18476,8 +18485,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "schema-utils": {
       "version": "0.4.5",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "7.2.3",
     "babel-loader": "8.0.0",
+    "babel-plugin-dynamic-import-node": "2.2.0",
     "classnames": "2.2.5",
     "concurrently": "^4.0.1",
     "css-loader": "0.28.9",


### PR DESCRIPTION
Depends on #922 

- Is the class name good? Should it be called `SimplenoteJSONImporter`? 🤔 
- [This assumes](https://github.com/Automattic/simplenote-electron/blob/04c09806ff7643b7e1a4ca98b3147a623f3b8561/lib/utils/import/simplenote/index.js#L52) that the import will be more or less instantaneous once the JSON file is read and parsed. (If this is insufficient, we might want to consider emitting the progress status events from CoreImporter instead of the source-specific parsers?)