### PR TITLE
Add rate limiter to imports

### DIFF
--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -12,7 +12,7 @@ const propertyWhitelist = [
   'tags',
 ];
 
-const MAX_REQUESTS_PER_SEC = 250;
+const MAX_REQUESTS_PER_SEC = 50;
 
 class CoreImporter extends EventEmitter {
   constructor({ noteBucket, tagBucket }) {

--- a/lib/utils/import/index.js
+++ b/lib/utils/import/index.js
@@ -1,3 +1,4 @@
+import Bottleneck from 'bottleneck';
 import { EventEmitter } from 'events';
 import { isEmpty, get, pick } from 'lodash';
 
@@ -11,11 +12,21 @@ const propertyWhitelist = [
   'tags',
 ];
 
+const MAX_REQUESTS_PER_SEC = 250;
+
 class CoreImporter extends EventEmitter {
   constructor({ noteBucket, tagBucket }) {
     super();
     this.noteBucket = noteBucket;
     this.tagBucket = tagBucket;
+
+    // Rate limiter for adding new notes to the bucket. Without this, the
+    // server may return 503 errors, which will result in unsynced notes.
+    this.limiter = new Bottleneck({
+      reservoir: MAX_REQUESTS_PER_SEC,
+      reservoirRefreshAmount: MAX_REQUESTS_PER_SEC,
+      reservoirRefreshInterval: 1000, // Must be divisible by 250. See https://github.com/SGrondin/bottleneck/issues/88
+    });
   }
 
   importNote = (note, { isTrashed = false, isMarkdown = false } = {}) => {
@@ -65,7 +76,10 @@ class CoreImporter extends EventEmitter {
       });
     }
 
-    return this.noteBucket.add(importedNote);
+    // Add to note bucket with rate limiting
+    return this.limiter
+      .schedule(() => this.noteBucket.add.bind(this.noteBucket)(importedNote))
+      .catch(console.log);
   };
 
   importNotes = (notes = {}, options) => {

--- a/lib/utils/import/test.js
+++ b/lib/utils/import/test.js
@@ -17,19 +17,19 @@ describe('CoreImporter', () => {
   describe('importNote', () => {
     it('should call noteBucket.add() with a note containing the required properties', () => {
       const note = {};
-      importer.importNote(note);
+      return importer.importNote(note).then(() => {
+        const passedNote = noteBucketAdd.mock.calls[0][0];
 
-      const passedNote = noteBucketAdd.mock.calls[0][0];
-
-      // Conforms to schema
-      expect(passedNote.publishURL).toBe('');
-      expect(passedNote.shareURL).toBe('');
-      expect(passedNote.deleted).toBe(false);
-      expect(passedNote.tags).toEqual([]);
-      expect(passedNote.systemTags).toEqual([]);
-      expect(passedNote.creationDate).toEqual(expect.any(Number));
-      expect(passedNote.modificationDate).toEqual(expect.any(Number));
-      expect(passedNote.content).toBe('');
+        // Conforms to schema
+        expect(passedNote.publishURL).toBe('');
+        expect(passedNote.shareURL).toBe('');
+        expect(passedNote.deleted).toBe(false);
+        expect(passedNote.tags).toEqual([]);
+        expect(passedNote.systemTags).toEqual([]);
+        expect(passedNote.creationDate).toEqual(expect.any(Number));
+        expect(passedNote.modificationDate).toEqual(expect.any(Number));
+        expect(passedNote.content).toBe('');
+      });
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3583,6 +3583,11 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
+    "bottleneck": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.14.0.tgz",
+      "integrity": "sha512-hM5zQPPpIe2/pn8rornETr2x7/HOBGJ5u1RW1js6zvE5453bRMMbtbZl0ojB8yNj7w2xNWddpNukrhOikHb7BQ=="
+    },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
   "dependencies": {
     "@babel/polyfill": "7.0.0",
     "@material-ui/core": "3.3.1",
+    "bottleneck": "2.14.0",
     "cookie": "0.3.1",
     "core-js": "2.5.7",
     "create-hash": "1.1.3",


### PR DESCRIPTION
This adds rate limiting to the CoreImporter so that we don't have to rely on the hacky workaround in `nudgeUnsynced` to get large imports unstuck:

https://github.com/Automattic/simplenote-electron/blob/0b079b92077b8caa0f38f400303c1aec01b2d428/lib/utils/sync/nudge-unsynced.js#L42

With my new familiarity with the LocalQueue 😌, I was able to realize that the stuck import notes were not stuck locally, nor were they being "ignored" by the server. They were sent out correctly, but then each of them were being returned 503 errors from the Simperium server.

@roundhill:
- Should `node-simperium` be patched to handle these errors?
- Should there be an official rate limit for the Simperium API? (In this app, I set the limit to 250 requests/sec. It is a little conservative, but I think it's fine because according to Tracks, imports larger than 100 notes are very rare.)

### To test

1. Set `localStorage.debug="sync:*,analytics"` and reload.
1. Import a file with >500 notes.

The syncing should complete, and `nudgeUnsynced` shouldn't log anything other than `0 unsynced notes`. (Or, you can try commenting out the `client.client.connect()` line quoted above.)

Import file (1000 notes) for your convenience: [few-tags-1000-800kb.json.zip](https://github.com/Automattic/simplenote-electron/files/2686889/few-tags-1000-800kb.json.zip)

### Next steps

Now that this is out of the way, I will modify the `nudgeUnsynced` function so that it specifically addresses the `v === 0` notes that resulted from unpersisted offline changes (#1098). We'll get rid of the `client.connect()` call there, thus fixing the `init` flood once and for all 🔨 