### PR TITLE
Add custom tooltips to toolbar buttons

### DIFF
--- a/lib/icon-button/index.js
+++ b/lib/icon-button/index.js
@@ -2,18 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from '@material-ui/core/Tooltip';
 
-export const IconButton = ({ disableTooltip, icon, title, ...props }) => (
-  <Tooltip
-    enterDelay={200}
-    open={disableTooltip ? false : undefined}
-    title={title}
-  >
-    <button
-      className="icon-button"
-      type="button"
-      aria-label={disableTooltip ? title : undefined}
-      {...props}
-    >
+export const IconButton = ({ icon, title, ...props }) => (
+  <Tooltip enterDelay={200} title={title}>
+    <button className="icon-button" type="button" {...props}>
       {icon}
     </button>
   </Tooltip>

--- a/lib/icon-button/index.js
+++ b/lib/icon-button/index.js
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 import Tooltip from '@material-ui/core/Tooltip';
 
 export const IconButton = ({ icon, title, ...props }) => (
-  <Tooltip enterDelay={200} title={title}>
+  <Tooltip
+    classes={{ tooltip: 'icon-button__tooltip' }}
+    enterDelay={200}
+    title={title}
+  >
     <button className="icon-button" type="button" {...props}>
       {icon}
     </button>

--- a/lib/icon-button/index.js
+++ b/lib/icon-button/index.js
@@ -8,7 +8,12 @@ export const IconButton = ({ disableTooltip, icon, title, ...props }) => (
     open={disableTooltip ? false : undefined}
     title={title}
   >
-    <button className="icon-button" type="button" aria-label={title} {...props}>
+    <button
+      className="icon-button"
+      type="button"
+      aria-label={disableTooltip ? title : undefined}
+      {...props}
+    >
       {icon}
     </button>
   </Tooltip>

--- a/lib/icon-button/index.js
+++ b/lib/icon-button/index.js
@@ -1,14 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Tooltip from '@material-ui/core/Tooltip';
 
-export const IconButton = ({ icon, ...props }) => (
-  <button className="icon-button" type="button" {...props}>
-    {icon}
-  </button>
+export const IconButton = ({ disableTooltip, icon, title, ...props }) => (
+  <Tooltip
+    enterDelay={200}
+    open={disableTooltip ? false : undefined}
+    title={title}
+  >
+    <button className="icon-button" type="button" aria-label={title} {...props}>
+      {icon}
+    </button>
+  </Tooltip>
 );
 
 IconButton.propTypes = {
+  disableTooltip: PropTypes.bool,
   icon: PropTypes.element.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 export default IconButton;

--- a/lib/icon-button/style.scss
+++ b/lib/icon-button/style.scss
@@ -17,3 +17,8 @@
     }
   }
 }
+
+.icon-button__tooltip {
+  position: relative;
+  top: -8px;
+}

--- a/lib/note-toolbar/index.jsx
+++ b/lib/note-toolbar/index.jsx
@@ -97,7 +97,7 @@ export class NoteToolbar extends Component {
               <IconButton
                 icon={isPreviewing ? <PreviewStopIcon /> : <PreviewIcon />}
                 onClick={this.setEditorMode}
-                title="Preview"
+                title="Preview • Ctrl+Shift+P"
               />
             </div>
           )}

--- a/lib/search-bar/index.jsx
+++ b/lib/search-bar/index.jsx
@@ -25,7 +25,12 @@ export const SearchBar = ({
   showTrash,
 }) => (
   <div className="search-bar theme-color-border">
-    <IconButton icon={<MenuIcon />} onClick={onToggleNavigation} title="Menu" />
+    <IconButton
+      icon={<MenuIcon />}
+      disableTooltip={true}
+      onClick={onToggleNavigation}
+      title="Menu"
+    />
     <SearchField />
     <IconButton
       disabled={showTrash}

--- a/lib/search-bar/index.jsx
+++ b/lib/search-bar/index.jsx
@@ -25,12 +25,7 @@ export const SearchBar = ({
   showTrash,
 }) => (
   <div className="search-bar theme-color-border">
-    <IconButton
-      icon={<MenuIcon />}
-      disableTooltip={true}
-      onClick={onToggleNavigation}
-      title="Menu"
-    />
+    <IconButton icon={<MenuIcon />} onClick={onToggleNavigation} title="Menu" />
     <SearchField />
     <IconButton
       disabled={showTrash}


### PR DESCRIPTION
These custom tooltips are a small usability enhancement over the current built-in `title` tooltips.

![tooltip](https://user-images.githubusercontent.com/555336/53108727-de196800-357a-11e9-86f1-c18da37750e5.gif)

Benefits:

1. We can control the delay to be shorter than the built-in tooltips. (I've set it to 200ms)
2. We can add hints for shortcuts to aid discovery. Many users had requested a shortcut for the Markdown Preview button, which already existed but was near impossible to discover.


Related: #700 #985 