### PR TITLE
Fix styles for many tags

### DIFF
--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -1,6 +1,7 @@
 .app-layout {
   display: flex;
   flex: 1 0 auto;
+  width: 100%;
 
   &.is-focus-mode.is-note-open {
     .app-layout__source-column {

--- a/lib/components/tag-chip/style.scss
+++ b/lib/components/tag-chip/style.scss
@@ -1,6 +1,6 @@
 .tag-chip {
   flex: none;
-  margin: 2px 12px 3px 0;
+  margin: 2px 8px 6px 0;
   padding: 1px 14px 3px 14px;
   border-radius: 14px;
   line-height: 1.25em;

--- a/lib/tag-field/style.scss
+++ b/lib/tag-field/style.scss
@@ -10,7 +10,7 @@
   line-height: 1.75em;
   white-space: nowrap;
   overflow: auto;
-  max-height: 78px; // about 2.5 rows
+  max-height: calc(2.5 * 1.75em + 16px); // about 2.5 rows
   padding: 8px 12px;
 
   &:focus {

--- a/lib/tag-field/style.scss
+++ b/lib/tag-field/style.scss
@@ -9,9 +9,9 @@
   flex: 1 1 auto;
   line-height: 1.75em;
   white-space: nowrap;
-  overflow: visible;
-  max-height: 120px;
-	padding: 8px 12px;
+  overflow: auto;
+  max-height: 78px; // about 2.5 rows
+  padding: 8px 12px;
 
   &:focus {
     outline: none;


### PR DESCRIPTION
Fixes #1017 

### Minor tweaks (in addition to the #1017 fix)

Adjusts spacing so the tags look nicer when on multiple rows:

<img width="400" alt="screen shot 2018-12-08 at 7 12 02" src="https://user-images.githubusercontent.com/555336/49675592-b1949a80-fab9-11e8-9c80-ba1cfa734374.png">

Sets the max height to about 2.5 rows (so the user can see there is more), and scrolls the rest:

<img width="400" alt="screen shot 2018-12-08 at 7 11 16" src="https://user-images.githubusercontent.com/555336/49675601-b6594e80-fab9-11e8-95f3-76344636dde3.png">
