### PR TITLE
Never launch in fullscreen mode

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -125,6 +125,8 @@ module.exports = function main() {
       mainWindow = null;
     });
 
+    if (mainWindow.isFullScreen()) mainWindow.setFullScreen(false);
+
     // wait until window is presentable
     mainWindow.once('ready-to-show', mainWindow.show);
   };

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -13,6 +13,8 @@ const {
 const path = require('path');
 const windowStateKeeper = require('electron-window-state');
 
+const platform = require('./platform');
+
 const buildViewMenu = require('./menus/view-menu');
 const buildEditMenu = require('./menus/edit-menu');
 const { isDev } = require('./env');
@@ -117,6 +119,15 @@ module.exports = function main() {
     // Disables navigation for app window drag and drop
     mainWindow.webContents.on('will-navigate', event => event.preventDefault());
 
+    // Fullscreen should be disabled on launch
+    if (platform.isOSX()) {
+      mainWindow.on('close', () => {
+        mainWindow.setFullScreen(false);
+      });
+    } else {
+      mainWindow.setFullScreen(false);
+    }
+
     // Emitted when the window is closed.
     mainWindow.on('closed', function() {
       // Dereference the window object, usually you would store windows
@@ -124,8 +135,6 @@ module.exports = function main() {
       // when you should delete the corresponding element.
       mainWindow = null;
     });
-
-    if (mainWindow.isFullScreen()) mainWindow.setFullScreen(false);
 
     // wait until window is presentable
     mainWindow.once('ready-to-show', mainWindow.show);


### PR DESCRIPTION
Closes #739 

Continuation of @rakhi2104's work from #904 

This ensures that the app always launches with Fullscreen Mode disabled.

Due to a strange difference in behavior, a single approach was insufficient. After some experimentation, it turns out that we need to take a different approach depending on platform:

- Mac → Disable fullscreen mode on window close
- Win & Linux → Disable fullscreen mode on launch

## To test

It would be better to test with the actual builds:

- Mac & Linux: https://circleci.com/gh/Automattic/simplenote-electron/1579#artifacts/containers/0
- Windows: https://ci.appveyor.com/project/Automattic/simplenote-electron/builds/20198046/artifacts

### Steps

1. Launch Electron app and set to Full Screen mode (View menu ▸ Toggle Full Screen)
1. Quit app
1. Relaunch app, and make sure that it is not in Full Screen mode