### PR TITLE
Improve alphabetical note sorting

### DIFF
--- a/lib/boot.js
+++ b/lib/boot.js
@@ -81,7 +81,7 @@ const client = initClient({
     },
   },
   database: 'simplenote',
-  version: 41,
+  version: 42,
 });
 
 const l = msg => {

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -56,6 +56,7 @@ const client = initClient({
         return {
           ...note,
           contentKey: content
+            .replace(/^\s*#+\s*/, '') // Remove leading whitespace and Markdown heading
             .replace(/\s+/g, ' ')
             .trim()
             .slice(0, 200)

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -60,7 +60,10 @@ const client = initClient({
             .replace(/\s+/g, ' ')
             .trim()
             .slice(0, 200)
-            .toLowerCase(),
+            .toLowerCase()
+            // Remove accents/diacritics (https://stackoverflow.com/questions/990904)
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, ''),
           pinned: systemTags.indexOf('pinned') !== -1,
         };
       },

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -28,6 +28,7 @@ import { content as welcomeMessage } from './welcome-message';
 
 import appState from './flux/app-state';
 import isDevConfig from './utils/is-dev-config';
+import { normalizeForSorting } from './utils/note-utils';
 const { newNote } = appState.actionCreators;
 
 const config = getConfig();
@@ -55,15 +56,7 @@ const client = initClient({
 
         return {
           ...note,
-          contentKey: content
-            .replace(/^\s*#+\s*/, '') // Remove leading whitespace and Markdown heading
-            .replace(/\s+/g, ' ')
-            .trim()
-            .slice(0, 200)
-            .toLowerCase()
-            // Remove accents/diacritics (https://stackoverflow.com/questions/990904)
-            .normalize('NFD')
-            .replace(/[\u0300-\u036f]/g, ''),
+          contentKey: normalizeForSorting(content),
           pinned: systemTags.indexOf('pinned') !== -1,
         };
       },

--- a/lib/utils/note-utils.js
+++ b/lib/utils/note-utils.js
@@ -1,4 +1,5 @@
 import removeMarkdown from 'remove-markdown';
+import { isFunction } from 'lodash';
 
 /**
  * Matches the title and excerpt in a note's content
@@ -70,6 +71,33 @@ export const noteTitleAndPreview = note => {
 
 export const isMarkdown = note => {
   return note && note.data && note.data.systemTags.includes('markdown');
+};
+
+/**
+ * Clean the text so it is ready to be sorted alphabetically.
+ *
+ * @param {string} text - The string to be normalized.
+ * @returns {string} The normalized string.
+ */
+export const normalizeForSorting = text => {
+  const maxLength = 200;
+
+  let normalizedText = text
+    .replace(/^\s*#+\s*/, '') // Remove leading whitespace and Markdown heading
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, maxLength)
+    .toLowerCase();
+
+  // Remove accents/diacritics (https://stackoverflow.com/questions/990904)
+  // if `normalize()` is available.
+  if (isFunction(normalizedText.normalize)) {
+    normalizedText = normalizedText
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '');
+  }
+
+  return normalizedText;
 };
 
 export default noteTitleAndPreview;

--- a/lib/utils/note-utils.test.js
+++ b/lib/utils/note-utils.test.js
@@ -1,5 +1,6 @@
 import noteTitleAndPreview, {
   defaults,
+  normalizeForSorting,
   previewCharacterLimit,
   titleCharacterLimit,
 } from './note-utils';
@@ -61,5 +62,34 @@ describe('noteTitleAndPreview', () => {
     const result = noteTitleAndPreview(note);
     expect(result.title).toHaveLength(titleCharacterLimit);
     expect(result.preview).toHaveLength(previewCharacterLimit);
+  });
+});
+
+describe('normalizeForSorting', () => {
+  it('should remove accents and diacritics', () => {
+    expect(normalizeForSorting('àéïñ')).toBe('aein');
+  });
+
+  it('should not choke when String.prototype.normalize() is not implemented', () => {
+    const originalNormalize = String.prototype.normalize;
+    String.prototype.normalize = undefined; // Not implemented in IE11
+    expect(normalizeForSorting('à')).toBe('à');
+    String.prototype.normalize = originalNormalize;
+  });
+
+  it('should remove leading whitespace', () => {
+    expect(normalizeForSorting('\tfoo')).toBe('foo');
+  });
+
+  it('should remove Markdown headings in the first line', () => {
+    expect(normalizeForSorting('# title')).toBe('title');
+  });
+
+  it('should collapse multiple spaces', () => {
+    expect(normalizeForSorting('foo   bar')).toBe('foo bar');
+  });
+
+  it('should lowercase the whole string', () => {
+    expect(normalizeForSorting('FOO')).toBe('foo');
   });
 });


### PR DESCRIPTION
Closes #1050 
Closes #1136 

When notes are sorted alphabetically in the Note List, it will now ignore accents/diacritics and the `#` characters used for Markdown headings.

### TODO

- [x] https://github.com/Automattic/simplenote-electron/pull/1144/commits/7737bea24c57f9e7ef98758099fb1fa3ec9a13fa Make it [work in IE11](https://github.com/Automattic/simplenote-electron/pull/1144#discussion_r246902765)

### To test

Try sorting notes with titles like `# asdf` and `àpres`.