### PR TITLE
Ensure that all imported notes are sent to the server

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -16,6 +16,7 @@ import NavigationBar from './navigation-bar';
 import AppLayout from './app-layout';
 import Auth from './auth';
 import DialogRenderer from './dialog-renderer';
+import { activityHooks, nudgeUnsynced } from './utils/sync';
 import analytics from './analytics';
 import classNames from 'classnames';
 import {
@@ -162,7 +163,9 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
 
       this.props.client
         .on('authorized', this.onAuthChanged)
-        .on('unauthorized', this.onAuthChanged);
+        .on('unauthorized', this.onAuthChanged)
+        .on('message', this.syncActivityHooks)
+        .on('send', this.syncActivityHooks);
 
       this.onNotesIndex();
       this.onTagsIndex();
@@ -345,6 +348,18 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       };
 
       return Math.max(filteredNotes.findIndex(noteIndex) - 1, 0);
+    };
+
+    syncActivityHooks = data => {
+      activityHooks(data, {
+        onIdle: () => {
+          nudgeUnsynced({
+            client: this.props.client,
+            noteBucket: this.props.noteBucket,
+            notes: this.props.appState.notes,
+          });
+        },
+      });
     };
 
     toggleShortcuts = doEnable => {

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import App from './app';
 import Modal from 'react-modal';
+import Debug from 'debug';
 import getConfig from '../get-config';
 import simperium from './simperium';
 import store from './state';
@@ -77,17 +78,18 @@ const client = simperium({
 });
 
 const l = msg => {
+  const debug = Debug('client');
+
   return function() {
-    // if (window.loggingEnabled)
-    console.log.apply(console, [msg].concat([].slice.call(arguments))); // eslint-disable-line no-console
+    debug.apply(debug, [msg].concat([].slice.call(arguments)));
   };
 };
 
 client
   .on('connect', l('Connected'))
   .on('disconnect', l('Not connected'))
-  // .on( 'message', l('<=') )
-  // .on( 'send', l('=>') )
+  .on('message', l('<='))
+  .on('send', l('=>'))
   .on('unauthorized', l('Not authorized'));
 
 client.on('unauthorized', () => {

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -1,5 +1,6 @@
 import { get, partition, some } from 'lodash';
 import update from 'react-addons-update';
+import Debug from 'debug';
 import ActionMap from './action-map';
 import isEmailTag from '../utils/is-email-tag';
 import filterNotes from '../utils/filter-notes';
@@ -7,6 +8,7 @@ import throttle from '../utils/throttle';
 import analytics from '../analytics';
 import { util as simperiumUtil } from 'simperium';
 
+const debug = Debug('appState');
 const typingThrottle = 3000;
 
 export const actionMap = new ActionMap({
@@ -318,6 +320,7 @@ export const actionMap = new ActionMap({
           const settings = getState().settings;
           const { sortType, sortReversed } = settings;
           var sortOrder;
+          debug('loadNotes');
 
           if (sortType === 'alphabetical') {
             sortOrder = sortReversed ? 'prev' : 'next';
@@ -337,6 +340,7 @@ export const actionMap = new ActionMap({
                 notes.push(cursor.value);
                 cursor.continue();
               } else {
+                debug(`noteCount: ${notes.length}`);
                 dispatch(this.action('notesLoaded', { notes: notes }));
               }
             };

--- a/lib/utils/import/simplenote/index.js
+++ b/lib/utils/import/simplenote/index.js
@@ -28,9 +28,9 @@ class SimplenoteImporter extends EventEmitter {
       return;
     }
 
-    // Limit file size we will read to 1mb
-    if (file.size > 1000000) {
-      this.emit('status', 'error', 'File should be less than 1 MB.');
+    // Limit file size we will read to 5mb
+    if (file.size > 5000000) {
+      this.emit('status', 'error', 'File should be less than 5 MB.');
       return;
     }
 

--- a/lib/utils/sync/activity-hooks.js
+++ b/lib/utils/sync/activity-hooks.js
@@ -5,7 +5,7 @@ const debug = Debug('sync:activityHooks');
 
 export const debounceWait = 500;
 
-export const onSyncActive = debounce(
+const onSyncActive = debounce(
   (data, onActive) => {
     debug('Sync active...');
 
@@ -20,7 +20,7 @@ export const onSyncActive = debounce(
   }
 );
 
-export const onSyncIdle = debounce((data, onIdle) => {
+const onSyncIdle = debounce((data, onIdle) => {
   debug('Sync idle');
 
   if (isFunction(onIdle)) {

--- a/lib/utils/sync/activity-hooks.js
+++ b/lib/utils/sync/activity-hooks.js
@@ -3,6 +3,8 @@ import Debug from 'debug';
 
 const debug = Debug('sync:activityHooks');
 
+export const debounceWait = 500;
+
 export const onSyncActive = debounce(
   (data, onActive) => {
     debug('Sync active...');
@@ -11,7 +13,7 @@ export const onSyncActive = debounce(
       onActive();
     }
   },
-  500,
+  debounceWait,
   {
     leading: true,
     trailing: false,
@@ -24,7 +26,7 @@ export const onSyncIdle = debounce((data, onIdle) => {
   if (isFunction(onIdle)) {
     onIdle();
   }
-}, 500);
+}, debounceWait);
 
 /**
  * Hook functions to sync active/idle events

--- a/lib/utils/sync/activity-hooks.js
+++ b/lib/utils/sync/activity-hooks.js
@@ -1,0 +1,47 @@
+import { debounce, isFunction, noop, startsWith } from 'lodash';
+import Debug from 'debug';
+
+const debug = Debug('sync:activityHooks');
+
+export const onSyncActive = debounce(
+  (data, onActive) => {
+    debug('Sync active...');
+
+    if (isFunction(onActive)) {
+      onActive();
+    }
+  },
+  500,
+  {
+    leading: true,
+    trailing: false,
+  }
+);
+
+export const onSyncIdle = debounce((data, onIdle) => {
+  debug('Sync idle');
+
+  if (isFunction(onIdle)) {
+    onIdle();
+  }
+}, 500);
+
+/**
+ * Hook functions to sync active/idle events
+ *
+ * @param {string} data - The data emitted by the simperium client's 'message' or 'send' event.
+ * @param {Object} hooks - The functions to hook.
+ * @param {function} onActive - The function to call when syncing becomes active.
+ * @param {function} onIdle - The function to call when syncing becomes idle.
+ */
+const activityHooks = (data, { onActive = noop, onIdle = noop }) => {
+  // Ignore if heartbeat
+  if (startsWith(data, 'h:')) {
+    return;
+  }
+
+  onSyncActive(data, onActive);
+  onSyncIdle(data, onIdle);
+};
+
+export default activityHooks;

--- a/lib/utils/sync/activity-hooks.test.js
+++ b/lib/utils/sync/activity-hooks.test.js
@@ -1,4 +1,4 @@
-import activityHooks from './activity-hooks';
+import activityHooks, { debounceWait } from './activity-hooks';
 import { times } from 'lodash';
 
 describe('sync:activityHooks', () => {
@@ -22,7 +22,7 @@ describe('sync:activityHooks', () => {
       expect(hooks.onIdle).toHaveBeenCalledTimes(1);
       expect(order).toEqual(['active', 'idle']);
       done();
-    }, 500);
+    }, debounceWait);
   });
 
   it('should ignore heartbeats', done => {
@@ -34,6 +34,6 @@ describe('sync:activityHooks', () => {
       expect(hooks.onActive).toHaveBeenCalledTimes(0);
       expect(hooks.onIdle).toHaveBeenCalledTimes(0);
       done();
-    }, 500);
+    }, debounceWait);
   });
 });

--- a/lib/utils/sync/activity-hooks.test.js
+++ b/lib/utils/sync/activity-hooks.test.js
@@ -1,0 +1,39 @@
+import activityHooks from './activity-hooks';
+import { times } from 'lodash';
+
+describe('sync:activityHooks', () => {
+  let order, hooks;
+
+  beforeEach(() => {
+    order = [];
+    hooks = {
+      onActive: jest.fn(() => order.push('active')),
+      onIdle: jest.fn(() => order.push('idle')),
+    };
+  });
+
+  it('should call the appropriate hook when syncing becomes active/idle', done => {
+    const myActivityHooks = activityHooks('0:mockdata', hooks);
+
+    times(3, myActivityHooks);
+
+    window.setTimeout(() => {
+      expect(hooks.onActive).toHaveBeenCalledTimes(1);
+      expect(hooks.onIdle).toHaveBeenCalledTimes(1);
+      expect(order).toEqual(['active', 'idle']);
+      done();
+    }, 500);
+  });
+
+  it('should ignore heartbeats', done => {
+    const myActivityHooks = activityHooks('h:1', hooks);
+
+    times(3, myActivityHooks);
+
+    window.setTimeout(() => {
+      expect(hooks.onActive).toHaveBeenCalledTimes(0);
+      expect(hooks.onIdle).toHaveBeenCalledTimes(0);
+      done();
+    }, 500);
+  });
+});

--- a/lib/utils/sync/index.js
+++ b/lib/utils/sync/index.js
@@ -1,0 +1,4 @@
+import activityHooks from './activity-hooks';
+import nudgeUnsynced from './nudge-unsynced';
+
+export { activityHooks, nudgeUnsynced };

--- a/lib/utils/sync/nudge-unsynced.js
+++ b/lib/utils/sync/nudge-unsynced.js
@@ -24,11 +24,17 @@ const nudgeUnsynced = ({ noteBucket, notes, client }) => {
     );
 
   Promise.all(notes.map(noteHasSynced)).then(result => {
-    const unsyncedNotes = result.filter(note => note.unsynced);
-    debug(`${unsyncedNotes.length} unsynced notes`);
+    let unsyncedNoteCount = 0;
+    const hasUnsyncedNotes = result.some(note => note.unsynced);
+
+    if (hasUnsyncedNotes && debug.enabled) {
+      unsyncedNoteCount = result.filter(note => note.unsynced).length;
+    }
+
+    debug(`${unsyncedNoteCount} unsynced notes`);
 
     // Re-init the client and prod the syncing to resume
-    if (unsyncedNotes.length) {
+    if (hasUnsyncedNotes) {
       client.client.connect();
     }
   });

--- a/lib/utils/sync/nudge-unsynced.js
+++ b/lib/utils/sync/nudge-unsynced.js
@@ -23,7 +23,7 @@ const nudgeUnsynced = ({ noteBucket, notes, client }) => {
       })
     );
 
-  Promise.all(notes.map(noteHasSynced)).then(result => {
+  return Promise.all(notes.map(noteHasSynced)).then(result => {
     let unsyncedNoteCount = 0;
     const hasUnsyncedNotes = result.some(note => note.unsynced);
 

--- a/lib/utils/sync/nudge-unsynced.js
+++ b/lib/utils/sync/nudge-unsynced.js
@@ -1,0 +1,37 @@
+/**
+ * Ensure that all imported notes are sent to the server
+ *
+ * Importing over 350­400 notes at once can cause the syncing to get
+ * stuck. This function checks if there are any local notes which have not
+ * been acknowledged by the server yet, and if so, reconnects the client
+ * to resume the syncing.
+ */
+import Debug from 'debug';
+
+const debug = Debug('sync:nudgeUnsynced');
+
+const nudgeUnsynced = ({ noteBucket, notes, client }) => {
+  const noteHasSynced = note =>
+    new Promise(resolve =>
+      noteBucket.getVersion(note.id, (e, v) => {
+        const result = {
+          id: note.id,
+          data: note.data,
+          unsynced: e || v === 0,
+        };
+        resolve(result);
+      })
+    );
+
+  Promise.all(notes.map(noteHasSynced)).then(result => {
+    const unsyncedNotes = result.filter(note => note.unsynced);
+    debug(`${unsyncedNotes.length} unsynced notes`);
+
+    // Re-init the client and prod the syncing to resume
+    if (unsyncedNotes.length) {
+      client.client.connect();
+    }
+  });
+};
+
+export default nudgeUnsynced;

--- a/lib/utils/sync/nudge-unsynced.js
+++ b/lib/utils/sync/nudge-unsynced.js
@@ -1,7 +1,7 @@
 /**
  * Ensure that all imported notes are sent to the server
  *
- * Importing over 350­400 notes at once can cause the syncing to get
+ * Importing over 350-400 notes at once can cause the syncing to get
  * stuck. This function checks if there are any local notes which have not
  * been acknowledged by the server yet, and if so, reconnects the client
  * to resume the syncing.

--- a/lib/utils/sync/nudge-unsynced.test.js
+++ b/lib/utils/sync/nudge-unsynced.test.js
@@ -1,0 +1,21 @@
+import nudgeUnsynced from './nudge-unsynced';
+
+describe('sync:nudgeUnsynced', () => {
+  it('should reconnect the client when an unsynced note exists', () => {
+    const mockArg = {
+      noteBucket: {
+        getVersion: (_, callback) => {
+          callback(undefined, 0); // no error, v === 0
+        },
+      },
+      notes: [{}],
+      client: {
+        client: { connect: jest.fn() },
+      },
+    };
+
+    nudgeUnsynced(mockArg).then(() => {
+      expect(mockArg.client.client.connect).toHaveBeenCalled();
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1663,6 +1663,15 @@
             "to-regex": "^3.0.1"
           },
           "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
             "define-property": {
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -3235,6 +3244,17 @@
             "private": "^0.1.8",
             "slash": "^1.0.0",
             "source-map": "^0.5.7"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
           }
         },
         "core-js": {
@@ -3295,6 +3315,17 @@
         "globals": "^9.18.0",
         "invariant": "^2.2.2",
         "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "babel-types": {
@@ -3494,6 +3525,17 @@
         "qs": "6.5.1",
         "raw-body": "2.3.2",
         "type-is": "~1.6.15"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "bonjour": {
@@ -4258,6 +4300,15 @@
             "to-regex": "^3.0.1"
           },
           "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
             "define-property": {
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -5003,6 +5054,15 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -5880,11 +5940,20 @@
       "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg=="
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+      "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+      "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
       }
     },
     "decamelize": {
@@ -6612,6 +6681,15 @@
         "sumchecker": "^1.2.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -6635,6 +6713,17 @@
         "isbinaryfile": "^3.0.2",
         "minimist": "^1.2.0",
         "plist": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "electron-packager": {
@@ -6874,6 +6963,15 @@
           "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
           "dev": true
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "fs-extra": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
@@ -6993,6 +7091,16 @@
         "pify": "^2.3.0",
         "rxjs": "^5.0.0-beta.12",
         "xmlhttprequest": "^1.8.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "electron-spellchecker": {
@@ -7012,6 +7120,16 @@
         "rxjs": "^5.0.1",
         "rxjs-serial-subscription": "^0.1.1",
         "spawn-rx": "^2.0.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "electron-to-chromium": {
@@ -7700,6 +7818,15 @@
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
           "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -7773,6 +7900,15 @@
         "yauzl": "2.4.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -7878,6 +8014,15 @@
             "to-regex": "^3.0.1"
           },
           "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
             "define-property": {
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -8254,6 +8399,17 @@
         "parseurl": "~1.3.2",
         "statuses": "~1.4.0",
         "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "find-cache-dir": {
@@ -9160,6 +9316,15 @@
         "read-pkg-up": "^2.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "load-json-file": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -10079,6 +10244,15 @@
             "to-regex": "^3.0.1"
           },
           "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
             "define-property": {
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -11382,6 +11556,17 @@
             "private": "^0.1.8",
             "slash": "^1.0.0",
             "source-map": "^0.5.7"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
           }
         },
         "source-map": {
@@ -11671,6 +11856,17 @@
             "private": "^0.1.8",
             "slash": "^1.0.0",
             "source-map": "^0.5.7"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
           }
         },
         "source-map": {
@@ -13837,6 +14033,17 @@
         "request": "^2.45.0",
         "single-line-log": "^1.1.2",
         "throttleit": "0.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "num2fraction": {
@@ -14581,6 +14788,17 @@
         "async": "^1.5.2",
         "debug": "^2.2.0",
         "mkdirp": "0.5.x"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "posix-character-classes": {
@@ -18423,6 +18641,15 @@
             "to-regex": "^3.0.1"
           },
           "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
             "define-property": {
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -18904,6 +19131,15 @@
         "statuses": "~1.4.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "mime": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
@@ -18931,6 +19167,17 @@
         "http-errors": "~1.6.2",
         "mime-types": "~2.1.17",
         "parseurl": "~1.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "serve-static": {
@@ -19169,6 +19416,15 @@
         "use": "^3.1.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -19291,6 +19547,15 @@
         "url-parse": "^1.1.8"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "faye-websocket": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
@@ -19373,6 +19638,16 @@
         "debug": "^2.5.1",
         "lodash.assign": "^4.2.0",
         "rxjs": "^5.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "spdx-correct": {
@@ -19419,6 +19694,17 @@
         "safe-buffer": "^5.0.1",
         "select-hose": "^2.0.0",
         "spdy-transport": "^2.0.18"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "spdy-transport": {
@@ -19434,6 +19720,17 @@
         "readable-stream": "^2.2.9",
         "safe-buffer": "^5.0.1",
         "wbuf": "^1.7.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "speedometer": {
@@ -19713,6 +20010,15 @@
         "es6-promise": "^4.0.5"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "es6-promise": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
@@ -20998,6 +21304,15 @@
             "to-regex": "^3.0.1"
           },
           "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
             "define-property": {
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -21681,6 +21996,14 @@
         "yaeti": "^0.0.6"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "nan": {
           "version": "2.11.1",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "classnames": "2.2.5",
     "concurrently": "^4.0.1",
     "css-loader": "0.28.9",
+    "debug": "4.1.0",
     "electron": "2.0.8",
     "electron-builder": "20.28.2",
     "electron-packager": "9.1.0",


### PR DESCRIPTION
Importing over 350-400 notes at once can cause the syncing to get stuck. When the syncing is stuck, it can be resumed by calling `client.connect()`.

How can we tell that syncing is stuck? We first need to be able to detect whether the syncing is active or idle. When syncing is idle despite there being unsynced notes left, we can tell that it is stuck. Then, we can resuscitate the transfer by calling `client.connect()`.

This workaround adds a way to detect syncing activity (active/idle), by attaching debounced listeners to the simperium client's `send` and `message` events. We can now hook arbitrary functions to these state changes. (This will probably come in handy when we add a syncing indicator in the future.)

#### Also changed

- Added the [`debug`](https://www.npmjs.com/package/debug) module for easier debugging (cc: @adlk)
- Increased the max file size for SimplenoteImporter to 5 MB

#### To test

1. To see the pertinent logs in the console, enter this into the devtools console and reload: `localStorage.debug = 'sync:*'`.
1. Try doing a 400+ note import. See that the syncing is reactivated when it goes idle with unsynced notes remaining.
1. After the sync is over, verify that you can log out without warnings.

Here are some import files of various sizes: [mock-simplenote-json.zip](https://github.com/Automattic/simplenote-electron/files/2553819/mock-simplenote-json.zip)
