### PR TITLE
Updates dark mode note list styling

### DIFF
--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -112,7 +112,7 @@
     }
 
     &.note-list-item-selected{
-      background: $blue-darkest;
+      background: #2c3338;
     }
 
     .note-list-item-excerpt {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -101,23 +101,6 @@
   }
 
   .note-list-item {
-    &:hover .note-list-item-pinner {
-      box-shadow: inset 0 0 0 2px $blue-darkest,
-        inset 0 0 0 3px $gray-darkest;
-
-      &:hover {
-        background: white
-      }
-    }
-    &:hover.note-list-item-selected .note-list-item-pinner {
-      box-shadow: inset 0 0 0 2px $gray-darkest;
-        // inset 0 0 0 3px $gray-lightest;
-
-      &:hover {
-        background: white
-      }
-    }
-
     &.note-list-item-pinned .note-list-item-pinner {
       background: $white;
       box-shadow: inset 0 0 0 2px darken($gray, 10%),
@@ -125,16 +108,6 @@
 
       &:hover {
         background: darken($gray, 30%);
-      }
-    }
-
-    &.note-list-item-pinned.note-list-item-selected .note-list-item-pinner {
-      background: $blue;
-      // box-shadow: inset 0 0 0 2px darken($blue, 10%),
-      //   inset 0 0 0 3px $gray-darkest;
-
-      &:hover {
-        background: lighten($blue, 10%);
       }
     }
 


### PR DESCRIPTION
### Fix
Fixes: https://github.com/Automattic/simplenote-electron/issues/1449
Removes hover and selected styling changes in dark mode

### Test
1. Build branch
2. Goto app
3. Set dark mode
4. Observe note list

### Review
One designer is required to review these changes, but anyone can perform the review.

<img width="332" alt="Screen Shot 2019-07-22 at 9 39 28 AM" src="https://user-images.githubusercontent.com/6817400/61636968-b717ad00-ac64-11e9-8346-4a9b43e97194.png">

