### PR TITLE
Prevent SearchBar from shrinking when no notes

### DIFF
--- a/lib/search-bar/style.scss
+++ b/lib/search-bar/style.scss
@@ -5,6 +5,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex: 0 0 auto;
 
   .button {
     padding: 0;


### PR DESCRIPTION
This fixes a flexbox problem that slightly squashes the height of the Search Bar when there are no notes in the Note List:

![search-bar](https://user-images.githubusercontent.com/555336/50248164-6a919800-041d-11e9-8c43-01370b91ba87.gif)
