### PR TITLE
Show Published icon in Condensed view

### DIFF
--- a/lib/note-list/index.jsx
+++ b/lib/note-list/index.jsx
@@ -234,7 +234,6 @@ const renderNote = (
   const note = notes['undefined' === typeof index ? rowIndex : index];
   const { title, preview } = getNoteTitleAndPreview(note);
   const isPublished = !isEmpty(note.data.publishURL);
-  const showPublishIcon = isPublished && 'condensed' !== noteDisplay;
 
   const classes = classNames('note-list-item', {
     'note-list-item-selected': !isSmallScreen && selectedNoteId === note.id,
@@ -270,7 +269,7 @@ const renderNote = (
       >
         <div className="note-list-item-title">
           <span>{matchify(titleSplits)}</span>
-          {showPublishIcon && (
+          {isPublished && (
             <div className="note-list-item-published-icon">
               <PublishIcon />
             </div>

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -113,7 +113,7 @@
   }
 
   .note-list-item-published-icon {
-    margin-left: auto;
+    margin-left: 4px;
     margin-right: 10px;
 
     & svg {
@@ -125,6 +125,7 @@
 
   .note-list-item-title {
     display: flex;
+    justify-content: space-between;
     font-size: 16px;
 
     & span {


### PR DESCRIPTION
Closes #547 

![publish-icon](https://user-images.githubusercontent.com/555336/50286153-d9b0d000-04a1-11e9-96a8-e4b043b34968.gif)

Not sure why this was explicitly hidden. Looks like it simply fell through the cracks in the original PR? (#228)