### PR TITLE
Prevent Markdown list prefixes from multiplying

### DIFF
--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -293,6 +293,9 @@ export default class NoteContentEditor extends Component {
     const { editorState } = this.state;
     const line = getCurrentBlock(editorState).getText();
 
+    const { anchorOffset, focusOffset } = editorState.getSelection();
+    const atBeginningOfLine = anchorOffset === 0 && focusOffset === 0;
+
     if (isLonelyBullet(line)) {
       this.handleEditorStateChange(finishList(editorState));
       return 'handled';
@@ -305,7 +308,7 @@ export default class NoteContentEditor extends Component {
       const nextTaskPrefix = line.replace(taskRegex, '$1- [ ] ');
       this.handleEditorStateChange(continueList(editorState, nextTaskPrefix));
       return 'handled';
-    } else if (listItemMatch) {
+    } else if (listItemMatch && !atBeginningOfLine) {
       this.handleEditorStateChange(continueList(editorState, listItemMatch[0]));
       return 'handled';
     }

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -301,7 +301,7 @@ export default class NoteContentEditor extends Component {
     const atBeginningOfLine =
       caretIsCollapsedAt(0) || caretIsCollapsedAt(firstCharIndex);
 
-    if (isLonelyBullet(line)) {
+    if (isLonelyBullet(line) && !atBeginningOfLine) {
       this.handleEditorStateChange(finishList(editorState));
       return 'handled';
     }

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -301,7 +301,11 @@ export default class NoteContentEditor extends Component {
     const atBeginningOfLine =
       caretIsCollapsedAt(0) || caretIsCollapsedAt(firstCharIndex);
 
-    if (isLonelyBullet(line) && !atBeginningOfLine) {
+    if (atBeginningOfLine) {
+      return 'not-handled';
+    }
+
+    if (isLonelyBullet(line)) {
       this.handleEditorStateChange(finishList(editorState));
       return 'handled';
     }
@@ -313,7 +317,7 @@ export default class NoteContentEditor extends Component {
       const nextTaskPrefix = line.replace(taskRegex, '$1- [ ] ');
       this.handleEditorStateChange(continueList(editorState, nextTaskPrefix));
       return 'handled';
-    } else if (listItemMatch && !atBeginningOfLine) {
+    } else if (listItemMatch) {
       this.handleEditorStateChange(continueList(editorState, listItemMatch[0]));
       return 'handled';
     }

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -293,8 +293,13 @@ export default class NoteContentEditor extends Component {
     const { editorState } = this.state;
     const line = getCurrentBlock(editorState).getText();
 
-    const { anchorOffset, focusOffset } = editorState.getSelection();
-    const atBeginningOfLine = anchorOffset === 0 && focusOffset === 0;
+    const firstCharIndex = line.search(/\S/);
+    const caretIsCollapsedAt = index => {
+      const { anchorOffset, focusOffset } = editorState.getSelection();
+      return anchorOffset === index && focusOffset === index;
+    };
+    const atBeginningOfLine =
+      caretIsCollapsedAt(0) || caretIsCollapsedAt(firstCharIndex);
 
     if (isLonelyBullet(line)) {
       this.handleEditorStateChange(finishList(editorState));


### PR DESCRIPTION
Based on #1145

Closes #776 

Here is the fixed behavior:

![list-multiply](https://user-images.githubusercontent.com/555336/51188371-2eb8f800-1921-11e9-9475-352bb3867f9a.gif)
