### PR TITLE
Fix: labels #1003

### DIFF
--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -10,11 +10,11 @@ const buildViewMenu = settings => {
         label: '&Sort Type',
         submenu: [
           {
-            label: 'Last &modified',
+            label: 'Date &modified',
             id: 'modificationDate',
           },
           {
-            label: 'Last &created',
+            label: 'Date &created',
             id: 'creationDate',
           },
           {

--- a/lib/dialogs/settings/index.jsx
+++ b/lib/dialogs/settings/index.jsx
@@ -235,8 +235,8 @@ export class SettingsDialog extends Component {
               onChange={setSortType}
               renderer={RadioGroup}
             >
-              <Item title="Last modified" slug="modificationDate" />
-              <Item title="Last created" slug="creationDate" />
+              <Item title="Date modified" slug="modificationDate" />
+              <Item title="Date created" slug="creationDate" />
               <Item title="Alphabetical" slug="alphabetical" />
             </SettingsGroup>
 


### PR DESCRIPTION
This is a fix created for the issue #1003 .

Labels changed as per request, both in the View Menu and the Settings Dialog: 

- Changed from: Last Modified and Last Created 
- Changed to: Date Modified and Date Created

**Test**

On the navigation tab open: 

- View > Sort type : Check if the text is correctly modified.
- File > Preferences > On the Settings tab switch to the Display sub-tab and check that the text reflect the changes in the code.

Both text should write Date Modified and Date Created.
