### PR TITLE
Don’t nudge unsynced notes when not authorized

### DIFF
--- a/lib/utils/sync/nudge-unsynced.js
+++ b/lib/utils/sync/nudge-unsynced.js
@@ -11,6 +11,10 @@ import Debug from 'debug';
 const debug = Debug('sync:nudgeUnsynced');
 
 const nudgeUnsynced = ({ noteBucket, notes, client }) => {
+  if (!client.isAuthorized()) {
+    return Promise.resolve(); // not an error, just resolve and move on
+  }
+
   const noteHasSynced = note =>
     new Promise(resolve =>
       noteBucket.getVersion(note.id, (e, v) => {

--- a/lib/utils/sync/nudge-unsynced.test.js
+++ b/lib/utils/sync/nudge-unsynced.test.js
@@ -1,8 +1,10 @@
 import nudgeUnsynced from './nudge-unsynced';
 
 describe('sync:nudgeUnsynced', () => {
-  it('should reconnect the client when an unsynced note exists', () => {
-    const mockArg = {
+  let mockArg;
+
+  beforeEach(() => {
+    mockArg = {
       noteBucket: {
         getVersion: (_, callback) => {
           callback(undefined, 0); // no error, v === 0
@@ -11,11 +13,21 @@ describe('sync:nudgeUnsynced', () => {
       notes: [{}],
       client: {
         client: { connect: jest.fn() },
+        isAuthorized: jest.fn().mockReturnValue(true),
       },
     };
+  });
 
-    nudgeUnsynced(mockArg).then(() => {
+  it('should reconnect the client when an unsynced note exists', () => {
+    return nudgeUnsynced(mockArg).then(() => {
       expect(mockArg.client.client.connect).toHaveBeenCalled();
+    });
+  });
+
+  it('should not reconnect the client if not authorized', () => {
+    mockArg.client.isAuthorized.mockReturnValue(false);
+    return nudgeUnsynced(mockArg).then(() => {
+      expect(mockArg.client.client.connect).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
This enhancement prevents `nudgeUnsynced()` from making unnecessary calls when the simperium client is not authorized.

**When logged out**: After this change, `nudgeUnsynced()` will neither check for unsynced notes nor try to reconnect the client. This may prevent problems in situations where there are a lot of simperium calls being made in the logged out state, due to bugs occurring elsewhere.

**When logged in**: Same as above, but this change shouldn't be all that relevant, now that we are logging out the user when the access token is unauthorized (#1022).

### To test

1. In devtools console, set `localStorage.debug="sync:*"` and reload.
2. In the logged out state, `sync:nudgeUnsynced` shouldn't be logged after the `sync:activityHooks Sync idle`.