### PR TITLE
Make the Markdown preview work in IE11

### DIFF
--- a/lib/utils/sanitize-html.js
+++ b/lib/utils/sanitize-html.js
@@ -175,7 +175,12 @@ export const sanitizeHtml = content => {
   const doc = parser.parseFromString(content, 'text/html');
 
   // this will let us visit every single DOM node programmatically
-  const walker = doc.createTreeWalker(doc.body);
+  const walker = doc.createTreeWalker(
+    doc.body,
+    NodeFilter.SHOW_ALL,
+    null,
+    false // IE11 requires this last argument
+  );
 
   /**
    * we don't want to remove nodes while walking the tree


### PR DESCRIPTION
Closes #1121 

IE11 was throwing an error on `document.createTreeWalker()`, because it is based on a now obsolete spec in which this method [required all four arguments](https://genius.engineering/psa-internet-explorer-requires-all-four-arguments-to-documentcreatetreewalker/).

### To test

Clicking the Markdown preview button works as expected on Chrome, Safari, Firefox, IE11, and Edge.