### PR TITLE
Expand clickable note editor area

### DIFF
--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -425,7 +425,11 @@ export default class NoteContentEditor extends Component {
 
   render() {
     return (
-      <div onCopy={this.copyPlainText} onCut={this.copyPlainText}>
+      <div
+        onCopy={this.copyPlainText}
+        onCut={this.copyPlainText}
+        style={{ height: '100%' }}
+      >
         <Editor
           key={this.editorKey}
           ref={this.saveEditorRef}


### PR DESCRIPTION
Closes #1182 

This was an inadvertent CSS problem caused by a wrapper div introduced in #1155.