### PR TITLE
Fix/webpack chunkname with hash

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = () => {
     output: {
       path: __dirname + '/dist',
       filename: 'app.js',
-      chunkFilename: '[name].js',
+      chunkFilename: '[name].[chunkhash].js',
       ...(config.is_app_engine && {
         publicPath: config.web_app_url + '/',
       }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,15 +12,6 @@ module.exports = () => {
 
   return {
     context: __dirname + '/lib',
-    optimization: {
-      namedModules: true,
-      namedChunks: true,
-      splitChunks: {
-        cacheGroups: {
-          default: false,
-        },
-      },
-    },
     mode: isDevMode ? 'development' : 'production',
     devtool:
       process.env.SOURCEMAP || (isDevMode && 'cheap-module-eval-source-map'),


### PR DESCRIPTION
Add `chunkhash` to `chunkFilename`

Alternative to #1516 (reverted here).

Reports of the wrong chunk being served with a particular build suggest
that cached, stale chunks may be served. This results in a broken
application.

Add chunkhash to the chunkFilename to ensure that the expected chunks
are requested and eliminate issues with cached chunks.

See
https://webpack.js.org/configuration/output/#outputchunkfilename

**Please test and review carefully, I'm new to this codebase**