### PR TITLE
Fix extra space when hitting enter on empty task

### DIFF
--- a/lib/editor/checkbox-utils.js
+++ b/lib/editor/checkbox-utils.js
@@ -18,7 +18,7 @@ export const shouldRemoveCheckbox = (editorState, prevEditorState) => {
   const prevBlockText = getBlockText(prevEditorState, currentBlock.getKey());
   const contentHasChanged = currentBlockText !== prevBlockText;
 
-  if (!contentHasChanged) {
+  if (!contentHasChanged || currentBlockText === '') {
     return false;
   }
 

--- a/lib/editor/checkbox-utils.test.js
+++ b/lib/editor/checkbox-utils.test.js
@@ -35,6 +35,23 @@ describe('checkbox-utils', () => {
       expect(result).toBe(false);
     });
 
+    it('should return false if the currently focused block is empty', () => {
+      const prevEditorState = EditorState.createWithContent(
+        ContentState.createFromText('foo')
+      );
+      const editorState = EditorState.push(
+        prevEditorState,
+        Modifier.removeRange(
+          prevEditorState.getCurrentContent(),
+          prevEditorState.getSelection().merge({ focusOffset: 3 }),
+          'forward'
+        ),
+        'remove-range'
+      );
+      const result = shouldRemoveCheckbox(editorState, prevEditorState);
+      expect(result).toBe(false);
+    });
+
     it('should return false if the currently focused block is still a valid tasklist item', () => {
       const prevEditorState = EditorState.createWithContent(
         ContentState.createFromText('- [ ] task')


### PR DESCRIPTION
This fixes a bug where an extra space was hanging around if you press enter on an empty checklist item and it gets removed:

![space-character](https://user-images.githubusercontent.com/789137/51419386-eb3bd500-1b3e-11e9-8c42-d8dd9bf2d47d.gif)

Originally reported here: https://github.com/Automattic/simplenote-electron/pull/1166#issuecomment-455730386