### PR TITLE
Persist Simperium LocalQueue to localStorage

### DIFF
--- a/lib/simperium/index.js
+++ b/lib/simperium/index.js
@@ -9,8 +9,23 @@ const Bucket = Client.Bucket;
 export const Auth = simperium.Auth;
 
 export default function(settings) {
-  return new BrowserClient(settings);
+  const browserClient = new BrowserClient(settings);
+  Object.values(browserClient.buckets).forEach(bucket => {
+    bucket.persistLocalQueue();
+  });
+  return browserClient;
 }
+
+Bucket.prototype.persistLocalQueue = function() {
+  const bucketName = this.name;
+  const { queues, sent } = this.channel.localQueue;
+  window.addEventListener('beforeunload', function() {
+    window.localStorage.setItem(
+      `localQueue:${bucketName}`,
+      JSON.stringify({ queues, sent })
+    );
+  });
+};
 
 Bucket.prototype.query = function(fn) {
   this.store.setup.then(fn);
@@ -56,8 +71,20 @@ function BrowserClient({ appID, token, bucketConfig, database, version }) {
     }.bind(this)
   );
 
-  for (let bucket in bucketConfig) {
-    this.buckets[bucket] = this.client.bucket(bucket);
+  for (let bucketName in bucketConfig) {
+    const bucket = this.client.bucket(bucketName);
+    const { queues, sent } =
+      JSON.parse(window.localStorage.getItem(`localQueue:${bucketName}`)) || {};
+    window.localStorage.removeItem(`localQueue:${bucketName}`);
+
+    Object.values(sent)
+      .filter(change => !queues[change.id])
+      .forEach(change => {
+        bucket.channel.localQueue.queues[change.id] = [change];
+      });
+    bucket.channel.localQueue.queues = queues;
+
+    this.buckets[bucketName] = bucket;
   }
 }
 

--- a/lib/simperium/index.js
+++ b/lib/simperium/index.js
@@ -1,6 +1,7 @@
 import simperium, { Client } from 'simperium';
 import bucket_store from './bucket-store';
 import ghost_store from './ghost-store';
+import localQueueStore from './local-queue-store';
 import util from 'util';
 import events from 'events';
 
@@ -10,22 +11,13 @@ export const Auth = simperium.Auth;
 
 export default function(settings) {
   const browserClient = new BrowserClient(settings);
-  Object.values(browserClient.buckets).forEach(bucket => {
-    bucket.persistLocalQueue();
+
+  window.addEventListener('beforeunload', () => {
+    Object.values(browserClient.buckets).forEach(localQueueStore.persist);
   });
+
   return browserClient;
 }
-
-Bucket.prototype.persistLocalQueue = function() {
-  const bucketName = this.name;
-  const { queues, sent } = this.channel.localQueue;
-  window.addEventListener('beforeunload', function() {
-    window.localStorage.setItem(
-      `localQueue:${bucketName}`,
-      JSON.stringify({ queues, sent })
-    );
-  });
-};
 
 Bucket.prototype.query = function(fn) {
   this.store.setup.then(fn);
@@ -73,17 +65,7 @@ function BrowserClient({ appID, token, bucketConfig, database, version }) {
 
   for (let bucketName in bucketConfig) {
     const bucket = this.client.bucket(bucketName);
-    const { queues, sent } =
-      JSON.parse(window.localStorage.getItem(`localQueue:${bucketName}`)) || {};
-    window.localStorage.removeItem(`localQueue:${bucketName}`);
-
-    Object.values(sent)
-      .filter(change => !queues[change.id])
-      .forEach(change => {
-        bucket.channel.localQueue.queues[change.id] = [change];
-      });
-    bucket.channel.localQueue.queues = queues;
-
+    localQueueStore.restoreTo(bucket);
     this.buckets[bucketName] = bucket;
   }
 }

--- a/lib/simperium/local-queue-store.js
+++ b/lib/simperium/local-queue-store.js
@@ -1,0 +1,40 @@
+import { isEmpty } from 'lodash';
+import Debug from 'debug';
+
+const debug = Debug('localQueueStore');
+
+function persist(bucket) {
+  const { queues, sent } = getLocalQueue(bucket);
+
+  window.localStorage.setItem(getKey(bucket), JSON.stringify({ queues, sent }));
+}
+
+function restoreTo(bucket) {
+  const key = getKey(bucket);
+  const localQueue = getLocalQueue(bucket);
+  const { queues = {}, sent = {} } =
+    JSON.parse(window.localStorage.getItem(key)) || {};
+  window.localStorage.removeItem(key);
+
+  localQueue.queues = queues;
+
+  // Offline changes may be enqueued to `sent`, if it happens before
+  // the channel realizes it has been disconnected.
+  Object.values(sent)
+    .filter(change => isEmpty(queues[change.id])) // avoid duplicate conflicting changes
+    .forEach(change => {
+      localQueue.queues[change.id] = [change];
+    });
+
+  debug(
+    `Restored %d offline changes for '${bucket.name}' bucket`,
+    Object.keys(localQueue.queues).length
+  );
+}
+
+export const getKey = bucket => `localQueue:${bucket.name}`;
+export const getLocalQueue = bucket => bucket.channel.localQueue;
+
+const localQueueStore = { persist, restoreTo };
+
+export default localQueueStore;

--- a/lib/simperium/local-queue-store.test.js
+++ b/lib/simperium/local-queue-store.test.js
@@ -1,0 +1,91 @@
+import 'jest-localstorage-mock';
+import simperium from 'simperium';
+
+import localQueueStore, { getKey, getLocalQueue } from './local-queue-store';
+
+describe('localQueueStore', () => {
+  const Bucket = () => simperium().bucket('myBucket');
+
+  describe('persist', () => {
+    let bucket, key;
+
+    beforeEach(() => {
+      localStorage.clear();
+      bucket = new Bucket();
+      key = getKey(bucket);
+    });
+
+    it('should save `queues` and `sent` to localStorage', () => {
+      const localQueue = getLocalQueue(bucket);
+      localQueue.queues = { foo: [{ id: 'foo' }] };
+      localQueue.sent = { foo: 'bar' };
+      localQueueStore.persist(bucket);
+
+      const { queues, sent } = localQueue;
+      const serializedValue = JSON.stringify({ queues, sent });
+      expect(localStorage.getItem(key)).toBe(serializedValue);
+    });
+  });
+
+  describe('restoreTo', () => {
+    let bucket, newBucket, key;
+
+    beforeEach(() => {
+      localStorage.clear();
+      bucket = new Bucket();
+      newBucket = new Bucket();
+      key = getKey(bucket);
+    });
+
+    it('should not modify `localQueue.sent`', () => {
+      getLocalQueue(bucket).sent = { foo: 'foo' };
+      localQueueStore.persist(bucket);
+      localQueueStore.restoreTo(newBucket);
+      expect(getLocalQueue(newBucket).sent).toEqual({});
+    });
+
+    it('should not modify the localQueue if persisted data does not exist', () => {
+      localQueueStore.restoreTo(newBucket);
+      expect(getLocalQueue(newBucket).queues).toEqual({});
+    });
+
+    it('should correctly restore empty objects', () => {
+      localQueueStore.persist(bucket);
+      localQueueStore.restoreTo(newBucket);
+      expect(getLocalQueue(newBucket).queues).toEqual({});
+    });
+
+    it('should add `sent` changes to `queues`', () => {
+      // Offline changes may be enqueued to `sent`, if it happens before
+      // the channel realizes it has been disconnected.
+      const mockChange = { id: 'foo' };
+      getLocalQueue(bucket).sent = { foo: mockChange };
+      getLocalQueue(bucket).queues = { foo: [] };
+      localQueueStore.persist(bucket);
+      localQueueStore.restoreTo(newBucket);
+      expect(getLocalQueue(newBucket).queues['foo']).toEqual([mockChange]);
+    });
+
+    it('should ignore `sent` changes for entities that have other changes in `queues`', () => {
+      // This avoids mangling the data with duplicate conflicting changes
+      getLocalQueue(bucket).sent = { foo: { id: 'foo' } };
+      const laterChange = ['this change should prevail'];
+      getLocalQueue(bucket).queues = { foo: laterChange };
+      localQueueStore.persist(bucket);
+      localQueueStore.restoreTo(newBucket);
+      expect(getLocalQueue(newBucket).queues['foo']).toEqual(laterChange);
+    });
+
+    it('should remove the localStorage item when done', () => {
+      localQueueStore.persist(bucket);
+      localQueueStore.restoreTo(newBucket);
+      expect(localStorage.getItem(key)).toBe(null);
+    });
+  });
+
+  describe('getKey', () => {
+    it('should generate a unique key', () => {
+      expect(getKey({ name: 'foo' })).not.toBe(getKey({ name: 'bar' }));
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -11666,6 +11666,12 @@
         "pretty-format": "^23.6.0"
       }
     },
+    "jest-localstorage-mock": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.3.0.tgz",
+      "integrity": "sha512-Lk+awEPuIz0PSERHtnsXyMVLvf/4mZ3sZBEjKG5sJHvey2/i2JfQmmb/NHhialMbHXZILBORzuH64YXhWGlLsQ==",
+      "dev": true
+    },
     "jest-matcher-utils": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "hard-source-webpack-plugin": "0.12.0",
     "html-webpack-plugin": "3.2.0",
     "jest": "23.6.0",
+    "jest-localstorage-mock": "2.3.0",
     "mini-css-extract-plugin": "^0.4.4",
     "node-sass": "4.9.3",
     "postcss-loader": "2.1.0",


### PR DESCRIPTION
This fixes a problem with sync, where offline changes wouldn't get sent to the server at all if you quit the app before going back online.

### Steps to reproduce

1. Start with an empty account.
2. Log in to the account, and go offline.
3. Add a new note.
4. Restart the app.
5. Go online again and wait for the syncing to resume.

The `c` command for the note will not be sent, even when you’re back online.

### Cause

Offline changes were being queued in a `LocalQueue`, but these did not persist across reloads. As a result, these changes would be lost.

### Fix

On the `beforeunload` event, persist the local queue of each bucket to localStorage. Then, restore these queues when the BrowserClient is instantiated.

`localQueueStore` is pretty tightly coupled to the internals of `node-simperium` 😅 I would eventually want `node-simperium` to be enhanced in way that I can just pass it a store provider, like with ghostStore and objectStore.

### In relation to the reconnect loop problem

This was likely the cause of #1095, where an unsynced new note (`v === 0`) stays in limbo forever. While this PR will prevent new occurrences of the reconnect loop, it doesn't address our users' unsynced notes that are already stuck in limbo. So in a separate PR, I'll see what I can do to actually sync over these stuck `v === 0` notes.