### PR TITLE
Simplify printing

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -289,9 +289,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       this.onLoadPreferences();
     };
 
-    onNotePrinted = () =>
-      this.props.actions.setShouldPrintNote({ shouldPrint: false });
-
     onNotesIndex = () =>
       this.props.actions.loadNotes({ noteBucket: this.props.noteBucket });
 
@@ -433,8 +430,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
                     allTags={state.tags}
                     filter={state.filter}
                     onUpdateNoteTags={this.onUpdateNoteTags}
-                    shouldPrint={state.shouldPrint}
-                    onNotePrinted={this.onNotePrinted}
                   />
                 }
               />

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -18,7 +18,6 @@ export class NoteEditor extends Component {
     shouldPrint: PropTypes.bool,
     onUpdateContent: PropTypes.func.isRequired,
     onUpdateNoteTags: PropTypes.func.isRequired,
-    onPrintNote: PropTypes.func,
     revision: PropTypes.object,
     setEditorMode: PropTypes.func.isRequired,
   };
@@ -34,14 +33,6 @@ export class NoteEditor extends Component {
 
   componentDidMount() {
     this.toggleShortcuts(true);
-  }
-
-  componentDidUpdate() {
-    // Immediately print once `shouldPrint` has been set
-    if (this.props.shouldPrint) {
-      window.print();
-      this.props.onNotePrinted();
-    }
   }
 
   componentWillUnmount() {

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -4,9 +4,7 @@ import { connect } from 'react-redux';
 import appState from '../flux/app-state';
 import NoteDetail from '../note-detail';
 import TagField from '../tag-field';
-import { get, property } from 'lodash';
-
-import { renderNoteToHtml } from '../utils/render-note-to-html';
+import { property } from 'lodash';
 
 export class NoteEditor extends Component {
   static displayName = 'NoteEditor';
@@ -118,7 +116,7 @@ export class NoteEditor extends Component {
   };
 
   render() {
-    const { editorMode, note, fontSize, shouldPrint } = this.props;
+    const { editorMode, note, fontSize } = this.props;
     const revision = this.props.revision || note;
     const tags = (revision && revision.data && revision.data.tags) || [];
     const isTrashed = !!(note && note.data.deleted);
@@ -128,17 +126,6 @@ export class NoteEditor extends Component {
       revision.data &&
       revision.data.systemTags &&
       revision.data.systemTags.indexOf('markdown') !== -1;
-
-    const content = get(revision, 'data.content', '');
-
-    const printStyle = {
-      fontSize: fontSize + 'px',
-    };
-
-    const printAttrs = {
-      style: printStyle,
-      class: 'note-print note-detail-markdown',
-    };
 
     return (
       <div className="note-editor theme-color-bg theme-color-fg">
@@ -151,17 +138,6 @@ export class NoteEditor extends Component {
           onChangeContent={this.props.onUpdateContent}
           fontSize={fontSize}
         />
-        {shouldPrint &&
-          markdownEnabled && (
-            <div
-              {...printAttrs}
-              dangerouslySetInnerHTML={{
-                __html: renderNoteToHtml(content),
-              }}
-            />
-          )}
-        {shouldPrint &&
-          !markdownEnabled && <div {...printAttrs}>{content}</div>}
         {note &&
           !isTrashed && (
             <TagField

--- a/scss/print.scss
+++ b/scss/print.scss
@@ -1,35 +1,26 @@
 @media print {
-  html,
-  body,
-  .app-layout__note-column {
-    overflow: visible;
-    height: auto;
+  .app-layout__source-column {
+    display: none;
+    border-left: 0;
   }
 
-  .app,
-  .simplenote-app,
-  .app-layout__note-column {
-    display: block;
-    height: auto;
-  }
-
-  .navigation,
-  .app-layout__source-column,
-  .revision-selector,
-  .note-toolbar-wrapper,
-  .note-detail-wrapper,
-  .note-detail-wrapper .note-detail,
-  .note-info,
-  .tag-field {
+  .tag-field,
+  .note-toolbar-wrapper {
     display: none;
   }
-}
 
-.note-print {
-  display: block;
-  max-width: 100%;
-  width: 100%;
-  padding: 5%;
-  color: $black;
-  overflow: visible;
+  .note-detail-wrapper {
+    overflow: visible;
+    border: 0;
+  }
+
+  .note-detail {
+    overflow: visible;
+  }
+
+  [class^="note-detail-"] {
+    max-width: 100%;
+    width: 100%;
+    color: $black;
+  }
 }

--- a/scss/print.scss
+++ b/scss/print.scss
@@ -22,5 +22,9 @@
     max-width: 100%;
     width: 100%;
     color: $black;
+
+    &.theme-color-fg {
+      color: $black;
+    }
   }
 }


### PR DESCRIPTION
In preparation for the web app, this PR accomplishes two main goals:

1. Notes can be printed from a web browser.
2. Printing behavior matches a web user's expectations better (i.e. is more WYSIWYG).

To do this, I simplified the print styles and made it so we no longer insert a separate rendering of the print content. This means that for Markdown notes, the printed content will now reflect what is actually displayed in the editor, instead of always printing the "rendered Markdown" version.

### Things to test

- Works in both Electron and in a web browser (using the browser's Print functionality)
- Prints sensibly (black text on white background) when in Dark Mode
- Correctly prints long content that spans multiple pages (The `textarea` workaround in #162 is no longer needed)
- Prints plain text, unrendered Markdown, and rendered Markdown as displayed in the editor