### PR TITLE
Fix NoteList excerpt caching

### DIFF
--- a/lib/note-list/get-note-title-and-preview.js
+++ b/lib/note-list/get-note-title-and-preview.js
@@ -10,15 +10,22 @@ const noteCache = new Map();
  * @param {Function} getValue Get the value for the cache
  * @returns {Object} note title and preview excerpt
  */
-const withCache = (getKey, getValue) => note => {
+export const withCache = (getKey, getValue) => note => {
   let cached = noteCache.get(note.id);
   const key = getKey(note);
 
-  if ('undefined' === typeof cached || key !== cached[0]) {
-    noteCache.set(note.id, [key, getValue(note)]);
+  if ('undefined' === typeof cached || key !== cached.key) {
+    noteCache.set(note.id, { key, value: getValue(note) });
     cached = noteCache.get(note.id);
   }
-  return cached[1];
+  return cached.value;
 };
 
-export default withCache(note => note.data.modificationDate, getNoteExcerpt);
+export const clearCache = () => noteCache.clear();
+
+const getNoteTitleAndPreview = withCache(
+  note => note.data.modificationDate,
+  getNoteExcerpt
+);
+
+export default getNoteTitleAndPreview;

--- a/lib/note-list/get-note-title-and-preview.js
+++ b/lib/note-list/get-note-title-and-preview.js
@@ -1,39 +1,24 @@
-import noteTitle from '../utils/note-utils';
+import getNoteExcerpt from '../utils/note-utils';
 
 /** @type {Map} stores a cache of computed note preview excerpts to prevent re-truncating note content */
 const noteCache = new Map();
 
 /**
- * Caches based on note id and note content
+ * Caches based on note id
  *
- * @param {Function} f sets the value of the cache
+ * @param {Function} getKey Get the key used for invalidating the cache
+ * @param {Function} getValue Get the value for the cache
  * @returns {Object} note title and preview excerpt
  */
-const noteTitleAndPreviewCache = f => note => {
+const withCache = (getKey, getValue) => note => {
   let cached = noteCache.get(note.id);
+  const key = getKey(note);
 
-  if ('undefined' === typeof cached || note.data.content !== cached[0]) {
-    noteCache.set(note.id, [note.data.content, f(note)]);
+  if ('undefined' === typeof cached || key !== cached[0]) {
+    noteCache.set(note.id, [key, getValue(note)]);
     cached = noteCache.get(note.id);
   }
-
-  return {
-    title: cached[1].title,
-    preview: cached[1].preview,
-  };
+  return cached[1];
 };
 
-/**
- * Gets the note title and preview excerpt
- *
- * This is cached by the note id and content
- *
- * @function
- * @param {Object} note note object
- * @returns {Object} note title and preview excerpt
- */
-const getNoteTitleAndPreview = noteTitleAndPreviewCache(note =>
-  noteTitle(note)
-);
-
-export default getNoteTitleAndPreview;
+export default withCache(note => note.data.content, getNoteExcerpt);

--- a/lib/note-list/get-note-title-and-preview.js
+++ b/lib/note-list/get-note-title-and-preview.js
@@ -1,0 +1,39 @@
+import noteTitle from '../utils/note-utils';
+
+/** @type {Map} stores a cache of computed note preview excerpts to prevent re-truncating note content */
+const noteCache = new Map();
+
+/**
+ * Caches based on note id and note content
+ *
+ * @param {Function} f sets the value of the cache
+ * @returns {Object} note title and preview excerpt
+ */
+const noteTitleAndPreviewCache = f => note => {
+  let cached = noteCache.get(note.id);
+
+  if ('undefined' === typeof cached || note.data.content !== cached[0]) {
+    noteCache.set(note.id, [note.data.content, f(note)]);
+    cached = noteCache.get(note.id);
+  }
+
+  return {
+    title: cached[1].title,
+    preview: cached[1].preview,
+  };
+};
+
+/**
+ * Gets the note title and preview excerpt
+ *
+ * This is cached by the note id and content
+ *
+ * @function
+ * @param {Object} note note object
+ * @returns {Object} note title and preview excerpt
+ */
+const getNoteTitleAndPreview = noteTitleAndPreviewCache(note =>
+  noteTitle(note)
+);
+
+export default getNoteTitleAndPreview;

--- a/lib/note-list/get-note-title-and-preview.js
+++ b/lib/note-list/get-note-title-and-preview.js
@@ -21,4 +21,4 @@ const withCache = (getKey, getValue) => note => {
   return cached[1];
 };
 
-export default withCache(note => note.data.content, getNoteExcerpt);
+export default withCache(note => note.data.modificationDate, getNoteExcerpt);

--- a/lib/note-list/get-note-title-and-preview.js
+++ b/lib/note-list/get-note-title-and-preview.js
@@ -15,8 +15,9 @@ export const withCache = (getKey, getValue) => note => {
   const key = getKey(note);
 
   if ('undefined' === typeof cached || key !== cached.key) {
-    noteCache.set(note.id, { key, value: getValue(note) });
-    cached = noteCache.get(note.id);
+    const newCacheObj = { key, value: getValue(note) };
+    noteCache.set(note.id, newCacheObj);
+    cached = newCacheObj;
   }
   return cached.value;
 };

--- a/lib/note-list/get-note-title-and-preview.test.js
+++ b/lib/note-list/get-note-title-and-preview.test.js
@@ -1,0 +1,40 @@
+import { clearCache, withCache } from './get-note-title-and-preview';
+
+describe('getNoteTitleAndPreview', () => {
+  describe('withCache', () => {
+    const getKey = note => note.mockKey;
+
+    afterEach(() => {
+      clearCache();
+    });
+
+    it('should only call getValue() when necessary', () => {
+      const getValue = jest.fn();
+
+      withCache(getKey, getValue)({ id: 0, mockKey: 'foo' }); // should call
+      withCache(getKey, getValue)({ id: 0, mockKey: 'foo' }); // shouldn't call
+      expect(getValue).toHaveBeenCalledTimes(1);
+      withCache(getKey, getValue)({ id: 0, mockKey: 'bar' }); // should call
+      expect(getValue).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return the cached value', () => {
+      const getValue = jest.fn().mockReturnValueOnce('mock value');
+
+      withCache(getKey, getValue)({ id: 0, mockKey: 'foo' });
+      const result = withCache(getKey, getValue)({ id: 0, mockKey: 'foo' });
+      expect(result).toBe('mock value');
+    });
+
+    it('should return an updated value when cache is invalidated', () => {
+      const getValue = jest
+        .fn()
+        .mockReturnValueOnce('initial value')
+        .mockReturnValueOnce('changed value');
+
+      withCache(getKey, getValue)({ id: 0, mockKey: 'foo' });
+      const result = withCache(getKey, getValue)({ id: 0, mockKey: 'bar' });
+      expect(result).toBe('changed value');
+    });
+  });
+});

--- a/lib/note-list/index.jsx
+++ b/lib/note-list/index.jsx
@@ -485,7 +485,7 @@ const mapStateToProps = ({ appState: state, settings: { noteDisplay } }) => {
    *
    * @type {String} preview excerpt for the current note
    */
-  const selectedNoteTitle =
+  const selectedNotePreview =
     selectedNote && getNoteTitleAndPreview(selectedNote).preview;
 
   return {
@@ -494,7 +494,7 @@ const mapStateToProps = ({ appState: state, settings: { noteDisplay } }) => {
     noteDisplay,
     notes: filteredNotes,
     prevNote,
-    selectedNoteTitle,
+    selectedNotePreview,
     selectedNoteContent: get(selectedNote, 'data.content'),
     selectedNoteId,
     showTrash: state.showTrash,

--- a/lib/note-list/index.jsx
+++ b/lib/note-list/index.jsx
@@ -22,7 +22,7 @@ import { connect } from 'react-redux';
 import appState from '../flux/app-state';
 import { tracks } from '../analytics';
 import filterNotes from '../utils/filter-notes';
-import noteTitle from '../utils/note-utils';
+import getNoteTitleAndPreview from './get-note-title-and-preview';
 
 AutoSizer.displayName = 'AutoSizer';
 List.displayName = 'List';
@@ -86,42 +86,6 @@ function getTextWidth(text, width) {
 
 /** @type {Map} stores a cache of computed row heights to prevent re-rendering the canvas calculation */
 const previewCache = new Map();
-
-/** @type {Map} stores a cache of computed note preview excerpts to prevent re-truncating note content */
-const noteCache = new Map();
-
-/**
- * Caches based on note id and note content
- *
- * @param {Function} f sets the value of the cache
- * @returns {Object} note title and preview excerpt
- */
-const noteTitleAndPreviewCache = f => note => {
-  let cached = noteCache.get(note.id);
-
-  if ('undefined' === typeof cached || note.data.content !== cached[0]) {
-    noteCache.set(note.id, [note.data.content, f(note)]);
-    cached = noteCache.get(note.id);
-  }
-
-  return {
-    title: cached[1].title,
-    preview: cached[1].preview,
-  };
-};
-
-/**
- * Gets the note title and preview excerpt
- *
- * This is cached by the note id and content
- *
- * @function
- * @param {Object} note note object
- * @returns {Object} note title and preview excerpt
- */
-const getNoteTitleAndPreview = noteTitleAndPreviewCache(note =>
-  noteTitle(note)
-);
 
 /**
  * Caches based on note id, width, note display format, and note preview excerpt

--- a/lib/note-list/index.jsx
+++ b/lib/note-list/index.jsx
@@ -97,17 +97,16 @@ const noteCache = new Map();
  * @returns {Object} note title and preview excerpt
  */
 const noteTitleAndPreviewCache = f => note => {
-  const cached = noteCache.get(note.id);
+  let cached = noteCache.get(note.id);
 
   if ('undefined' === typeof cached || note.data.content !== cached[0]) {
     noteCache.set(note.id, [note.data.content, f(note)]);
+    cached = noteCache.get(note.id);
   }
 
-  const source = cached || noteCache.get(note.id);
-
   return {
-    title: source[1].title,
-    preview: source[1].preview,
+    title: cached[1].title,
+    preview: cached[1].preview,
   };
 };
 

--- a/lib/note-list/index.jsx
+++ b/lib/note-list/index.jsx
@@ -353,11 +353,11 @@ export class NoteList extends Component {
     window.addEventListener('resize', this.recomputeHeights);
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     if (
-      nextProps.noteDisplay !== this.props.noteDisplay ||
-      nextProps.notes !== this.props.notes ||
-      nextProps.selectedNoteContent !== this.props.selectedNoteContent
+      prevProps.noteDisplay !== this.props.noteDisplay ||
+      prevProps.notes !== this.props.notes ||
+      prevProps.selectedNoteContent !== this.props.selectedNoteContent
     ) {
       this.recomputeHeights();
     }


### PR DESCRIPTION
This is mostly a code maintenance PR, but with three functional fixes:

1. ca2775d — While the result of `noteTitle()` was being cached for row height calculation, the cached results weren't being used inside `render()`. This was aggravating the issue in #1073.
1. cdb4d60 — `noteTitleAndPreviewCache()` wasn't returning updated data when the cache should have been invalidated. This fix should make row height calculation more reliable.
1. 97cd223 — `noteTitleAndPreviewCache()` was comparing the whole note content to decide whether to invalidate the cache. Changing this to compare modification dates should be faster and use less memory.

### Side note

The `render()` in NoteList is being called twice for every click in the editor (!), which seems very strange and is something we should look into...