### PR TITLE
Remove Simperium link from about page

### DIFF
--- a/lib/dialogs/about/index.jsx
+++ b/lib/dialogs/about/index.jsx
@@ -56,18 +56,6 @@ export class AboutDialog extends Component {
             <li>
               <a
                 target="_blank"
-                href="https://simperium.com"
-                rel="noopener noreferrer"
-              >
-                <span className="about-links-title">Simperium</span>
-                <br />
-                Add data sync to your app
-              </a>
-              <TopRightArrowIcon />
-            </li>
-            <li>
-              <a
-                target="_blank"
                 href="https://github.com/Automattic/simplenote-electron"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
### Fix
Fixes: https://github.com/Automattic/simplenote-electron/issues/1436

Removes Simperium link from the about page.

### Test
1. Run this branch locally
2. Click the about link in the hamburger menu
3. Do you see the Simperium link?
4. If not approve. :)

### Review
Only one developer is required to review these changes, but anyone can perform the review.

After:
<img width="490" alt="Screen Shot 2019-07-18 at 10 49 40 AM" src="https://user-images.githubusercontent.com/6817400/61468440-4c583000-a94b-11e9-8e07-05b307b8e86d.png">
Before:
<img width="486" alt="Screen Shot 2019-07-18 at 10 49 24 AM" src="https://user-images.githubusercontent.com/6817400/61468442-4c583000-a94b-11e9-9772-d695debac332.png">
