### PR TITLE
Fixes webpack bug where wrong file is requested

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,15 @@ module.exports = () => {
 
   return {
     context: __dirname + '/lib',
+    optimization: {
+      namedModules: true,
+      namedChunks: true,
+      splitChunks: {
+        cacheGroups: {
+          default: false,
+        },
+      },
+    },
     mode: isDevMode ? 'development' : 'production',
     devtool:
       process.env.SOURCEMAP || (isDevMode && 'cheap-module-eval-source-map'),


### PR DESCRIPTION
### Fix
Webpack was optimizing dynamic imports renaming the files to 1.js, 2.js etc.  We were getting errors where the file requested was the not the expected file.  I changed the optimizations to use named modules so that it can't get confused. 

### Test
1.  This error is not really reproducible.  @theck13 was the only one to reproduce.  The plan is merge to develop then test using develop.simplenote.com

### Review
Only one developer is required to review these changes, but anyone can perform the review.