### PR TITLE
Fix checkbox vertical alignment in Windows/Linux

### DIFF
--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -170,8 +170,11 @@
     }
 
     input {
+      position: relative;
+      bottom: .0625em;
       margin-right: 4px;
       height: 1em;
+      vertical-align: middle;
     }
   }
 


### PR DESCRIPTION
## Before
<img width="124" alt="screen shot 2019-01-25 at 21 09 39" src="https://user-images.githubusercontent.com/555336/51746446-7f7edc80-20e9-11e9-9623-dcaf26acaaa5.png">

## After
<img width="121" alt="screen shot 2019-01-25 at 21 09 23" src="https://user-images.githubusercontent.com/555336/51746447-7f7edc80-20e9-11e9-8e49-efe7c29a82b0.png">

And still looks ok on Mac:

<img width="111" alt="screen shot 2019-01-25 at 21 40 46" src="https://user-images.githubusercontent.com/555336/51746567-eb614500-20e9-11e9-8125-9b7ee103a4d1.png">
