### PR TITLE
Make text in Markdown preview selectable

### DIFF
--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -139,6 +139,10 @@
     border-top: 1px solid lighten($gray, 20%);
   }
 
+  a {
+    cursor: pointer;
+  }
+
   blockquote {
     font-style: italic;
     border-left: 4px solid lighten($gray, 20%);

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -114,7 +114,7 @@
 .note-detail-markdown {
   @import '../node_modules/highlight.js/styles/solarized-light.css';
 
-  user-select: auto;
+  user-select: text;
 
   h1,
   h2,


### PR DESCRIPTION
Partial fix for #744 

_2019-01-07 update:_

While this makes the preview text selectable by mouse, and by "Select All" in a plain web browser, "Select All" in Electron will still not work.

"Select All" not working here is an issue with Electron, and will be fixed when we update to Electron >3.0.0.