### PR TITLE
Fix erratic cursor jumps to last line

### DIFF
--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -267,13 +267,16 @@ export const App = connect(mapStateToProps, mapDispatchToProps)(
 
     onNoteRemoved = () => this.onNotesIndex();
 
-    onNoteUpdate = (noteId, data, remoteUpdateInfo) =>
-      this.props.actions.noteUpdated({
-        noteBucket: this.props.noteBucket,
-        noteId,
-        data,
-        remoteUpdateInfo,
-      });
+    onNoteUpdate = (noteId, data, remoteUpdateInfo = {}) => {
+      if (remoteUpdateInfo.patch) {
+        this.props.actions.noteUpdatedRemotely({
+          noteBucket: this.props.noteBucket,
+          noteId,
+          data,
+          remoteUpdateInfo,
+        });
+      }
+    };
 
     onLoadPreferences = callback =>
       this.props.actions.loadPreferences({

--- a/lib/editor/utils.js
+++ b/lib/editor/utils.js
@@ -39,3 +39,31 @@ export function getSelectedText(editorState) {
 
   return selectedText;
 }
+
+export function getEquivalentSelectionState(oldEditorState, newEditorState) {
+  // Find the block index for the old focus/anchor keys
+  // Use the new focus/anchor keys at that index with the old focus/anchor offsets
+  const oldEditorSelection = oldEditorState.getSelection();
+  const oldAnchorKey = oldEditorSelection.getAnchorKey();
+  const oldFocusKey = oldEditorSelection.getFocusKey();
+  const oldEditorBlocks = oldEditorState.getCurrentContent().getBlocksAsArray();
+  let oldAnchorPosition;
+  let oldFocusPosition;
+  for (let i = 0; i < oldEditorBlocks.length; i++) {
+    if (oldEditorBlocks[i].getKey() === oldAnchorKey) {
+      oldAnchorPosition = i;
+    }
+    if (oldEditorBlocks[i].getKey() === oldFocusKey) {
+      oldFocusPosition = i;
+    }
+  }
+  const newEditorBlocks = newEditorState.getCurrentContent().getBlocksAsArray();
+  return {
+    anchorKey: newEditorBlocks[oldAnchorPosition].getKey(),
+    anchorOffset: oldEditorSelection.getAnchorOffset(),
+    focusKey: newEditorBlocks[oldFocusPosition].getKey(),
+    focusOffset: oldEditorSelection.getFocusOffset(),
+    isBackward: oldEditorSelection.getIsBackward(),
+    hasFocus: oldEditorSelection.getHasFocus(),
+  };
+}

--- a/lib/editor/utils.js
+++ b/lib/editor/utils.js
@@ -58,12 +58,12 @@ export function getEquivalentSelectionState(oldEditorState, newEditorState) {
     }
   }
   const newEditorBlocks = newEditorState.getCurrentContent().getBlocksAsArray();
-  return {
+  return newEditorState.getSelection().merge({
     anchorKey: newEditorBlocks[oldAnchorPosition].getKey(),
     anchorOffset: oldEditorSelection.getAnchorOffset(),
     focusKey: newEditorBlocks[oldFocusPosition].getKey(),
     focusOffset: oldEditorSelection.getFocusOffset(),
     isBackward: oldEditorSelection.getIsBackward(),
     hasFocus: oldEditorSelection.getHasFocus(),
-  };
+  });
 }

--- a/lib/editor/utils.js
+++ b/lib/editor/utils.js
@@ -3,7 +3,13 @@ export function plainTextContent(editorState) {
 }
 
 export function getCurrentBlock(editorState) {
-  const key = editorState.getSelection().getFocusKey();
+  let key = editorState.getSelection().getFocusKey();
+
+  // There seems to be a bug in DraftJS where getFocusKey() can return a
+  // ContentBlock instead of the key string.
+  if (typeof key !== 'string') {
+    key = key.key;
+  }
   return editorState.getCurrentContent().getBlockForKey(key);
 }
 

--- a/lib/editor/utils.js
+++ b/lib/editor/utils.js
@@ -58,11 +58,25 @@ export function getEquivalentSelectionState(oldEditorState, newEditorState) {
     }
   }
   const newEditorBlocks = newEditorState.getCurrentContent().getBlocksAsArray();
+
+  // Ensure that indices and offsets don't go beyond the new upper bounds
+  const lastBlockPosition = newEditorBlocks.length - 1;
+  const adjustedAnchorPosition = Math.min(oldAnchorPosition, lastBlockPosition);
+  const adjustedFocusPosition = Math.min(oldFocusPosition, lastBlockPosition);
+  const adjustedAnchorOffset = Math.min(
+    oldEditorSelection.getAnchorOffset(),
+    newEditorBlocks[adjustedAnchorPosition].getLength()
+  );
+  const adjustedFocusOffset = Math.min(
+    oldEditorSelection.getFocusOffset(),
+    newEditorBlocks[adjustedFocusPosition].getLength()
+  );
+
   return newEditorState.getSelection().merge({
-    anchorKey: newEditorBlocks[oldAnchorPosition].getKey(),
-    anchorOffset: oldEditorSelection.getAnchorOffset(),
-    focusKey: newEditorBlocks[oldFocusPosition].getKey(),
-    focusOffset: oldEditorSelection.getFocusOffset(),
+    anchorKey: newEditorBlocks[adjustedAnchorPosition].getKey(),
+    anchorOffset: adjustedAnchorOffset,
+    focusKey: newEditorBlocks[adjustedFocusPosition].getKey(),
+    focusOffset: adjustedFocusOffset,
     isBackward: oldEditorSelection.getIsBackward(),
     hasFocus: oldEditorSelection.getHasFocus(),
   });

--- a/lib/editor/utils.test.js
+++ b/lib/editor/utils.test.js
@@ -1,5 +1,5 @@
 import { ContentState, EditorState, SelectionState } from 'draft-js';
-import { getSelectedText } from './utils';
+import { getEquivalentSelectionState, getSelectedText } from './utils';
 
 describe('getSelectedText', () => {
   const sourceText = `
@@ -46,5 +46,95 @@ describe('getSelectedText', () => {
     expect(getSelectedText(stateWithSelection)).toBe(
       sourceText.trim().slice(1, sourceText.length - 2)
     );
+  });
+});
+
+describe('getEquivalentSelectionState', () => {
+  const createEditorState = text =>
+    EditorState.createWithContent(ContentState.createFromText(text));
+
+  it('should preserve the offsets of the old state', () => {
+    let oldEditorState = createEditorState('foo');
+    const newEditorState = createEditorState('foo');
+    const anchorOffset = 0;
+    const focusOffset = 3;
+    oldEditorState = EditorState.forceSelection(
+      oldEditorState,
+      oldEditorState.getSelection().merge({ anchorOffset, focusOffset })
+    );
+
+    const result = getEquivalentSelectionState(oldEditorState, newEditorState);
+    expect(result.anchorOffset).toBe(anchorOffset);
+    expect(result.focusOffset).toBe(focusOffset);
+  });
+
+  it('should preserve the hasFocus and isBackward of the old state', () => {
+    let oldEditorState = createEditorState('foo');
+    const newEditorState = createEditorState('foo');
+    const hasFocus = true;
+    const isBackward = true;
+    oldEditorState = EditorState.forceSelection(
+      oldEditorState,
+      oldEditorState.getSelection().merge({ hasFocus, isBackward })
+    );
+
+    const result = getEquivalentSelectionState(oldEditorState, newEditorState);
+    expect(result.hasFocus).toBe(hasFocus);
+    expect(result.isBackward).toBe(isBackward);
+  });
+
+  it('should have an anchor & focus key that corresponds to their indices in the old state', () => {
+    let oldEditorState = createEditorState('foo\nbar\nbaz');
+    const newEditorState = createEditorState('foo\nbar\nbaz');
+    const anchorBlockIndex = 1;
+    const focusBlockIndex = 2;
+    const oldBlocks = oldEditorState.getCurrentContent().getBlocksAsArray();
+    oldEditorState = EditorState.forceSelection(
+      oldEditorState,
+      oldEditorState.getSelection().merge({
+        anchorKey: oldBlocks[anchorBlockIndex].key,
+        focusKey: oldBlocks[focusBlockIndex].key,
+      })
+    );
+
+    const result = getEquivalentSelectionState(oldEditorState, newEditorState);
+    const newBlocks = newEditorState.getCurrentContent().getBlocksAsArray();
+    expect(result.anchorKey).toBe(newBlocks[anchorBlockIndex].key);
+    expect(result.focusKey).toBe(newBlocks[focusBlockIndex].key);
+  });
+
+  it('should not go out of bounds if the offsets are invalid in the new state', () => {
+    let oldEditorState = createEditorState('foo');
+    const newEditorState = createEditorState('f');
+    const anchorOffset = 3;
+    const focusOffset = 3;
+    oldEditorState = EditorState.forceSelection(
+      oldEditorState,
+      oldEditorState.getSelection().merge({ anchorOffset, focusOffset })
+    );
+
+    const result = getEquivalentSelectionState(oldEditorState, newEditorState);
+    expect(result.anchorOffset).toBe(1);
+    expect(result.focusOffset).toBe(1);
+  });
+
+  it('should not go out of bounds if the block indices are invalid in the new state', () => {
+    let oldEditorState = createEditorState('foo\nbar');
+    const newEditorState = createEditorState('foo');
+    const anchorBlockIndex = 1;
+    const focusBlockIndex = 1;
+    const oldBlocks = oldEditorState.getCurrentContent().getBlocksAsArray();
+    oldEditorState = EditorState.forceSelection(
+      oldEditorState,
+      oldEditorState.getSelection().merge({
+        anchorKey: oldBlocks[anchorBlockIndex].key,
+        focusKey: oldBlocks[focusBlockIndex].key,
+      })
+    );
+
+    const result = getEquivalentSelectionState(oldEditorState, newEditorState);
+    const newBlocks = newEditorState.getCurrentContent().getBlocksAsArray();
+    expect(result.anchorKey).toBe(newBlocks[0].key);
+    expect(result.focusKey).toBe(newBlocks[0].key);
   });
 });

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -392,13 +392,13 @@ export const actionMap = new ActionMap({
       });
     },
 
-    noteUpdated: {
+    noteUpdatedRemotely: {
       creator({ noteBucket, noteId, data, remoteUpdateInfo = {} }) {
         return (dispatch, getState) => {
           var state = getState().appState;
           const { original, patch } = remoteUpdateInfo;
 
-          debug('noteUpdated: %O', data);
+          debug('noteUpdatedRemotely: %O', data);
 
           if (state.selectedNoteId !== noteId || !patch) {
             return;

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -207,7 +207,6 @@ export const actionMap = new ActionMap({
               tags: [].concat(state.tag ? state.tag.data.name : []),
             },
             (e, note) => {
-              dispatch(this.action('loadNotes', { noteBucket }));
               dispatch(
                 this.action('loadAndSelectNote', {
                   noteBucket,

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -281,10 +281,10 @@ export const actionMap = new ActionMap({
     },
 
     loadAndSelectNote: {
-      creator({ noteBucket, noteId }) {
+      creator({ noteBucket, noteId, hasRemoteUpdate = false }) {
         return dispatch => {
           noteBucket.get(noteId, (e, note) => {
-            dispatch(this.action('selectNote', { note }));
+            dispatch(this.action('selectNote', { note, hasRemoteUpdate }));
           });
         };
       },
@@ -375,10 +375,10 @@ export const actionMap = new ActionMap({
       },
     },
 
-    selectNote(state, { note }) {
+    selectNote(state, { note, hasRemoteUpdate }) {
       return update(state, {
         editingTags: { $set: false },
-        note: { $set: note },
+        note: { $set: { ...note, hasRemoteUpdate } },
         selectedNoteId: { $set: note.id },
         revisions: { $set: null },
       });
@@ -444,6 +444,7 @@ export const actionMap = new ActionMap({
             this.action('loadAndSelectNote', {
               noteBucket,
               noteId,
+              hasRemoteUpdate: true,
             })
           );
         };

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -286,7 +286,7 @@ export default class NoteContentEditor extends Component {
 
     // Handle transfer of focus from oldEditorState to newEditorState
     if (oldEditorState.getSelection().getHasFocus()) {
-      let newSelectionState = getNewSelectionState(
+      const newSelectionState = getNewSelectionState(
         oldEditorState,
         newEditorState
       );

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -258,10 +258,9 @@ export default class NoteContentEditor extends Component {
           oldEditorState,
           newEditorState
         );
-        const selection = newEditorState.getSelection();
         newEditorState = EditorState.forceSelection(
           newEditorState,
-          selection.merge(newSelectionState)
+          newSelectionState
         );
       }
 

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -269,11 +269,15 @@ export default class NoteContentEditor extends Component {
       this.forceUpdate();
     }
 
-    // If another note is selected or the filter changes,
+    // If another note/revision is selected or the filter changes,
     // create a new editor state from scratch.
     // TODO: Set the new filter decorator without starting from scratch
     // so the undo stack can be preserved.
-    if (noteId !== prevProps.noteId || filter !== prevProps.filter) {
+    if (
+      noteId !== prevProps.noteId ||
+      content.version !== prevProps.content.version ||
+      filter !== prevProps.filter
+    ) {
       this.setState({
         editorState: this.createNewEditorState(content.text, filter),
       });

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -238,11 +238,24 @@ export default class NoteContentEditor extends Component {
 
     const nextContent = plainTextContent(newEditorState);
     const prevContent = plainTextContent(prevEditorState);
+    const contentChanged = nextContent !== prevContent;
 
-    const announceChanges =
-      nextContent !== prevContent
-        ? () => this.props.onChangeContent(nextContent)
-        : noop;
+    // Workaround for bug when a new note is created when the cursor is
+    // in the editor for an existing note. Seems like the `hasFocus` change on
+    // the blur causes this setState change to override the incoming
+    // setState change in componentDidUpdate.
+    // TODO: Fix it in a way that is not hacky
+    if (
+      editorState.getSelection().hasFocus !==
+        prevEditorState.getSelection().hasFocus &&
+      !contentChanged // this keeps the checkboxes working
+    ) {
+      return;
+    }
+
+    const announceChanges = contentChanged
+      ? () => this.props.onChangeContent(nextContent)
+      : noop;
 
     this.setState({ editorState: newEditorState }, announceChanges);
   };

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -1,6 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ContentState, Editor, EditorState, Modifier } from 'draft-js';
+import {
+  ContentState,
+  Editor,
+  EditorState,
+  Modifier,
+  SelectionState,
+} from 'draft-js';
 import MultiDecorator from 'draft-js-multidecorators';
 import { compact, get, includes, invoke, noop } from 'lodash';
 
@@ -278,8 +284,14 @@ export default class NoteContentEditor extends Component {
       content.version !== prevProps.content.version ||
       filter !== prevProps.filter
     ) {
+      const newEditorState = this.createNewEditorState(content.text, filter);
       this.setState({
-        editorState: this.createNewEditorState(content.text, filter),
+        editorState: EditorState.forceSelection(
+          newEditorState,
+          SelectionState.createEmpty(
+            newEditorState.getCurrentContent().getFirstBlock()
+          ).merge({ hasFocus: false }) // workaround for empty notes
+        ),
       });
       return;
     }

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -143,6 +143,34 @@ function continueList(editorState, itemPrefix) {
   );
 }
 
+function getNewSelectionState(oldEditorState, newEditorState) {
+  // Find the block index for the old focus/anchor keys
+  // Use the new focus/anchor keys at that index with the old focus/anchor offsets
+  const oldEditorSelection = oldEditorState.getSelection();
+  const oldAnchorKey = oldEditorSelection.getAnchorKey();
+  const oldFocusKey = oldEditorSelection.getFocusKey();
+  const oldEditorBlocks = oldEditorState.getCurrentContent().getBlocksAsArray();
+  let oldAnchorPosition;
+  let oldFocusPosition;
+  for (let i = 0; i < oldEditorBlocks.length; i++) {
+    if (oldEditorBlocks[i].getKey() === oldAnchorKey) {
+      oldAnchorPosition = i;
+    }
+    if (oldEditorBlocks[i].getKey() === oldFocusKey) {
+      oldFocusPosition = i;
+    }
+  }
+  const newEditorBlocks = newEditorState.getCurrentContent().getBlocksAsArray();
+  return {
+    anchorKey: newEditorBlocks[oldAnchorPosition].getKey(),
+    anchorOffset: oldEditorSelection.getAnchorOffset(),
+    focusKey: newEditorBlocks[oldFocusPosition].getKey(),
+    focusOffset: oldEditorSelection.getFocusOffset(),
+    isBackward: oldEditorSelection.getIsBackward(),
+    hasFocus: oldEditorSelection.getHasFocus(),
+  };
+}
+
 export default class NoteContentEditor extends Component {
   static propTypes = {
     content: PropTypes.string.isRequired,
@@ -256,11 +284,17 @@ export default class NoteContentEditor extends Component {
 
     let newEditorState = this.createNewEditorState(newContent, nextFilter);
 
-    // avoids weird caret position if content is changed
-    // while the editor had focus, see
-    // https://github.com/facebook/draft-js/issues/410#issuecomment-223408160
+    // Handle transfer of focus from oldEditorState to newEditorState
     if (oldEditorState.getSelection().getHasFocus()) {
-      newEditorState = EditorState.moveFocusToEnd(newEditorState);
+      let newSelectionState = getNewSelectionState(
+        oldEditorState,
+        newEditorState
+      );
+      const selection = newEditorState.getSelection();
+      newEditorState = EditorState.forceSelection(
+        newEditorState,
+        selection.merge(newSelectionState)
+      );
     }
 
     this.setState({ editorState: newEditorState });

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -186,7 +186,7 @@ export default class NoteContentEditor extends Component {
   };
 
   createNewEditorState = (text, filter) => {
-    return EditorState.createWithContent(
+    const newEditorState = EditorState.createWithContent(
       ContentState.createFromText(text, TEXT_DELIMITER),
       new MultiDecorator(
         compact([
@@ -194,6 +194,12 @@ export default class NoteContentEditor extends Component {
           checkboxDecorator(this.replaceRangeWithText),
         ])
       )
+    );
+    return EditorState.forceSelection(
+      newEditorState,
+      SelectionState.createEmpty(
+        newEditorState.getCurrentContent().getFirstBlock()
+      ).merge({ hasFocus: false }) // workaround for glitch when note is empty
     );
   };
 
@@ -284,14 +290,8 @@ export default class NoteContentEditor extends Component {
       content.version !== prevProps.content.version ||
       filter !== prevProps.filter
     ) {
-      const newEditorState = this.createNewEditorState(content.text, filter);
       this.setState({
-        editorState: EditorState.forceSelection(
-          newEditorState,
-          SelectionState.createEmpty(
-            newEditorState.getCurrentContent().getFirstBlock()
-          ).merge({ hasFocus: false }) // workaround for empty notes
-        ),
+        editorState: this.createNewEditorState(content.text, filter),
       });
       return;
     }

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -6,6 +6,7 @@ import { compact, get, includes, invoke, noop } from 'lodash';
 
 import {
   getCurrentBlock,
+  getEquivalentSelectionState,
   getSelectedText,
   plainTextContent,
 } from './editor/utils';
@@ -145,34 +146,6 @@ function continueList(editorState, itemPrefix) {
   );
 }
 
-function getNewSelectionState(oldEditorState, newEditorState) {
-  // Find the block index for the old focus/anchor keys
-  // Use the new focus/anchor keys at that index with the old focus/anchor offsets
-  const oldEditorSelection = oldEditorState.getSelection();
-  const oldAnchorKey = oldEditorSelection.getAnchorKey();
-  const oldFocusKey = oldEditorSelection.getFocusKey();
-  const oldEditorBlocks = oldEditorState.getCurrentContent().getBlocksAsArray();
-  let oldAnchorPosition;
-  let oldFocusPosition;
-  for (let i = 0; i < oldEditorBlocks.length; i++) {
-    if (oldEditorBlocks[i].getKey() === oldAnchorKey) {
-      oldAnchorPosition = i;
-    }
-    if (oldEditorBlocks[i].getKey() === oldFocusKey) {
-      oldFocusPosition = i;
-    }
-  }
-  const newEditorBlocks = newEditorState.getCurrentContent().getBlocksAsArray();
-  return {
-    anchorKey: newEditorBlocks[oldAnchorPosition].getKey(),
-    anchorOffset: oldEditorSelection.getAnchorOffset(),
-    focusKey: newEditorBlocks[oldFocusPosition].getKey(),
-    focusOffset: oldEditorSelection.getFocusOffset(),
-    isBackward: oldEditorSelection.getIsBackward(),
-    hasFocus: oldEditorSelection.getHasFocus(),
-  };
-}
-
 export default class NoteContentEditor extends Component {
   static propTypes = {
     content: PropTypes.string.isRequired,
@@ -281,7 +254,7 @@ export default class NoteContentEditor extends Component {
 
       // Handle transfer of focus from oldEditorState to newEditorState
       if (oldEditorState.getSelection().getHasFocus()) {
-        const newSelectionState = getNewSelectionState(
+        const newSelectionState = getEquivalentSelectionState(
           oldEditorState,
           newEditorState
         );

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -18,6 +18,8 @@ import insertOrRemoveCheckboxes from './editor/insert-or-remove-checkboxes';
 import { getIpcRenderer } from './utils/electron';
 import analytics from './analytics';
 
+const TEXT_DELIMITER = '\n';
+
 const isLonelyBullet = line =>
   includes(['-', '*', '+', '- [ ]', '- [x]'], line.trim());
 
@@ -202,7 +204,7 @@ export default class NoteContentEditor extends Component {
 
   createNewEditorState = (text, filter) => {
     return EditorState.createWithContent(
-      ContentState.createFromText(text, '\n'),
+      ContentState.createFromText(text, TEXT_DELIMITER),
       new MultiDecorator(
         compact([
           filterHasText(filter) && matchingTextDecorator(searchPattern(filter)),
@@ -282,7 +284,11 @@ export default class NoteContentEditor extends Component {
       return; // identical to rendered content
     }
 
-    let newEditorState = this.createNewEditorState(newContent, nextFilter);
+    let newEditorState = EditorState.push(
+      oldEditorState,
+      ContentState.createFromText(newContent, TEXT_DELIMITER),
+      'replace-text'
+    );
 
     // Handle transfer of focus from oldEditorState to newEditorState
     if (oldEditorState.getSelection().getHasFocus()) {

--- a/lib/note-detail/index.jsx
+++ b/lib/note-detail/index.jsx
@@ -192,7 +192,10 @@ export class NoteDetail extends Component {
       spellCheckEnabled,
     } = this.props;
 
-    const content = get(this.props, 'note.data.content', '');
+    const content = {
+      text: get(note, 'data.content', ''),
+      hasRemoteUpdate: get(note, 'hasRemoteUpdate', false),
+    };
     const divStyle = { fontSize: `${fontSize}px` };
 
     const mainClasses = classNames('note-detail', {
@@ -227,6 +230,7 @@ export class NoteDetail extends Component {
                   spellCheckEnabled={spellCheckEnabled}
                   storeFocusEditor={this.storeFocusContentEditor}
                   storeHasFocus={this.storeEditorHasFocus}
+                  noteId={get(note, 'id', null)}
                   content={content}
                   filter={filter}
                   onChangeContent={this.queueNoteSave}

--- a/lib/note-detail/index.jsx
+++ b/lib/note-detail/index.jsx
@@ -195,6 +195,7 @@ export class NoteDetail extends Component {
     const content = {
       text: get(note, 'data.content', ''),
       hasRemoteUpdate: get(note, 'hasRemoteUpdate', false),
+      version: get(note, 'version', undefined),
     };
     const divStyle = { fontSize: `${fontSize}px` };
 


### PR DESCRIPTION
Closes #1185 
Based on @qualitymanifest's work in #1192 

Some background on the issue is detailed in https://github.com/Automattic/simplenote-electron/pull/1192#issuecomment-460751822.

## TODO
- [x] Fix "New Note"
- [x] Fix revision selection
- [x] Test as [hotfix on 1.4.0](https://ci.appveyor.com/project/Automattic/simplenote-electron/builds/22210349) (Electron 2)

## In relation to #36

Before this PR, the cursor just moved to the end when a remote change came in. After this PR, the cursor will be restored to the same paragraph/character indices. So definitely a UX improvement. However, we aren't doing any calculation based on the Simperium patch, which means it doesn't do anything fancy like advance the cursor six characters if six characters were inserted before it.

## Technical notes

It seemed like @qualitymanifest's approach might be sufficient (as long as the undo stack was preserved https://github.com/Automattic/simplenote-electron/commit/23d10c450e7d12a2e5cdfe54c1b0147ea01a2130), but it turned out that it would cause flickers and data loss if CJK typing was involved 😬 

To protect CJK typing, we absolutely need a way to distinguish between `content` updates that come from local changes vs. those coming remotely from the server. I did this by adding a property to the Redux state https://github.com/Automattic/simplenote-electron/commit/b8c71f25ccd9c0d9714e0857a795cc86b1625d4f.

Combined with a new `noteId` prop on the component, we can now distinguish between the three kinds of `content` updates:

a. Another note was selected
b. The content was changed locally
c. A remote change came in from the server

They will be handled as such: (a) will recreate an editorState from scratch, (b) will be ignored (so the internal state in DraftJS will stay in control), and (c) will be sent through @qualitymanifest's special focus handling.

## Testing

Some things to try:

- Try to trigger the original bug as detailed in https://github.com/Automattic/simplenote-electron/issues/1185#issuecomment-460163194
- Open the same note on a different Simplenote client, and see how remote changes are applied.
- Is Markdown preview working as expected?
- Are checklists working as expected?