### PR TITLE
Fix crash when receiving remote change in unfocused editor

### DIFF
--- a/lib/editor/utils.js
+++ b/lib/editor/utils.js
@@ -3,14 +3,28 @@ export function plainTextContent(editorState) {
 }
 
 export function getCurrentBlock(editorState) {
-  let key = editorState.getSelection().getFocusKey();
+  let key = getBlockKey('focus', editorState);
+  return editorState.getCurrentContent().getBlockForKey(key);
+}
+
+function getBlockKey(type, editorState) {
+  const selection = editorState.getSelection();
+  let key;
+
+  if (type === 'anchor') {
+    key = selection.getAnchorKey();
+  } else if (type === 'focus') {
+    key = selection.getFocusKey();
+  } else {
+    throw new Error('Key type string is invalid.');
+  }
 
   // There seems to be a bug in DraftJS where getFocusKey() can return a
   // ContentBlock instead of the key string.
   if (typeof key !== 'string') {
     key = key.key;
   }
-  return editorState.getCurrentContent().getBlockForKey(key);
+  return key;
 }
 
 export function getSelectedText(editorState) {
@@ -49,9 +63,8 @@ export function getSelectedText(editorState) {
 export function getEquivalentSelectionState(oldEditorState, newEditorState) {
   // Find the block index for the old focus/anchor keys
   // Use the new focus/anchor keys at that index with the old focus/anchor offsets
-  const oldEditorSelection = oldEditorState.getSelection();
-  const oldAnchorKey = oldEditorSelection.getAnchorKey();
-  const oldFocusKey = oldEditorSelection.getFocusKey();
+  const oldAnchorKey = getBlockKey('anchor', oldEditorState);
+  const oldFocusKey = getBlockKey('focus', oldEditorState);
   const oldEditorBlocks = oldEditorState.getCurrentContent().getBlocksAsArray();
   let oldAnchorPosition;
   let oldFocusPosition;
@@ -64,6 +77,7 @@ export function getEquivalentSelectionState(oldEditorState, newEditorState) {
     }
   }
   const newEditorBlocks = newEditorState.getCurrentContent().getBlocksAsArray();
+  const oldEditorSelection = oldEditorState.getSelection();
 
   // Ensure that indices and offsets don't go beyond the new upper bounds
   const lastBlockPosition = newEditorBlocks.length - 1;


### PR DESCRIPTION
This fixes an uncaught bug in #1193, where we get a WSOD when the selected note receives a remote change while the editor is unfocused.

This was caused by the same strange behavior we worked around in `getCurrentBlock()`, where the selectionState methods `getAnchorKey()` and `getFocusKey()` could sometimes return a `ContentBlock` instead of the key string.

## To test

1. Select a note, and make sure it is not focused. (Click somewhere outside the editor)
1. In a different client, edit that same note.

→ Should not result in a WSOD