### PR TITLE
Strip markdown in note list previews

### DIFF
--- a/lib/utils/note-utils.js
+++ b/lib/utils/note-utils.js
@@ -1,3 +1,5 @@
+import removeMarkdown from 'remove-markdown';
+
 /**
  * Matches the title and excerpt in a note's content
  *
@@ -10,28 +12,18 @@
 const noteTitleAndPreviewRegExp = /\s*(\S[^\n]*)\s*(\S[^\n]*)?/;
 
 /**
- * Matches the title and excerpt in a note's content skipping opening # from title
- *
- * Both the title and the excerpt are determined as
- * content starting with something that isn't
- * whitespace and leads up to a newline or line end
- *
- * @type {RegExp} matches a title and excerpt in note content skipping opening #'s from title and preview
- */
-const noteTitleAndPreviewMdRegExp = /(?:#{0,6}\s+)?(\S[^\n]*)\s*(?:#{0,6}\s+)?(\S[^\n]*)?/;
-
-/**
  * Returns the title and excerpt for a given note
  *
  * @param {Object} note a note object
  * @returns {Object} title and excerpt (if available)
  */
 export const noteTitleAndPreview = note => {
-  const content = note && note.data && note.data.content;
+  let content = (note && note.data && note.data.content) || '';
+  content = isMarkdown(note)
+    ? removeMarkdown(content, { stripListLeaders: false })
+    : content;
 
-  const match = isMarkdown(note)
-    ? noteTitleAndPreviewMdRegExp.exec(content || '')
-    : noteTitleAndPreviewRegExp.exec(content || '');
+  const match = noteTitleAndPreviewRegExp.exec(content);
 
   const defaults = {
     title: 'New Note...',

--- a/package-lock.json
+++ b/package-lock.json
@@ -18056,6 +18056,11 @@
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
     },
+    "remove-markdown": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.3.0.tgz",
+      "integrity": "sha1-XktmdJOpNXlyjz1S7MHbnKUF3Jg="
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "redux": "3.7.2",
     "redux-localstorage": "0.4.1",
     "redux-thunk": "2.2.0",
+    "remove-markdown": "^0.3.0",
     "sanitize-filename": "1.6.1",
     "sax": "1.2.4",
     "showdown": "1.8.6",


### PR DESCRIPTION
Note list previews have raw markdown text which really doesn't help in anyway. This patch drops the markdown from both previews and titles of note list items.

Example:
![image](https://user-images.githubusercontent.com/12156014/48252084-bc5fff00-e429-11e8-9d1c-f2d00c0a5a20.png)
