### PR TITLE
Extract text manipulation helpers

### DIFF
--- a/lib/editor/text-manipulation-helpers.js
+++ b/lib/editor/text-manipulation-helpers.js
@@ -1,0 +1,129 @@
+import { EditorState, Modifier } from 'draft-js';
+import { includes } from 'lodash';
+
+import { getCurrentBlock } from './utils';
+
+export const isLonelyBullet = line =>
+  includes(['-', '*', '+', '- [ ]', '- [x]'], line.trim());
+
+export function indentCurrentBlock(editorState) {
+  const selection = editorState.getSelection();
+  const selectionStart = selection.getStartOffset();
+
+  const line = getCurrentBlock(editorState).getText();
+  const atStart = isLonelyBullet(line);
+  const offset = atStart ? 0 : selectionStart;
+
+  // add tab
+  const afterInsert = EditorState.push(
+    editorState,
+    Modifier.replaceText(
+      editorState.getCurrentContent(),
+      selection.isCollapsed()
+        ? selection.merge({
+            anchorOffset: offset,
+            focusOffset: offset,
+          })
+        : selection,
+      '\t'
+    ),
+    'insert-characters'
+  );
+
+  // move selection to where it was
+  return EditorState.forceSelection(
+    afterInsert,
+    afterInsert.getSelection().merge({
+      anchorOffset: selectionStart + 1, // +1 because 1 char was added
+      focusOffset: selectionStart + 1,
+    })
+  );
+}
+
+export function outdentCurrentBlock(editorState) {
+  const selection = editorState.getSelection();
+  const selectionStart = selection.getStartOffset();
+
+  const line = getCurrentBlock(editorState).getText();
+  const atStart = isLonelyBullet(line);
+  const rangeStart = atStart ? 0 : selectionStart - 1;
+  const rangeEnd = atStart ? 1 : selectionStart;
+
+  const prevChar = line.slice(rangeStart, rangeEnd);
+  // there's no indentation to remove
+  if (prevChar !== '\t') {
+    return editorState;
+  }
+
+  // remove tab
+  const afterRemove = EditorState.push(
+    editorState,
+    Modifier.removeRange(
+      editorState.getCurrentContent(),
+      selection.merge({
+        anchorOffset: rangeStart,
+        focusOffset: rangeEnd,
+      })
+    ),
+    'remove-range'
+  );
+
+  // move selection to where it was
+  return EditorState.forceSelection(
+    afterRemove,
+    selection.merge({
+      anchorOffset: selectionStart - 1, // -1 because 1 char was removed
+      focusOffset: selectionStart - 1,
+    })
+  );
+}
+
+export function finishList(editorState) {
+  // remove `- ` from the current line
+  const withoutBullet = EditorState.push(
+    editorState,
+    Modifier.removeRange(
+      editorState.getCurrentContent(),
+      editorState.getSelection().merge({
+        anchorOffset: 0,
+        focusOffset: getCurrentBlock(editorState).getLength(),
+      })
+    ),
+    'remove-range'
+  );
+
+  // move selection to the start of the line
+  return EditorState.forceSelection(
+    withoutBullet,
+    withoutBullet.getCurrentContent().getSelectionAfter()
+  );
+}
+
+export function continueList(editorState, itemPrefix) {
+  // create a new line
+  const withNewLine = EditorState.push(
+    editorState,
+    Modifier.splitBlock(
+      editorState.getCurrentContent(),
+      editorState.getSelection()
+    ),
+    'split-block'
+  );
+
+  // insert `- ` in the new line
+  const withBullet = EditorState.push(
+    withNewLine,
+    Modifier.insertText(
+      withNewLine.getCurrentContent(),
+      withNewLine.getCurrentContent().getSelectionAfter(),
+      itemPrefix
+    ),
+    'insert-characters'
+  );
+
+  // move selection to the end of the new line
+  return EditorState.forceSelection(
+    withBullet,
+    withBullet.getCurrentContent().getSelectionAfter()
+  );
+}


### PR DESCRIPTION
This is a janitorial PR that simply extracts the text manipulation functions out of `note-content-editor.jsx`, since the file was growing bigger. No code changes.