### PR TITLE
Fix Button Styles for Navigation Drawer

### DIFF
--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -6,16 +6,18 @@
   white-space: nowrap;
   text-align: left;
 
-  svg {
-    fill: $gray;
-  }
-
   &.is-selected {
-    color: $blue;
+    .button {
+      color: $blue;
+    }
 
     svg[class^='icon-'] {
       fill: $blue;
     }
+  }
+
+  .button-borderless:active {
+    color: darken($blue, 20%);
   }
 }
 


### PR DESCRIPTION
The styles have been off for the buttons in the tag drawer for a while:

<img width="280" alt="screen shot 2018-11-20 at 4 19 27 pm" src="https://user-images.githubusercontent.com/789137/48810956-61a78c80-ece0-11e8-84c3-340596204b90.png">

This updates the CSS for these buttons so that the:
 * SVG icon fill matches the color of the text.
 * Selected item is blue (both icon and text).
 * The `:active` state for the buttons should be a dark blue for both icon and text.

After:
<img width="214" alt="screen shot 2018-11-20 at 4 18 20 pm" src="https://user-images.githubusercontent.com/789137/48810984-8bf94a00-ece0-11e8-8993-0f1d9400b29c.png">

**To Test**
* Open the navigation drawer, and select `Trash`. The colors should remain the same for the buttons depending on their selected or active state.
* Test both themes to ensure proper coloring of the buttons.
* Verify other buttons in the app still look correct.