### PR TITLE
Add easier debugging & validation to Tracks event recording

### DIFF
--- a/lib/analytics/index.js
+++ b/lib/analytics/index.js
@@ -1,3 +1,5 @@
+const debug = require('debug')('analytics');
+
 /**
  * Internal dependencies
  */
@@ -32,15 +34,7 @@ const analytics = {
 
   tracks: {
     recordEvent: function(eventName, eventProperties) {
-      if (!window.analyticsEnabled || process.env.NODE_ENV === 'development') {
-        return;
-      }
-
       const prefix = analytics.getPlatformPrefix();
-
-      if (!prefix) {
-        return;
-      }
 
       const fullEventName = `${prefix}_${eventName}`;
       const fullEventProperties = {
@@ -48,7 +42,15 @@ const analytics = {
         device_info_app_version: config.version, // eslint-disable-line no-undef
       };
 
-      window._tkq.push(['recordEvent', fullEventName, fullEventProperties]);
+      debug(`${fullEventName}: %o`, fullEventProperties);
+
+      if (
+        window.analyticsEnabled &&
+        prefix &&
+        process.env.NODE_ENV !== 'development'
+      ) {
+        window._tkq.push(['recordEvent', fullEventName, fullEventProperties]);
+      }
     },
   },
 

--- a/lib/analytics/index.js
+++ b/lib/analytics/index.js
@@ -43,6 +43,7 @@ const analytics = {
       };
 
       debug(`${fullEventName}: %o`, fullEventProperties);
+      analytics.tracks.validateEvent(fullEventName, fullEventProperties);
 
       if (
         window.analyticsEnabled &&
@@ -50,6 +51,25 @@ const analytics = {
         process.env.NODE_ENV !== 'development'
       ) {
         window._tkq.push(['recordEvent', fullEventName, fullEventProperties]);
+      }
+    },
+    validateEvent: function(fullEventName, fullEventProperties) {
+      if (process.env.NODE_ENV !== 'development') {
+        return;
+      }
+
+      const validName = /^[a-z_][a-z0-9_]*$/;
+
+      if (!validName.test(fullEventName)) {
+        throw new Error(`Event ${fullEventName} is invalid`);
+      }
+
+      for (const propName in fullEventProperties) {
+        if (!validName.test(propName)) {
+          throw new Error(
+            `Property ${propName} in event ${fullEventName} is invalid`
+          );
+        }
       }
     },
   },

--- a/lib/analytics/test.js
+++ b/lib/analytics/test.js
@@ -88,5 +88,21 @@ describe('Analytics', () => {
         my_property: 'test_property',
       });
     });
+
+    it('should throw an error if in dev mode and event name is invalid', () => {
+      global.process.env.NODE_ENV = 'development';
+      expect(() => {
+        analytics.tracks.recordEvent('eventWithInvalidName');
+      }).toThrow();
+    });
+
+    it('should throw an error if in dev mode and event prop name is invalid', () => {
+      global.process.env.NODE_ENV = 'development';
+      expect(() => {
+        analytics.tracks.recordEvent('test_event', {
+          propWithInvalidName: true,
+        });
+      }).toThrow();
+    });
   });
 });


### PR DESCRIPTION
This adds two improvements:

- Add `debug` to `tracks.recordEvent()`, so we can easily see what events will be sent. (Set `localStorage.debug="analytics"` in the devtools console and reload)
- Validate event names/props in development, so we can avoid mistakes like #1049.