### PR TITLE
Delete AppData on uninstall

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -48,7 +48,8 @@
   },
   "nsis": {
     "perMachine": true,
-    "artifactName": "Simplenote-win-${version}-${arch}.${ext}"
+    "artifactName": "Simplenote-win-${version}-${arch}.${ext}",
+    "deleteAppDataOnUninstall": true
   },
   "linux": {
     "icon": "resources/images/",


### PR DESCRIPTION
This ensures that all user data is deleted when uninstalling the app on Windows.

## Test builds

- [Win (exe)](https://ci.appveyor.com/api/buildjobs/shergaexp1r350wd/artifacts/release%2FSimplenote-win-1.3.0-beta.1.exe)
- [Win (appx)](https://ci.appveyor.com/api/buildjobs/a0k5vkc1vl0ow6q1/artifacts/release%2FSimplenote-win-1.3.0-beta.1-ia32.appx)

1. Install app and log in
1. Quit app and uninstall

→ Verify that `C:\Users\<user>\AppData\Roaming\Simplenote\` is gone at this point.

Then, reinstall the app and launch to see that you are not automatically logged in.