### PR TITLE
Prevent NoteList excerpts from being too short

### DIFF
--- a/lib/utils/note-utils.js
+++ b/lib/utils/note-utils.js
@@ -22,8 +22,10 @@ const noteTitleAndPreviewRegExp = /\s*(\S[^\n]*)\s*(\S[^\n]*)?/;
  */
 const noteTitleAndPreviewMdRegExp = /(?:#{0,6}\s+)?(\S[^\n]*)\s*(?:#{0,6}\s+)?(\S[^\n]*)?/;
 
-// Ample amount of characters for 'Expanded' list view
-const characterLimit = 300;
+export const titleCharacterLimit = 200;
+
+// Ample amount of characters for the 'Expanded' list view
+export const previewCharacterLimit = 300;
 
 // Defaults for notes with empty content
 export const defaults = {
@@ -38,8 +40,7 @@ export const defaults = {
  * @returns {Object} title and excerpt (if available)
  */
 export const noteTitleAndPreview = note => {
-  let content = (note && note.data && note.data.content) || '';
-  content = content.substring(0, characterLimit);
+  const content = (note && note.data && note.data.content) || '';
 
   const match = isMarkdown(note)
     ? noteTitleAndPreviewMdRegExp.exec(content || '')
@@ -49,7 +50,10 @@ export const noteTitleAndPreview = note => {
     return defaults;
   }
 
-  let [, title, preview] = match;
+  let [, title = defaults.title, preview = defaults.preview] = match;
+
+  title = title.slice(0, titleCharacterLimit);
+  preview = preview.slice(0, previewCharacterLimit);
 
   if (preview && isMarkdown(note)) {
     // Workaround for a bug in `remove-markdown`
@@ -61,10 +65,7 @@ export const noteTitleAndPreview = note => {
     });
   }
 
-  return {
-    title: title.slice(0, 200) || defaults.title,
-    preview: preview || defaults.preview,
-  };
+  return { title, preview };
 };
 
 export const isMarkdown = note => {

--- a/lib/utils/note-utils.test.js
+++ b/lib/utils/note-utils.test.js
@@ -1,4 +1,8 @@
-import noteTitleAndPreview, { defaults } from './note-utils';
+import noteTitleAndPreview, {
+  defaults,
+  previewCharacterLimit,
+  titleCharacterLimit,
+} from './note-utils';
 
 describe('noteTitleAndPreview', () => {
   let note;
@@ -46,5 +50,16 @@ describe('noteTitleAndPreview', () => {
     noteTitleAndPreview(note);
     const elapsedMs = Date.now() - startTime;
     expect(elapsedMs).toBeLessThanOrEqual(1);
+  });
+
+  it('should have enough text for an Expanded preview, even if the title is very long', () => {
+    // Longer than the char limits
+    const title = 'foo'.repeat(titleCharacterLimit);
+    const paragraph = 'foo'.repeat(previewCharacterLimit);
+
+    note.data.content = title + '\n' + paragraph;
+    const result = noteTitleAndPreview(note);
+    expect(result.title).toHaveLength(titleCharacterLimit);
+    expect(result.preview).toHaveLength(previewCharacterLimit);
   });
 });


### PR DESCRIPTION
The excerpts in the NoteList could be too short in edge cases where the first line of the note was too long:

<img width="837" alt="screen_shot_2018-12-19_at_1_52_42" src="https://user-images.githubusercontent.com/555336/50169436-ec57c780-0330-11e9-8382-f8525aa2daaf.png">

This PR fixes that by setting separate character limits for the title and the preview.