### PR TITLE
Disable simple line breaks in Markdown renderer

### DIFF
--- a/lib/utils/render-note-to-html.js
+++ b/lib/utils/render-note-to-html.js
@@ -14,6 +14,7 @@ export const renderNoteToHtml = content => {
         extensions: ['enableCheckboxes'],
       });
       markdownConverter.setFlavor('github');
+      markdownConverter.setOption('simpleLineBreaks', false); // override GFM
 
       return sanitizeHtml(markdownConverter.makeHtml(content));
     }


### PR DESCRIPTION
Closes #1165 

Line breaks were rendered in GFM style, which deviates from our other Simplenote apps, as well as  from normal Markdown. This PR overrides that setting in Showdown to maintain consistency across our apps.

## Raw

```
# Markdown note

Line one
Line two
```

## Before

<img width="258" alt="screen shot 2019-01-22 at 3 42 15" src="https://user-images.githubusercontent.com/555336/51493266-2a487f80-1df8-11e9-915b-9fc99e7192b2.png">

## After

<img width="265" alt="screen shot 2019-01-22 at 3 41 54" src="https://user-images.githubusercontent.com/555336/51493271-2fa5ca00-1df8-11e9-84e4-3399ba217f99.png">