### PR TITLE
Skip appx store build on untagged commits

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,7 @@ for:
         - configuration: AppX-WindowsStore
     before_build:
       - openssl aes-256-cbc -d -in .\resources\secrets\config.json.enc -out .\config.json -k "%CSC_ENC_KEY%"
+    skip_non_tags: true
     environment:
       CSC_LINK: ""
     build_script:


### PR DESCRIPTION
This tweak will make AppVeyor skip the Windows Store (unsigned appx) build on untagged (= non-release) commits. It is unnecessary, and skipping it would save 10–15 min.

https://ci.appveyor.com/project/Automattic/simplenote-electron/builds/21184748