### PR TITLE
Prevent flooding redux with unnecessary `loadNotes` dispatches

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -151,7 +151,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
 
       this.props.noteBucket
         .on('index', this.onNotesIndex)
-        .on('update', debounce(this.onNoteUpdate, 200))
+        .on('update', debounce(this.onNoteUpdate, 200, { maxWait: 1000 }))
         .on('remove', this.onNoteRemoved);
 
       this.props.preferencesBucket.on('update', this.onLoadPreferences);

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -19,6 +19,7 @@ import DialogRenderer from './dialog-renderer';
 import analytics from './analytics';
 import classNames from 'classnames';
 import {
+  debounce,
   noop,
   get,
   has,
@@ -150,14 +151,14 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
 
       this.props.noteBucket
         .on('index', this.onNotesIndex)
-        .on('update', this.onNoteUpdate)
+        .on('update', debounce(this.onNoteUpdate, 200))
         .on('remove', this.onNoteRemoved);
 
       this.props.preferencesBucket.on('update', this.onLoadPreferences);
 
       this.props.tagBucket
         .on('index', this.onTagsIndex)
-        .on('update', this.onTagsIndex)
+        .on('update', debounce(this.onTagsIndex, 200))
         .on('remove', this.onTagsIndex);
 
       this.props.client

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -484,20 +484,10 @@ export const actionMap = new ActionMap({
       creator({ noteBucket, noteId, data, remoteUpdateInfo = {} }) {
         return (dispatch, getState) => {
           var state = getState().appState;
-          const { original, patch, isIndexing } = remoteUpdateInfo;
+          const { original, patch } = remoteUpdateInfo;
 
-          if (isIndexing) {
-            // Increase index counter
-            this.indexCtr++;
-          } else if (this.indexCtr > 0) {
-            // completed indexing, reset counter
-            this.indexCtr = 0;
-          }
-
-          // Refresh the notes list. Rate limit if indexing
-          if (!isIndexing || (isIndexing && this.indexCtr % 30 === 0)) {
-            dispatch(this.action('loadNotes', { noteBucket }));
-          }
+          // Refresh the notes list
+          dispatch(this.action('loadNotes', { noteBucket }));
 
           if (state.selectedNoteId !== noteId || !patch) {
             return;


### PR DESCRIPTION
**Problem**: When importing a file with many notes (let's say 500+), the notes would show up in the app, but the NoteList was unresponsive to clicks. When you clicked another note in the list, nothing would happen. 

**Cause**: The expensive `loadNotes` action was being dispatched on every noteBucket `update` event, blocking other state changes.

**Fix**: Debounce the `update` event handlers.

## To test

1. Import a file with 500+ notes.
2. Once there are notes in the NoteList, you should immediately be able to click away to different notes.

Here are some import files of various sizes: [mock-simplenote-json.zip](https://github.com/Automattic/simplenote-electron/files/2553819/mock-simplenote-json.zip)