### PR TITLE
Prevent unintended artifacts from being published

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ for:
     build_script:
       - make build
       - make test
-      - npx electron-builder --win
+      - npx electron-builder --win -p onTag
 
   # Windows Store build / .appx / unsigned
   - matrix:
@@ -46,7 +46,7 @@ for:
     build_script:
       - make build
       - make test
-      - npx electron-builder --win --config=./electron-builder-appx.json
+      - npx electron-builder --win --config=./electron-builder-appx.json -p onTag
 
   # Windows Store test build / .appx / signed
   - matrix:


### PR DESCRIPTION
This PR ensures that our .exe and unsigned .appx artifacts are only published when the commit is tagged.

## Why?

The builds attached to a GitHub release draft could be overwritten by unintended artifacts coming from an untagged commit. This could happen with any AppVeyor artifacts that were built while a release draft (with matching version number) is present. Pretty dangerous, since we could very well be continuing development while a release is still in draft and in the smoke testing phase.

This was due to the [default publish behavior](https://www.electron.build/configuration/publish#how-to-publish) in `electron-builder`.

## Tests

### With original config 😱

Artifacts are published to the matching GitHub release draft, even though the commit is untagged.
https://ci.appveyor.com/project/Automattic/simplenote-electron/builds/21991311/job/sdqkar57r529uwud#L433

### With fixed config 😌

Artifacts are not published to the matching release draft.
https://ci.appveyor.com/project/Automattic/simplenote-electron/builds/21980661/job/ft63pqnfo4cb4hqj