### PR TITLE
Add :focus outline to dropzone

### DIFF
--- a/lib/dialogs/import/dropzone/style.scss
+++ b/lib/dialogs/import/dropzone/style.scss
@@ -9,6 +9,11 @@
   background: lighten($gray, 40%);
   transition: padding .2s ease-out, background .2s ease-out;
 
+  &:focus-within {
+    overflow: hidden;
+    outline: $focus-outline;
+  }
+
   @at-root .theme-dark & {
     background: darken($gray, 35%);
   }


### PR DESCRIPTION
This adds a :focus outline which was missing on the importer dropzone.

![dropzone-focus](https://user-images.githubusercontent.com/555336/48084877-392d8600-e23c-11e8-92eb-3ab7252d4112.gif)