### PR TITLE
Fix/symbol transform for ie

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -12,6 +12,7 @@ module.exports = function(api) {
     '@babel/preset-react',
   ];
   const plugins = [
+    '@babel/plugin-transform-typeof-symbol',
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-proposal-object-rest-spread',
     '@babel/plugin-syntax-dynamic-import',

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -1,4 +1,6 @@
+import 'core-js/stable';
 import 'regenerator-runtime/runtime';
+import 'unorm';
 
 import React from 'react';
 import App from './app';

--- a/package-lock.json
+++ b/package-lock.json
@@ -3932,9 +3932,9 @@
       }
     },
     "core-js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.0.tgz",
-      "integrity": "sha512-gybgLzmr7SQRSF6UzGYXducx4eE10ONQlyEnQoqiGPbmbn7zLkb73tPfc4YbZN0lvcTQwoLNPjq4RuCaCumGyQ=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+      "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
     },
     "core-js-compat": {
       "version": "3.1.4",
@@ -15603,6 +15603,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "unorm": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@material-ui/core": "4.3.2",
     "bottleneck": "2.19.5",
     "cookie": "0.4.0",
-    "core-js": "3.2.0",
+    "core-js": "3.2.1",
     "date-fns": "1.30.1",
     "draft-js": "0.11.0",
     "draft-js-multidecorators": "1.0.0",
@@ -132,6 +132,7 @@
     "simperium": "0.3.3",
     "string-replace-to-array": "1.0.3",
     "turndown": "5.0.3",
+    "unorm": "^1.6.0",
     "valid-url": "1.0.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@babel/plugin-proposal-class-properties": "7.5.5",
     "@babel/plugin-proposal-object-rest-spread": "7.5.5",
     "@babel/plugin-syntax-dynamic-import": "7.2.0",
+    "@babel/plugin-transform-typeof-symbol": "^7.2.0",
     "@babel/preset-env": "7.5.5",
     "@babel/preset-react": "7.0.0",
     "autoprefixer": "9.6.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,6 +44,7 @@ module.exports = () => {
         },
         {
           test: /\.jsx?$/,
+          exclude: /node_modules\/core-js/,
           use: [
             {
               loader: 'babel-loader',


### PR DESCRIPTION
### Fix

Fixes: #1544

IE11 is broken because it doesn't have the polyfills it needs.  This PR adds those polyfills.

### Test
1. `npm run dev` on develop
2. Observe IE11 is borked
3. `npm run dev` this branch
4. Observe IE11 loads albeit slowly

### Review
Only one developer is required to review these changes, but anyone can perform the review.