### PR TITLE
Find and re-push stuck version 0 notes

### DIFF
--- a/lib/utils/sync/nudge-unsynced.js
+++ b/lib/utils/sync/nudge-unsynced.js
@@ -1,10 +1,16 @@
 /**
- * Ensure that all imported notes are sent to the server
+ * Ensure that all version 0 notes are sent to the server.
  *
- * Importing over 350-400 notes at once can cause the syncing to get
- * stuck. This function checks if there are any local notes which have not
- * been acknowledged by the server yet, and if so, reconnects the client
- * to resume the syncing.
+ * Version 0 notes (new notes, usually created offline, that have not yet been
+ * acknowledged by the server) could get stuck in that state, probably due to the
+ * fact that the local queues were not persisted. If the app was quit
+ * while offline, those offline changes could be lost and never sent to the
+ * server unless another change is made to that note while online.
+ * See https://github.com/Automattic/simplenote-electron/pull/1098
+ *
+ * While the persistence issue is now fixed, it doesn't address the notes that
+ * have already been caught in version 0 limbo. This function finds those notes
+ * and explicitly re-pushes them to the note bucket.
  */
 import Debug from 'debug';
 
@@ -15,6 +21,15 @@ const nudgeUnsynced = ({ noteBucket, notes, client }) => {
     return Promise.resolve(); // not an error, just resolve and move on
   }
 
+  return noteBucket.hasLocalChanges().then(hasChanges => {
+    if (hasChanges) {
+      return Promise.resolve(); // let the local queue be processed first
+    }
+    return updateUnsyncedNotes({ noteBucket, notes });
+  });
+};
+
+const updateUnsyncedNotes = ({ noteBucket, notes }) => {
   const noteHasSynced = note =>
     new Promise(resolve =>
       noteBucket.getVersion(note.id, (e, v) => {
@@ -28,19 +43,10 @@ const nudgeUnsynced = ({ noteBucket, notes, client }) => {
     );
 
   return Promise.all(notes.map(noteHasSynced)).then(result => {
-    let unsyncedNoteCount = 0;
-    const hasUnsyncedNotes = result.some(note => note.unsynced);
+    const unsyncedNotes = result.filter(note => note.unsynced);
 
-    if (hasUnsyncedNotes && debug.enabled) {
-      unsyncedNoteCount = result.filter(note => note.unsynced).length;
-    }
-
-    debug(`${unsyncedNoteCount} unsynced notes`);
-
-    // Re-init the client and prod the syncing to resume
-    if (hasUnsyncedNotes) {
-      client.client.connect();
-    }
+    debug(`${unsyncedNotes.length} unsynced notes`);
+    unsyncedNotes.forEach(note => noteBucket.update(note.id, note.data));
   });
 };
 

--- a/lib/utils/sync/nudge-unsynced.test.js
+++ b/lib/utils/sync/nudge-unsynced.test.js
@@ -1,15 +1,21 @@
 import nudgeUnsynced from './nudge-unsynced';
+import simperium from 'simperium';
 
 describe('sync:nudgeUnsynced', () => {
-  let mockArg;
+  let mockArg, noteBucket;
+  const mockUnsyncedNote = (bool = true) => {
+    noteBucket.getVersion = (_, callback) => {
+      callback(undefined, bool ? 0 : 1); // no error, v === 0
+    };
+  };
 
   beforeEach(() => {
+    noteBucket = simperium().bucket('note');
+    noteBucket.update = jest.fn();
+    mockUnsyncedNote(true);
+
     mockArg = {
-      noteBucket: {
-        getVersion: (_, callback) => {
-          callback(undefined, 0); // no error, v === 0
-        },
-      },
+      noteBucket,
       notes: [{}],
       client: {
         client: { connect: jest.fn() },
@@ -18,16 +24,30 @@ describe('sync:nudgeUnsynced', () => {
     };
   });
 
-  it('should reconnect the client when an unsynced note exists', () => {
+  it('should update noteBucket when there are no local queued changes and an unsynced note exists', () => {
     return nudgeUnsynced(mockArg).then(() => {
-      expect(mockArg.client.client.connect).toHaveBeenCalled();
+      expect(noteBucket.update).toHaveBeenCalled();
     });
   });
 
-  it('should not reconnect the client if not authorized', () => {
+  it('should not update noteBucket when there are local queued changes', () => {
+    noteBucket.hasLocalChanges = jest.fn().mockResolvedValue(true);
+    return nudgeUnsynced(mockArg).then(() => {
+      expect(noteBucket.update).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should not update noteBucket when there are no unsynced notes', () => {
+    mockUnsyncedNote(false);
+    return nudgeUnsynced(mockArg).then(() => {
+      expect(noteBucket.update).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should not update noteBucket if not authorized', () => {
     mockArg.client.isAuthorized.mockReturnValue(false);
     return nudgeUnsynced(mockArg).then(() => {
-      expect(mockArg.client.client.connect).not.toHaveBeenCalled();
+      expect(noteBucket.update).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Closes #1095 

As mentioned in #1101, this addresses the version 0 notes that resulted from unpersisted offline changes (#1098). This PR branch doesn't include the localQueue persistence commit, so that it is easier to produce a stuck version 0 note for testing purposes.

### To test

1. Start with an empty account.
2. Log in to the account, and go offline.
3. Add a new note.
4. Restart the app.
5. Go online again and wait for the syncing to resume.

After the restart in step 4, the new note is at version 0 with no change in the local queue, but the nudgeUnsynced function will push it over to the server. It should not trigger an infinite loop of the sync activity hooks.