### PR TITLE
Add support for sorting the tags list

### DIFF
--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -84,7 +84,18 @@ const buildViewMenu = settings => {
         ),
       },
       {
-        label: '&Theme',
+        label: '&Tags',
+        submenu: [
+          {
+            label: '&Sort Alphabetically',
+            type: 'checkbox',
+            checked: settings.sortTagsAlpha,
+            click: appCommandSender({ action: 'toggleSortTagsAlpha' }),
+          },
+        ],
+      },
+      {
+        label: 'T&heme',
         submenu: [
           {
             label: '&Light',

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -58,12 +58,17 @@ const mapStateToProps = state => ({
   isAuthorized: selectors.auth.isAuthorized(state),
 });
 
-function mapDispatchToProps(dispatch, { noteBucket }) {
+function mapDispatchToProps(dispatch, { noteBucket, tagBucket }) {
   const actionCreators = Object.assign({}, appState.actionCreators);
 
   const thenReloadNotes = action => a => {
     dispatch(action(a));
     dispatch(actionCreators.loadNotes({ noteBucket }));
+  };
+
+  const thenReloadTags = action => a => {
+    dispatch(action(a));
+    dispatch(actionCreators.loadTags({ tagBucket }));
   };
 
   return {
@@ -85,6 +90,7 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
     ),
     setSortType: thenReloadNotes(settingsActions.setSortType),
     toggleSortOrder: thenReloadNotes(settingsActions.toggleSortOrder),
+    toggleSortTagsAlpha: thenReloadTags(settingsActions.toggleSortTagsAlpha),
 
     openTagList: () => dispatch(actionCreators.toggleNavigation()),
     resetAuth: () => dispatch(reduxActions.auth.reset()),

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -69,15 +69,12 @@ const client = simperium({
     preferences: function(objectStore) {
       console.log('Configure preferences', objectStore); // eslint-disable-line no-console
     },
-    tag: {
-      configure: function(objectStore) {
-        // Create an index on the tag name
-        objectStore.createIndex('name', 'data.name');
-      },
+    tag: function(objectStore) {
+      console.log('Configure tag', objectStore); // eslint-disable-line no-console
     },
   },
   database: 'simplenote',
-  version: 42,
+  version: 41,
 });
 
 const l = msg => {

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -69,12 +69,15 @@ const client = simperium({
     preferences: function(objectStore) {
       console.log('Configure preferences', objectStore); // eslint-disable-line no-console
     },
-    tag: function(objectStore) {
-      console.log('Configure tag', objectStore); // eslint-disable-line no-console
+    tag: {
+      configure: function(objectStore) {
+        // Create an index on the tag name
+        objectStore.createIndex('name', 'data.name');
+      },
     },
   },
   database: 'simplenote',
-  version: 41,
+  version: 42,
 });
 
 const l = msg => {

--- a/lib/dialogs/settings/index.jsx
+++ b/lib/dialogs/settings/index.jsx
@@ -140,6 +140,7 @@ export class SettingsDialog extends Component {
       setNoteDisplay,
       setSortType,
       toggleSortOrder,
+      toggleSortTagsAlpha,
     } = this.props;
 
     const {
@@ -149,6 +150,7 @@ export class SettingsDialog extends Component {
         noteDisplay,
         sortType,
         sortReversed: sortIsReversed,
+        sortTagsAlpha,
         accountName,
       },
     } = this.props;
@@ -248,6 +250,16 @@ export class SettingsDialog extends Component {
               renderer={ToggleGroup}
             >
               <Item title="Reversed" slug="reversed" />
+            </SettingsGroup>
+
+            <SettingsGroup
+              title="Tags"
+              slug="sortTagsAlpha"
+              activeSlug={sortTagsAlpha ? 'alpha' : ''}
+              onChange={toggleSortTagsAlpha}
+              renderer={ToggleGroup}
+            >
+              <Item title="Sort Alphabetically" slug="alpha" />
             </SettingsGroup>
 
             <SettingsGroup

--- a/lib/editable-list/index.jsx
+++ b/lib/editable-list/index.jsx
@@ -12,6 +12,7 @@ export class EditableList extends Component {
     editing: PropTypes.bool.isRequired,
     items: PropTypes.array.isRequired,
     renderItem: PropTypes.func.isRequired,
+    sortTagsAlpha: PropTypes.bool.isRequired,
     getItemKey: PropTypes.func,
     onRemove: PropTypes.func,
     onReorder: PropTypes.func,

--- a/lib/editable-list/index.jsx
+++ b/lib/editable-list/index.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import SmallCrossOutlineIcon from '../icons/cross-outline-small';
@@ -64,7 +65,7 @@ export class EditableList extends Component {
   };
 
   render() {
-    const { editing, onRemove, onReorder } = this.props;
+    const { editing, onRemove, onReorder, sortTagsAlpha } = this.props;
     const { reorderedItems, reorderingId } = this.state;
     const classes = classNames('editable-list', this.props.className, {
       'editable-list-editing': this.props.editing,
@@ -104,18 +105,19 @@ export class EditableList extends Component {
                 </span>
               </span>
 
-              {onReorder && (
-                <span
-                  className="editable-list-reorder"
-                  tabIndex={editing ? '0' : '-1'}
-                  onDragStart={e => e.preventDefault()}
-                  onMouseDown={this.onReorderStart.bind(this, itemId)}
-                  onTouchStart={this.onReorderStart.bind(this, itemId)}
-                  onKeyDown={this.onReorderKeyDown.bind(this, itemId)}
-                >
-                  <ReorderIcon />
-                </span>
-              )}
+              {onReorder &&
+                !sortTagsAlpha && (
+                  <span
+                    className="editable-list-reorder"
+                    tabIndex={editing ? '0' : '-1'}
+                    onDragStart={e => e.preventDefault()}
+                    onMouseDown={this.onReorderStart.bind(this, itemId)}
+                    onTouchStart={this.onReorderStart.bind(this, itemId)}
+                    onKeyDown={this.onReorderKeyDown.bind(this, itemId)}
+                  >
+                    <ReorderIcon />
+                  </span>
+                )}
             </li>
           );
         })}
@@ -301,4 +303,8 @@ export class EditableList extends Component {
   };
 }
 
-export default EditableList;
+const mapStateToProps = ({ settings: { sortTagsAlpha } }) => ({
+  sortTagsAlpha,
+});
+
+export default connect(mapStateToProps)(EditableList);

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -691,8 +691,7 @@ export const actionMap = new ActionMap({
             db
               .transaction('tag')
               .objectStore('tag')
-              .index('name')
-              .openCursor().onsuccess = e => {
+              .openCursor(null, 'prev').onsuccess = e => {
               var cursor = e.target.result;
               if (cursor) {
                 tags.push(cursor.value);
@@ -708,7 +707,14 @@ export const actionMap = new ActionMap({
 
     tagsLoaded(state, { tags, sortTagsAlpha }) {
       tags = tags.slice();
-      if (!sortTagsAlpha) {
+      if (sortTagsAlpha) {
+        // Sort tags alphabetically by 'name' value
+        tags.sort((a, b) => {
+          return get(a, 'data.name', '')
+            .toLowerCase()
+            .localeCompare(get(b, 'data.name', '').toLowerCase());
+        });
+      } else {
         // Sort the tags by their 'index' value
         tags.sort((a, b) => (a.data.index | 0) - (b.data.index | 0));
       }

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -684,19 +684,21 @@ export const actionMap = new ActionMap({
 
     loadTags: {
       creator({ tagBucket }) {
-        return dispatch => {
+        return (dispatch, getState) => {
+          const sortTagsAlpha = getState().settings.sortTagsAlpha;
           tagBucket.query(db => {
             var tags = [];
             db
               .transaction('tag')
               .objectStore('tag')
-              .openCursor(null, 'prev').onsuccess = e => {
+              .index('name')
+              .openCursor().onsuccess = e => {
               var cursor = e.target.result;
               if (cursor) {
                 tags.push(cursor.value);
                 cursor.continue();
               } else {
-                dispatch(this.action('tagsLoaded', { tags: tags }));
+                dispatch(this.action('tagsLoaded', { tags, sortTagsAlpha }));
               }
             };
           });
@@ -704,9 +706,12 @@ export const actionMap = new ActionMap({
       },
     },
 
-    tagsLoaded(state, { tags }) {
+    tagsLoaded(state, { tags, sortTagsAlpha }) {
       tags = tags.slice();
-      tags.sort((a, b) => (a.data.index | 0) - (b.data.index | 0));
+      if (!sortTagsAlpha) {
+        // Sort the tags by their 'index' value
+        tags.sort((a, b) => (a.data.index | 0) - (b.data.index | 0));
+      }
 
       return update(state, {
         tags: { $set: tags },

--- a/lib/state/settings/actions.js
+++ b/lib/state/settings/actions.js
@@ -48,6 +48,17 @@ export const setSortType = sortType => ({
   sortType,
 });
 
+export const setSortTagsAlpha = sortTagsAlpha => ({
+  type: 'setSortTagsAlpha',
+  sortTagsAlpha,
+});
+
+export const toggleSortTagsAlpha = () => (dispatch, getState) => {
+  const { settings: { sortTagsAlpha } } = getState();
+
+  dispatch(setSortTagsAlpha(!sortTagsAlpha));
+};
+
 export const setMarkdown = markdownEnabled => ({
   type: 'setMarkdownEnabled',
   markdownEnabled,

--- a/lib/state/settings/reducer.js
+++ b/lib/state/settings/reducer.js
@@ -17,6 +17,14 @@ const sortReversed = (state = false, action) => {
   return action.sortReversed;
 };
 
+const sortTagsAlpha = (state = false, action) => {
+  if ('setSortTagsAlpha' !== action.type) {
+    return state;
+  }
+
+  return action.sortTagsAlpha || false;
+};
+
 const theme = (state = 'light', action) => {
   if ('setTheme' !== action.type) {
     return state;
@@ -98,6 +106,7 @@ export default combineReducers({
   noteDisplay,
   sortType,
   sortReversed,
+  sortTagsAlpha,
   spellCheckEnabled,
   theme,
   wpToken,

--- a/lib/tag-list/index.jsx
+++ b/lib/tag-list/index.jsx
@@ -81,8 +81,8 @@ export class TagList extends Component {
         </div>
         <EditableList
           className="tag-list-items"
-          items={this.props.tags}
-          editing={this.props.editingTags}
+          items={tags}
+          editing={editingTags}
           renderItem={this.renderItem}
           onRemove={this.props.onTrashTag}
           onReorder={this.props.onReorderTags}


### PR DESCRIPTION
Adding a new setting to the app that allows you to sort the tags list alphabetically:

![sort-tags](https://user-images.githubusercontent.com/789137/49049209-e4be5c00-f192-11e8-8fa9-0dd2006713cf.gif)

I've added a new indexed db on the tag name, which automatically returns the results sorted by the index. This makes it super fast for us to get the sorted tags list!

It also adds a new `sortTagsAlpha` boolean to the state, which we use in a few places to apply the proper sorting and to disable the 'drag' icon when editing tags when alpha sort is enabled.

**To Test**
* Launch the app and view the tags list. It should be in the custom order.
* Select View -> Tags -> Sort Alphabetically. The tags list should now be sorted alphabetically.
* Edit the tags list, you should not see the drag icon to reorder the list.
* Turn off alphabetical sort, it should go back to the previous custom order. You should be able to Edit the tags list and reorder items again.
