### PR TITLE
Keep editor in sync with selected note in NoteList

### DIFF
--- a/lib/note-list/index.jsx
+++ b/lib/note-list/index.jsx
@@ -227,6 +227,8 @@ export class NoteList extends Component {
   static displayName = 'NoteList';
 
   static propTypes = {
+    closeNote: PropTypes.func.isRequired,
+    filter: PropTypes.string.isRequired,
     isSmallScreen: PropTypes.bool.isRequired,
     notes: PropTypes.array.isRequired,
     selectedNoteId: PropTypes.any,
@@ -254,12 +256,35 @@ export class NoteList extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    const {
+      closeNote,
+      filter,
+      notes,
+      onSelectNote,
+      selectedNoteId,
+    } = this.props;
+
     if (
       prevProps.noteDisplay !== this.props.noteDisplay ||
-      prevProps.notes !== this.props.notes ||
+      prevProps.notes !== notes ||
       prevProps.selectedNoteContent !== this.props.selectedNoteContent
     ) {
       this.recomputeHeights();
+    }
+
+    // Ensure that the note selected here is also selected in the editor
+    if (selectedNoteId !== prevProps.selectedNoteId) {
+      onSelectNote(selectedNoteId);
+    }
+
+    // Deselect the currently selected note if it doesn't match the search query
+    if (filter !== prevProps.filter) {
+      const selectedNotePassesFilter = notes.some(
+        note => note.id === selectedNoteId
+      );
+      if (!selectedNotePassesFilter) {
+        closeNote();
+      }
     }
   }
 
@@ -381,7 +406,12 @@ export class NoteList extends Component {
   onPinNote = note => this.props.onPinNote(note, !note.pinned);
 }
 
-const { emptyTrash, loadAndSelectNote, pinNote } = appState.actionCreators;
+const {
+  closeNote,
+  emptyTrash,
+  loadAndSelectNote,
+  pinNote,
+} = appState.actionCreators;
 const { recordEvent } = tracks;
 
 const mapStateToProps = ({ appState: state, settings: { noteDisplay } }) => {
@@ -436,6 +466,7 @@ const mapStateToProps = ({ appState: state, settings: { noteDisplay } }) => {
 };
 
 const mapDispatchToProps = (dispatch, { noteBucket }) => ({
+  closeNote: () => dispatch(closeNote()),
   onEmptyTrash: () => dispatch(emptyTrash({ noteBucket })),
   onSelectNote: noteId => {
     dispatch(loadAndSelectNote({ noteBucket, noteId }));


### PR DESCRIPTION
Based on #1218 

This is a fix for an inconsistency in the UI state, where the selected note in the Note List (highlighted in blue) could get out of sync with the note shown in the editor.

There were at least two cases where this would occur:

- Start searching for a note, and the editor will continue showing the initially selected note even when the query doesn't match it anymore.
- When you switch from All Notes to the Trash view, the first trashed note is selected blue in the Note List, but the editor is blank.