### PR TITLE
Fix CJK-related crashes after tab character

### DIFF
--- a/lib/editor/tab-decorator.js
+++ b/lib/editor/tab-decorator.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import SimpleDecorator from 'draft-js-simpledecorator';
+
+/**
+ * Wrap tab characters in a span to prevent CJK-related crashes
+ *
+ * The sole purpose of this decorator is to prevent DraftJS from
+ * crashing when dealing with CJK characters after a tab. The span somehow
+ * prevents DraftJS's internal focus state from getting out of sync with the
+ * visible caret. See below for steps to reproduce the original bug:
+ * https://github.com/Automattic/simplenote-electron/issues/780#issuecomment-449771120
+ *
+ * TODO: Figure out if this is a bug that should be fixed in DraftJS itself.
+ */
+const tabDecorator = () => {
+  const strategy = (contentBlock, callback) => {
+    const tabRegex = /\t/g;
+    const text = contentBlock.getText();
+    let match;
+
+    while ((match = tabRegex.exec(text)) !== null) {
+      const start = match.index;
+      const end = start + match[0].length;
+
+      callback(start, end);
+    }
+  };
+
+  const WrappedTab = ({ children }) => <span>{children}</span>;
+
+  return new SimpleDecorator(strategy, WrappedTab);
+};
+
+export default tabDecorator;

--- a/lib/editor/tab-decorator.js
+++ b/lib/editor/tab-decorator.js
@@ -10,7 +10,7 @@ import SimpleDecorator from 'draft-js-simpledecorator';
  * visible caret. See below for steps to reproduce the original bug:
  * https://github.com/Automattic/simplenote-electron/issues/780#issuecomment-449771120
  *
- * TODO: Figure out if this is a bug that should be fixed in DraftJS itself.
+ * TODO: This workaround can be removed when we update to Electron >3.0.0.
  */
 const tabDecorator = () => {
   const strategy = (contentBlock, callback) => {

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -12,6 +12,7 @@ import {
 import { filterHasText, searchPattern } from './utils/filter-notes';
 import matchingTextDecorator from './editor/matching-text-decorator';
 import checkboxDecorator from './editor/checkbox-decorator';
+import tabDecorator from './editor/tab-decorator';
 import { removeCheckbox, shouldRemoveCheckbox } from './editor/checkbox-utils';
 import { taskRegex } from './note-detail/toggle-task/constants';
 import insertOrRemoveCheckboxes from './editor/insert-or-remove-checkboxes';
@@ -179,6 +180,7 @@ export default class NoteContentEditor extends Component {
         compact([
           filterHasText(filter) && matchingTextDecorator(searchPattern(filter)),
           checkboxDecorator(this.replaceRangeWithText),
+          tabDecorator(),
         ])
       )
     );


### PR DESCRIPTION
Closes #780 

_Update: This seems to have been a bug in the Chrome version in Electron 2. It doesn't reproduce at all in Electron >3.0.0. So this workaround should be unnecessary once we update._

This is a really unsatisfying workaround that doesn't address any root causes and I don't like it 😐I first suspected a focus management bug in our [`indentCurrentBlock()`](https://github.com/Automattic/simplenote-electron/blob/master/lib/note-content-editor.jsx#L24) code, but as far as I could tell that doesn't seem to be the case here. Hopefully we can dig a little deeper into the issue sometime in the future, but since this is a pretty serious bug for our CJK users this workaround should help in the meantime.

## To test

Refer to this comment for repro steps: https://github.com/Automattic/simplenote-electron/issues/780#issuecomment-449771120

Note that the original bug only applies to Electron, and not Chrome/Firefox/Safari.