### PR TITLE
An Install section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A Simplenote [React](https://reactjs.org/) client packaged in [Electron](https:/
 
 _Note: Simplenote API features such as sharing and publishing will not work with development builds. Due to a limitation of `make` installation paths used for build cannot have spaces._
 
+You can also use snap to permanently install it on Linux: `sudo snap install simplenote`
+
 ## Building
 
 - **`make package-osx`**


### PR DESCRIPTION
Added mention to snap install. Much better than manually installing and it should at least be mentioned in the Readme for a faster and simpler install. Maybe not in the `Running` section, but perhaps in a new `Installing` section?

<!-- Don’t worry if the AppVeyor check fails. We are in the process of setting this up and it is currently not working for forked PRs. Just make sure that `npm test` passes on your local machine. Thank you!  -->
