### PR TITLE
Tweak dropzone color to preserve dashed border

### DIFF
--- a/lib/dialogs/import/dropzone/style.scss
+++ b/lib/dialogs/import/dropzone/style.scss
@@ -6,7 +6,7 @@
   padding: 24px;
   border-width: 2px;
   border-style: dashed;
-  background: lighten($gray, 40%);
+  background: lighten($gray, 45%);
   transition: padding .2s ease-out, background .2s ease-out;
 
   &:focus-within {


### PR DESCRIPTION
## Before

<img width="380" alt="screen shot 2019-02-19 at 3 02 20" src="https://user-images.githubusercontent.com/555336/53003956-7cbaa180-3473-11e9-8888-f3aa24cd4580.png">

## After

<img width="375" alt="screen shot 2019-02-19 at 3 02 05" src="https://user-images.githubusercontent.com/555336/53003951-788e8400-3473-11e9-8576-816edd4c1de5.png">

Dark Mode is unaffected:

<img width="386" alt="screen shot 2019-02-19 at 3 01 49" src="https://user-images.githubusercontent.com/555336/53004022-9bb93380-3473-11e9-93dc-f36e96a5e981.png">
