### PR TITLE
Auto-detect note language (for spelling and fonts)

### DIFF
--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -1,3 +1,4 @@
+const platform = require('../detect/platform');
 const { appCommandSender } = require('./utils');
 
 const buildEditMenu = settings => {
@@ -49,6 +50,13 @@ const buildEditMenu = settings => {
         type: 'checkbox',
         checked: settings.spellCheckEnabled,
         click: appCommandSender({ action: 'toggleSpellCheck' }),
+      },
+      {
+        label: '&Auto-Detect Language',
+        type: 'checkbox',
+        checked: settings.languageDetectionEnabled,
+        click: appCommandSender({ action: 'toggleLanguageDetection' }),
+        visible: !platform.isOSX(), // currently not working on Mac
       },
     ],
   };

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -95,6 +95,7 @@ const mapDispatchToProps: S.MapDispatch<
         'setAccountName',
         'toggleAutoHideMenuBar',
         'toggleFocusMode',
+        'toggleLanguageDetection',
         'toggleSpellCheck',
       ]),
       dispatch

--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -5,6 +5,11 @@ declare global {
 
   interface Window {
     analyticsEnabled: boolean;
+    spellCheckHandler?: {
+      currentSpellcheckerLanguage: string | undefined;
+      provideHintText: (text: string) => Promise<void>;
+      switchLanguage: (language: string) => void;
+    };
     testEvents: (string | [string, ...any[]])[];
     _tkq: TKQItem[] & { a: unknown };
     wpcom: {

--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -24,6 +24,7 @@ export class NoteDetail extends Component<Props> {
   static displayName = 'NoteDetail';
 
   static propTypes = {
+    detectLanguage: PropTypes.bool.isRequired,
     dialogs: PropTypes.array.isRequired,
     fontSize: PropTypes.number,
     onChangeContent: PropTypes.func.isRequired,
@@ -37,6 +38,7 @@ export class NoteDetail extends Component<Props> {
   };
 
   static defaultProps = {
+    detectLanguage: false,
     storeFocusEditor: noop,
     storeHasFocus: noop,
   };
@@ -60,6 +62,8 @@ export class NoteDetail extends Component<Props> {
   }
 
   focusEditor = () => this.focusContentEditor && this.focusContentEditor();
+
+  saveEditorRef = ref => (this.editor = ref);
 
   isValidNote = note => note && note.id;
 
@@ -180,6 +184,7 @@ export class NoteDetail extends Component<Props> {
 
   render() {
     const {
+      detectLanguage,
       note,
       fontSize,
       previewingMarkdown,
@@ -217,6 +222,8 @@ export class NoteDetail extends Component<Props> {
                 style={divStyle}
               >
                 <NoteContentEditor
+                  ref={this.saveEditorRef}
+                  detectLanguage={detectLanguage}
                   spellCheckEnabled={spellCheckEnabled}
                   storeFocusEditor={this.storeFocusContentEditor}
                   storeHasFocus={this.storeEditorHasFocus}
@@ -238,6 +245,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
   ui,
   settings,
 }) => ({
+  detectLanguage: settings.languageDetectionEnabled,
   dialogs: state.dialogs,
   note: ui.selectedRevision || ui.note,
   showNoteInfo: ui.showNoteInfo,

--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { get, debounce, noop } from 'lodash';
 import analytics from '../analytics';
-import appState from '../flux/app-state';
 import { viewExternalUrl } from '../utils/url-utils';
 import NoteContentEditor from '../note-content-editor';
 import SimplenoteCompactLogo from '../icons/simplenote-compact';
@@ -24,7 +23,6 @@ export class NoteDetail extends Component<Props> {
   static displayName = 'NoteDetail';
 
   static propTypes = {
-    detectLanguage: PropTypes.bool.isRequired,
     dialogs: PropTypes.array.isRequired,
     fontSize: PropTypes.number,
     onChangeContent: PropTypes.func.isRequired,
@@ -32,13 +30,11 @@ export class NoteDetail extends Component<Props> {
     note: PropTypes.object,
     noteBucket: PropTypes.object.isRequired,
     previewingMarkdown: PropTypes.bool,
-    spellCheckEnabled: PropTypes.bool.isRequired,
     storeFocusEditor: PropTypes.func,
     storeHasFocus: PropTypes.func,
   };
 
   static defaultProps = {
-    detectLanguage: false,
     storeFocusEditor: noop,
     storeHasFocus: noop,
   };
@@ -62,8 +58,6 @@ export class NoteDetail extends Component<Props> {
   }
 
   focusEditor = () => this.focusContentEditor && this.focusContentEditor();
-
-  saveEditorRef = ref => (this.editor = ref);
 
   isValidNote = note => note && note.id;
 
@@ -183,13 +177,7 @@ export class NoteDetail extends Component<Props> {
   };
 
   render() {
-    const {
-      detectLanguage,
-      note,
-      fontSize,
-      previewingMarkdown,
-      spellCheckEnabled,
-    } = this.props;
+    const { note, fontSize, previewingMarkdown } = this.props;
 
     const content = {
       text: get(note, 'data.content', ''),
@@ -222,9 +210,6 @@ export class NoteDetail extends Component<Props> {
                 style={divStyle}
               >
                 <NoteContentEditor
-                  ref={this.saveEditorRef}
-                  detectLanguage={detectLanguage}
-                  spellCheckEnabled={spellCheckEnabled}
                   storeFocusEditor={this.storeFocusContentEditor}
                   storeHasFocus={this.storeEditorHasFocus}
                   noteId={get(note, 'id', null)}
@@ -240,16 +225,10 @@ export class NoteDetail extends Component<Props> {
   }
 }
 
-const mapStateToProps: S.MapState<StateProps> = ({
-  appState: state,
-  ui,
-  settings,
-}) => ({
-  detectLanguage: settings.languageDetectionEnabled,
+const mapStateToProps: S.MapState<StateProps> = ({ appState: state, ui }) => ({
   dialogs: state.dialogs,
   note: ui.selectedRevision || ui.note,
   showNoteInfo: ui.showNoteInfo,
-  spellCheckEnabled: settings.spellCheckEnabled,
 });
 
 export default connect(mapStateToProps)(NoteDetail);

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -47,6 +47,7 @@ export type SetSpellCheck = Action<
 >;
 export type SetTheme = Action<'setTheme', { theme: T.Theme }>;
 export type SetWPToken = Action<'setWPToken', { token: string }>;
+export type ToggleLanguageDetection = Action<'toggleLanguageDetection'>;
 
 /*
  * Normal action types
@@ -128,6 +129,7 @@ export type ActionType =
   | SetWPToken
   | StoreRevisions
   | ToggleEditMode
+  | ToggleLanguageDetection
   | ToggleNavigation
   | ToggleNoteInfo
   | ToggleRevisions

--- a/lib/state/settings/actions.ts
+++ b/lib/state/settings/actions.ts
@@ -103,3 +103,7 @@ export const toggleAutoHideMenuBar = () => (dispatch, getState) => {
     autoHideMenuBar: newValue,
   });
 };
+
+export const toggleLanguageDetection: A.ActionCreator<A.ToggleLanguageDetection> = () => ({
+  type: 'toggleLanguageDetection',
+});

--- a/lib/state/settings/reducer.ts
+++ b/lib/state/settings/reducer.ts
@@ -8,6 +8,7 @@ export const initialState = {
   autoHideMenuBar: false,
   focusModeEnabled: false,
   fontSize: 16,
+  languageDetectionEnabled: false,
   lineLength: 'narrow' as T.LineLength,
   markdownEnabled: false,
   noteDisplay: 'comfy' as T.ListDisplayMode,
@@ -53,6 +54,11 @@ const reducer: A.Reducer<typeof initialState> = (
       return { ...state, theme: action.theme };
     case 'setWPToken':
       return { ...state, wpToken: action.token };
+    case 'toggleLanguageDetection':
+      return {
+        ...state,
+        languageDetectionEnabled: !state.languageDetectionEnabled,
+      };
     default:
       return state;
   }


### PR DESCRIPTION
Closes #949 
Closes #788

This enhances the spellchecker by adding language auto-detection. It's working pretty well in my testing, and hopefully it will be a better experience than having to manually select a language from a dropdown.

## Bonus: Better fonts on Windows

As a bonus, I'm using the auto-detected language to set a `lang` attribute to the note body. This will help Electron in Windows to select language-appropriate fonts when the primary OS language is not set to that (#788). One limitation to this is that it's only for the Note Editor, and not the NoteList, since that would be too costly. Still, it's an improvement over the current behavior.

## To test

These changes only affect Electron on Windows and Linux. (Don't know why, but the language detection feature in `electron-spellchecker` is [disabled on Mac](https://github.com/electron-userland/electron-spellchecker/blob/5fa6bd78c10dcf8d1c0cfe6b03bf973bd3917132/src/spell-check-handler.js#L365). It's strange because it works if I just comment out that line.)

You can set `localStorage.debug="electron-spellchecker:*"` in the devtools console and reload to see the language switching in action. Language will be determined every time a different note is selected, or whenever the spelling/auto-detection menu items are toggled. If a language cannot be detected (either by being too short or ambiguous), it will use the OS language.

### Test instructions on Linux/Windows

1. Enable `Check Spelling` in the Edit menu.
1. Grab some dummy text in several spell-checkable languages (English, French, German, etc.) and make a new note for each language text. Assuming that your system language is set to English, non-English words should be considered spelling errors and have squiggly lines.
1. Enable `Auto-Detect Language` in the Edit menu.
1. Now see the non-English notes again. Squiggly lines should be gone. (It may take a few seconds because the spelling dictionaries need to be downloaded first.)
1. Delete some characters from a word or two to make spelling errors, and see that they show squiggly lines.

### Test instructions on Mac

1. See that the `Auto-Detect Language` option in the Edit menu is hidden. (Feature is disabled on Mac)