### PR TITLE
Fixes tos link in electron app

### DIFF
--- a/lib/auth/index.jsx
+++ b/lib/auth/index.jsx
@@ -11,6 +11,7 @@ import Spinner from '../components/spinner';
 import { hasInvalidCredentials, hasLoginError } from '../state/auth/selectors';
 import { reset } from '../state/auth/actions';
 import { setWPToken } from '../state/settings/actions';
+import { viewExternalUrl } from '../utils/url-utils';
 
 export class Auth extends Component {
   static propTypes = {
@@ -146,7 +147,16 @@ export class Auth extends Component {
           {isCreatingAccount && (
             <div className="terms">
               By creating an account you agree to our
-              <a href="http://simplenote.com/terms/">Terms of Service</a>.
+              <a
+                href="http://simplenote.com/terms/"
+                onClick={event => {
+                  event.preventDefault();
+                  viewExternalUrl('http://simplenote.com/terms/');
+                }}
+              >
+                Terms of Service
+              </a>
+              .
             </div>
           )}
           <p className="login__signup">

--- a/lib/auth/index.jsx
+++ b/lib/auth/index.jsx
@@ -148,7 +148,7 @@ export class Auth extends Component {
             <div className="terms">
               By creating an account you agree to our
               <a
-                href="http://simplenote.com/terms/"
+                href="https://simplenote.com/terms/"
                 onClick={event => {
                   event.preventDefault();
                   viewExternalUrl('http://simplenote.com/terms/');

--- a/lib/auth/index.jsx
+++ b/lib/auth/index.jsx
@@ -151,7 +151,7 @@ export class Auth extends Component {
                 href="https://simplenote.com/terms/"
                 onClick={event => {
                   event.preventDefault();
-                  viewExternalUrl('http://simplenote.com/terms/');
+                  viewExternalUrl( 'https://simplenote.com/terms/' );
                 }}
               >
                 Terms of Service


### PR DESCRIPTION
### Fix
Fixes https://github.com/Automattic/simplenote-electron/issues/1521

Fixes ToS link in Electron.  Anchor tags require a little extra to work in Electron.

### Test
1. build and run this branch `npm run dev`
2. Click Sign up link
3. Click terms of service link
4. Should open browser

### Review
Only one developer is required to review these changes, but anyone can perform the review.
