### PR TITLE
Fix note editor not syncing remote changes

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -293,14 +293,12 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
 
     onNoteRemoved = () => this.onNotesIndex();
 
-    onNoteUpdate = (noteId, data, original, patch, isIndexing) =>
+    onNoteUpdate = (noteId, data, remoteUpdateInfo) =>
       this.props.actions.noteUpdated({
         noteBucket: this.props.noteBucket,
         noteId,
         data,
-        original,
-        patch,
-        isIndexing,
+        remoteUpdateInfo,
       });
 
     onLoadPreferences = callback =>

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -481,9 +481,10 @@ export const actionMap = new ActionMap({
     },
 
     noteUpdated: {
-      creator({ noteBucket, noteId, original, data, patch, isIndexing }) {
+      creator({ noteBucket, noteId, data, remoteUpdateInfo = {} }) {
         return (dispatch, getState) => {
           var state = getState().appState;
+          const { original, patch, isIndexing } = remoteUpdateInfo;
 
           if (isIndexing) {
             // Increase index counter
@@ -521,13 +522,13 @@ export const actionMap = new ActionMap({
 
           if (!diffsAreEqual) {
             // generate a patch that composes both the working changes and upstream changes
-            patch = simperiumUtil.change.transform(
+            const newPatch = simperiumUtil.change.transform(
               working_diff,
               patch,
               original
             );
             // apply the new patch to the upstream data
-            let rebased = simperiumUtil.change.apply(patch, data);
+            let rebased = simperiumUtil.change.apply(newPatch, data);
 
             // TODO: determine where the cursor is and put it in the correct place
             // when applying the rebased content

--- a/package-lock.json
+++ b/package-lock.json
@@ -11506,7 +11506,7 @@
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
@@ -18745,9 +18745,9 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simperium": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/simperium/-/simperium-0.3.2.tgz",
-      "integrity": "sha512-4cr+dEApxsgBmvv356gt8lBLohMQrCJ/NStKLW7P0d5rFdpuuc9CmtN4xr5aQi2Yqtseu8P4h6eP8KBinrwxaw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/simperium/-/simperium-0.3.3.tgz",
+      "integrity": "sha512-WEHl5WKzEpywWMiveu+XyJas2b8VQ4k/IPes9PEpT22T4FtI7ftmkvusEEpXJZz/4WfpAjK3rFLj6b99RyFkhA==",
       "requires": {
         "uuid": "^3.2.1",
         "websocket": "^1.0.22"

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "redux-thunk": "2.2.0",
     "sanitize-filename": "1.6.1",
     "showdown": "1.8.6",
-    "simperium": "0.3.2",
+    "simperium": "0.3.3",
     "valid-url": "1.0.9"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Use simperium 0.3.3 to fix #976, the API was changed slightly to pass a `remoteUpdateInfo` object.

**To Test**
* Open a note in the app.
* Make a change to the same note in another client.
* The editor should update to the new note content.
* Other sync operations like creating a new note should still work as expected.