### PR TITLE
Fix NoteList dark background in Ubuntu

### DIFF
--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -3,6 +3,7 @@
   flex-direction: column;
   flex: 1 1 auto;
   overflow: hidden;
+  background: inherit;
 
   .condensed .note-list-item-excerpt {
     display: none;


### PR DESCRIPTION
Closes #1170 

## Before

<img width="298" alt="screen shot 2019-02-13 at 17 55 49" src="https://user-images.githubusercontent.com/555336/52699289-c52c1800-2fb8-11e9-9817-51ad922f14d2.png">

## After

<img width="296" alt="screen shot 2019-02-13 at 17 55 30" src="https://user-images.githubusercontent.com/555336/52699302-ca896280-2fb8-11e9-92be-ffa85dd6ab8f.png">
