### PR TITLE
Fix cursor position jump when setting new EditorState

### DIFF
--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -288,7 +288,7 @@ export default class NoteContentEditor extends Component {
 
     // Handle transfer of focus from oldEditorState to newEditorState
     if (oldEditorState.getSelection().getHasFocus()) {
-      let newSelectionState = getNewSelectionState(
+      const newSelectionState = getNewSelectionState(
         oldEditorState,
         newEditorState
       );


### PR DESCRIPTION
Closes https://github.com/Automattic/simplenote-electron/issues/1185

As I describe here https://github.com/Automattic/simplenote-electron/issues/1185#issuecomment-460163194 you can reproduce this issue fairly easily if you get your keystroke timing right, and you can verify that it's happening by putting a `console.log` in that `if` statement. After making these changes, the `console.log` would still run, but the cursor maintains the correct position.

No offense taken if you don't want to merge this, it was largely done just to see if I could tackle it. If you do, it seems to be working great but it definitely needs some thorough testing.