### PR TITLE
Fix password change handling

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -287,6 +287,10 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       setAuthorized();
       analytics.initialize(accountName);
       this.onLoadPreferences();
+
+      // 'Kick' the app to ensure content is loaded after signing in
+      this.props.actions.loadNotes({ noteBucket: this.props.noteBucket });
+      this.props.actions.loadTags({ tagBucket: this.props.tagBucket });
     };
 
     onNotePrinted = () =>

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -168,8 +168,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
         .on('message', this.syncActivityHooks)
         .on('send', this.syncActivityHooks);
 
-      this.onNotesIndex();
-      this.onTagsIndex();
       this.onLoadPreferences(() =>
         // Make sure that tracking starts only after preferences are loaded
         analytics.tracks.recordEvent('application_opened')
@@ -289,8 +287,8 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       this.onLoadPreferences();
 
       // 'Kick' the app to ensure content is loaded after signing in
-      this.props.actions.loadNotes({ noteBucket: this.props.noteBucket });
-      this.props.actions.loadTags({ tagBucket: this.props.tagBucket });
+      this.onNotesIndex();
+      this.onTagsIndex();
     };
 
     onNotePrinted = () =>

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -207,7 +207,7 @@ let props = {
 // If we sign in with a different username, ensure storage is reset
 const resetStorageIfAccountChanged = newAccountName => {
   const accountName = get(store.getState(), 'settings.accountName', '');
-  if (accountName && accountName !== newAccountName) {
+  if (accountName !== newAccountName) {
     client.reset();
   }
 };

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -18,7 +18,7 @@ import { Auth } from 'simperium';
 import { parse } from 'cookie';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
-import { some } from 'lodash';
+import { get, some } from 'lodash';
 
 import '../scss/style.scss';
 
@@ -33,8 +33,8 @@ const cookie = parse(document.cookie);
 const auth = new Auth(config.app_id, config.app_key);
 const appProvider = 'simplenote.com';
 
-const token = cookie.token || localStorage.access_token;
 const appID = config.app_id;
+let token = cookie.token || localStorage.access_token;
 
 // Redirect to web sign in if running on App Engine
 if (!token && config.is_app_engine) {
@@ -93,9 +93,11 @@ client
   .on('unauthorized', l('Not authorized'));
 
 client.on('unauthorized', () => {
-  // if there is no token, drop data, if there is a token it could potentially just be
-  // a password change or something similar so don't kill the data
+  // If a token exists, we probaly reached this point from a password change.
+  // The client should sign out the user, but preserve db content in case
+  // some data has not synced yet.
   if (token) {
+    client.clearAuthorization();
     return;
   }
 
@@ -118,6 +120,7 @@ let props = {
     auth
       .authorize(username, password)
       .then(user => {
+        resetStorageIfAccountChanged(username);
         if (!user.access_token) {
           return store.dispatch(resetAuth);
         }
@@ -125,6 +128,7 @@ let props = {
         store.dispatch(setAccountName(username));
         store.dispatch(setAuthorized());
         localStorage.access_token = user.access_token;
+        token = user.access_token;
         client.setUser(user);
         analytics.tracks.recordEvent('user_signed_in');
       })
@@ -150,6 +154,7 @@ let props = {
     auth
       .create(username, password, appProvider)
       .then(user => {
+        resetStorageIfAccountChanged(username);
         if (!user.access_token) {
           return store.dispatch(resetAuth);
         }
@@ -157,6 +162,7 @@ let props = {
         store.dispatch(setAccountName(username));
         store.dispatch(setAuthorized());
         localStorage.setItem('access_token', user.access_token);
+        token = user.access_token;
         client.setUser(user);
         analytics.tracks.recordEvent('user_account_created');
         analytics.tracks.recordEvent('user_signed_in');
@@ -194,6 +200,14 @@ let props = {
 
     analytics.tracks.recordEvent('user_signed_in');
   },
+};
+
+// If we sign in with a different username, ensure storage is reset
+const resetStorageIfAccountChanged = newAccountName => {
+  const accountName = get(store.getState(), 'settings.accountName', '');
+  if (accountName && accountName !== newAccountName) {
+    client.reset();
+  }
 };
 
 Modal.setAppElement('#root');

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -191,7 +191,9 @@ let props = {
     analytics.tracks.recordEvent('user_signed_out');
   },
   authorizeUserWithToken: (accountName, userToken) => {
+    resetStorageIfAccountChanged(accountName);
     localStorage.setItem('access_token', userToken);
+    token = userToken;
     store.dispatch(setAccountName(accountName));
     store.dispatch(setAuthorized());
 

--- a/lib/simperium/index.js
+++ b/lib/simperium/index.js
@@ -127,7 +127,6 @@ BrowserClient.prototype.bucket = function(name) {
 };
 
 BrowserClient.prototype.setUser = function(user) {
-  // todo, set the user access token and have the buckets reconnect
   this.client.setAccessToken(user.access_token);
   this.emit('authorized');
 };

--- a/lib/simperium/index.js
+++ b/lib/simperium/index.js
@@ -138,3 +138,8 @@ BrowserClient.prototype.deauthorize = function() {
   this.client.disconnect();
   this.reset();
 };
+
+BrowserClient.prototype.clearAuthorization = function() {
+  this.client.setAccessToken(null);
+  this.client.disconnect();
+};


### PR DESCRIPTION
This is at least a partial fix for the reports we've been getting in #1007 and potentially others.

**The Issue**
We were not signing out the user when their token was no longer valid. If a user changes their password at app.simplenote.com/settings, Simperium creates a new token and invalidates all of the existing ones for the user.

**Another Issue 🤪**
I discovered that we were preserving the IndexedDB content when this invalid token scenario was reached. This is by design so that unsynced notes get preserved, but if a user signed in with a different account than the previous one, all of the content would still be in the app. We now check if the accounts changed when signing in again and clear out the db if they are different.

**To Test**
* Sign in to an account in the app.
* Head to https://app.simplenote.com/settings for the same account, and change the password.
* Make any change in the app, like editing a note. The token should now be invalid and you get signed out.
* Sign back in with the same account, all of the content should still be there.
* Repeat the same above steps, but instead sign in with a different account. You should only see the notes associated with that account.