### PR TITLE
Move jest config to file and update deprecated option

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  setupFilesAfterEnv: ['./setup-tests.js'],
+  globals: {
+    config: {
+      appVersion: 'foo',
+    },
+  },
+  roots: ['desktop', 'lib'],
+  testRegex: '(/test/.*\\.jsx?)|(test\\.jsx?)$',
+};

--- a/package.json
+++ b/package.json
@@ -30,19 +30,6 @@
     "> 1%",
     "ie >= 11"
   ],
-  "jest": {
-    "globals": {
-      "config": {
-        "appVersion": "foo"
-      }
-    },
-    "roots": [
-      "desktop",
-      "lib"
-    ],
-    "setupTestFrameworkScriptFile": "<rootDir>setup-tests.js",
-    "testRegex": "(/test/.*\\.jsx?)|(test\\.jsx?)$"
-  },
   "prettier": {
     "bracketSpacing": true,
     "singleQuote": true,


### PR DESCRIPTION
### Fix
Fixes #1355 

"setupFilesAfterEnv" has been deprecated.  This POR moves the configuration to a separate file from the package.json and update the setup file configuration.

### Test
1. Pull branch
2. Run `npm test`

### Review
Only one developer is required to review these changes, but anyone can perform the review.
