### PR TITLE
Extract tag-related functions from appState

### DIFF
--- a/lib/app-layout/index.js
+++ b/lib/app-layout/index.js
@@ -30,7 +30,6 @@ export const AppLayout = ({
   onNoteClosed,
   onNoteOpened,
   onUpdateContent,
-  onUpdateNoteTags,
 }) => {
   const mainClasses = classNames('app-layout', {
     'is-focus-mode': isFocusMode,
@@ -63,7 +62,6 @@ export const AppLayout = ({
             note={note}
             revisions={revisions || []}
             onUpdateContent={onUpdateContent}
-            onUpdateNoteTags={onUpdateNoteTags}
           />
           <NoteToolbarContainer
             onNoteClosed={onNoteClosed}
@@ -74,7 +72,6 @@ export const AppLayout = ({
             note={note}
             noteBucket={noteBucket}
             onUpdateContent={onUpdateContent}
-            onUpdateNoteTags={onUpdateNoteTags}
             tags={
               get(note, 'data.tags', []) /* flattened to trigger re-render */
             }
@@ -97,7 +94,6 @@ AppLayout.propTypes = {
   onNoteClosed: PropTypes.func.isRequired,
   onNoteOpened: PropTypes.func.isRequired,
   onUpdateContent: PropTypes.func.isRequired,
-  onUpdateNoteTags: PropTypes.func.isRequired,
 };
 
 export default AppLayout;

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -319,12 +319,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
         content,
       });
 
-    onUpdateNoteTags = (note, tags) =>
-      this.props.actions.updateNoteTags({
-        note,
-        tags,
-      });
-
     // gets the index of the note located before the currently selected one
     getPreviousNoteIndex = note => {
       const filteredNotes = filterNotes(this.props.appState);
@@ -410,7 +404,6 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
                 onNoteClosed={() => this.setState({ isNoteOpen: false })}
                 onNoteOpened={() => this.setState({ isNoteOpen: true })}
                 onUpdateContent={this.onUpdateContent}
-                onUpdateNoteTags={this.onUpdateNoteTags}
               />
               {state.showNoteInfo && <NoteInfo noteBucket={noteBucket} />}
             </div>

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -65,7 +65,7 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
 
   const thenReloadTags = action => a => {
     dispatch(action(a));
-    loadTags();
+    dispatch(loadTags());
   };
 
   return {
@@ -85,6 +85,7 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
       ]),
       dispatch
     ),
+    loadTags: () => dispatch(loadTags()),
     setSortType: thenReloadNotes(settingsActions.setSortType),
     toggleSortOrder: thenReloadNotes(settingsActions.toggleSortOrder),
     toggleSortTagsAlpha: thenReloadTags(settingsActions.toggleSortTagsAlpha),
@@ -119,6 +120,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       client: PropTypes.object.isRequired,
       isDevConfig: PropTypes.bool.isRequired,
       isSmallScreen: PropTypes.bool.isRequired,
+      loadTags: PropTypes.func.isRequired,
       noteBucket: PropTypes.object.isRequired,
       preferencesBucket: PropTypes.object.isRequired,
       tagBucket: PropTypes.object.isRequired,
@@ -159,9 +161,9 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
       this.props.preferencesBucket.on('update', this.onLoadPreferences);
 
       this.props.tagBucket
-        .on('index', loadTags)
-        .on('update', debounce(loadTags, 200))
-        .on('remove', loadTags);
+        .on('index', this.props.loadTags)
+        .on('update', debounce(this.props.loadTags, 200))
+        .on('remove', this.props.loadTags);
 
       this.props.client
         .on('authorized', this.onAuthChanged)
@@ -279,7 +281,7 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
 
       // 'Kick' the app to ensure content is loaded after signing in
       this.onNotesIndex();
-      loadTags();
+      this.props.loadTags();
     };
 
     onNotesIndex = () =>

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -4,8 +4,8 @@ import React from 'react';
 import App from './app';
 import Modal from 'react-modal';
 import Debug from 'debug';
+import { initClient } from './client';
 import getConfig from '../get-config';
-import simperium from './simperium';
 import store from './state';
 import {
   reset as resetAuth,
@@ -44,7 +44,7 @@ if (!token && config.is_app_engine) {
   window.location = `${config.app_engine_url}/signin?new=true`;
 }
 
-const client = simperium({
+const client = initClient({
   appID,
   token,
   bucketConfig: {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,0 +1,10 @@
+import simperium from './simperium';
+
+let client;
+
+export const initClient = config => {
+  client = simperium(config);
+  return client;
+};
+
+export default () => client;

--- a/lib/dialogs/settings/index.jsx
+++ b/lib/dialogs/settings/index.jsx
@@ -22,7 +22,6 @@ export class SettingsDialog extends Component {
     buckets: PropTypes.shape({
       noteBucket: PropTypes.object.isRequired,
       preferencesBucket: PropTypes.object.isRequired,
-      tagBucket: PropTypes.object.isRequired,
     }),
     dialog: PropTypes.shape({ title: PropTypes.string.isRequired }),
     onSignOut: PropTypes.func.isRequired,

--- a/lib/dialogs/settings/panels/display.jsx
+++ b/lib/dialogs/settings/panels/display.jsx
@@ -9,15 +9,15 @@ import ToggleGroup from '../../toggle-settings-group';
 
 import appState from '../../../flux/app-state';
 import * as settingsActions from '../../../state/settings/actions';
+import { loadTags } from '../../../state/domain/tags';
 
 const DisplayPanel = props => {
   const {
     actions,
     activeTheme,
-    buckets: { noteBucket, tagBucket },
+    buckets: { noteBucket },
     lineLength,
     loadNotes,
-    loadTags,
     noteDisplay,
     sortIsReversed,
     sortTagsAlpha,
@@ -88,7 +88,7 @@ const DisplayPanel = props => {
         activeSlug={sortTagsAlpha ? 'alpha' : ''}
         onChange={withCallback({
           action: actions.toggleSortTagsAlpha,
-          callback: () => loadTags(tagBucket),
+          callback: props.loadTags,
         })}
         renderer={ToggleGroup}
       >
@@ -114,7 +114,6 @@ DisplayPanel.propTypes = {
   activeTheme: PropTypes.string.isRequired,
   buckets: PropTypes.shape({
     noteBucket: PropTypes.object.isRequired,
-    tagBucket: PropTypes.object.isRequired,
   }),
   lineLength: PropTypes.string.isRequired,
   loadNotes: PropTypes.func.isRequired,
@@ -137,11 +136,11 @@ const mapStateToProps = ({ settings }) => {
 };
 
 const mapDispatchToProps = dispatch => {
-  const { loadNotes, loadTags } = appState.actionCreators;
+  const { loadNotes } = appState.actionCreators;
   return {
     actions: bindActionCreators(settingsActions, dispatch),
     loadNotes: noteBucket => dispatch(loadNotes({ noteBucket })),
-    loadTags: tagBucket => dispatch(loadTags({ tagBucket })),
+    loadTags: () => dispatch(loadTags()),
   };
 };
 

--- a/lib/dialogs/share/index.jsx
+++ b/lib/dialogs/share/index.jsx
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import createHash from 'create-hash/browser';
 import { includes, isEmpty } from 'lodash';
 
 import analytics from '../../analytics';
 import isEmailTag from '../../utils/is-email-tag';
+import { updateNoteTags } from '../../state/domain/notes';
 import Dialog from '../../dialog';
 import TabPanels from '../../components/tab-panels';
 import PanelTitle from '../../components/panel-title';
@@ -20,6 +22,7 @@ export class ShareDialog extends Component {
     appState: PropTypes.object.isRequired,
     requestClose: PropTypes.func.isRequired,
     tagBucket: PropTypes.object.isRequired,
+    updateNoteTags: PropTypes.func.isRequired,
   };
 
   onTogglePublished = event => {
@@ -53,7 +56,7 @@ export class ShareDialog extends Component {
     this.collaboratorElement.value = '';
 
     if (collaborator !== '' && tags.indexOf(collaborator) === -1) {
-      this.props.actions.updateNoteTags({
+      this.props.updateNoteTags({
         note,
         tags: [...tags, collaborator],
       });
@@ -67,10 +70,7 @@ export class ShareDialog extends Component {
     let tags = (note.data && note.data.tags) || [];
     tags = tags.filter(tag => tag !== collaborator);
 
-    this.props.actions.updateNoteTags({
-      note,
-      tags,
-    });
+    this.props.updateNoteTags({ note, tags });
     analytics.tracks.recordEvent('editor_note_collaborator_removed');
   };
 
@@ -225,4 +225,4 @@ export class ShareDialog extends Component {
   }
 }
 
-export default ShareDialog;
+export default connect(null, { updateNoteTags })(ShareDialog);

--- a/lib/dialogs/share/index.jsx
+++ b/lib/dialogs/share/index.jsx
@@ -54,8 +54,6 @@ export class ShareDialog extends Component {
 
     if (collaborator !== '' && tags.indexOf(collaborator) === -1) {
       this.props.actions.updateNoteTags({
-        noteBucket: this.props.noteBucket,
-        tagBucket: this.props.tagBucket,
         note,
         tags: [...tags, collaborator],
       });
@@ -70,8 +68,6 @@ export class ShareDialog extends Component {
     tags = tags.filter(tag => tag !== collaborator);
 
     this.props.actions.updateNoteTags({
-      noteBucket: this.props.noteBucket,
-      tagBucket: this.props.tagBucket,
       note,
       tags,
     });

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -2,14 +2,11 @@ import { get, partition, some } from 'lodash';
 import update from 'react-addons-update';
 import Debug from 'debug';
 import ActionMap from './action-map';
-import isEmailTag from '../utils/is-email-tag';
 import filterNotes from '../utils/filter-notes';
-import throttle from '../utils/throttle';
 import analytics from '../analytics';
 import { util as simperiumUtil } from 'simperium';
 
 const debug = Debug('appState');
-const typingThrottle = 3000;
 
 export const actionMap = new ActionMap({
   namespace: 'App',
@@ -174,97 +171,6 @@ export const actionMap = new ActionMap({
       return update(state, {
         editingTags: { $set: !state.editingTags },
       });
-    },
-
-    newTag: {
-      creator({ tagBucket, name }) {
-        return () => {
-          // tag.id must be the tag name in lower case and percent escaped
-          const tagId = encodeURIComponent(name.toLowerCase());
-          tagBucket.update(tagId, { name });
-        };
-      },
-    },
-
-    renameTag: {
-      creator({ tagBucket, noteBucket, tag, name }) {
-        return (dispatch, getState) => {
-          let oldTagName = tag.data.name;
-          if (oldTagName === name) {
-            return;
-          }
-
-          let { notes } = getState().appState;
-          let changedNoteIds = [];
-
-          tag.data.name = name;
-
-          // update the tag bucket but don't fire a sync immediately
-          tagBucket.update(tag.id, tag.data, { sync: false });
-
-          // similarly, update the note bucket
-          for (let i = 0; i < notes.length; i++) {
-            let note = notes[i];
-            let noteTags = note.data.tags || [];
-            let tagIndex = noteTags.indexOf(oldTagName);
-
-            if (tagIndex !== -1) {
-              noteTags.splice(tagIndex, 1, name);
-              note.data.tags = noteTags.filter(
-                noteTag => noteTag !== oldTagName
-              );
-              noteBucket.update(note.id, note.data, { sync: false });
-              changedNoteIds.push(note.id);
-            }
-          }
-
-          throttle(tag.id, typingThrottle, () => {
-            tagBucket.touch(tag.id, () => {
-              dispatch(this.action('loadTags', { tagBucket }));
-
-              for (let i = 0; i < changedNoteIds.length; i++) {
-                noteBucket.touch(changedNoteIds[i]);
-              }
-            });
-          });
-        };
-      },
-    },
-
-    trashTag: {
-      creator({ tagBucket, noteBucket, tag }) {
-        return (dispatch, getState) => {
-          var { notes } = getState().appState;
-          var tagName = tag.data.name;
-
-          for (let i = 0; i < notes.length; i++) {
-            let note = notes[i];
-            let noteTags = note.data.tags || [];
-            let newTags = noteTags.filter(noteTag => noteTag !== tagName);
-
-            if (newTags.length !== noteTags.length) {
-              note.data.tags = newTags;
-              noteBucket.update(note.id, note.data);
-            }
-          }
-
-          tagBucket.remove(tag.id, () => {
-            dispatch(this.action('loadTags', { tagBucket }));
-          });
-        };
-      },
-    },
-
-    reorderTags: {
-      creator({ tagBucket, tags }) {
-        return () => {
-          for (let i = 0; i < tags.length; i++) {
-            let tag = tags[i];
-            tag.data.index = i;
-            tagBucket.update(tag.id, tag.data);
-          }
-        };
-      },
     },
 
     search(state, { filter }) {
@@ -558,42 +464,6 @@ export const actionMap = new ActionMap({
       },
     },
 
-    updateNoteTags: {
-      creator({ noteBucket, tagBucket, note, tags }) {
-        return (dispatch, getState) => {
-          if (note) {
-            let state = getState().appState;
-
-            note.data.tags = tags;
-            note.data.modificationDate = Math.floor(Date.now() / 1000);
-            noteBucket.update(note.id, note.data);
-
-            dispatch(this.action('selectNote', { note }));
-
-            let currentTagNames = state.tags.map(tag => tag.data.name);
-            for (let i = 0; i < tags.length; i++) {
-              let tag = tags[i];
-
-              if (currentTagNames.indexOf(tag) !== -1) {
-                continue;
-              }
-
-              if (isEmailTag(tag)) {
-                continue;
-              }
-
-              dispatch(
-                this.action('newTag', {
-                  tagBucket,
-                  name: tag,
-                })
-              );
-            }
-          }
-        };
-      },
-    },
-
     trashNote: {
       creator({ noteBucket, note, previousIndex }) {
         return dispatch => {
@@ -679,29 +549,6 @@ export const actionMap = new ActionMap({
         showNavigation: { $set: false },
         editingTags: { $set: false },
       });
-    },
-
-    loadTags: {
-      creator({ tagBucket }) {
-        return (dispatch, getState) => {
-          const sortTagsAlpha = getState().settings.sortTagsAlpha;
-          tagBucket.query(db => {
-            var tags = [];
-            db
-              .transaction('tag')
-              .objectStore('tag')
-              .openCursor(null, 'prev').onsuccess = e => {
-              var cursor = e.target.result;
-              if (cursor) {
-                tags.push(cursor.value);
-                cursor.continue();
-              } else {
-                dispatch(this.action('tagsLoaded', { tags, sortTagsAlpha }));
-              }
-            };
-          });
-        };
-      },
     },
 
     tagsLoaded(state, { tags, sortTagsAlpha }) {

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -19,7 +19,6 @@ export class NoteEditor extends Component {
     note: PropTypes.object,
     fontSize: PropTypes.number,
     onUpdateContent: PropTypes.func.isRequired,
-    onUpdateNoteTags: PropTypes.func.isRequired,
     revision: PropTypes.object,
     setEditorMode: PropTypes.func.isRequired,
   };
@@ -139,7 +138,6 @@ export class NoteEditor extends Component {
               allTags={this.props.allTags.map(property('data.name'))}
               note={this.props.note}
               tags={tags}
-              onUpdateNoteTags={this.props.onUpdateNoteTags.bind(null, note)}
             />
           )}
       </div>

--- a/lib/revision-selector/index.jsx
+++ b/lib/revision-selector/index.jsx
@@ -7,6 +7,7 @@ import { orderBy } from 'lodash';
 import classNames from 'classnames';
 import Slider from '../components/slider';
 import appState from '../flux/app-state';
+import { updateNoteTags } from '../state/domain/notes';
 
 const sortedRevisions = revisions =>
   orderBy(revisions, 'data.modificationDate', 'asc');
@@ -17,10 +18,10 @@ export class RevisionSelector extends Component {
     note: PropTypes.object,
     revisions: PropTypes.array.isRequired,
     onUpdateContent: PropTypes.func.isRequired,
-    onUpdateNoteTags: PropTypes.func.isRequired,
     setRevision: PropTypes.func.isRequired,
     resetIsViewingRevisions: PropTypes.func.isRequired,
     cancelRevision: PropTypes.func.isRequired,
+    updateNoteTags: PropTypes.func.isRequired,
   };
 
   constructor(...args) {
@@ -67,12 +68,7 @@ export class RevisionSelector extends Component {
   handleClickOutside = () => this.onCancelRevision();
 
   onAcceptRevision = () => {
-    const {
-      note,
-      onUpdateContent,
-      onUpdateNoteTags,
-      resetIsViewingRevisions,
-    } = this.props;
+    const { note, onUpdateContent, resetIsViewingRevisions } = this.props;
     const { revisions, selection } = this.state;
     const revision = revisions[selection];
 
@@ -80,7 +76,7 @@ export class RevisionSelector extends Component {
       const { data: { content, tags } } = revision;
 
       onUpdateContent(note, content);
-      onUpdateNoteTags(note, tags);
+      this.props.updateNoteTags({ note, tags });
       resetIsViewingRevisions();
     }
     this.resetSelection();
@@ -174,6 +170,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(setRevision({ revision: null }));
     dispatch(setIsViewingRevisions({ isViewingRevisions: false }));
   },
+  updateNoteTags: arg => dispatch(updateNoteTags(arg)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(

--- a/lib/state/domain/buckets.js
+++ b/lib/state/domain/buckets.js
@@ -1,0 +1,11 @@
+import client from '../../client';
+
+export const noteBucket = () => client().bucket('note');
+export const preferencesBucket = () => client().bucket('preferences');
+export const tagBucket = () => client().bucket('tag');
+
+export default {
+  noteBucket,
+  preferencesBucket,
+  tagBucket,
+};

--- a/lib/state/domain/notes.js
+++ b/lib/state/domain/notes.js
@@ -1,17 +1,18 @@
 import { store } from '../';
+import { noteBucket } from './buckets';
 import appState from '../../flux/app-state';
 import isEmailTag from '../../utils/is-email-tag';
 import { createTag } from './tags';
 
 const { selectNote } = appState.actionCreators;
 
-export const updateNoteTags = ({ noteBucket, tagBucket, note, tags }) => {
+export const updateNoteTags = ({ note, tags }) => {
   if (note) {
     let state = store.getState().appState;
 
     note.data.tags = tags;
     note.data.modificationDate = Math.floor(Date.now() / 1000);
-    noteBucket.update(note.id, note.data);
+    noteBucket().update(note.id, note.data);
 
     store.dispatch(selectNote({ note }));
 
@@ -27,7 +28,7 @@ export const updateNoteTags = ({ noteBucket, tagBucket, note, tags }) => {
         continue;
       }
 
-      createTag({ tagBucket, name: tag });
+      createTag({ name: tag });
     }
   }
 };

--- a/lib/state/domain/notes.js
+++ b/lib/state/domain/notes.js
@@ -1,0 +1,33 @@
+import { store } from '../';
+import appState from '../../flux/app-state';
+import isEmailTag from '../../utils/is-email-tag';
+import { createTag } from './tags';
+
+const { selectNote } = appState.actionCreators;
+
+export const updateNoteTags = ({ noteBucket, tagBucket, note, tags }) => {
+  if (note) {
+    let state = store.getState().appState;
+
+    note.data.tags = tags;
+    note.data.modificationDate = Math.floor(Date.now() / 1000);
+    noteBucket.update(note.id, note.data);
+
+    store.dispatch(selectNote({ note }));
+
+    let currentTagNames = state.tags.map(tag => tag.data.name);
+    for (let i = 0; i < tags.length; i++) {
+      let tag = tags[i];
+
+      if (currentTagNames.indexOf(tag) !== -1) {
+        continue;
+      }
+
+      if (isEmailTag(tag)) {
+        continue;
+      }
+
+      createTag({ tagBucket, name: tag });
+    }
+  }
+};

--- a/lib/state/domain/notes.js
+++ b/lib/state/domain/notes.js
@@ -1,4 +1,3 @@
-import { store } from '../';
 import { noteBucket } from './buckets';
 import appState from '../../flux/app-state';
 import isEmailTag from '../../utils/is-email-tag';
@@ -7,28 +6,30 @@ import { createTag } from './tags';
 const { selectNote } = appState.actionCreators;
 
 export const updateNoteTags = ({ note, tags }) => {
-  if (note) {
-    let state = store.getState().appState;
+  return (dispatch, getState) => {
+    if (note) {
+      let state = getState().appState;
 
-    note.data.tags = tags;
-    note.data.modificationDate = Math.floor(Date.now() / 1000);
-    noteBucket().update(note.id, note.data);
+      note.data.tags = tags;
+      note.data.modificationDate = Math.floor(Date.now() / 1000);
+      noteBucket().update(note.id, note.data);
 
-    store.dispatch(selectNote({ note }));
+      dispatch(selectNote({ note }));
 
-    let currentTagNames = state.tags.map(tag => tag.data.name);
-    for (let i = 0; i < tags.length; i++) {
-      let tag = tags[i];
+      let currentTagNames = state.tags.map(tag => tag.data.name);
+      for (let i = 0; i < tags.length; i++) {
+        let tag = tags[i];
 
-      if (currentTagNames.indexOf(tag) !== -1) {
-        continue;
+        if (currentTagNames.indexOf(tag) !== -1) {
+          continue;
+        }
+
+        if (isEmailTag(tag)) {
+          continue;
+        }
+
+        createTag({ name: tag });
       }
-
-      if (isEmailTag(tag)) {
-        continue;
-      }
-
-      createTag({ name: tag });
     }
-  }
+  };
 };

--- a/lib/state/domain/tags.js
+++ b/lib/state/domain/tags.js
@@ -40,13 +40,13 @@ export const reorderTags = ({ tags }) => () => {
   }
 };
 
-export const renameTag = ({ tag, name }) => {
+export const renameTag = ({ tag, name }) => (dispatch, getState) => {
   let oldTagName = tag.data.name;
   if (oldTagName === name) {
     return;
   }
 
-  let { notes } = store.getState().appState;
+  let { notes } = getState().appState;
   let changedNoteIds = [];
 
   tag.data.name = name;
@@ -73,7 +73,7 @@ export const renameTag = ({ tag, name }) => {
       dispatch(loadTags());
 
       for (let i = 0; i < changedNoteIds.length; i++) {
-        noteBucket.touch(changedNoteIds[i]);
+        noteBucket().touch(changedNoteIds[i]);
       }
     });
   });

--- a/lib/state/domain/tags.js
+++ b/lib/state/domain/tags.js
@@ -1,4 +1,5 @@
 import { store } from '../';
+import { noteBucket, tagBucket } from './buckets';
 import appState from '../../flux/app-state';
 import throttle from '../../utils/throttle';
 
@@ -6,9 +7,9 @@ const typingThrottle = 3000;
 
 const { tagsLoaded } = appState.actionCreators;
 
-export const loadTags = ({ tagBucket }) => {
+export const loadTags = () => {
   const sortTagsAlpha = store.getState().settings.sortTagsAlpha;
-  tagBucket.query(db => {
+  tagBucket().query(db => {
     var tags = [];
     db
       .transaction('tag')
@@ -25,21 +26,21 @@ export const loadTags = ({ tagBucket }) => {
   });
 };
 
-export const createTag = ({ tagBucket, name }) => {
+export const createTag = ({ name }) => {
   // tag.id must be the tag name in lower case and percent escaped
   const tagId = encodeURIComponent(name.toLowerCase());
-  tagBucket.update(tagId, { name });
+  tagBucket().update(tagId, { name });
 };
 
-export const reorderTags = ({ tagBucket, tags }) => {
+export const reorderTags = ({ tags }) => {
   for (let i = 0; i < tags.length; i++) {
     let tag = tags[i];
     tag.data.index = i;
-    tagBucket.update(tag.id, tag.data);
+    tagBucket().update(tag.id, tag.data);
   }
 };
 
-export const renameTag = ({ tagBucket, noteBucket, tag, name }) => {
+export const renameTag = ({ tag, name }) => {
   let oldTagName = tag.data.name;
   if (oldTagName === name) {
     return;
@@ -51,7 +52,7 @@ export const renameTag = ({ tagBucket, noteBucket, tag, name }) => {
   tag.data.name = name;
 
   // update the tag bucket but don't fire a sync immediately
-  tagBucket.update(tag.id, tag.data, { sync: false });
+  tagBucket().update(tag.id, tag.data, { sync: false });
 
   // similarly, update the note bucket
   for (let i = 0; i < notes.length; i++) {
@@ -62,14 +63,14 @@ export const renameTag = ({ tagBucket, noteBucket, tag, name }) => {
     if (tagIndex !== -1) {
       noteTags.splice(tagIndex, 1, name);
       note.data.tags = noteTags.filter(noteTag => noteTag !== oldTagName);
-      noteBucket.update(note.id, note.data, { sync: false });
+      noteBucket().update(note.id, note.data, { sync: false });
       changedNoteIds.push(note.id);
     }
   }
 
   throttle(tag.id, typingThrottle, () => {
-    tagBucket.touch(tag.id, () => {
-      store.dispatch(loadTags({ tagBucket }));
+    tagBucket().touch(tag.id, () => {
+      loadTags();
 
       for (let i = 0; i < changedNoteIds.length; i++) {
         noteBucket.touch(changedNoteIds[i]);
@@ -78,7 +79,7 @@ export const renameTag = ({ tagBucket, noteBucket, tag, name }) => {
   });
 };
 
-export const trashTag = ({ tagBucket, noteBucket, tag }) => {
+export const trashTag = ({ tag }) => {
   var { notes } = store.getState().appState;
   var tagName = tag.data.name;
 
@@ -89,11 +90,9 @@ export const trashTag = ({ tagBucket, noteBucket, tag }) => {
 
     if (newTags.length !== noteTags.length) {
       note.data.tags = newTags;
-      noteBucket.update(note.id, note.data);
+      noteBucket().update(note.id, note.data);
     }
   }
 
-  tagBucket.remove(tag.id, () => {
-    store.dispatch(loadTags({ tagBucket }));
-  });
+  tagBucket().remove(tag.id, loadTags);
 };

--- a/lib/state/domain/tags.js
+++ b/lib/state/domain/tags.js
@@ -1,4 +1,3 @@
-import { store } from '../';
 import { noteBucket, tagBucket } from './buckets';
 import appState from '../../flux/app-state';
 import throttle from '../../utils/throttle';
@@ -79,8 +78,8 @@ export const renameTag = ({ tag, name }) => (dispatch, getState) => {
   });
 };
 
-export const trashTag = ({ tag }) => {
-  var { notes } = store.getState().appState;
+export const trashTag = ({ tag }) => (dispatch, getState) => {
+  var { notes } = getState().appState;
   var tagName = tag.data.name;
 
   for (let i = 0; i < notes.length; i++) {

--- a/lib/state/domain/tags.js
+++ b/lib/state/domain/tags.js
@@ -32,7 +32,7 @@ export const createTag = ({ name }) => {
   tagBucket().update(tagId, { name });
 };
 
-export const reorderTags = ({ tags }) => {
+export const reorderTags = ({ tags }) => () => {
   for (let i = 0; i < tags.length; i++) {
     let tag = tags[i];
     tag.data.index = i;

--- a/lib/state/domain/tags.js
+++ b/lib/state/domain/tags.js
@@ -7,8 +7,8 @@ const typingThrottle = 3000;
 
 const { tagsLoaded } = appState.actionCreators;
 
-export const loadTags = () => {
-  const sortTagsAlpha = store.getState().settings.sortTagsAlpha;
+export const loadTags = () => (dispatch, getState) => {
+  const sortTagsAlpha = getState().settings.sortTagsAlpha;
   tagBucket().query(db => {
     var tags = [];
     db
@@ -20,7 +20,7 @@ export const loadTags = () => {
         tags.push(cursor.value);
         cursor.continue();
       } else {
-        store.dispatch(tagsLoaded({ tags, sortTagsAlpha }));
+        dispatch(tagsLoaded({ tags, sortTagsAlpha }));
       }
     };
   });
@@ -70,7 +70,7 @@ export const renameTag = ({ tag, name }) => {
 
   throttle(tag.id, typingThrottle, () => {
     tagBucket().touch(tag.id, () => {
-      loadTags();
+      dispatch(loadTags());
 
       for (let i = 0; i < changedNoteIds.length; i++) {
         noteBucket.touch(changedNoteIds[i]);
@@ -94,5 +94,5 @@ export const trashTag = ({ tag }) => {
     }
   }
 
-  tagBucket().remove(tag.id, loadTags);
+  tagBucket().remove(tag.id, () => dispatch(loadTags()));
 };

--- a/lib/state/domain/tags.js
+++ b/lib/state/domain/tags.js
@@ -1,0 +1,99 @@
+import { store } from '../';
+import appState from '../../flux/app-state';
+import throttle from '../../utils/throttle';
+
+const typingThrottle = 3000;
+
+const { tagsLoaded } = appState.actionCreators;
+
+export const loadTags = ({ tagBucket }) => {
+  const sortTagsAlpha = store.getState().settings.sortTagsAlpha;
+  tagBucket.query(db => {
+    var tags = [];
+    db
+      .transaction('tag')
+      .objectStore('tag')
+      .openCursor(null, 'prev').onsuccess = e => {
+      var cursor = e.target.result;
+      if (cursor) {
+        tags.push(cursor.value);
+        cursor.continue();
+      } else {
+        store.dispatch(tagsLoaded({ tags, sortTagsAlpha }));
+      }
+    };
+  });
+};
+
+export const createTag = ({ tagBucket, name }) => {
+  // tag.id must be the tag name in lower case and percent escaped
+  const tagId = encodeURIComponent(name.toLowerCase());
+  tagBucket.update(tagId, { name });
+};
+
+export const reorderTags = ({ tagBucket, tags }) => {
+  for (let i = 0; i < tags.length; i++) {
+    let tag = tags[i];
+    tag.data.index = i;
+    tagBucket.update(tag.id, tag.data);
+  }
+};
+
+export const renameTag = ({ tagBucket, noteBucket, tag, name }) => {
+  let oldTagName = tag.data.name;
+  if (oldTagName === name) {
+    return;
+  }
+
+  let { notes } = store.getState().appState;
+  let changedNoteIds = [];
+
+  tag.data.name = name;
+
+  // update the tag bucket but don't fire a sync immediately
+  tagBucket.update(tag.id, tag.data, { sync: false });
+
+  // similarly, update the note bucket
+  for (let i = 0; i < notes.length; i++) {
+    let note = notes[i];
+    let noteTags = note.data.tags || [];
+    let tagIndex = noteTags.indexOf(oldTagName);
+
+    if (tagIndex !== -1) {
+      noteTags.splice(tagIndex, 1, name);
+      note.data.tags = noteTags.filter(noteTag => noteTag !== oldTagName);
+      noteBucket.update(note.id, note.data, { sync: false });
+      changedNoteIds.push(note.id);
+    }
+  }
+
+  throttle(tag.id, typingThrottle, () => {
+    tagBucket.touch(tag.id, () => {
+      store.dispatch(loadTags({ tagBucket }));
+
+      for (let i = 0; i < changedNoteIds.length; i++) {
+        noteBucket.touch(changedNoteIds[i]);
+      }
+    });
+  });
+};
+
+export const trashTag = ({ tagBucket, noteBucket, tag }) => {
+  var { notes } = store.getState().appState;
+  var tagName = tag.data.name;
+
+  for (let i = 0; i < notes.length; i++) {
+    let note = notes[i];
+    let noteTags = note.data.tags || [];
+    let newTags = noteTags.filter(noteTag => noteTag !== tagName);
+
+    if (newTags.length !== noteTags.length) {
+      note.data.tags = newTags;
+      noteBucket.update(note.id, note.data);
+    }
+  }
+
+  tagBucket.remove(tag.id, () => {
+    store.dispatch(loadTags({ tagBucket }));
+  });
+};

--- a/lib/tag-field/index.jsx
+++ b/lib/tag-field/index.jsx
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Overlay } from 'react-overlays';
 import isEmailTag from '../utils/is-email-tag';
+import { updateNoteTags } from '../state/domain/notes';
 import EmailToolTip from '../tag-email-tooltip';
 import TagChip from '../components/tag-chip';
 import TagInput from '../tag-input';
@@ -26,8 +28,8 @@ export class TagField extends Component {
     storeHasFocus: PropTypes.func,
     tags: PropTypes.array.isRequired,
     unusedTags: PropTypes.arrayOf(PropTypes.string),
+    updateNoteTags: PropTypes.func.isRequired,
     usedTags: PropTypes.arrayOf(PropTypes.string),
-    onUpdateNoteTags: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -75,7 +77,7 @@ export class TagField extends Component {
       intersectionBy(allTags, newTags, s => s.toLocaleLowerCase()), // use existing case if tag known
       differenceBy(newTags, allTags, s => s.toLocaleLowerCase()) // add completely new tags
     );
-    this.props.onUpdateNoteTags(nextTagList);
+    this.updateTags(nextTagList);
     this.storeTagInput('');
     invoke(this, 'tagInput.focus');
     analytics.tracks.recordEvent('editor_tag_added');
@@ -85,10 +87,10 @@ export class TagField extends Component {
     this.state.selectedTag && !!this.state.selectedTag.length;
 
   deleteTag = tagName => {
-    const { onUpdateNoteTags, tags } = this.props;
+    const { tags } = this.props;
     const { selectedTag } = this.state;
 
-    onUpdateNoteTags(differenceBy(tags, [tagName], s => s.toLocaleLowerCase()));
+    this.updateTags(differenceBy(tags, [tagName], s => s.toLocaleLowerCase()));
 
     if (selectedTag === tagName) {
       this.setState({ selectedTag: '' }, () => {
@@ -128,6 +130,9 @@ export class TagField extends Component {
     this.selectLastTag();
     e.preventDefault();
   };
+
+  updateTags = tags =>
+    this.props.updateNoteTags({ note: this.props.note, tags });
 
   selectLastTag = () =>
     this.setState({ selectedTag: this.props.tags.slice(-1).shift() });
@@ -231,4 +236,4 @@ export class TagField extends Component {
   }
 }
 
-export default TagField;
+export default connect(null, { updateNoteTags })(TagField);

--- a/lib/tag-list/index.jsx
+++ b/lib/tag-list/index.jsx
@@ -6,12 +6,11 @@ import PanelTitle from '../components/panel-title';
 import EditableList from '../editable-list';
 import { get } from 'lodash';
 import appState from '../flux/app-state';
-import { reorderTags } from '../state/domain/tags';
+import { renameTag, reorderTags } from '../state/domain/tags';
 import { tracks } from '../analytics';
 
 const {
   editTags,
-  renameTag,
   selectTagAndSelectFirstNote,
   trashTag,
 } = appState.actionCreators;
@@ -23,20 +22,21 @@ export class TagList extends Component {
   static propTypes = {
     onSelectTag: PropTypes.func.isRequired,
     onEditTags: PropTypes.func.isRequired,
-    onRenameTag: PropTypes.func.isRequired,
     onTrashTag: PropTypes.func.isRequired,
+    renameTag: PropTypes.func.isRequired,
     reorderTags: PropTypes.func.isRequired,
     tags: PropTypes.array.isRequired,
   };
 
   renderItem = tag => {
-    const { onRenameTag, selectedTag } = this.props;
+    const { selectedTag } = this.props;
     const isSelected = tag.data.name === get(selectedTag, 'data.name', '');
     const classes = classNames('tag-list-input', 'theme-color-fg', {
       active: isSelected,
     });
 
-    const handleRenameTag = ({ target: { value } }) => onRenameTag(tag, value);
+    const handleRenameTag = ({ target: { value } }) =>
+      this.props.renameTag({ tag, name: value });
 
     return (
       <input
@@ -103,15 +103,6 @@ const mapStateToProps = ({ appState: state }) => ({
 
 const mapDispatchToProps = (dispatch, { noteBucket, tagBucket }) => ({
   onEditTags: () => dispatch(editTags()),
-  onRenameTag: (tag, name) =>
-    dispatch(
-      renameTag({
-        name,
-        noteBucket,
-        tag,
-        tagBucket,
-      })
-    ),
   onSelectTag: tag => {
     dispatch(selectTagAndSelectFirstNote({ tag }));
     recordEvent('list_tag_viewed');
@@ -126,6 +117,7 @@ const mapDispatchToProps = (dispatch, { noteBucket, tagBucket }) => ({
     );
     recordEvent('list_tag_deleted');
   },
+  renameTag: arg => dispatch(renameTag(arg)),
   reorderTags: arg => dispatch(reorderTags(arg)),
 });
 

--- a/lib/tag-list/index.jsx
+++ b/lib/tag-list/index.jsx
@@ -6,12 +6,12 @@ import PanelTitle from '../components/panel-title';
 import EditableList from '../editable-list';
 import { get } from 'lodash';
 import appState from '../flux/app-state';
+import { reorderTags } from '../state/domain/tags';
 import { tracks } from '../analytics';
 
 const {
   editTags,
   renameTag,
-  reorderTags,
   selectTagAndSelectFirstNote,
   trashTag,
 } = appState.actionCreators;
@@ -25,7 +25,7 @@ export class TagList extends Component {
     onEditTags: PropTypes.func.isRequired,
     onRenameTag: PropTypes.func.isRequired,
     onTrashTag: PropTypes.func.isRequired,
-    onReorderTags: PropTypes.func.isRequired,
+    reorderTags: PropTypes.func.isRequired,
     tags: PropTypes.array.isRequired,
   };
 
@@ -49,6 +49,8 @@ export class TagList extends Component {
       />
     );
   };
+
+  onReorderTags = tags => this.props.reorderTags({ tags });
 
   onSelectTag = (tag, event) => {
     if (!this.props.editingTags) {
@@ -85,7 +87,7 @@ export class TagList extends Component {
           editing={editingTags}
           renderItem={this.renderItem}
           onRemove={this.props.onTrashTag}
-          onReorder={this.props.onReorderTags}
+          onReorder={this.onReorderTags}
           selectedTag={this.props.selectedTag}
         />
       </div>
@@ -110,13 +112,6 @@ const mapDispatchToProps = (dispatch, { noteBucket, tagBucket }) => ({
         tagBucket,
       })
     ),
-  onReorderTags: tags =>
-    dispatch(
-      reorderTags({
-        tags,
-        tagBucket,
-      })
-    ),
   onSelectTag: tag => {
     dispatch(selectTagAndSelectFirstNote({ tag }));
     recordEvent('list_tag_viewed');
@@ -131,6 +126,7 @@ const mapDispatchToProps = (dispatch, { noteBucket, tagBucket }) => ({
     );
     recordEvent('list_tag_deleted');
   },
+  reorderTags: arg => dispatch(reorderTags(arg)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(TagList);

--- a/lib/tag-list/index.jsx
+++ b/lib/tag-list/index.jsx
@@ -6,14 +6,10 @@ import PanelTitle from '../components/panel-title';
 import EditableList from '../editable-list';
 import { get } from 'lodash';
 import appState from '../flux/app-state';
-import { renameTag, reorderTags } from '../state/domain/tags';
+import { renameTag, reorderTags, trashTag } from '../state/domain/tags';
 import { tracks } from '../analytics';
 
-const {
-  editTags,
-  selectTagAndSelectFirstNote,
-  trashTag,
-} = appState.actionCreators;
+const { editTags, selectTagAndSelectFirstNote } = appState.actionCreators;
 const { recordEvent } = tracks;
 
 export class TagList extends Component {
@@ -22,10 +18,10 @@ export class TagList extends Component {
   static propTypes = {
     onSelectTag: PropTypes.func.isRequired,
     onEditTags: PropTypes.func.isRequired,
-    onTrashTag: PropTypes.func.isRequired,
     renameTag: PropTypes.func.isRequired,
     reorderTags: PropTypes.func.isRequired,
     tags: PropTypes.array.isRequired,
+    trashTag: PropTypes.func.isRequired,
   };
 
   renderItem = tag => {
@@ -60,6 +56,11 @@ export class TagList extends Component {
     }
   };
 
+  onTrashTag = tag => {
+    this.props.trashTag({ tag });
+    recordEvent('list_tag_deleted');
+  };
+
   render() {
     const { editingTags, onEditTags, tags } = this.props;
 
@@ -86,7 +87,7 @@ export class TagList extends Component {
           items={tags}
           editing={editingTags}
           renderItem={this.renderItem}
-          onRemove={this.props.onTrashTag}
+          onRemove={this.onTrashTag}
           onReorder={this.onReorderTags}
           selectedTag={this.props.selectedTag}
         />
@@ -101,24 +102,15 @@ const mapStateToProps = ({ appState: state }) => ({
   tags: state.tags,
 });
 
-const mapDispatchToProps = (dispatch, { noteBucket, tagBucket }) => ({
+const mapDispatchToProps = dispatch => ({
   onEditTags: () => dispatch(editTags()),
   onSelectTag: tag => {
     dispatch(selectTagAndSelectFirstNote({ tag }));
     recordEvent('list_tag_viewed');
   },
-  onTrashTag: tag => {
-    dispatch(
-      trashTag({
-        noteBucket,
-        tag,
-        tagBucket,
-      })
-    );
-    recordEvent('list_tag_deleted');
-  },
   renameTag: arg => dispatch(renameTag(arg)),
   reorderTags: arg => dispatch(reorderTags(arg)),
+  trashTag: arg => dispatch(trashTag(arg)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(TagList);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3437,6 +3437,12 @@
         }
       }
     },
+    "base64-arraybuffer-es6": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.4.2.tgz",
+      "integrity": "sha512-HaJx92u12By863ZXVHZs4Bp1nkKaLpbs3Ec9SI1OKzq60Hz+Ks6z7UvdD8pIx61Ck3e8F9MH/IPEu5T0xKSbkQ==",
+      "dev": true
+    },
     "base64-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
@@ -7958,6 +7964,17 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fake-indexeddb": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-2.0.4.tgz",
+      "integrity": "sha1-QBcV3rf8lQGGbJ8ym953QlmeLeg=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.1",
+        "realistic-structured-clone": "^2.0.1",
+        "setimmediate": "^1.0.5"
+      }
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -17822,6 +17839,18 @@
         "set-immediate-shim": "^1.0.1"
       }
     },
+    "realistic-structured-clone": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-2.0.2.tgz",
+      "integrity": "sha512-5IEvyfuMJ4tjQOuKKTFNvd+H9GSbE87IcendSBannE28PTrbolgaVg5DdEApRKhtze794iXqVUFKV60GLCNKEg==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.5.3",
+        "domexception": "^1.0.1",
+        "typeson": "^5.8.2",
+        "typeson-registry": "^1.0.0-alpha.20"
+      }
+    },
     "realpath-native": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",
@@ -20530,6 +20559,37 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "requires": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "typeson": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/typeson/-/typeson-5.11.0.tgz",
+      "integrity": "sha512-S5KtLzcU4dr4BXh8VuJDYugsRGsDQYlumCbrmwuAX1a1GNpbVYK4p9wluCIfTVPFvVyV6wRfExXX6Q1+YDItEQ==",
+      "dev": true
+    },
+    "typeson-registry": {
+      "version": "1.0.0-alpha.26",
+      "resolved": "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.26.tgz",
+      "integrity": "sha512-R0wwXIYSiJMh+1XfvyUsCnEGVERoJcNrMl9e/ka30dJ+gQyh4/0NU9WHaqUm8oHtZzZYCz+A5fDRCiXYIq7H1Q==",
+      "dev": true,
+      "requires": {
+        "base64-arraybuffer-es6": "0.4.2",
+        "typeson": "5.11.0",
+        "uuid": "3.3.2",
+        "whatwg-url": "7.0.0"
+      },
+      "dependencies": {
+        "whatwg-url": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "eslint-plugin-jest": "21.12.1",
     "eslint-plugin-prettier": "2.6.0",
     "eslint-plugin-react": "7.6.1",
+    "fake-indexeddb": "^2.0.4",
     "hard-source-webpack-plugin": "0.12.0",
     "html-webpack-plugin": "3.2.0",
     "jest": "23.6.0",

--- a/setup-tests.js
+++ b/setup-tests.js
@@ -1,4 +1,7 @@
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import mockIndexedDB from 'fake-indexeddb';
 
 Enzyme.configure({ adapter: new Adapter() });
+
+global.indexedDB = mockIndexedDB;


### PR DESCRIPTION
As a first step towards splitting up the unwieldy `app-state.js` file, this extracts some of the tag-related functions into a separate place.

I chose the tag-related parts to begin with because they are relatively small, and because it will help fix some of the tag-related bugs I've recently found.

### How should we split `app-state.js`?

It is currently hard to manage because not only does it contain all sections of the app state, it contains both action creators and reducers. It also contains functions that are mainly concerned with updating Simperium buckets rather than the in-memory state.

It will likely take some tinkering to figure out the best way to structure it all, but hopefully this will get the ball rolling.

### Stop passing around buckets as arguments

Another thing that is complicating things is having to pass around references to the noteBucket/tagBucket. Our React components shouldn't have to deal with these buckets.

### To test

Tag-related feature should work as expected, aside from known issues that are unrelated to this refactor (#1118, #1120).

Fun fact: Aside from the changes in package-lock.json, there is a net reduction of a few dozen lines of code 🙂