### PR TITLE
Refactor border between Source and Note columns

### DIFF
--- a/lib/app-layout/index.js
+++ b/lib/app-layout/index.js
@@ -57,7 +57,7 @@ export const AppLayout = ({
             onNoteOpened={onNoteOpened}
           />
         </div>
-        <div className="app-layout__note-column theme-color-bg theme-color-fg">
+        <div className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border">
           <RevisionSelector
             note={note}
             revisions={revisions || []}

--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -121,6 +121,7 @@
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
+  border-left: 1px solid;
 
   @media only screen and (max-width: $single-column) {
     position: absolute;

--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -10,7 +10,7 @@
       width: 0;
       transition: width .2s ease-in-out, opacity .2s ease-in-out;
     }
-    .theme-color-border {
+    .app-layout__note-column {
       border-left-width: 0px;
       transition: border-left-width .2s;
     }

--- a/lib/note-detail/index.jsx
+++ b/lib/note-detail/index.jsx
@@ -200,7 +200,7 @@ export class NoteDetail extends Component {
     });
 
     return (
-      <div className="note-detail-wrapper theme-color-border">
+      <div className="note-detail-wrapper">
         {!note ? (
           <div className="note-detail-placeholder">
             <SimplenoteCompactLogo />

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -4,7 +4,6 @@
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
-  border-left: 1px solid lighten($gray, 30%);
   padding-top: 0;
 }
 

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -4,7 +4,6 @@
   flex: none;
   height: $toolbar-height;
   border-bottom: 1px solid lighten($gray, 30%);
-  border-left: 1px solid lighten($gray, 30%);
 }
 
 .note-toolbar {

--- a/lib/tag-field/index.jsx
+++ b/lib/tag-field/index.jsx
@@ -186,7 +186,7 @@ export class TagField extends Component {
     const { selectedTag, showEmailTooltip, tagInput } = this.state;
 
     return (
-      <div className="tag-field theme-color-border">
+      <div className="tag-field">
         <div
           className={classNames('tag-editor', {
             'has-selection': this.hasSelection(),

--- a/lib/tag-field/style.scss
+++ b/lib/tag-field/style.scss
@@ -1,7 +1,3 @@
-.tag-field {
-  border-left: 1px solid lighten($gray, 30%);
-}
-
 .tag-editor {
   display: flex;
   justify-content: flex-start;


### PR DESCRIPTION
Closes https://github.com/Automattic/simplenote-electron/issues/1150

In SCSS:
	- Added `border-left` to `.app-layout__note-column` in app-layout
	- Removed `border-left` from `.tag-field` in tag-field, `.note-detail-wrapper` in note-detail, and `.note-toolbar-wrapper` in note-toolbar

In JSX:
	- Added `.theme-color-border` to `.app-layout__note-column` div in app-layout
	- Removed `.theme-color-border` from tag-field and note-detail
	- Left `.theme-color-border` in note-toolbar due to `border-bottom`

Tested on Linux using various screen widths in Focus Mode and regular mode, both in light and dark themes.