### PR TITLE
Configure Windows Store build with prod database

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,8 @@ for:
   - matrix:
       only:
         - configuration: AppX-WindowsStore
+    before_build:
+      - openssl aes-256-cbc -d -in .\resources\secrets\config.json.enc -out .\config.json -k "%CSC_ENC_KEY%"
     environment:
       CSC_LINK: ""
     build_script:


### PR DESCRIPTION
The Windows Store build seems to be configured with the dev database, I think because of a missing step in the `before_build`.