### PR TITLE
Alert if browser does not support indexeddb

### DIFF
--- a/lib/simperium/ghost-store.js
+++ b/lib/simperium/ghost-store.js
@@ -37,6 +37,7 @@ setup.then(function() {
 });
 
 setup.catch(function(e) {
+  window.alert('Your browser is not supported.  This may be because you have history turned off.');
   console.error(e); // eslint-disable-line no-console
 });
 

--- a/lib/simperium/ghost-store.js
+++ b/lib/simperium/ghost-store.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-shadow */
-
 var Promise = require('promise');
 
 var db = window.indexedDB,
@@ -37,7 +36,21 @@ setup.then(function() {
 });
 
 setup.catch(function(e) {
-  window.alert('Your browser is not supported.  This may be because you have history turned off.');
+  var oldApp = window.confirm(`
+    There was an issue retrieving your notes
+
+    You are using a new version of the Simplenote web app which requires access to the local database to display your notes.
+
+    Possible causes:
+    - The browser you are using is no longer supported
+    - You are using a private browsing mode
+    - You have history turned off
+    
+    Would you like to go to the old web app?
+  `);
+  if (oldApp) {
+    window.location = 'https://app.simplenote.com/old';
+  }
   console.error(e); // eslint-disable-line no-console
 });
 

--- a/lib/simperium/ghost-store.js
+++ b/lib/simperium/ghost-store.js
@@ -37,16 +37,11 @@ setup.then(function() {
 
 setup.catch(function(e) {
   var oldApp = window.confirm(`
-    There was an issue retrieving your notes
+  Simplenote is unable to retrieve your notes.
+  
+  This can happen if you are using a private browsing mode or you have history turned off.
 
-    You are using a new version of the Simplenote web app which requires access to the local database to display your notes.
-
-    Possible causes:
-    - The browser you are using is no longer supported
-    - You are using a private browsing mode
-    - You have history turned off
-    
-    Would you like to go to the old web app?
+  Would you like to try again using a limited version of the app?
   `);
   if (oldApp) {
     window.location = 'https://app.simplenote.com/old';


### PR DESCRIPTION
### Fix
When users have history turned off in Firefox or the browser does not support indexedDB they will see "No notes".  This should a browser alert letting them know their browser is unsupported.

### Test
1. Turn off history in Firefox
2. `npm run dev`
3. Open app in FF
4. Observe alert

### Review
Only one developer is required to review these changes, but anyone can perform the review.
