### PR TITLE
Add wiggle room to activity-hooks test timeout

### DIFF
--- a/lib/utils/sync/activity-hooks.test.js
+++ b/lib/utils/sync/activity-hooks.test.js
@@ -2,6 +2,7 @@ import activityHooks, { debounceWait } from './activity-hooks';
 import { times } from 'lodash';
 
 describe('sync:activityHooks', () => {
+  const delay = debounceWait + 5; // wiggle room
   let order, hooks;
 
   beforeEach(() => {
@@ -22,7 +23,7 @@ describe('sync:activityHooks', () => {
       expect(hooks.onIdle).toHaveBeenCalledTimes(1);
       expect(order).toEqual(['active', 'idle']);
       done();
-    }, debounceWait);
+    }, delay);
   });
 
   it('should ignore heartbeats', done => {
@@ -34,6 +35,6 @@ describe('sync:activityHooks', () => {
       expect(hooks.onActive).toHaveBeenCalledTimes(0);
       expect(hooks.onIdle).toHaveBeenCalledTimes(0);
       done();
-    }, debounceWait);
+    }, delay);
   });
 });


### PR DESCRIPTION
This will hopefully fix an `activity-hooks` test that is failing sporadically ([1](https://ci.appveyor.com/project/Automattic/simplenote-electron/builds/20565958/job/frrelehmixpnv8w1), [2](https://ci.appveyor.com/project/Automattic/simplenote-electron/builds/20648637/job/w3yyejlhvu2thmma)) on AppVeyor.