### PR TITLE
Evernote import: Add better support for clipped web content

### DIFF
--- a/lib/utils/import/evernote/enml-to-markdown.js
+++ b/lib/utils/import/evernote/enml-to-markdown.js
@@ -1,7 +1,11 @@
 import TurndownService from 'turndown';
-import { get, identity } from 'lodash';
+import { identity, startsWith } from 'lodash';
 
-const mediaPlaceholderFor = node => `(${node.getAttribute('type')})`;
+const mediaPlaceholderFor = node => {
+  const alt = node.getAttribute('alt');
+  const type = node.getAttribute('type') || 'media';
+  return alt ? `${alt}` : `(${type})`;
+};
 
 const enmlToMarkdown = enml => {
   // Do not escape Markdown characters
@@ -10,9 +14,18 @@ const enmlToMarkdown = enml => {
 
   const turndownService = new TurndownService({
     blankReplacement: (content, node) => {
-      if (get(node, 'firstChild.nodeName') === 'EN-MEDIA') {
-        return mediaPlaceholderFor(node.firstChild);
+      if (node.nodeName === 'EN-MEDIA') {
+        return mediaPlaceholderFor(node);
       }
+
+      const imageLinks = Array.from(node.querySelectorAll('a'));
+      if (imageLinks.length) {
+        return imageLinks.map(() => content).join(' ');
+      }
+
+      return Array.from(node.querySelectorAll('en-media'))
+        .map(mediaPlaceholderFor)
+        .join(' ');
     },
     codeBlockStyle: 'fenced',
     emDelimiter: '*',
@@ -44,7 +57,19 @@ const enmlToMarkdown = enml => {
       filter: 'a',
       replacement: (content, node) => {
         const href = node.getAttribute('href');
-        return content === href ? content : `[${content}](${href})`;
+        if (!href || content === href) {
+          return content;
+        }
+        return `[${content}](${href})`;
+      },
+    })
+    .addRule('svgImages', {
+      filter: node =>
+        node.nodeName === 'IMG' &&
+        startsWith(node.getAttribute('src'), 'data:image/svg'),
+      replacement: (content, node) => {
+        node.setAttribute('type', 'image/svg');
+        return mediaPlaceholderFor(node);
       },
     })
     .addRule('lineItems', {

--- a/lib/utils/import/evernote/enml-to-markdown.js
+++ b/lib/utils/import/evernote/enml-to-markdown.js
@@ -4,7 +4,7 @@ import { identity, startsWith } from 'lodash';
 const mediaPlaceholderFor = node => {
   const alt = node.getAttribute('alt');
   const type = node.getAttribute('type') || 'media';
-  return alt ? `${alt}` : `(${type})`;
+  return alt ? `${alt} (${type})` : `(${type})`;
 };
 
 const enmlToMarkdown = enml => {

--- a/lib/utils/import/evernote/test/enml-to-markdown.test.js
+++ b/lib/utils/import/evernote/test/enml-to-markdown.test.js
@@ -27,4 +27,28 @@ describe('enmlToMarkdown', () => {
     );
     expect(rendered).toBe('- UL like\n1. OL like\n# H1 like');
   });
+
+  it('should use alt text when available', () => {
+    const rendered = enmlToMarkdown(
+      '<en-media alt="Alt text" type="image/jpeg"></en-media>'
+    );
+    expect(rendered).toBe('Alt text');
+  });
+
+  it('should handle nested media in blank tags', () => {
+    const rendered = enmlToMarkdown(
+      '<p><a href="http://example.com"><en-media type="image/jpeg"></en-media></a></p>'
+    );
+    expect(rendered).toBe('[(image/jpeg)](http://example.com)');
+  });
+
+  it('should handle A tags with missing hrefs', () => {
+    const rendered = enmlToMarkdown('<a>Link</a>');
+    expect(rendered).toBe('Link');
+  });
+
+  it('should handle inline svgs', () => {
+    const rendered = enmlToMarkdown('<img src="data:image/svg+xmlblahblah" />');
+    expect(rendered).toBe('(image/svg)');
+  });
 });

--- a/lib/utils/import/evernote/test/enml-to-markdown.test.js
+++ b/lib/utils/import/evernote/test/enml-to-markdown.test.js
@@ -32,7 +32,7 @@ describe('enmlToMarkdown', () => {
     const rendered = enmlToMarkdown(
       '<en-media alt="Alt text" type="image/jpeg"></en-media>'
     );
-    expect(rendered).toBe('Alt text');
+    expect(rendered).toBe('Alt text (image/jpeg)');
   });
 
   it('should handle nested media in blank tags', () => {


### PR DESCRIPTION
This adds some better handling of Evernote notes clipped from a web browser.

### Enhancements

* use alt text when available
* handle nested media in blank tags
* handle `<a>` tags with missing hrefs
* handle inline svgs