### PR TITLE
Update selected note when notes have reloaded

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -353,22 +353,24 @@ export const actionMap = new ActionMap({
       const [pinned, notPinned] = partition(notes, note => note.pinned);
       const pinSortedNotes = [...pinned, ...notPinned];
 
-      // Set the selected note after loading notes
-      // Selects either the first note or the previous note in the list
-      if (!state.note) {
+      let selectedNote = null;
+
+      if (state.note) {
+        // Load the newest version of the selected note
+        selectedNote = notes.find(note => note.id === state.note.id);
+      } else {
+        // If no note is selected, select either the first note
+        // or the previous note in the list
         const filteredNotes = filterNotes(state, pinSortedNotes);
         if (filteredNotes.length > 0) {
-          const selectedNote = filteredNotes[Math.max(state.previousIndex, 0)];
-          return update(state, {
-            notes: { $set: pinSortedNotes },
-            note: { $set: selectedNote },
-            selectedNoteId: { $set: selectedNote.id },
-          });
+          selectedNote = filteredNotes[Math.max(state.previousIndex, 0)];
         }
       }
 
       return update(state, {
         notes: { $set: pinSortedNotes },
+        note: { $set: selectedNote },
+        selectedNoteId: { $set: get(selectedNote, 'id', null) },
       });
     },
 

--- a/lib/flux/test.js
+++ b/lib/flux/test.js
@@ -1,10 +1,13 @@
 import { noop } from 'lodash';
 import appState from './app-state';
 
-const { loadPreferences } = appState.actionCreators;
+jest.mock('../utils/filter-notes', () => {
+  return (state, newNotes) => newNotes;
+});
 
 describe('appState action creators', () => {
   describe('loadPreferences', () => {
+    const { loadPreferences } = appState.actionCreators;
     let preferencesBucket, preferences, dispatch;
 
     beforeEach(() => {
@@ -36,6 +39,60 @@ describe('appState action creators', () => {
         'preferences-key',
         {}
       );
+    });
+  });
+});
+
+describe('appState action reducers', () => {
+  describe('notesLoaded', () => {
+    const notesLoaded = appState.actionReducers['App.notesLoaded'];
+
+    describe('when a note is currently selected', () => {
+      it('should load the newest version of the selected note', () => {
+        const oldState = {
+          notes: [{}],
+          note: { id: 'foo', data: 'old' },
+        };
+        const newNote = { id: 'foo', data: 'new' };
+        const newNoteArray = [newNote];
+        const newState = notesLoaded(oldState, {
+          notes: newNoteArray,
+        });
+        expect(newState.notes).toEqual(newNoteArray);
+        expect(newState.note).toEqual(newNote);
+      });
+    });
+
+    describe('when no note is currently selected', () => {
+      it('should load the first filtered note if there is no valid previousIndex', () => {
+        const oldState = {
+          notes: [],
+          note: null,
+          previousIndex: -1,
+        };
+        const firstNote = { id: 'foo', data: 'first' };
+        const newNoteArray = [firstNote, {}];
+        const newState = notesLoaded(oldState, {
+          notes: newNoteArray,
+        });
+        expect(newState.notes).toEqual(newNoteArray);
+        expect(newState.note).toEqual(firstNote);
+      });
+
+      it('should load the previousIndex note if there is a previousIndex', () => {
+        const oldState = {
+          notes: [],
+          note: null,
+          previousIndex: 1,
+        };
+        const previousIndexNote = { id: 'foo', data: 'previous' };
+        const newNoteArray = [{}, previousIndexNote];
+        const newState = notesLoaded(oldState, {
+          notes: newNoteArray,
+        });
+        expect(newState.notes).toEqual(newNoteArray);
+        expect(newState.note).toEqual(previousIndexNote);
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #1120 

This ensures that the state's selected note data will be correctly updated in the `notesLoaded` reducer. This was mostly being taken care of by the `noteUpdated` function, but it was only for remote changes. Therefore, the state could get out of sync when `noteUpdated` was called as a result of a local update, such as tag renaming.

I would say this is a band-aid fix. Hopefully we can gradually refactor the state management code to make things clearer and simpler. (As started in #1126)