### PR TITLE
Support the unicode bullet as a list item bullet in unordered lists

### DIFF
--- a/lib/editor/text-manipulation-helpers.js
+++ b/lib/editor/text-manipulation-helpers.js
@@ -4,7 +4,7 @@ import { includes } from 'lodash';
 import { getCurrentBlock } from './utils';
 
 export const isLonelyBullet = line =>
-  includes(['-', '*', '+', '- [ ]', '- [x]'], line.trim());
+  includes(['-', '*', '+', '- [ ]', '- [x]', '•'], line.trim());
 
 export function indentCurrentBlock(editorState) {
   const selection = editorState.getSelection();

--- a/lib/editor/text-manipulation-helpers.js
+++ b/lib/editor/text-manipulation-helpers.js
@@ -4,7 +4,7 @@ import { includes } from 'lodash';
 import { getCurrentBlock } from './utils';
 
 export const isLonelyBullet = line =>
-  includes(['-', '*', '+', '- [ ]', '- [x]', '•'], line.trim());
+  includes(['-', '*', '+', '- [ ]', '- [x]', '\u2022'], line.trim());
 
 export function indentCurrentBlock(editorState) {
   const selection = editorState.getSelection();

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -236,7 +236,7 @@ export default class NoteContentEditor extends Component {
     // matches lines that start with `- `, `* `, `+ `, or `\u2022` (bullet)
     // preceded by 0 or more space characters
     // i.e. a line prefixed by a list bullet
-    const listItemRe = /^[ \t\u2000-\u200a]*[-*+•]\s/;
+    const listItemRe = /^[ \t\u2000-\u200a]*[-*+\u2022]\s/;
 
     const { editorState } = this.state;
     const line = getCurrentBlock(editorState).getText();

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -233,10 +233,10 @@ export default class NoteContentEditor extends Component {
   };
 
   handleReturn = () => {
-    // matches lines that start with `- `, `* `, or `+ `
+    // matches lines that start with `- `, `* `, `+ `, or `•`
     // preceded by 0 or more space characters
     // i.e. a line prefixed by a list bullet
-    const listItemRe = /^[ \t\u2000-\u200a]*[-*+]\s/;
+    const listItemRe = /^[ \t\u2000-\u200a]*[-*+•]\s/;
 
     const { editorState } = this.state;
     const line = getCurrentBlock(editorState).getText();

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -233,7 +233,7 @@ export default class NoteContentEditor extends Component {
   };
 
   handleReturn = () => {
-    // matches lines that start with `- `, `* `, `+ `, or `•`
+    // matches lines that start with `- `, `* `, `+ `, or `\u2022` (bullet)
     // preceded by 0 or more space characters
     // i.e. a line prefixed by a list bullet
     const listItemRe = /^[ \t\u2000-\u200a]*[-*+•]\s/;


### PR DESCRIPTION
### Fix
Support the unicode bullet character `•` as a list item bullet because lists copied from HTML or word documents may contain this character.

### Test
1. Open Simplenote
2. Create an unordered list with unicode bullets `•`
```
  • list item a
  • list item b
```
3. Press enter after the first item
4. A new list item should be opened, starting with a unicode bullet `•`

### Review
Everyone can review this if they want :)

### Release
> Added support for the unicode bullet `•` in list items
