### PR TITLE
Remove unneeded border in print styles

### DIFF
--- a/scss/print.scss
+++ b/scss/print.scss
@@ -1,7 +1,10 @@
 @media print {
   .app-layout__source-column {
     display: none;
-    border-left: 0;
+  }
+
+  .app-layout__note-column {
+    border: 0;
   }
 
   .tag-field,
@@ -11,7 +14,6 @@
 
   .note-detail-wrapper {
     overflow: visible;
-    border: 0;
   }
 
   .note-detail {


### PR DESCRIPTION
This fixes a CSS regression in the print styles.

## To test

Do a print preview of a note.