### PR TITLE
Remove markdown in preview without triggering bug

### DIFF
--- a/lib/utils/note-utils.js
+++ b/lib/utils/note-utils.js
@@ -1,3 +1,5 @@
+import removeMarkdown from 'remove-markdown';
+
 /**
  * Matches the title and excerpt in a note's content
  *
@@ -23,6 +25,12 @@ const noteTitleAndPreviewMdRegExp = /(?:#{0,6}\s+)?(\S[^\n]*)\s*(?:#{0,6}\s+)?(\
 // Ample amount of characters for 'Expanded' list view
 const characterLimit = 300;
 
+// Defaults for notes with empty content
+export const defaults = {
+  title: 'New Note...',
+  preview: '',
+};
+
 /**
  * Returns the title and excerpt for a given note
  *
@@ -37,16 +45,21 @@ export const noteTitleAndPreview = note => {
     ? noteTitleAndPreviewMdRegExp.exec(content || '')
     : noteTitleAndPreviewRegExp.exec(content || '');
 
-  const defaults = {
-    title: 'New Note...',
-    preview: '',
-  };
-
   if (!match) {
     return defaults;
   }
 
-  const [, title, preview] = match;
+  let [, title, preview] = match;
+
+  if (preview && isMarkdown(note)) {
+    // Workaround for a bug in `remove-markdown`
+    // See https://github.com/stiang/remove-markdown/issues/35
+    const previewWithSpacesTrimmed = preview.replace(/(\s)\s+/g, '$1');
+
+    preview = removeMarkdown(previewWithSpacesTrimmed, {
+      stripListLeaders: false,
+    });
+  }
 
   return {
     title: title.slice(0, 200) || defaults.title,

--- a/lib/utils/note-utils.test.js
+++ b/lib/utils/note-utils.test.js
@@ -1,0 +1,50 @@
+import noteTitleAndPreview, { defaults } from './note-utils';
+
+describe('noteTitleAndPreview', () => {
+  let note;
+
+  beforeEach(() => {
+    note = {
+      data: {
+        content: '',
+        systemTags: ['markdown'],
+      },
+    };
+  });
+
+  it('should return default values if note content is empty', () => {
+    const result = noteTitleAndPreview(note);
+    expect(result).toEqual(defaults);
+  });
+
+  it('should return the title and preview when note is not Markdown', () => {
+    note.data.content = 'My title\nThe preview';
+    note.data.systemTags = [];
+    const result = noteTitleAndPreview(note);
+    expect(result).toEqual({
+      title: 'My title',
+      preview: 'The preview',
+    });
+  });
+
+  it('should return the title and preview with Markdown removed when note is Markdown', () => {
+    note.data.content = '# My title\nThe [preview](https://test.com)';
+    const result = noteTitleAndPreview(note);
+    expect(result).toEqual({
+      title: 'My title',
+      preview: 'The preview',
+    });
+  });
+
+  // Test that it doesn't trigger the bug in `remove-markdown`
+  // See https://github.com/stiang/remove-markdown/issues/35
+  it('should complete in a reasonable amount of time', () => {
+    const bugInducingString =
+      '# aaa                                               bbb';
+    note.data.content = bugInducingString + '\n' + bugInducingString;
+    const startTime = Date.now();
+    noteTitleAndPreview(note);
+    const elapsedMs = Date.now() - startTime;
+    expect(elapsedMs).toBeLessThanOrEqual(1);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -18009,6 +18009,11 @@
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
     },
+    "remove-markdown": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.3.0.tgz",
+      "integrity": "sha1-XktmdJOpNXlyjz1S7MHbnKUF3Jg="
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "redux": "3.7.2",
     "redux-localstorage": "0.4.1",
     "redux-thunk": "2.2.0",
+    "remove-markdown": "0.3.0",
     "sanitize-filename": "1.6.1",
     "sax": "1.2.4",
     "semver": "^5.5.1",


### PR DESCRIPTION
This restores the `remove-markdown` module removed in #1073.

As a workaround for the bug in `remove-markdown`, we can collapse multiple repeating `\s` chars into a single one, before the text is passed to the markdown removing function.

https://github.com/Automattic/simplenote-electron/blob/1302e6b4d0c27e05ed4e1711af9214e6c1746189/lib/utils/note-utils.js#L57

I [added a test](https://github.com/Automattic/simplenote-electron/blob/1302e6b4d0c27e05ed4e1711af9214e6c1746189/lib/utils/note-utils.test.js#L41) to ensure that the markdown removal takes less than 1 ms or so to complete. You can run the test case with the space trimming step commented out, and see that it takes around 15 ms.

This workaround, paired with the Note List caching fix (#1078), should fix the performance issues in #1057. (Unless there are other bugs in play!)