### PR TITLE
Close note after trash commands in mobile width

### DIFF
--- a/lib/note-toolbar-container.js
+++ b/lib/note-toolbar-container.js
@@ -53,6 +53,7 @@ export class NoteToolbarContainer extends Component {
     const { noteBucket } = this.props;
     const previousIndex = this.getPreviousNoteIndex(note);
     this.props.trashNote({ noteBucket, note, previousIndex });
+    this.props.onNoteClosed();
     analytics.tracks.recordEvent('editor_note_deleted');
   };
 
@@ -60,12 +61,14 @@ export class NoteToolbarContainer extends Component {
     const { noteBucket } = this.props;
     const previousIndex = this.getPreviousNoteIndex(note);
     this.props.deleteNoteForever({ noteBucket, note, previousIndex });
+    this.props.onNoteClosed();
   };
 
   onRestoreNote = note => {
     const { noteBucket } = this.props;
     const previousIndex = this.getPreviousNoteIndex(note);
     this.props.restoreNote({ noteBucket, note, previousIndex });
+    this.props.onNoteClosed();
     analytics.tracks.recordEvent('editor_note_restored');
   };
 


### PR DESCRIPTION
In mobile widths, executing trash-related actions would not take the user back to the Note List view. This PR fixes the issue.

![mobile-trash](https://user-images.githubusercontent.com/555336/50480230-0888f200-0a1e-11e9-8182-54ab2e50ffec.gif)

### To test

These trash-related actions should take you back to the Note List view when in a mobile-width window:

- Trash note
- Restore note
- Delete Forever