### PR TITLE
Refactor Settings dialog and improve a11y for TabbedDialog

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -373,6 +373,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
         isAuthorized,
         isDevConfig,
         noteBucket,
+        preferencesBucket,
         settings,
         tagBucket,
         isSmallScreen,
@@ -430,7 +431,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
           )}
           <DialogRenderer
             appProps={this.props}
-            buckets={{ noteBucket, tagBucket }}
+            buckets={{ noteBucket, preferencesBucket, tagBucket }}
             themeClass={themeClass}
             closeDialog={this.props.actions.closeDialog}
             dialogs={this.props.appState.dialogs}

--- a/lib/dialog/style.scss
+++ b/lib/dialog/style.scss
@@ -44,22 +44,16 @@
 }
 
 .dialog-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
   border-bottom: 1px solid lighten($gray, 30%);
-
-  ul {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
+  list-style: none;
 
   li {
     margin: 0 0.5em;
-  }
-
-  button {
     border-top: 2px solid transparent;
     border-bottom: 2px solid transparent;
     padding: 0.75em 0.75em;

--- a/lib/dialogs/settings/index.jsx
+++ b/lib/dialogs/settings/index.jsx
@@ -17,10 +17,15 @@ export class SettingsDialog extends Component {
   static propTypes = {
     actions: PropTypes.object.isRequired,
     appState: PropTypes.object.isRequired,
+    buckets: PropTypes.shape({
+      noteBucket: PropTypes.object.isRequired,
+      preferencesBucket: PropTypes.object.isRequired,
+      tagBucket: PropTypes.object.isRequired,
+    }),
+    dialog: PropTypes.shape({ title: PropTypes.string.isRequired }),
     onSignOut: PropTypes.func.isRequired,
     isElectron: PropTypes.bool.isRequired,
     onSetWPToken: PropTypes.func.isRequired,
-    preferencesBucket: PropTypes.object.isRequired,
     requestClose: PropTypes.func.isRequired,
     settings: PropTypes.object.isRequired,
     toggleShareAnalyticsPreference: PropTypes.func.isRequired,
@@ -28,13 +33,13 @@ export class SettingsDialog extends Component {
 
   onToggleShareAnalyticsPreference = () => {
     this.props.toggleShareAnalyticsPreference({
-      preferencesBucket: this.props.preferencesBucket,
+      preferencesBucket: this.props.buckets.preferencesBucket,
     });
   };
 
   onSignOutRequested = () => {
     // Safety first! Check for any unsynced notes before signing out.
-    const { noteBucket } = this.props;
+    const { noteBucket } = this.props.buckets;
     const { notes } = this.props.appState;
 
     noteBucket.hasLocalChanges((error, hasChanges) => {
@@ -113,16 +118,15 @@ export class SettingsDialog extends Component {
   };
 
   render() {
-    const { dialog, requestClose, settings } = this.props;
+    const { buckets, dialog, requestClose, settings } = this.props;
     const { analyticsEnabled } = this.props.appState.preferences;
 
     return (
       <TabbedDialog
         className="settings"
-        title="Settings"
+        title={dialog.title}
         tabNames={settingTabs}
         onDone={requestClose}
-        {...dialog}
       >
         <div className="dialog-column">
           <AccountPanel
@@ -135,7 +139,7 @@ export class SettingsDialog extends Component {
           />
         </div>
         <div className="dialog-column">
-          <DisplayPanel />
+          <DisplayPanel buckets={buckets} />
         </div>
       </TabbedDialog>
     );

--- a/lib/dialogs/settings/index.jsx
+++ b/lib/dialogs/settings/index.jsx
@@ -6,9 +6,7 @@ import TabbedDialog from '../../tabbed-dialog';
 import { viewExternalUrl } from '../../utils/url-utils';
 
 import AccountPanel from './panels/account';
-import RadioGroup from '../radio-settings-group';
-import ToggleGroup from '../toggle-settings-group';
-import SettingsGroup, { Item } from '../settings-group';
+import DisplayPanel from './panels/display';
 
 import appState from '../../flux/app-state';
 import { setWPToken } from '../../state/settings/actions';
@@ -24,6 +22,7 @@ export class SettingsDialog extends Component {
     onSetWPToken: PropTypes.func.isRequired,
     preferencesBucket: PropTypes.object.isRequired,
     requestClose: PropTypes.func.isRequired,
+    settings: PropTypes.object.isRequired,
     toggleShareAnalyticsPreference: PropTypes.func.isRequired,
   };
 
@@ -114,28 +113,7 @@ export class SettingsDialog extends Component {
   };
 
   render() {
-    const { dialog, requestClose } = this.props;
-    const {
-      activateTheme,
-      setLineLength,
-      setNoteDisplay,
-      setSortType,
-      toggleSortOrder,
-      toggleSortTagsAlpha,
-    } = this.props;
-
-    const {
-      settings: {
-        theme: activeTheme,
-        lineLength,
-        noteDisplay,
-        sortType,
-        sortReversed: sortIsReversed,
-        sortTagsAlpha,
-        accountName,
-      },
-    } = this.props;
-
+    const { dialog, requestClose, settings } = this.props;
     const { analyticsEnabled } = this.props.appState.preferences;
 
     return (
@@ -148,7 +126,7 @@ export class SettingsDialog extends Component {
       >
         <div className="dialog-column">
           <AccountPanel
-            accountName={accountName}
+            accountName={settings.accountName}
             analyticsEnabled={analyticsEnabled}
             requestSignOut={this.onSignOutRequested}
             toggleShareAnalyticsPreference={
@@ -156,72 +134,8 @@ export class SettingsDialog extends Component {
             }
           />
         </div>
-        <div className="dialog-column settings-display">
-          <SettingsGroup
-            title="Note display"
-            slug="noteDisplay"
-            activeSlug={noteDisplay}
-            onChange={setNoteDisplay}
-            renderer={RadioGroup}
-          >
-            <Item title="Comfy" slug="comfy" />
-            <Item title="Condensed" slug="condensed" />
-            <Item title="Expanded" slug="expanded" />
-          </SettingsGroup>
-
-          <SettingsGroup
-            title="Line length"
-            slug="lineLength"
-            activeSlug={lineLength}
-            onChange={setLineLength}
-            renderer={RadioGroup}
-          >
-            <Item title="Narrow" slug="narrow" />
-            <Item title="Full" slug="full" />
-          </SettingsGroup>
-
-          <SettingsGroup
-            title="Sort type"
-            slug="sortType"
-            activeSlug={sortType}
-            onChange={setSortType}
-            renderer={RadioGroup}
-          >
-            <Item title="Date modified" slug="modificationDate" />
-            <Item title="Date created" slug="creationDate" />
-            <Item title="Alphabetical" slug="alphabetical" />
-          </SettingsGroup>
-
-          <SettingsGroup
-            title="Sort order"
-            slug="sortOrder"
-            activeSlug={sortIsReversed ? 'reversed' : ''}
-            onChange={toggleSortOrder}
-            renderer={ToggleGroup}
-          >
-            <Item title="Reversed" slug="reversed" />
-          </SettingsGroup>
-
-          <SettingsGroup
-            title="Tags"
-            slug="sortTagsAlpha"
-            activeSlug={sortTagsAlpha ? 'alpha' : ''}
-            onChange={toggleSortTagsAlpha}
-            renderer={ToggleGroup}
-          >
-            <Item title="Sort Alphabetically" slug="alpha" />
-          </SettingsGroup>
-
-          <SettingsGroup
-            title="Theme"
-            slug="theme"
-            activeSlug={activeTheme}
-            onChange={activateTheme}
-            renderer={RadioGroup}
-          >
-            <Item title="Light" slug="light" />
-            <Item title="Dark" slug="dark" />
-          </SettingsGroup>
+        <div className="dialog-column">
+          <DisplayPanel />
         </div>
       </TabbedDialog>
     );

--- a/lib/dialogs/settings/index.jsx
+++ b/lib/dialogs/settings/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+
 import TabbedDialog from '../../tabbed-dialog';
 import { viewExternalUrl } from '../../utils/url-utils';
 import TopRightArrowIcon from '../../icons/arrow-top-right';
@@ -117,23 +118,6 @@ export class SettingsDialog extends Component {
 
   render() {
     const { dialog, requestClose } = this.props;
-
-    return (
-      <TabbedDialog
-        className="settings"
-        title="Settings"
-        tabs={settingTabs}
-        onDone={requestClose}
-        renderTabName={this.renderTabName}
-        renderTabContent={this.renderTabContent}
-        {...dialog}
-      />
-    );
-  }
-
-  renderTabName = tabName => tabName;
-
-  renderTabContent = tabName => {
     const {
       activateTheme,
       setLineLength,
@@ -157,125 +141,126 @@ export class SettingsDialog extends Component {
 
     const { analyticsEnabled } = this.props.appState.preferences;
 
-    switch (tabName) {
-      case 'account':
-        return (
-          <div className="dialog-column settings-account">
-            <PanelTitle headingLevel="3">Account</PanelTitle>
-            <div className="settings-items theme-color-border">
-              <div className="settings-item theme-color-border">
-                <span className="settings-account-name">{accountName}</span>
-              </div>
+    return (
+      <TabbedDialog
+        className="settings"
+        title="Settings"
+        tabNames={settingTabs}
+        onDone={requestClose}
+        {...dialog}
+      >
+        <div className="dialog-column settings-account">
+          <PanelTitle headingLevel="3">Account</PanelTitle>
+          <div className="settings-items theme-color-border">
+            <div className="settings-item theme-color-border">
+              <span className="settings-account-name">{accountName}</span>
             </div>
-
-            <ul className="dialog-actions">
-              <li>
-                <button
-                  type="button"
-                  className="button button button-borderless"
-                  onClick={this.onEditAccount}
-                >
-                  Edit Account <TopRightArrowIcon />
-                </button>
-              </li>
-              <li>
-                <SettingsGroup
-                  title="Privacy"
-                  slug="shareAnalytics"
-                  activeSlug={analyticsEnabled ? 'enabled' : ''}
-                  description="Help us improve Simplenote by sharing usage data with our analytics tool."
-                  onChange={this.onToggleShareAnalyticsPreference}
-                  learnMoreURL="https://automattic.com/cookies"
-                  renderer={ToggleGroup}
-                >
-                  <Item title="Share analytics" slug="enabled" />
-                </SettingsGroup>
-              </li>
-              <li>
-                <button
-                  type="button"
-                  className="button button-primary"
-                  onClick={this.onSignOutRequested}
-                >
-                  Log Out
-                </button>
-              </li>
-            </ul>
           </div>
-        );
 
-      case 'display':
-        return (
-          <div className="dialog-column settings-display">
-            <SettingsGroup
-              title="Note display"
-              slug="noteDisplay"
-              activeSlug={noteDisplay}
-              onChange={setNoteDisplay}
-              renderer={RadioGroup}
-            >
-              <Item title="Comfy" slug="comfy" />
-              <Item title="Condensed" slug="condensed" />
-              <Item title="Expanded" slug="expanded" />
-            </SettingsGroup>
+          <ul className="dialog-actions">
+            <li>
+              <button
+                type="button"
+                className="button button button-borderless"
+                onClick={this.onEditAccount}
+              >
+                Edit Account <TopRightArrowIcon />
+              </button>
+            </li>
+            <li>
+              <SettingsGroup
+                title="Privacy"
+                slug="shareAnalytics"
+                activeSlug={analyticsEnabled ? 'enabled' : ''}
+                description="Help us improve Simplenote by sharing usage data with our analytics tool."
+                onChange={this.onToggleShareAnalyticsPreference}
+                learnMoreURL="https://automattic.com/cookies"
+                renderer={ToggleGroup}
+              >
+                <Item title="Share analytics" slug="enabled" />
+              </SettingsGroup>
+            </li>
+            <li>
+              <button
+                type="button"
+                className="button button-primary"
+                onClick={this.onSignOutRequested}
+              >
+                Log Out
+              </button>
+            </li>
+          </ul>
+        </div>
+        <div className="dialog-column settings-display">
+          <SettingsGroup
+            title="Note display"
+            slug="noteDisplay"
+            activeSlug={noteDisplay}
+            onChange={setNoteDisplay}
+            renderer={RadioGroup}
+          >
+            <Item title="Comfy" slug="comfy" />
+            <Item title="Condensed" slug="condensed" />
+            <Item title="Expanded" slug="expanded" />
+          </SettingsGroup>
 
-            <SettingsGroup
-              title="Line length"
-              slug="lineLength"
-              activeSlug={lineLength}
-              onChange={setLineLength}
-              renderer={RadioGroup}
-            >
-              <Item title="Narrow" slug="narrow" />
-              <Item title="Full" slug="full" />
-            </SettingsGroup>
+          <SettingsGroup
+            title="Line length"
+            slug="lineLength"
+            activeSlug={lineLength}
+            onChange={setLineLength}
+            renderer={RadioGroup}
+          >
+            <Item title="Narrow" slug="narrow" />
+            <Item title="Full" slug="full" />
+          </SettingsGroup>
 
-            <SettingsGroup
-              title="Sort type"
-              slug="sortType"
-              activeSlug={sortType}
-              onChange={setSortType}
-              renderer={RadioGroup}
-            >
-              <Item title="Date modified" slug="modificationDate" />
-              <Item title="Date created" slug="creationDate" />
-              <Item title="Alphabetical" slug="alphabetical" />
-            </SettingsGroup>
+          <SettingsGroup
+            title="Sort type"
+            slug="sortType"
+            activeSlug={sortType}
+            onChange={setSortType}
+            renderer={RadioGroup}
+          >
+            <Item title="Date modified" slug="modificationDate" />
+            <Item title="Date created" slug="creationDate" />
+            <Item title="Alphabetical" slug="alphabetical" />
+          </SettingsGroup>
 
-            <SettingsGroup
-              title="Sort order"
-              slug="sortOrder"
-              activeSlug={sortIsReversed ? 'reversed' : ''}
-              onChange={toggleSortOrder}
-              renderer={ToggleGroup}
-            >
-              <Item title="Reversed" slug="reversed" />
-            </SettingsGroup>
+          <SettingsGroup
+            title="Sort order"
+            slug="sortOrder"
+            activeSlug={sortIsReversed ? 'reversed' : ''}
+            onChange={toggleSortOrder}
+            renderer={ToggleGroup}
+          >
+            <Item title="Reversed" slug="reversed" />
+          </SettingsGroup>
 
-            <SettingsGroup
-              title="Tags"
-              slug="sortTagsAlpha"
-              activeSlug={sortTagsAlpha ? 'alpha' : ''}
-              onChange={toggleSortTagsAlpha}
-              renderer={ToggleGroup}
-            >
-              <Item title="Sort Alphabetically" slug="alpha" />
-            </SettingsGroup>
+          <SettingsGroup
+            title="Tags"
+            slug="sortTagsAlpha"
+            activeSlug={sortTagsAlpha ? 'alpha' : ''}
+            onChange={toggleSortTagsAlpha}
+            renderer={ToggleGroup}
+          >
+            <Item title="Sort Alphabetically" slug="alpha" />
+          </SettingsGroup>
 
-            <SettingsGroup
-              title="Theme"
-              slug="theme"
-              activeSlug={activeTheme}
-              onChange={activateTheme}
-              renderer={RadioGroup}
-            >
-              <Item title="Light" slug="light" />
-              <Item title="Dark" slug="dark" />
-            </SettingsGroup>
-          </div>
-        );
-    }
-  };
+          <SettingsGroup
+            title="Theme"
+            slug="theme"
+            activeSlug={activeTheme}
+            onChange={activateTheme}
+            renderer={RadioGroup}
+          >
+            <Item title="Light" slug="light" />
+            <Item title="Dark" slug="dark" />
+          </SettingsGroup>
+        </div>
+      </TabbedDialog>
+    );
+  }
 }
 
 const { toggleShareAnalyticsPreference } = appState.actionCreators;

--- a/lib/dialogs/settings/index.jsx
+++ b/lib/dialogs/settings/index.jsx
@@ -4,9 +4,8 @@ import PropTypes from 'prop-types';
 
 import TabbedDialog from '../../tabbed-dialog';
 import { viewExternalUrl } from '../../utils/url-utils';
-import TopRightArrowIcon from '../../icons/arrow-top-right';
-import PanelTitle from '../../components/panel-title';
 
+import AccountPanel from './panels/account';
 import RadioGroup from '../radio-settings-group';
 import ToggleGroup from '../toggle-settings-group';
 import SettingsGroup, { Item } from '../settings-group';
@@ -27,8 +26,6 @@ export class SettingsDialog extends Component {
     requestClose: PropTypes.func.isRequired,
     toggleShareAnalyticsPreference: PropTypes.func.isRequired,
   };
-
-  onEditAccount = () => viewExternalUrl('https://app.simplenote.com/settings');
 
   onToggleShareAnalyticsPreference = () => {
     this.props.toggleShareAnalyticsPreference({
@@ -149,47 +146,15 @@ export class SettingsDialog extends Component {
         onDone={requestClose}
         {...dialog}
       >
-        <div className="dialog-column settings-account">
-          <PanelTitle headingLevel="3">Account</PanelTitle>
-          <div className="settings-items theme-color-border">
-            <div className="settings-item theme-color-border">
-              <span className="settings-account-name">{accountName}</span>
-            </div>
-          </div>
-
-          <ul className="dialog-actions">
-            <li>
-              <button
-                type="button"
-                className="button button button-borderless"
-                onClick={this.onEditAccount}
-              >
-                Edit Account <TopRightArrowIcon />
-              </button>
-            </li>
-            <li>
-              <SettingsGroup
-                title="Privacy"
-                slug="shareAnalytics"
-                activeSlug={analyticsEnabled ? 'enabled' : ''}
-                description="Help us improve Simplenote by sharing usage data with our analytics tool."
-                onChange={this.onToggleShareAnalyticsPreference}
-                learnMoreURL="https://automattic.com/cookies"
-                renderer={ToggleGroup}
-              >
-                <Item title="Share analytics" slug="enabled" />
-              </SettingsGroup>
-            </li>
-            <li>
-              <button
-                type="button"
-                className="button button-primary"
-                onClick={this.onSignOutRequested}
-              >
-                Log Out
-              </button>
-            </li>
-          </ul>
+        <div className="dialog-column">
+          <AccountPanel
+            accountName={accountName}
+            analyticsEnabled={analyticsEnabled}
+            requestSignOut={this.onSignOutRequested}
+            toggleShareAnalyticsPreference={
+              this.onToggleShareAnalyticsPreference
+            }
+          />
         </div>
         <div className="dialog-column settings-display">
           <SettingsGroup

--- a/lib/dialogs/settings/panels/account.jsx
+++ b/lib/dialogs/settings/panels/account.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import PanelTitle from '../../../components/panel-title';
+import SettingsGroup, { Item } from '../../settings-group';
+import ToggleGroup from '../../toggle-settings-group';
+import TopRightArrowIcon from '../../../icons/arrow-top-right';
+
+import { viewExternalUrl } from '../../../utils/url-utils';
+
+const AccountPanel = props => {
+  const {
+    accountName,
+    analyticsEnabled,
+    requestSignOut,
+    toggleShareAnalyticsPreference,
+  } = props;
+
+  const onEditAccount = () =>
+    viewExternalUrl('https://app.simplenote.com/settings');
+
+  return (
+    <div className="settings-account">
+      <PanelTitle headingLevel="3">Account</PanelTitle>
+
+      <div className="settings-items theme-color-border">
+        <div className="settings-item theme-color-border">
+          <span className="settings-account-name">{accountName}</span>
+        </div>
+      </div>
+
+      <ul className="dialog-actions">
+        <li>
+          <button
+            type="button"
+            className="button button-borderless"
+            onClick={onEditAccount}
+          >
+            Edit Account <TopRightArrowIcon />
+          </button>
+        </li>
+        <li>
+          <SettingsGroup
+            title="Privacy"
+            slug="shareAnalytics"
+            activeSlug={analyticsEnabled ? 'enabled' : ''}
+            description="Help us improve Simplenote by sharing usage data with our analytics tool."
+            onChange={toggleShareAnalyticsPreference}
+            learnMoreURL="https://automattic.com/cookies"
+            renderer={ToggleGroup}
+          >
+            <Item title="Share analytics" slug="enabled" />
+          </SettingsGroup>
+        </li>
+        <li>
+          <button
+            type="button"
+            className="button button-primary"
+            onClick={requestSignOut}
+          >
+            Log Out
+          </button>
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+AccountPanel.propTypes = {
+  accountName: PropTypes.string.isRequired,
+  analyticsEnabled: PropTypes.bool.isRequired,
+  requestSignOut: PropTypes.func.isRequired,
+  toggleShareAnalyticsPreference: PropTypes.func.isRequired,
+};
+
+export default AccountPanel;

--- a/lib/dialogs/settings/panels/display.jsx
+++ b/lib/dialogs/settings/panels/display.jsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import PropTypes from 'prop-types';
+
+import RadioGroup from '../../radio-settings-group';
+import SettingsGroup, { Item } from '../../settings-group';
+import ToggleGroup from '../../toggle-settings-group';
+
+import * as settingsActions from '../../../state/settings/actions';
+
+const DisplayPanel = props => {
+  const {
+    actions,
+    activeTheme,
+    lineLength,
+    noteDisplay,
+    sortIsReversed,
+    sortTagsAlpha,
+    sortType,
+  } = props;
+
+  return (
+    <div className="dialog-column settings-display">
+      <SettingsGroup
+        title="Note display"
+        slug="noteDisplay"
+        activeSlug={noteDisplay}
+        onChange={actions.setNoteDisplay}
+        renderer={RadioGroup}
+      >
+        <Item title="Comfy" slug="comfy" />
+        <Item title="Condensed" slug="condensed" />
+        <Item title="Expanded" slug="expanded" />
+      </SettingsGroup>
+
+      <SettingsGroup
+        title="Line length"
+        slug="lineLength"
+        activeSlug={lineLength}
+        onChange={actions.setLineLength}
+        renderer={RadioGroup}
+      >
+        <Item title="Narrow" slug="narrow" />
+        <Item title="Full" slug="full" />
+      </SettingsGroup>
+
+      <SettingsGroup
+        title="Sort type"
+        slug="sortType"
+        activeSlug={sortType}
+        onChange={actions.setSortType}
+        renderer={RadioGroup}
+      >
+        <Item title="Date modified" slug="modificationDate" />
+        <Item title="Date created" slug="creationDate" />
+        <Item title="Alphabetical" slug="alphabetical" />
+      </SettingsGroup>
+
+      <SettingsGroup
+        title="Sort order"
+        slug="sortOrder"
+        activeSlug={sortIsReversed ? 'reversed' : ''}
+        onChange={actions.toggleSortOrder}
+        renderer={ToggleGroup}
+      >
+        <Item title="Reversed" slug="reversed" />
+      </SettingsGroup>
+
+      <SettingsGroup
+        title="Tags"
+        slug="sortTagsAlpha"
+        activeSlug={sortTagsAlpha ? 'alpha' : ''}
+        onChange={actions.toggleSortTagsAlpha}
+        renderer={ToggleGroup}
+      >
+        <Item title="Sort Alphabetically" slug="alpha" />
+      </SettingsGroup>
+
+      <SettingsGroup
+        title="Theme"
+        slug="theme"
+        activeSlug={activeTheme}
+        onChange={actions.activateTheme}
+        renderer={RadioGroup}
+      >
+        <Item title="Light" slug="light" />
+        <Item title="Dark" slug="dark" />
+      </SettingsGroup>
+    </div>
+  );
+};
+
+DisplayPanel.propTypes = {
+  actions: PropTypes.object.isRequired,
+  activeTheme: PropTypes.string.isRequired,
+  lineLength: PropTypes.string.isRequired,
+  noteDisplay: PropTypes.string.isRequired,
+  sortIsReversed: PropTypes.bool.isRequired,
+  sortTagsAlpha: PropTypes.bool.isRequired,
+  sortType: PropTypes.string.isRequired,
+};
+
+const mapStateToProps = ({ settings }) => {
+  return {
+    activeTheme: settings.theme,
+    lineLength: settings.lineLength,
+    noteDisplay: settings.noteDisplay,
+    sortIsReversed: settings.sortReversed,
+    sortTagsAlpha: settings.sortTagsAlpha,
+    sortType: settings.sortType,
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  actions: bindActionCreators(settingsActions, dispatch),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(DisplayPanel);

--- a/lib/dialogs/settings/panels/display.jsx
+++ b/lib/dialogs/settings/panels/display.jsx
@@ -7,18 +7,27 @@ import RadioGroup from '../../radio-settings-group';
 import SettingsGroup, { Item } from '../../settings-group';
 import ToggleGroup from '../../toggle-settings-group';
 
+import appState from '../../../flux/app-state';
 import * as settingsActions from '../../../state/settings/actions';
 
 const DisplayPanel = props => {
   const {
     actions,
     activeTheme,
+    buckets: { noteBucket, tagBucket },
     lineLength,
+    loadNotes,
+    loadTags,
     noteDisplay,
     sortIsReversed,
     sortTagsAlpha,
     sortType,
   } = props;
+
+  const withCallback = ({ action, callback }) => arg => {
+    action(arg);
+    callback();
+  };
 
   return (
     <div className="dialog-column settings-display">
@@ -49,7 +58,10 @@ const DisplayPanel = props => {
         title="Sort type"
         slug="sortType"
         activeSlug={sortType}
-        onChange={actions.setSortType}
+        onChange={withCallback({
+          action: actions.setSortType,
+          callback: () => loadNotes(noteBucket),
+        })}
         renderer={RadioGroup}
       >
         <Item title="Date modified" slug="modificationDate" />
@@ -61,7 +73,10 @@ const DisplayPanel = props => {
         title="Sort order"
         slug="sortOrder"
         activeSlug={sortIsReversed ? 'reversed' : ''}
-        onChange={actions.toggleSortOrder}
+        onChange={withCallback({
+          action: actions.toggleSortOrder,
+          callback: () => loadNotes(noteBucket),
+        })}
         renderer={ToggleGroup}
       >
         <Item title="Reversed" slug="reversed" />
@@ -71,7 +86,10 @@ const DisplayPanel = props => {
         title="Tags"
         slug="sortTagsAlpha"
         activeSlug={sortTagsAlpha ? 'alpha' : ''}
-        onChange={actions.toggleSortTagsAlpha}
+        onChange={withCallback({
+          action: actions.toggleSortTagsAlpha,
+          callback: () => loadTags(tagBucket),
+        })}
         renderer={ToggleGroup}
       >
         <Item title="Sort Alphabetically" slug="alpha" />
@@ -94,7 +112,13 @@ const DisplayPanel = props => {
 DisplayPanel.propTypes = {
   actions: PropTypes.object.isRequired,
   activeTheme: PropTypes.string.isRequired,
+  buckets: PropTypes.shape({
+    noteBucket: PropTypes.object.isRequired,
+    tagBucket: PropTypes.object.isRequired,
+  }),
   lineLength: PropTypes.string.isRequired,
+  loadNotes: PropTypes.func.isRequired,
+  loadTags: PropTypes.func.isRequired,
   noteDisplay: PropTypes.string.isRequired,
   sortIsReversed: PropTypes.bool.isRequired,
   sortTagsAlpha: PropTypes.bool.isRequired,
@@ -112,8 +136,13 @@ const mapStateToProps = ({ settings }) => {
   };
 };
 
-const mapDispatchToProps = dispatch => ({
-  actions: bindActionCreators(settingsActions, dispatch),
-});
+const mapDispatchToProps = dispatch => {
+  const { loadNotes, loadTags } = appState.actionCreators;
+  return {
+    actions: bindActionCreators(settingsActions, dispatch),
+    loadNotes: noteBucket => dispatch(loadNotes({ noteBucket })),
+    loadTags: tagBucket => dispatch(loadTags({ tagBucket })),
+  };
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(DisplayPanel);

--- a/lib/dialogs/share/index.jsx
+++ b/lib/dialogs/share/index.jsx
@@ -101,149 +101,130 @@ export class ShareDialog extends Component {
 
   render() {
     const { dialog, requestClose } = this.props;
-
-    return (
-      <TabbedDialog
-        className="settings"
-        title="Share"
-        tabs={shareTabs}
-        onDone={requestClose}
-        renderTabName={this.renderTabName}
-        renderTabContent={this.renderTabContent}
-        {...dialog}
-      />
-    );
-  }
-
-  renderTabName = tabName => tabName;
-
-  renderTabContent = tabName => {
     const { note } = this.props.appState;
+
     const data = (note && note.data) || {};
     const isPublished = includes(data.systemTags, 'published');
     const publishURL = this.getPublishURL(data.publishURL);
 
-    switch (tabName) {
-      case 'collaborate':
-        return (
-          <div className="dialog-column share-collaborate">
+    return (
+      <TabbedDialog
+        className="settings"
+        title={dialog.title}
+        tabNames={shareTabs}
+        onDone={requestClose}
+      >
+        <div className="dialog-column share-collaborate">
+          <div className="settings-group">
+            <p>
+              Add an email address of another Simplenote user to share a note.
+              You&apos;ll both be able to edit and view the note.
+            </p>
+            <div className="settings-items theme-color-border">
+              <form
+                className="settings-item theme-color-border"
+                onSubmit={this.onAddCollaborator}
+              >
+                <input
+                  ref={e => (this.collaboratorElement = e)}
+                  type="email"
+                  pattern="[^@]+@[^@]+"
+                  className="settings-item-text-input transparent-input"
+                  placeholder="email@example.com"
+                  spellCheck={false}
+                />
+                <div className="settings-item-control">
+                  <button type="submit" className="button button-borderless">
+                    Add Email
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+          <div className="settings-group">
+            <div className="share-collaborators-heading theme-color-border">
+              <PanelTitle headingLevel="3">Collaborators</PanelTitle>
+            </div>
+            <ul className="share-collaborators">
+              {this.collaborators().map(collaborator => (
+                <li key={collaborator} className="share-collaborator">
+                  <span className="share-collaborator-photo">
+                    <img
+                      src={this.gravatarURL(collaborator)}
+                      width="34"
+                      height="34"
+                    />
+                  </span>
+                  <span className="share-collaborator-name">
+                    {collaborator}
+                  </span>
+                  <button
+                    className="share-collaborator-remove button button-borderless button-danger"
+                    onClick={this.onRemoveCollaborator.bind(this, collaborator)}
+                  >
+                    Remove
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+        <div className="dialog-column share-publish">
+          <div className="settings-group">
+            <div className="settings-items theme-color-border">
+              <label
+                htmlFor="settings-field-public"
+                className="settings-item theme-color-border"
+              >
+                <div className="settings-item-label">Make public link</div>
+                <div className="settings-item-control">
+                  <ToggleControl
+                    id="settings-field-public"
+                    onChange={this.onTogglePublished}
+                    checked={isPublished}
+                  />
+                </div>
+              </label>
+            </div>
+            <p>
+              Ready to share your note with the world? Anyone with the public
+              link will be able to view the latest version.
+            </p>
+          </div>
+          {isPublished && (
             <div className="settings-group">
-              <p>
-                Add an email address of another Simplenote user to share a note.
-                You&apos;ll both be able to edit and view the note.
-              </p>
+              <PanelTitle headingLevel="3">Public link</PanelTitle>
               <div className="settings-items theme-color-border">
-                <form
-                  className="settings-item theme-color-border"
-                  onSubmit={this.onAddCollaborator}
-                >
+                <div className="settings-item theme-color-border">
                   <input
-                    ref={e => (this.collaboratorElement = e)}
-                    type="email"
-                    pattern="[^@]+@[^@]+"
+                    ref={e => (this.publishUrlElement = e)}
                     className="settings-item-text-input transparent-input"
-                    placeholder="email@example.com"
+                    placeholder={
+                      isPublished ? 'Publishing note…' : 'Note not published'
+                    }
+                    value={publishURL}
                     spellCheck={false}
                   />
                   <div className="settings-item-control">
-                    <button type="submit" className="button button-borderless">
-                      Add Email
-                    </button>
-                  </div>
-                </form>
-              </div>
-            </div>
-            <div className="settings-group">
-              <div className="share-collaborators-heading theme-color-border">
-                <PanelTitle headingLevel="3">Collaborators</PanelTitle>
-              </div>
-              <ul className="share-collaborators">
-                {this.collaborators().map(collaborator => (
-                  <li key={collaborator} className="share-collaborator">
-                    <span className="share-collaborator-photo">
-                      <img
-                        src={this.gravatarURL(collaborator)}
-                        width="34"
-                        height="34"
-                      />
-                    </span>
-                    <span className="share-collaborator-name">
-                      {collaborator}
-                    </span>
                     <button
-                      className="share-collaborator-remove button button-borderless button-danger"
-                      onClick={this.onRemoveCollaborator.bind(
-                        this,
-                        collaborator
-                      )}
+                      ref={e => (this.copyUrlElement = e)}
+                      disabled={!publishURL}
+                      type="button"
+                      className="button button-borderless"
+                      onClick={this.copyPublishURL}
                     >
-                      Remove
+                      Copy
                     </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
-        );
-
-      case 'publish':
-        return (
-          <div className="dialog-column share-publish">
-            <div className="settings-group">
-              <div className="settings-items theme-color-border">
-                <label
-                  htmlFor="settings-field-public"
-                  className="settings-item theme-color-border"
-                >
-                  <div className="settings-item-label">Make public link</div>
-                  <div className="settings-item-control">
-                    <ToggleControl
-                      id="settings-field-public"
-                      onChange={this.onTogglePublished}
-                      checked={isPublished}
-                    />
-                  </div>
-                </label>
-              </div>
-              <p>
-                Ready to share your note with the world? Anyone with the public
-                link will be able to view the latest version.
-              </p>
-            </div>
-            {isPublished && (
-              <div className="settings-group">
-                <PanelTitle headingLevel="3">Public link</PanelTitle>
-                <div className="settings-items theme-color-border">
-                  <div className="settings-item theme-color-border">
-                    <input
-                      ref={e => (this.publishUrlElement = e)}
-                      className="settings-item-text-input transparent-input"
-                      placeholder={
-                        isPublished ? 'Publishing note…' : 'Note not published'
-                      }
-                      value={publishURL}
-                      spellCheck={false}
-                    />
-                    <div className="settings-item-control">
-                      <button
-                        ref={e => (this.copyUrlElement = e)}
-                        disabled={!publishURL}
-                        type="button"
-                        className="button button-borderless"
-                        onClick={this.copyPublishURL}
-                      >
-                        Copy
-                      </button>
-                    </div>
                   </div>
                 </div>
-                {publishURL && <p>Note published!</p>}
               </div>
-            )}
-          </div>
-        );
-    }
-  };
+              {publishURL && <p>Note published!</p>}
+            </div>
+          )}
+        </div>
+      </TabbedDialog>
+    );
+  }
 }
 
 export default ShareDialog;

--- a/lib/tabbed-dialog.jsx
+++ b/lib/tabbed-dialog.jsx
@@ -1,59 +1,36 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+
 import Dialog from './dialog';
 
 export class TabbedDialog extends Component {
   static propTypes = {
+    children: PropTypes.node.isRequired,
     className: PropTypes.string,
-    tabs: PropTypes.array.isRequired,
-    renderTabName: PropTypes.func.isRequired,
-    renderTabContent: PropTypes.func.isRequired,
+    tabNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   };
 
-  componentWillMount() {
-    this.setState({
-      currentTab: this.props.tabs[0],
-    });
-  }
-
-  setCurrentTab = ({ target: { dataset: { tabName } } }) =>
-    this.setState({ currentTab: tabName });
-
   render() {
-    const {
-      className,
-      tabs,
-      renderTabName,
-      renderTabContent,
-      ...dialog
-    } = this.props;
-    const { currentTab } = this.state;
+    const { children, className, tabNames, ...props } = this.props;
 
     return (
-      <Dialog className={className} {...dialog}>
-        <nav className="dialog-tabs theme-color-border">
-          <ul>
-            {tabs.map((tab, key) => (
-              <li key={key}>
-                <button
-                  type="button"
-                  className={classNames('button button-borderless', {
-                    'dialog-tab-active': tab === currentTab,
-                  })}
-                  data-tab-name={tab}
-                  onClick={this.setCurrentTab}
-                >
-                  {renderTabName(tab)}
-                </button>
-              </li>
+      <Dialog className={className} {...props}>
+        <Tabs selectedTabClassName="dialog-tab-active">
+          <TabList className="dialog-tabs theme-color-border">
+            {tabNames.map((tabName, key) => (
+              <Tab className="button button-borderless" key={key}>
+                {tabName}
+              </Tab>
             ))}
-          </ul>
-        </nav>
+          </TabList>
 
-        <div className="dialog-tab-content">
-          {renderTabContent(this.state.currentTab)}
-        </div>
+          <div className="dialog-tab-content">
+            {children.map((tabPanel, key) => (
+              <TabPanel key={key}>{tabPanel}</TabPanel>
+            ))}
+          </div>
+        </Tabs>
       </Dialog>
     );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17623,6 +17623,15 @@
         "prop-types": "^15.6.0"
       }
     },
+    "react-tabs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-2.3.0.tgz",
+      "integrity": "sha512-pYaefgVy76/36AMEP+B8YuVVzDHa3C5UFZ3REU78zolk0qMxEhKvUFofvDCXyLZwf0RZjxIfiwok1BEb18nHyA==",
+      "requires": {
+        "classnames": "^2.2.0",
+        "prop-types": "^15.5.0"
+      }
+    },
     "react-test-renderer": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.2.0.tgz",
@@ -20461,7 +20470,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY="
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "react-modal": "3.6.1",
     "react-overlays": "0.8.3",
     "react-redux": "5.0.7",
+    "react-tabs": "2.3.0",
     "react-transition-group": "2.5.0",
     "react-virtualized": "9.18.5",
     "redux": "3.7.2",


### PR DESCRIPTION
Closes #981 

This is in preparation for the new "Tools" tab panel we will add to contain the Import/Export functions.

It is mainly a Settings dialog refactor, but also replaces the TabbedDialog implementation with an accessible one so our tab panels are screen reader friendly.

### To test

The Settings dialog and Share dialog should work as expected, and look correct in Light/Dark modes.