### PR TITLE
Remove left border in Focus Mode

### DIFF
--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -10,6 +10,10 @@
       width: 0;
       transition: width .2s ease-in-out, opacity .2s ease-in-out;
     }
+    .theme-color-border {
+      border-left-width: 0px;
+      transition: border-left-width .2s;
+    }
   }
 
   &.is-navigation-open {


### PR DESCRIPTION
Fixes https://github.com/Automattic/simplenote-electron/issues/1116

I Included a transition delay so that the border remains while the note list is being "pushed" out of the way, I'm assuming this is the desired behavior.
