### PR TITLE
Remove hacky focus manipulation in DraftJS

### DIFF
--- a/lib/editor/utils.js
+++ b/lib/editor/utils.js
@@ -3,28 +3,8 @@ export function plainTextContent(editorState) {
 }
 
 export function getCurrentBlock(editorState) {
-  let key = getBlockKey('focus', editorState);
+  let key = editorState.getSelection().focusKey;
   return editorState.getCurrentContent().getBlockForKey(key);
-}
-
-function getBlockKey(type, editorState) {
-  const selection = editorState.getSelection();
-  let key;
-
-  if (type === 'anchor') {
-    key = selection.getAnchorKey();
-  } else if (type === 'focus') {
-    key = selection.getFocusKey();
-  } else {
-    throw new Error('Key type string is invalid.');
-  }
-
-  // There seems to be a bug in DraftJS where getFocusKey() can return a
-  // ContentBlock instead of the key string.
-  if (typeof key !== 'string') {
-    key = key.key;
-  }
-  return key;
 }
 
 export function getSelectedText(editorState) {
@@ -63,8 +43,8 @@ export function getSelectedText(editorState) {
 export function getEquivalentSelectionState(oldEditorState, newEditorState) {
   // Find the block index for the old focus/anchor keys
   // Use the new focus/anchor keys at that index with the old focus/anchor offsets
-  const oldAnchorKey = getBlockKey('anchor', oldEditorState);
-  const oldFocusKey = getBlockKey('focus', oldEditorState);
+  const oldAnchorKey = oldEditorState.getSelection().anchorKey;
+  const oldFocusKey = oldEditorState.getSelection().focusKey;
   const oldEditorBlocks = oldEditorState.getCurrentContent().getBlocksAsArray();
   let oldAnchorPosition;
   let oldFocusPosition;

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -1,12 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {
-  ContentState,
-  Editor,
-  EditorState,
-  Modifier,
-  SelectionState,
-} from 'draft-js';
+import { ContentState, Editor, EditorState, Modifier } from 'draft-js';
 import MultiDecorator from 'draft-js-multidecorators';
 import { compact, get, includes, invoke, noop } from 'lodash';
 
@@ -195,12 +189,12 @@ export default class NoteContentEditor extends Component {
         ])
       )
     );
-    return EditorState.forceSelection(
-      newEditorState,
-      SelectionState.createEmpty(
-        newEditorState.getCurrentContent().getFirstBlock()
-      ).merge({ hasFocus: false }) // workaround for glitch when note is empty
-    );
+
+    // Focus the editor for a new, empty note when not searching
+    if (text === '' && filter === '') {
+      return EditorState.moveFocusToEnd(newEditorState);
+    }
+    return newEditorState;
   };
 
   state = {
@@ -216,6 +210,7 @@ export default class NoteContentEditor extends Component {
     this.props.storeFocusEditor(this.focus);
     this.props.storeHasFocus(this.hasFocus);
     this.ipc.on('appCommand', this.onAppCommand);
+    this.editor.blur();
   }
 
   handleEditorStateChange = editorState => {

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -235,19 +235,6 @@ export default class NoteContentEditor extends Component {
     const prevContent = plainTextContent(prevEditorState);
     const contentChanged = nextContent !== prevContent;
 
-    // Workaround for bug when a new note is created when the cursor is
-    // in the editor for an existing note. Seems like the `hasFocus` change on
-    // the blur causes this setState change to override the incoming
-    // setState change in componentDidUpdate.
-    // TODO: Fix it in a way that is not hacky
-    if (
-      editorState.getSelection().hasFocus !==
-        prevEditorState.getSelection().hasFocus &&
-      !contentChanged // this keeps the checkboxes working
-    ) {
-      return;
-    }
-
     const announceChanges = contentChanged
       ? () => this.props.onChangeContent(nextContent)
       : noop;

--- a/lib/note-detail/index.jsx
+++ b/lib/note-detail/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { get, debounce, invoke, noop } from 'lodash';
+import { get, debounce, noop } from 'lodash';
 import classNames from 'classnames';
 
 import analytics from '../analytics';
@@ -69,24 +69,12 @@ export class NoteDetail extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const {
-      filter,
-      note,
-      onNotePrinted,
-      previewingMarkdown,
-      shouldPrint,
-    } = this.props;
-    const content = get(note, 'data.content', '');
+    const { note, onNotePrinted, previewingMarkdown, shouldPrint } = this.props;
 
     // Immediately print once `shouldPrint` has been set
     if (shouldPrint) {
       window.print();
       onNotePrinted();
-    }
-
-    // Focus the editor for a new, empty note when not searching
-    if (this.isValidNote(note) && content === '' && filter === '') {
-      invoke(this, 'editor.focus');
     }
 
     const prevContent = get(prevProps, 'note.data.content', '');


### PR DESCRIPTION
I finally figured out what was causing the strange glitches that made me write some really hacky workarounds in #1193 and #1195. It was caused by `focus` events originating from `NoteDetail`, not `NoteContentEditor`! 💥

## Testing

These things should work as expected:

- Checkboxes
- In the Note List, switching from a written note to an empty note (and vice versa)
- Place the cursor somewhere in the note text, and then create a new note
- Create a new note while the editor is *not* focused
- Remote changes coming in to the currently selected note