### PR TITLE
Aria Label

### DIFF
--- a/lib/search-field/index.jsx
+++ b/lib/search-field/index.jsx
@@ -69,6 +69,7 @@ export class SearchField extends Component {
         <input
           ref={this.storeInput}
           type="text"
+          aria-label={"Search field"}
           placeholder={placeholder}
           onChange={this.update}
           onKeyUp={this.interceptEsc}


### PR DESCRIPTION
Added aria label for search field

### Fix
I added this line to the input of `aria-label={"Search field"}`

### Test
1. Open simplenote-electron app and inspect Elements.
Follow chain of:

body -> div root -> div app-theme light -> div simplenote-app is-electron is-macos -> each nested single div class until search-bar color-theme-border -> div search-field

2. Change should appear within the <input>

3. Run chrome devtools accessibility test or test with a screen reader.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

