### PR TITLE
Add a hash to app.js to blow out cache

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = () => {
     entry: ['./boot'],
     output: {
       path: __dirname + '/dist',
-      filename: 'app.js',
+      filename: 'app.[hash].js',
       chunkFilename: '[name].[chunkhash].js',
       ...(config.is_app_engine && {
         publicPath: config.web_app_url + '/',


### PR DESCRIPTION
### Fix
adds hash to app.js to clear cache when updates are made.

### Test
1. Open dev tools, goto network panel
2. Goto: https://develop.simplenote.com/
3. Observe app.*****.js has a hash

### Review
Only one developer is required to review these changes, but anyone can perform the review.
