### PR TITLE
Init Flood Fixes

### DIFF
--- a/lib/boot.js
+++ b/lib/boot.js
@@ -183,6 +183,7 @@ let props = {
   },
   onSignOut: () => {
     delete localStorage.access_token;
+    token = null;
     store.dispatch(setAccountName(null));
     client.deauthorize();
     if (config.signout) {


### PR DESCRIPTION
The app is sending _a lot_ of `index` and `cv` websocket commands to Simperium. So far I've learned that the app can get in a reconnect loop after signing out.

When we sign out we call:

https://github.com/Automattic/simplenote-electron/blob/21bb3d746fab1e5f5f0b0f56aa8958fda1eb4dc3/lib/boot.js#L188

Which then emits `unauthorize` here, but we still have the `token` var set which seems to be the culprit:
https://github.com/Automattic/simplenote-electron/blob/21bb3d746fab1e5f5f0b0f56aa8958fda1eb4dc3/lib/boot.js#L96-L108

The websocket then tries to connect and `init` over and over again. Setting the `token` to `null` when signing out seems to fix it.

Another case for fixing #1026!

I'm not sure if this is the sole issue of these init calls floods, because the Simperium logs are showing valid tokens being passed for the majority of the requests.

