### PR TITLE
Removes New Relic dependdency as it is unused

### DIFF
--- a/vip/package.json
+++ b/vip/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@automattic/vip-go": "0.3.2",
-    "express": "4.17.1",
-    "newrelic": "4.13.1"
+    "express": "4.17.1"
   }
 }


### PR DESCRIPTION
### Fix
New Relic is unused by our application on VIP Go systems. https://github.com/Automattic/simplenote-electron/blob/develop/vip/webapp/index.js
