### PR TITLE
Web: Reset app storage upon user email mismatch

### DIFF
--- a/lib/boot.js
+++ b/lib/boot.js
@@ -225,7 +225,10 @@ const redirectToWebSigninIfNecessary = () => {
 };
 
 // Set account email if app engine provided it
-if (cookie.email && config.is_app_engine) {
+if (cookie.email) {
+  // If the stored email doesn't match, we should reset the app storage
+  resetStorageIfAccountChanged(cookie.email);
+
   store.dispatch(setAccountName(cookie.email));
 }
 

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -225,7 +225,7 @@ const redirectToWebSigninIfNecessary = () => {
 };
 
 // Set account email if app engine provided it
-if (cookie.email) {
+if (cookie.email && config.is_app_engine) {
   // If the stored email doesn't match, we should reset the app storage
   resetStorageIfAccountChanged(cookie.email);
 


### PR DESCRIPTION
Ensures that the app storage gets reset if the app loads with a mismatched email that was passed in the cookie. This only applies to the web app.

I tested this by adding a cookie in the developer tools named `email` that was different than the one of my currently signed in account.