### PR TITLE
Ensure that selected note is updated on launch when there are multiple updates

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -151,7 +151,8 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
 
       this.props.noteBucket
         .on('index', this.onNotesIndex)
-        .on('update', debounce(this.onNoteUpdate, 200, { maxWait: 1000 }))
+        .on('update', this.onNoteUpdate)
+        .on('update', debounce(this.onNotesIndex, 200, { maxWait: 1000 })) // refresh notes list
         .on('remove', this.onNoteRemoved);
 
       this.props.preferencesBucket.on('update', this.onLoadPreferences);

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -490,8 +490,7 @@ export const actionMap = new ActionMap({
           var state = getState().appState;
           const { original, patch } = remoteUpdateInfo;
 
-          // Refresh the notes list
-          dispatch(this.action('loadNotes', { noteBucket }));
+          debug('noteUpdated: %O', data);
 
           if (state.selectedNoteId !== noteId || !patch) {
             return;


### PR DESCRIPTION
This fixes a syncing bug I found while looking into #825.

### Steps to reproduce

1. After `make dev`, log in to the same account in both Electron and in a browser.
1. Pin a note to the top of the list.
1. Close the browser tab.
1. In Electron, make a change to the first line of the pinned note.
1. Make a change to the second note in the list.
1. Open the app in a browser tab.

The pinned note title is updated in the note list, but not in the editor.

### Cause

This bug was introduced with the importer feature, where we started to debounce the `noteUpdated` action for performance reasons. This could then prevent the currently selected note from updating in the editor, if the update event was one of the calls dropped by the debounce.

### Fix

Separate out the `loadNotes` call from the `onNoteUpdate` function, and only debounce the `loadNotes` call (contained in `onNotesIndex`).