### PR TITLE
Change nav bar icon from Tag to Hamburger Menu

### DIFF
--- a/lib/icons/menu.jsx
+++ b/lib/icons/menu.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function MenuIcon() {
+  return (
+    <svg
+      className="icon-menu"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+    >
+      <path d="M21 6v2H3V6h18zM3 18h18v-2H3v2zm0-5h18v-2H3v2z" />
+    </svg>
+  );
+}

--- a/lib/search-bar/index.jsx
+++ b/lib/search-bar/index.jsx
@@ -12,7 +12,7 @@ import { tracks } from '../analytics';
 import IconButton from '../icon-button';
 import NewNoteIcon from '../icons/new-note';
 import SearchField from '../search-field';
-import TagsIcon from '../icons/tags';
+import MenuIcon from '../icons/menu';
 import { withoutTags } from '../utils/filter-notes';
 
 const { newNote, search, toggleNavigation } = appState.actionCreators;
@@ -25,7 +25,7 @@ export const SearchBar = ({
   showTrash,
 }) => (
   <div className="search-bar theme-color-border">
-    <IconButton icon={<TagsIcon />} onClick={onToggleNavigation} title="Tags" />
+    <IconButton icon={<MenuIcon />} onClick={onToggleNavigation} title="Menu" />
     <SearchField />
     <IconButton
       disabled={showTrash}

--- a/lib/search-field/style.scss
+++ b/lib/search-field/style.scss
@@ -4,7 +4,7 @@
   align-items: center;
   width: 100%;
   height: 1.75em;
-  margin: 0 12px;
+  margin: 1px 12px 0;
   border-radius: 50px;
   border: 1px solid lighten($gray, 30%);
   padding: 0 8px 1px 15px;


### PR DESCRIPTION
This changes the menu icon in the top left from a Tag icon to a Hamburger menu icon.

<img width="911" alt="screen shot 2018-12-20 at 0 22 42" src="https://user-images.githubusercontent.com/555336/50230743-a2ceb180-03f0-11e9-9642-bab66abc0f41.png">

This is in preparation for deploying this as a web app, since we will need to put the Settings button in there.

### Side note

The trade-off for improving discoverability of the Settings button (and Trash!) is that we may be reducing discoverability of the "filter notes by tag" feature. I think we can alleviate this by adding a feature to filter notes by clicking on a note tag in the editor. The current onclick behavior (removes the tag) is problematic anyway #491, so we can maybe add an `x` badge on hover for a separate remove function.