### PR TITLE
Add “Debugging Console” menu item in production builds

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -210,6 +210,18 @@ function createMenuTemplate(settings) {
           shell.openExternal('https://simplenote.com/help');
         },
       },
+      {
+        type: 'separator',
+      },
+      {
+        label: 'Advanced',
+        submenu: [
+          {
+            label: 'Debugging Console',
+            role: 'toggleDevTools',
+          },
+        ],
+      },
     ],
   };
 

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -1,5 +1,4 @@
 const { buildRadioGroup, appCommandSender } = require('./utils');
-const { isDev } = require('../env');
 
 const buildViewMenu = settings => {
   settings = settings || {};
@@ -150,20 +149,6 @@ const buildViewMenu = settings => {
       },
     ],
   };
-
-  if (isDev) {
-    menu.submenu.push(
-      {
-        type: 'separator',
-      },
-      {
-        role: 'toggleDevTools',
-      },
-      {
-        role: 'reload',
-      }
-    );
-  }
 
   return menu;
 };


### PR DESCRIPTION
This adds a devtools menu item as `Help ▸ Advanced ▸ Debugging Console` in production builds as well, in order to:

- help with remote debugging
- work around the inability to run the Windows Store build with `--devtools`

Thanks @adlk for the suggestion 🙂 