### PR TITLE
Fix incorrect fallback timestamp in Evernote importer

### DIFF
--- a/lib/utils/import/evernote/index.js
+++ b/lib/utils/import/evernote/index.js
@@ -118,7 +118,7 @@ class EvernoteImporter extends EventEmitter {
     let convertedDate = moment(dateString).unix();
     if (isNaN(convertedDate)) {
       // Fall back to current date
-      convertedDate = Date.now();
+      convertedDate = moment().unix();
     }
 
     return convertedDate;


### PR DESCRIPTION
This fixes an incorrect fallback timestamp that was in milliseconds instead of seconds.