### PR TITLE
Ensure that imported notes contain the properties required by the bucket schema

### DIFF
--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -51,6 +51,17 @@ class CoreImporter extends EventEmitter {
         new Date(importedNote.creationDate).getTime() / 1000;
     }
 
+    // Make sure that dates exist
+    importedNote.creationDate =
+      importedNote.creationDate || importedNote.modificationDate || Date.now();
+    importedNote.modificationDate =
+      importedNote.modificationDate || importedNote.creationDate || Date.now();
+
+    // Make sure that content property exists
+    if (!importedNote.hasOwnProperty('content')) {
+      importedNote.content = '';
+    }
+
     // Add the tags to the tag bucket
     if (importedNote.tags) {
       importedNote.tags.map(tagName => {

--- a/lib/utils/import/test.js
+++ b/lib/utils/import/test.js
@@ -1,29 +1,56 @@
 import CoreImporter from './';
 
-describe('Importer', () => {
+describe('CoreImporter', () => {
   let importer;
+  let noteBucketAdd = jest.fn();
 
   beforeEach(() => {
-    importer = new CoreImporter({ noteBucket: {}, tagBucket: {} });
+    importer = new CoreImporter({
+      noteBucket: {
+        add: noteBucketAdd,
+      },
+      tagBucket: {},
+    });
     importer.emit = jest.fn();
   });
 
-  it('should emit error when no notes are passed', () => {
-    importer.importNotes();
-    expect(importer.emit).toBeCalledWith(
-      'status',
-      'error',
-      'No notes to import.'
-    );
+  describe('importNote', () => {
+    it('should call noteBucket.add() with a note containing the required properties', () => {
+      const note = {};
+      importer.importNote(note);
+
+      const passedNote = noteBucketAdd.mock.calls[0][0];
+
+      // Conforms to schema
+      expect(passedNote.publishURL).toBe('');
+      expect(passedNote.shareURL).toBe('');
+      expect(passedNote.deleted).toBe(false);
+      expect(passedNote.tags).toEqual([]);
+      expect(passedNote.systemTags).toEqual([]);
+      expect(passedNote.creationDate).toEqual(expect.any(Number));
+      expect(passedNote.modificationDate).toEqual(expect.any(Number));
+      expect(passedNote.content).toBe('');
+    });
   });
 
-  it('should emit error when invalid object is passed', () => {
-    const bogusNotes = { actveNotes: [] };
-    importer.importNotes(bogusNotes);
-    expect(importer.emit).toBeCalledWith(
-      'status',
-      'error',
-      'Invalid import format: No active or trashed notes found.'
-    );
+  describe('importNotes', () => {
+    it('should emit error when no notes are passed', () => {
+      importer.importNotes();
+      expect(importer.emit).toBeCalledWith(
+        'status',
+        'error',
+        'No notes to import.'
+      );
+    });
+
+    it('should emit error when invalid object is passed', () => {
+      const bogusNotes = { actveNotes: [] };
+      importer.importNotes(bogusNotes);
+      expect(importer.emit).toBeCalledWith(
+        'status',
+        'error',
+        'Invalid import format: No active or trashed notes found.'
+      );
+    });
   });
 });


### PR DESCRIPTION
This fixes a bug where some imports using export data generated from Evernote Windows could fail silently.

### Cause

Export data from Evernote Windows did not always include an `<updated>` tag, which we were using to add a `modificationDate` property to the imported note. Our Simperium `note` bucket in production had a schema in place that would reject non-conforming data with an error 400. Simperium was rejecting notes because the required `modificationDate` property was missing.

### What was done to address it

- Add the same schema to the `note` bucket in development as well (unrelated to this PR).
- Make sure that every required property is contained in the notes that are added to the note bucket.
- `creationDate` and `modificationDate` will fall back on the other if only one of them exists, and then fall back to `Date.now()` as a last resort.

### To test

Try importing an authentic export generated from Evernote Windows, or any `.enex` file with the `updated` tag removed.