### PR TITLE
Removes babel version that is no longer needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2450,12 +2450,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
-    "babel-core": {
-      "version": "7.0.0-bridge.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true
-    },
     "babel-eslint": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@babel/preset-env": "7.5.5",
     "@babel/preset-react": "7.0.0",
     "autoprefixer": "9.6.1",
-    "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.2",
     "babel-loader": "8.0.6",
     "babel-plugin-dynamic-import-node": "2.3.0",


### PR DESCRIPTION
### Fix
"babel-core": "7.0.0-bridge.0", was required by Jest to function.  Jets has since been updated to work with Babel 7 properly.

### Test
1. Run the tests
