### PR TITLE
Make tag entry and removal smoother

### DIFF
--- a/lib/tag-field/index.jsx
+++ b/lib/tag-field/index.jsx
@@ -91,10 +91,10 @@ export class TagField extends Component {
     onUpdateNoteTags(differenceBy(tags, [tagName], s => s.toLocaleLowerCase()));
 
     if (selectedTag === tagName) {
-      this.setState({ selectedTag: '' });
+      this.setState({ selectedTag: '' }, () => {
+        invoke(this, 'tagInput.focus');
+      });
     }
-
-    invoke(this, 'tagInput.focus');
 
     analytics.tracks.recordEvent('editor_tag_removed');
   };


### PR DESCRIPTION
Adding and removing tags was not a smooth experience because the cursor went away after removing a tag with <kbd>Backspace</kbd>.

This fixes the problem, so that we can smoothly remove and add multiple tags without re-clicking the entry field.

### Before

![tags-before](https://user-images.githubusercontent.com/555336/48278348-99b50100-e490-11e8-859c-8a783bff91f5.gif)

### After

![tags-after](https://user-images.githubusercontent.com/555336/48278356-9c175b00-e490-11e8-912e-e3139ffde0ea.gif)