### PR TITLE
Fixes public path for electron

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,9 @@ module.exports = () => {
       path: __dirname + '/dist',
       filename: 'app.js',
       chunkFilename: '[name].js',
-      publicPath: config.is_app_engine ? config.web_app_url + '/' : '/',
+      ...(config.is_app_engine && {
+        publicPath: config.web_app_url + '/',
+      }),
     },
     module: {
       rules: [


### PR DESCRIPTION
### Fix
If it is not config.is_app_engine then no path should be given

### Test
1. Download built mac app from this PR: https://circleci.com/gh/Automattic/simplenote-electron/4717#artifacts/containers/0
2. Do you see login?

### Review
Only one developer is required to review these changes, but anyone can perform the review.
