### PR TITLE
Check before reselecting note in updateNoteContent

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -544,7 +544,7 @@ export const actionMap = new ActionMap({
 
     updateNoteContent: {
       creator({ noteBucket, note, content }) {
-        return dispatch => {
+        return (dispatch, getState) => {
           if (note) {
             note.data.content = content;
             note.data.modificationDate = Math.floor(Date.now() / 1000);
@@ -552,7 +552,10 @@ export const actionMap = new ActionMap({
             // update the bucket and sync
             noteBucket.update(note.id, note.data);
 
-            dispatch(this.action('selectNote', { note }));
+            // Check if note is still selected (to avoid race conditions)
+            if (getState().appState.note.id === note.id) {
+              dispatch(this.action('selectNote', { note }));
+            }
           }
         };
       },


### PR DESCRIPTION
Closes #1125 

This fixes an issue where a local change to a note's content would reselect that note in the Editor, even when the user had already navigated away to a different note.

## To test

### Test case from original issue

> 1. Start a new note
> 1. Type for a bit on it, then create a new note with the ctrl + N shortcut

↑ Do this quickly. Stop typing and immediately create a new note.

### Another test case

1. Type in a note.
1. Immediately click on a different note.