### PR TITLE
Make CoreImporter methods return Promise

### DIFF
--- a/lib/dialogs/import/source-importer/progress/text.jsx
+++ b/lib/dialogs/import/source-importer/progress/text.jsx
@@ -5,10 +5,15 @@ const ImportProgressText = props => {
   const { currentValue, isDone } = props;
 
   const unit = currentValue === 1 ? 'note' : 'notes';
+  let text;
 
-  const text = isDone
-    ? `Done! ${currentValue} ${unit} imported.`
-    : `${currentValue} ${unit} imported...`;
+  if (isDone) {
+    text = `Done! ${currentValue} ${unit} imported.`;
+  } else {
+    text = currentValue
+      ? `${currentValue} ${unit} imported...`
+      : 'Importing...';
+  }
 
   return (
     <p role="status" aria-live="polite">

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -62,7 +62,7 @@ class CoreImporter extends EventEmitter {
       });
     }
 
-    this.noteBucket.add(importedNote);
+    return this.noteBucket.add(importedNote);
   };
 
   importNotes = (notes = {}, options) => {
@@ -80,10 +80,14 @@ class CoreImporter extends EventEmitter {
       return;
     }
 
-    get(notes, 'activeNotes', []).map(note => this.importNote(note, options));
-    get(notes, 'trashedNotes', []).map(note =>
+    const activeNotesPromises = get(notes, 'activeNotes', []).map(note =>
+      this.importNote(note, options)
+    );
+    const trashedNotesPromises = get(notes, 'trashedNotes', []).map(note =>
       this.importNote(note, { ...options, isTrashed: true })
     );
+
+    return Promise.all(activeNotesPromises.concat(trashedNotesPromises));
   };
 }
 

--- a/lib/utils/import/simplenote/index.js
+++ b/lib/utils/import/simplenote/index.js
@@ -48,8 +48,9 @@ class SimplenoteImporter extends EventEmitter {
       const noteCount =
         dataObj.activeNotes.length + dataObj.trashedNotes.length;
 
-      coreImporter.importNotes(dataObj, this.options);
-      this.emit('status', 'complete', noteCount);
+      coreImporter.importNotes(dataObj, this.options).then(() => {
+        this.emit('status', 'complete', noteCount);
+      });
     };
 
     fileReader.readAsText(file);


### PR DESCRIPTION
This enhances the CoreImporter import methods to return a Promise, so that consumers can have a better idea of when the import (at least to indexedDB) has been completed.

This is important for large imports (1000+ notes), where there is a considerable lag between when `importNotes()` is called and when all the notes have actually been written to indexedDB. There needs to be some kind of visual indication to the user that the notes are being processed.

#### To test

1. Start with an empty account for easier testing.
1. Import a large Simplenote json file (1000+ notes).
1. The progress bar in the Import dialog should stay running until the imported notes are first visible in the NoteList.

Here are some import files of various sizes: [mock-simplenote-json.zip](https://github.com/Automattic/simplenote-electron/files/2553819/mock-simplenote-json.zip)