### PR TITLE
added styles for both light and dark theme to highlight note and chan…

### DIFF
--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -107,10 +107,7 @@
   }
 
   &.note-list-item-selected {
-    .note-list-item-title,
-    .note-list-item-excerpt {
-      color: $blue;
-    }
+    background: lighten($blue, 30%);
   }
 
   .note-list-item-published-icon {
@@ -136,6 +133,6 @@
   }
 
   .note-list-item-excerpt {
-    color: $gray;
+    color: $gray-darkest;
   }
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -5,6 +5,8 @@ $blue-light: lighten($blue, 20%);
 
 $blue-active-highlight: lighten($blue, 10%);
 
+$blue-darkest: darken($blue, 20%);
+
 // Grays
 $gray: #808080;
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -102,11 +102,19 @@
 
   .note-list-item {
     &:hover .note-list-item-pinner {
-      box-shadow: inset 0 0 0 2px darken($gray, 30%),
+      box-shadow: inset 0 0 0 2px $blue-darkest,
         inset 0 0 0 3px $gray-darkest;
 
       &:hover {
-        background: darken($gray, 10%);
+        background: white
+      }
+    }
+    &:hover.note-list-item-selected .note-list-item-pinner {
+      box-shadow: inset 0 0 0 2px $gray-darkest;
+        // inset 0 0 0 3px $gray-lightest;
+
+      &:hover {
+        background: white
       }
     }
 
@@ -122,22 +130,32 @@
 
     &.note-list-item-pinned.note-list-item-selected .note-list-item-pinner {
       background: $blue;
-      box-shadow: inset 0 0 0 2px darken($blue, 10%),
-        inset 0 0 0 3px $gray-darkest;
+      // box-shadow: inset 0 0 0 2px darken($blue, 10%),
+      //   inset 0 0 0 3px $gray-darkest;
 
       &:hover {
         background: lighten($blue, 10%);
       }
     }
 
-    .note-list-item-excerpt {
-      color: lighten($gray, 9.9%);
+    &.note-list-item-selected{
+      background: $blue-darkest;
     }
 
-    &.note-list-item-selected .note-list-item-excerpt {
-      color: $blue;
+    .note-list-item-excerpt {
+      color: white;
     }
+
+
   }
+    &.note-list-item-selected .note-list-item-excerpt .note-list-item-pinner {
+      box-shadow: inset 0 0 0 2px $gray-darkest,
+        inset 0 0 0 3px $gray-darkest;
+
+      &:hover {
+        background: $gray-darkest;
+      }
+    }
 
   .note-detail-markdown {
     @import '../node_modules/highlight.js/styles/solarized-dark.css';


### PR DESCRIPTION
…ge colors for accessibility

### Fix
Changed the note selected blue to a more accessible color on light and dark mode. Changed the text and pinner colors to be more accessible based on new selection color. 
https://github.com/Automattic/simplenote-electron/issues/1397
<img width="404" alt="Screen Shot 2019-06-21 at 5 55 13 PM" src="https://user-images.githubusercontent.com/31510727/59953388-d2b54b00-944d-11e9-8d10-03f356a74c81.png">
<img width="404" alt="Screen Shot 2019-06-21 at 5 55 58 PM" src="https://user-images.githubusercontent.com/31510727/59953395-d943c280-944d-11e9-83c3-26553ba158f6.png">
<img width="404" alt="Screen Shot 2019-06-21 at 5 56 11 PM" src="https://user-images.githubusercontent.com/31510727/59953396-dd6fe000-944d-11e9-951f-3e7d0fe6bfd1.png">


### Test
1. Go to homepage
2. Select a note to see color change 
3. Switch to dark mode
4. Hover over non-pinned, non-selected note to see first color pinner
5. Select note
6. Hover over non-pinned, selected note to see the second color pinner

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

