### PR TITLE
Fix padding for trash toolbar in Mac Electron

### DIFF
--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -52,7 +52,7 @@
 .note-toolbar-trashed {
   display: flex;
   align-items: center;
-  padding: 10px 16px;
+  padding: 0 16px;
   justify-content: flex-end;
 
   .note-toolbar__button {


### PR DESCRIPTION
The vertical alignment of the buttons was off in Mac Electron. This fix does not affect other platforms.

## Before
<img width="822" alt="screen shot 2018-11-11 at 23 24 02" src="https://user-images.githubusercontent.com/555336/48314278-9cd3fc80-e60a-11e8-8731-63089ccc1c3a.png">

## After
<img width="866" alt="screen shot 2018-11-11 at 23 23 42" src="https://user-images.githubusercontent.com/555336/48314279-9e9dc000-e60a-11e8-9175-39736a2cdb27.png">
