### PR TITLE
Copy text from DraftJS EditorState instead of browser selection

### DIFF
--- a/lib/editor/utils.js
+++ b/lib/editor/utils.js
@@ -6,3 +6,36 @@ export function getCurrentBlock(editorState) {
   const key = editorState.getSelection().getFocusKey();
   return editorState.getCurrentContent().getBlockForKey(key);
 }
+
+export function getSelectedText(editorState) {
+  const contentState = editorState.getCurrentContent();
+  const selectionState = editorState.getSelection();
+
+  const startKey = selectionState.getStartKey();
+  const startBlock = editorState.getCurrentContent().getBlockForKey(startKey);
+  const start = selectionState.getStartOffset();
+  const endKey = selectionState.getEndKey();
+  const end = selectionState.getEndOffset();
+
+  if (startKey === endKey) {
+    return startBlock.getText().slice(start, end);
+  }
+
+  let selectedText = '';
+  selectedText += startBlock.getText().slice(start) + '\n';
+
+  const endBlock = editorState.getCurrentContent().getBlockForKey(endKey);
+
+  let thisBlock = startBlock;
+
+  while ((thisBlock = contentState.getBlockAfter(thisBlock.key))) {
+    if (thisBlock.key === endKey) {
+      break;
+    }
+    selectedText += thisBlock.getText() + '\n';
+  }
+
+  selectedText += endBlock.getText().slice(0, end);
+
+  return selectedText;
+}

--- a/lib/editor/utils.test.js
+++ b/lib/editor/utils.test.js
@@ -1,0 +1,50 @@
+import { ContentState, EditorState, SelectionState } from 'draft-js';
+import { getSelectedText } from './utils';
+
+describe('getSelectedText', () => {
+  const sourceText = `
+# My note
+
+- [ ] task`;
+  let editorState, contentState;
+
+  beforeEach(() => {
+    editorState = EditorState.createWithContent(
+      ContentState.createFromText(sourceText)
+    );
+    contentState = editorState.getCurrentContent();
+  });
+
+  it('should return the selected content as text', () => {
+    const lastBlock = contentState.getLastBlock();
+    const selectionState = SelectionState.createEmpty(
+      contentState.getFirstBlock().key
+    ).merge({
+      focusKey: lastBlock.key,
+      focusOffset: lastBlock.getText().length,
+    });
+    const stateWithSelection = EditorState.acceptSelection(
+      editorState,
+      selectionState
+    );
+    expect(getSelectedText(stateWithSelection)).toBe(sourceText);
+  });
+
+  it('should handle partial selection', () => {
+    const lastBlock = contentState.getLastBlock();
+    const firstBlock = contentState.getFirstBlock();
+    const selectionState = SelectionState.createEmpty(firstBlock.key).merge({
+      anchorKey: contentState.getBlockAfter(firstBlock.key).key,
+      anchorOffset: 1,
+      focusKey: lastBlock.key,
+      focusOffset: lastBlock.getText().length - 1,
+    });
+    const stateWithSelection = EditorState.acceptSelection(
+      editorState,
+      selectionState
+    );
+    expect(getSelectedText(stateWithSelection)).toBe(
+      sourceText.trim().slice(1, sourceText.length - 2)
+    );
+  });
+});

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 import { ContentState, Editor, EditorState, Modifier } from 'draft-js';
 import { compact, get, includes, invoke, noop } from 'lodash';
 
-import { getCurrentBlock, plainTextContent } from './editor/utils';
+import {
+  getCurrentBlock,
+  getSelectedText,
+  plainTextContent,
+} from './editor/utils';
 import { filterHasText, searchPattern } from './utils/filter-notes';
 import MultiDecorator from 'draft-js-multidecorators';
 import matchingTextDecorator from './editor/matching-text-decorator';
@@ -331,18 +335,33 @@ export default class NoteContentEditor extends Component {
     return 'not-handled';
   };
 
+  /**
+   * Copy the raw text as determined by the DraftJS SelectionState.
+   *
+   * By not relying on the browser's interpretation of the contenteditable
+   * selection, this allows for the clipboard data to more accurately reflect
+   * the internal plain text data.
+   */
+  copyPlainText = event => {
+    const textToCopy = getSelectedText(this.state.editorState);
+    event.clipboardData.setData('text/plain', textToCopy);
+    event.preventDefault();
+  };
+
   render() {
     return (
-      <Editor
-        key={this.editorKey}
-        ref={this.saveEditorRef}
-        spellCheck={this.props.spellCheckEnabled}
-        stripPastedStyles
-        onChange={this.handleEditorStateChange}
-        editorState={this.state.editorState}
-        onTab={this.onTab}
-        handleReturn={this.handleReturn}
-      />
+      <div onCopy={this.copyPlainText} onCut={this.copyPlainText}>
+        <Editor
+          key={this.editorKey}
+          ref={this.saveEditorRef}
+          spellCheck={this.props.spellCheckEnabled}
+          stripPastedStyles
+          onChange={this.handleEditorStateChange}
+          editorState={this.state.editorState}
+          onTab={this.onTab}
+          handleReturn={this.handleReturn}
+        />
+      </div>
     );
   }
 }


### PR DESCRIPTION
Based on #1154 
Closes #1129

This enhances the cut/copy behavior in the Note Editor, by retrieving the selection from the DraftJS state rather than the browser selection. This allows us to:

- Copy the raw Markdown text, even if they are decorated (e.g. `- [ ] task`) in the browser.
- Ensure that plain text (not HTML) is being copied. (Fixes #1129)
- Retain IE11 compatibility. (Related: #1082)

### To test

- Copying text in Dark Mode and pasting it into a rich text editor should not make the text white.
- Tasklist items can be copied as Markdown text. (Caveat: Due to a limitation with the contenteditable, checkboxes cannot be selected unless the selection range starts on the previous line or before.)