### PR TITLE
Move Simplenote `lastModified` concerns into Simplenote Importer

### DIFF
--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -5,7 +5,6 @@ const propertyWhitelist = [
   'content',
   'creationDate',
   'deleted',
-  'lastModified',
   'markdown',
   'modificationDate',
   'pinned',
@@ -37,13 +36,6 @@ class CoreImporter extends EventEmitter {
     if (importedNote.markdown || isMarkdown) {
       importedNote.systemTags.push('markdown');
       delete importedNote.markdown;
-    }
-
-    // Accout for Simplenote's exported `lastModified` date. Convert to timestamp
-    if (importedNote.lastModified && isNaN(importedNote.lastModified)) {
-      importedNote.modificationDate =
-        new Date(importedNote.lastModified).getTime() / 1000;
-      delete importedNote.lastModified;
     }
 
     if (importedNote.creationDate && isNaN(importedNote.creationDate)) {

--- a/lib/utils/import/simplenote/index.js
+++ b/lib/utils/import/simplenote/index.js
@@ -47,8 +47,12 @@ class SimplenoteImporter extends EventEmitter {
       const dataObj = JSON.parse(fileContent);
       const noteCount =
         dataObj.activeNotes.length + dataObj.trashedNotes.length;
+      const processedNotes = {
+        activeNotes: convertModificationDates(dataObj.activeNotes),
+        trashedNotes: convertModificationDates(dataObj.trashedNotes),
+      };
 
-      coreImporter.importNotes(dataObj, this.options).then(() => {
+      coreImporter.importNotes(processedNotes, this.options).then(() => {
         this.emit('status', 'complete', noteCount);
       });
     };
@@ -56,5 +60,22 @@ class SimplenoteImporter extends EventEmitter {
     fileReader.readAsText(file);
   };
 }
+
+export const convertModificationDates = notes => {
+  return notes.map(({ lastModified, ...note }) => {
+    // Account for Simplenote's exported `lastModified` date
+    let modificationDate = note.modificationDate || lastModified;
+
+    // Convert to timestamp
+    if (modificationDate && isNaN(modificationDate)) {
+      modificationDate = new Date(modificationDate).getTime() / 1000;
+    }
+    const resultNote = { ...note };
+    if (modificationDate) {
+      resultNote.modificationDate = modificationDate;
+    }
+    return resultNote;
+  });
+};
 
 export default SimplenoteImporter;

--- a/lib/utils/import/simplenote/test.js
+++ b/lib/utils/import/simplenote/test.js
@@ -1,0 +1,76 @@
+import SimplenoteImporter, { convertModificationDates } from './';
+import CoreImporter from '../';
+jest.mock('../');
+
+describe('SimplenoteImporter', () => {
+  let importer;
+
+  beforeEach(() => {
+    importer = new SimplenoteImporter({
+      noteBucket: {},
+      tagBucket: {},
+      options: { foo: true },
+    });
+    importer.emit = jest.spyOn(importer, 'emit');
+    CoreImporter.mockClear();
+    CoreImporter.mockImplementation(function() {
+      this.importNotes = jest.fn(() => ({
+        then: callback => callback(),
+      }));
+    });
+  });
+
+  it('should emit error when no notes are passed', () => {
+    importer.importNotes();
+    expect(importer.emit).toBeCalledWith(
+      'status',
+      'error',
+      'No file to import.'
+    );
+  });
+
+  it('should call coreImporter.importNotes with all notes and options', done => {
+    const notes = {
+      activeNotes: [{}, {}],
+      trashedNotes: [{}],
+    };
+    importer.on('status', () => {
+      const args = CoreImporter.mock.instances[0].importNotes.mock.calls[0];
+      expect(args[0].activeNotes).toHaveLength(2);
+      expect(args[0].trashedNotes).toHaveLength(1);
+      expect(args[1].foo).toBe(true);
+      done();
+    });
+    importer.importNotes([new File([JSON.stringify(notes)], 'foo.json')]);
+  });
+
+  describe('convertModificationDates', () => {
+    it('should convert `lastModified` ISO strings to `modificationDate` Unix timestamps', () => {
+      const processedNotes = convertModificationDates([
+        {
+          lastModified: '2018-10-15T14:09:10.382Z',
+          otherProp: 'value',
+        },
+        {
+          modificationDate: '1539612550',
+          otherProp: 'value',
+        },
+      ]);
+      expect(processedNotes).toEqual([
+        {
+          modificationDate: 1539612550.382,
+          otherProp: 'value',
+        },
+        {
+          modificationDate: '1539612550',
+          otherProp: 'value',
+        },
+      ]);
+    });
+
+    it('should not add undefined properties', () => {
+      const processedNotes = convertModificationDates([{}]);
+      expect(Object.keys(processedNotes[0])).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
This moves the `lastModified` → `modificationDate` conversion logic out of CoreImporter and into SimplenoteImporter, for better separation of concerns and easier testing.

TODO for another time: #1034

### To test

Check that Simplenote .json imports still work.