### PR TITLE
Revert Note List Markdown Rendering

### DIFF
--- a/lib/utils/note-utils.js
+++ b/lib/utils/note-utils.js
@@ -1,5 +1,3 @@
-import removeMarkdown from 'remove-markdown';
-
 /**
  * Matches the title and excerpt in a note's content
  *
@@ -12,6 +10,20 @@ import removeMarkdown from 'remove-markdown';
 const noteTitleAndPreviewRegExp = /\s*(\S[^\n]*)\s*(\S[^\n]*)?/;
 
 /**
+ * Matches the title and excerpt in a note's content skipping opening # from title
+ *
+ * Both the title and the excerpt are determined as
+ * content starting with something that isn't
+ * whitespace and leads up to a newline or line end
+ *
+ * @type {RegExp} matches a title and excerpt in note content skipping opening #'s from title and preview
+ */
+const noteTitleAndPreviewMdRegExp = /(?:#{0,6}\s+)?(\S[^\n]*)\s*(?:#{0,6}\s+)?(\S[^\n]*)?/;
+
+// Ample amount of characters for 'Expanded' list view
+const characterLimit = 300;
+
+/**
  * Returns the title and excerpt for a given note
  *
  * @param {Object} note a note object
@@ -19,11 +31,11 @@ const noteTitleAndPreviewRegExp = /\s*(\S[^\n]*)\s*(\S[^\n]*)?/;
  */
 export const noteTitleAndPreview = note => {
   let content = (note && note.data && note.data.content) || '';
-  content = isMarkdown(note)
-    ? removeMarkdown(content, { stripListLeaders: false })
-    : content;
+  content = content.substring(0, characterLimit);
 
-  const match = noteTitleAndPreviewRegExp.exec(content);
+  const match = isMarkdown(note)
+    ? noteTitleAndPreviewMdRegExp.exec(content || '')
+    : noteTitleAndPreviewRegExp.exec(content || '');
 
   const defaults = {
     title: 'New Note...',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11569,7 +11569,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
@@ -14201,7 +14201,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
@@ -18008,11 +18008,6 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
-    },
-    "remove-markdown": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.3.0.tgz",
-      "integrity": "sha1-XktmdJOpNXlyjz1S7MHbnKUF3Jg="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -21849,7 +21844,7 @@
         },
         "globby": {
           "version": "6.1.0",
-          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
@@ -21862,7 +21857,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -21983,7 +21978,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "redux": "3.7.2",
     "redux-localstorage": "0.4.1",
     "redux-thunk": "2.2.0",
-    "remove-markdown": "^0.3.0",
     "sanitize-filename": "1.6.1",
     "sax": "1.2.4",
     "semver": "^5.5.1",


### PR DESCRIPTION
I think the user in #1057 may be encountering this bug, (props @mirka for finding it!):

https://github.com/stiang/remove-markdown/issues/35

All this PR is revert back to the old way of parsing markdown in the notes list (only headers), and limits the amount of characters to process for a note.

Other ideas welcome :) Maybe the bug will be fixed in `remove-markdown` soon?
