### PR TITLE
Publish icon spacing fixed.

### DIFF
--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -114,6 +114,7 @@
 
   .note-list-item-published-icon {
     margin-left: auto;
+    margin-right: 10px;
 
     & svg {
       fill: $gray;


### PR DESCRIPTION
Here is preview with changes applied:
<img width="362" alt="screen shot 2018-11-09 at 10 13 54" src="https://user-images.githubusercontent.com/1477453/48250891-82323580-e408-11e8-9236-31cfd61ad640.png">
