### PR TITLE
Never publish appx test builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ for:
     build_script:
       - make build
       - make test
-      - npx electron-builder --win --config=./electron-builder-appx.json
+      - npx electron-builder --win --config=./electron-builder-appx.json -p never
 
 artifacts:
   - path: release\*.exe


### PR DESCRIPTION
This PR is fixing a bug where, based on the build duration, the appx test build could overwrite the windows store appx build. 