### PR TITLE
Verify last used monitor availability when restoring window position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6000,7 +6000,8 @@
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -7191,13 +7192,22 @@
       }
     },
     "electron-window-state": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-4.1.1.tgz",
-      "integrity": "sha1-azT9wxs4UU3+yLfI97XUrdtnYy0=",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-5.0.3.tgz",
+      "integrity": "sha512-1mNTwCfkolXl3kMf50yW3vE2lZj0y92P/HYWFBrb+v2S/pCka5mdwN3cagKm458A7NjndSwijynXgcLWRodsVg==",
       "requires": {
-        "deep-equal": "^1.0.1",
-        "jsonfile": "^2.2.3",
+        "jsonfile": "^4.0.0",
         "mkdirp": "^0.5.1"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
       }
     },
     "elegant-spinner": {
@@ -12190,6 +12200,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "electron-progressbar": "1.1.0",
     "electron-spellchecker": "^1.1.2",
     "electron-updater": "^3.1.6",
-    "electron-window-state": "4.1.1",
+    "electron-window-state": "5.0.3",
     "file-saver": "2.0.0",
     "focus-visible": "^4.1.5",
     "gridicons": "^3.1.1",


### PR DESCRIPTION
Closes #592 

[`electron-window-state`](https://github.com/mawie81/electron-window-state/) (the module we are using to persist window position after quit) had not been checking whether a last used external monitor had been disconnected. So if Simplenote was last positioned on an external monitor that is now disconnected, the Simplenote window would be unrecoverable.

## To test

I tested this on an actual Windows machine, since I couldn't reproduce the original issue on a Mac. 

Note: To reproduce the original issue, your external display must be configured to be on the LEFT of your main display.

1. Launch the app and move the window to an external display.
1. Quit the app.
1. Disconnect the external display.
1. Relaunch the app.

The app window should be visible on the main screen.