### PR TITLE
Add source argument to Edit Account link

### DIFF
--- a/lib/dialogs/settings/panels/account.jsx
+++ b/lib/dialogs/settings/panels/account.jsx
@@ -6,6 +6,7 @@ import SettingsGroup, { Item } from '../../settings-group';
 import ToggleGroup from '../../toggle-settings-group';
 import TopRightArrowIcon from '../../../icons/arrow-top-right';
 
+import getConfig from '../../../../get-config';
 import { viewExternalUrl } from '../../../utils/url-utils';
 
 const AccountPanel = props => {
@@ -16,8 +17,10 @@ const AccountPanel = props => {
     toggleShareAnalyticsPreference,
   } = props;
 
-  const onEditAccount = () =>
-    viewExternalUrl('https://app.simplenote.com/settings');
+  const onEditAccount = () => {
+    const source = getConfig().is_app_engine ? 'react' : 'electron';
+    viewExternalUrl(`https://app.simplenote.com/settings?from=${source}`);
+  };
 
   return (
     <div className="settings-account">


### PR DESCRIPTION
Closes #1146 

Passes `react` or `electron` depending on whether it's the web or desktop app. (So we can disable the "Back to notes" link altogether when coming from Electron.)