### PR TITLE
 User correct simperium method to disconnect web socket

### DIFF
--- a/lib/simperium/index.js
+++ b/lib/simperium/index.js
@@ -134,11 +134,11 @@ BrowserClient.prototype.setUser = function(user) {
 BrowserClient.prototype.deauthorize = function() {
   this.client.setAccessToken(null);
   this.emit('unauthorized');
-  this.client.disconnect();
+  this.client.end();
   this.reset();
 };
 
 BrowserClient.prototype.clearAuthorization = function() {
   this.client.setAccessToken(null);
-  this.client.disconnect();
+  this.client.end();
 };


### PR DESCRIPTION
It looks like we were using the wrong simperium method to disconnect the web socket. It has two methods:

**disconnect():**
This disconnects from the socket, but doesn't stop the reconnect timer, so it will keep trying to reconnect.

https://github.com/Simperium/node-simperium/blob/master/src/simperium/client.js#L191-L197

**end()**:
This properly stops the retry timer, then calls `disconnect()`. We have a winner!

https://github.com/Simperium/node-simperium/blob/master/src/simperium/client.js#L199-L203

**To Test**
* Sign out of the app, check the console and you shouldn't see any continuous websocket activity.
* Sign in to the app, verify sync works (authorizing a user starts the websocket again).
* Now change your password at app.simplenote.com and make any change to the app. You should be signed out, and not see any continuous websocket activity.
* Sign in again with your changed password and verify sync is working.


