### PR TITLE
Fix CJK tag entry

### DIFF
--- a/lib/tag-input/index.jsx
+++ b/lib/tag-input/index.jsx
@@ -33,6 +33,10 @@ export class TagInput extends Component {
     storeHasFocus: noop,
   };
 
+  state = {
+    isComposing: false,
+  };
+
   componentDidMount() {
     this.props.storeFocusInput(this.focusInput);
     this.props.storeHasFocus(this.hasFocus);
@@ -118,10 +122,21 @@ export class TagInput extends Component {
     event.stopPropagation();
   };
 
-  onChange = ({ target: { textContent: value } }) =>
+  onChange = ({ target: { textContent: value } }) => {
+    if (this.state.isComposing) {
+      return;
+    }
+
     value.endsWith(',') && value.trim().length // commas should automatically insert non-zero tags
       ? this.props.onSelect(value.slice(0, -1).trim())
       : this.props.onChange(value.trim(), this.focusInput);
+  };
+
+  onCompositionEnd = () => {
+    this.setState({ isComposing: false }, () =>
+      this.onChange({ target: { textContent: this.inputField.textContent } })
+    );
+  };
 
   removePastedFormatting = event => {
     document.execCommand(
@@ -167,6 +182,8 @@ export class TagInput extends Component {
           ref={this.storeInput}
           className="tag-input__entry"
           contentEditable="true"
+          onCompositionStart={() => this.setState({ isComposing: true })}
+          onCompositionEnd={this.onCompositionEnd}
           onInput={this.onChange}
           onKeyDown={this.interceptKeys}
           placeholder="Add a tag…"


### PR DESCRIPTION
Closes #696 
Closes #774 

### Before (Unusable ☹️)

![before](https://user-images.githubusercontent.com/555336/48274607-0b884d00-e487-11e8-972c-925582430ad5.gif)

### After 👍 

![after](https://user-images.githubusercontent.com/555336/48274618-104d0100-e487-11e8-8701-5e39154704ce.gif)

### To test

1. Enable Japanese input mode (Hiragana)
1. In the tag field, type in the key sequence `nihongotagu` and hit <kbd>Space</kbd> to convert into `日本語タグ`
1. Hit <kbd>Enter</kbd> to finalize the conversion
1. Hit <kbd>Enter</kbd> again to add the tag to the note
1. Remove the tag from the note
1. Type in the key sequence `nihongo`, hit <kbd>Space</kbd> to convert into `日本語`, and hit <kbd>Enter</kbd> to finalize
1. See that the autocomplete to `日本語タグ` is working
