### PR TITLE
Add check for local config over dev config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/**/*
+config-local.json
 desktop-build/
 dist/
 release/

--- a/get-config.js
+++ b/get-config.js
@@ -1,3 +1,15 @@
+function readLocalConfig() {
+  try {
+    const config = require('./config-local');
+    if (typeof config === 'function') {
+      throw new Error('Invalid config file. Config must be JSON.');
+    }
+    return config;
+  } catch {
+    return false;
+  }
+}
+
 function readConfig() {
   try {
     const config = require('./config');
@@ -17,7 +29,7 @@ function readConfig() {
 }
 
 function getConfig() {
-  var config = readConfig();
+  var config = readLocalConfig() || readConfig();
   var pkg = require('./package.json');
   config.version = pkg.version;
   return config;


### PR DESCRIPTION
### Fix
Locally I want to have a git ignored config.  This allows for a local config to be used.

### Test
1. Check out branch
2. Run build
3. Does build run?
4. Copy /config.json to /config-local.json
5. Run build
6. Does build run?

### Review
Only one developer is required to review these changes, but anyone can perform the review.
