### PR TITLE
Disable ghMentions option in Showdown converter

### DIFF
--- a/lib/utils/render-note-to-html.js
+++ b/lib/utils/render-note-to-html.js
@@ -15,6 +15,7 @@ export const renderNoteToHtml = content => {
       });
       markdownConverter.setFlavor('github');
       markdownConverter.setOption('simpleLineBreaks', false); // override GFM
+      markdownConverter.setOption('ghMentions', false); // override GFM
 
       return sanitizeHtml(markdownConverter.makeHtml(content));
     }


### PR DESCRIPTION
<!-- Don’t worry if the AppVeyor check fails. We are in the process of setting this up and it is currently not working for forked PRs. Just make sure that `npm test` passes on your local machine. Thank you!  -->

Fixes https://github.com/Automattic/simplenote-electron/issues/1238 — typing @text will no longer create a link to a GitHub user in markdown preview, it will just display standard text.