### PR TITLE
Update description in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplenote",
-  "description": "Light, clean, and free. Simplenote is modern note taking app available for iOS, Android, Mac, Windows, Linux, and the web.",
+  "description": "Simplenote is an easy way to keep notes, lists, ideas and more. Your notes stay in sync with all your devices for free.",
   "author": {
     "name": "Automattic, Inc.",
     "email": "support@simplenote.com"


### PR DESCRIPTION
Refs #917 

Updated package.json description to the app store description for the macOS native app. It now looks like this in Ubuntu:

<img width="800" alt="screen shot 2018-11-20 at 2 12 34 pm" src="https://user-images.githubusercontent.com/789137/48806576-9bbc6280-eccf-11e8-9f7b-a952565f28a8.png">

Note: I don't think it is possible to set the icon, proper capitalized app name, or app license at the moment. See: https://github.com/electron-userland/electron-builder/issues/1921

I also downloaded Slack and it looks just as bad :)
