### PR TITLE
Update colours to color-studio.blog

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,7 @@
 - Renamed CHANGELOG.md to RELEASE-NOTES.txt
 - Open new note automatically upon creation
 - Open new note automatically upon creation [1566](https://github.com/Automattic/simplenote-electron/issues/1566)
-- Updated colors to use Color Studio in alignment with new design guidelines
+- Updated colors to use Color Studio, the color palette for Automattic products
 
 ## [v1.7.0](https://github.com/Automattic/simplenote-electron/releases/tag/v1.7.0) (2019-08-12)
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - Renamed CHANGELOG.md to RELEASE-NOTES.txt
 - Open new note automatically upon creation
 - Open new note automatically upon creation [1566](https://github.com/Automattic/simplenote-electron/issues/1566)
+- Updated colors to use Color Studio in alignment with new design guidelines
 
 ## [v1.7.0](https://github.com/Automattic/simplenote-electron/releases/tag/v1.7.0) (2019-08-12)
 

--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -73,7 +73,7 @@
     animation: pulse 2s infinite ease-in-out;
 
     path {
-      fill: lighten($gray, 25%);
+      fill: $studio-gray-5;
     }
   }
 

--- a/lib/components/dev-badge/style.scss
+++ b/lib/components/dev-badge/style.scss
@@ -5,8 +5,8 @@
   right: 12px;
   bottom: 12px;
   padding: 2px 4px;
-  background: $gray-lightest;
-  color: $gray-darkest;
+  background: $studio-gray-5;
+  color: $studio-gray-80;
   font-size: .75rem;
   line-height: 1;
 }

--- a/lib/components/progress-bar/style.scss
+++ b/lib/components/progress-bar/style.scss
@@ -1,12 +1,12 @@
 .progress-bar {
   @at-root .theme-light & {
-    background-color: lighten($gray, 30%);
+    background-color: $studio-gray-5;
   }
   @at-root .theme-dark & {
-    background-color: darken($gray, 30%);
+    background-color: $studio-gray-80;
   }
 }
 
 .progress-bar__bar {
-  background-color: $gray !important;
+  background-color: $studio-gray-50 !important;
 }

--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -13,12 +13,12 @@
     display: flex;
     align-items: center;
     height: 2px;
-    background: $white;
+    background: $studio-white;
     border-radius: 5px;
   }
   &::-moz-range-track {
     height: 2px;
-    background: $white;
+    background: $studio-white;
     border-radius: 5px;
   }
   &::-ms-track {
@@ -28,10 +28,10 @@
     color: transparent;
   }
   &::-ms-fill-lower {
-    background: $white;
+    background: $studio-white;
   }
   &::-ms-fill-upper {
-    background: $white;
+    background: $studio-white;
   }
 
   // Thumb
@@ -41,7 +41,7 @@
     border-radius: 50%;
     border: 2px solid $studio-blue-50;
     appearance: none;
-    background: $white;
+    background: $studio-white;
     transition: 0.15s ease-in-out;
 
     &:active {
@@ -52,7 +52,7 @@
     border-radius: 50%;
     border: 2px solid $studio-blue-50;
     appearance: none;
-    background: $white;
+    background: $studio-white;
     transition: 0.15s ease-in-out;
 
     &:active {
@@ -65,7 +65,7 @@
     border-radius: 50%;
     border: 2px solid $studio-blue-50;
     appearance: none;
-    background: $white;
+    background: $studio-white;
     transition: 0.15s ease-in-out;
 
     &:active {

--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -8,10 +8,6 @@
   appearance: none;
   max-height: 18px;
 
-  &:focus {
-    outline-color: lighten($blue, 20%);
-  }
-
   // Track
   &::-webkit-slider-runnable-track {
     display: flex;
@@ -27,7 +23,7 @@
   }
   &::-ms-track {
     height: 2px;
-    border-color: $blue;
+    border-color: $studio-blue-50;
     border-width: 7px 0;
     color: transparent;
   }
@@ -43,7 +39,7 @@
     width: 14px;
     height: 14px;
     border-radius: 50%;
-    border: 2px solid $blue;
+    border: 2px solid $studio-blue-50;
     appearance: none;
     background: $white;
     transition: 0.15s ease-in-out;
@@ -54,7 +50,7 @@
   }
   &::-moz-range-thumb {
     border-radius: 50%;
-    border: 2px solid $blue;
+    border: 2px solid $studio-blue-50;
     appearance: none;
     background: $white;
     transition: 0.15s ease-in-out;
@@ -67,7 +63,7 @@
     width: 16px;
     height: 16px;
     border-radius: 50%;
-    border: 2px solid $blue;
+    border: 2px solid $studio-blue-50;
     appearance: none;
     background: $white;
     transition: 0.15s ease-in-out;

--- a/lib/components/spinner/style.scss
+++ b/lib/components/spinner/style.scss
@@ -7,6 +7,6 @@
   }
 
   &.is-white {
-    color: $white;
+    color: $studio-white;
   }
 }

--- a/lib/components/spinner/style.scss
+++ b/lib/components/spinner/style.scss
@@ -1,9 +1,9 @@
 .spinner__circle {
   @at-root .theme-light & {
-    color: lighten($gray, 30%);
+    color: $studio-gray-5;
   }
   @at-root .theme-dark & {
-    color: darken($gray, 30%);
+    color: $studio-gray-80;
   }
 
   &.is-white {

--- a/lib/components/sync-status/style.scss
+++ b/lib/components/sync-status/style.scss
@@ -24,7 +24,7 @@
 .sync-status-popover__paper {
   padding: .5em 1em;
   border-radius: $border-radius;
-  border: 1px solid lighten($gray, 30%);
+  border: 1px solid $studio-gray-5;
   font-size: .75rem;
 
   &.has-unsynced-changes {
@@ -36,7 +36,7 @@
   max-width: 18em;
   margin-bottom: .75em;
   padding-bottom: 1em;
-  border-bottom: 1px solid lighten($gray, 30%);
+  border-bottom: 1px $studio-gray-5;
   line-height: 1.45;
 }
 

--- a/lib/components/tab-panels/style.scss
+++ b/lib/components/tab-panels/style.scss
@@ -4,7 +4,7 @@
   justify-content: center;
   margin: 0;
   padding: 0;
-  border-bottom: 1px solid lighten($gray, 30%);
+  border-bottom: 1px solid $studio-gray-5;
   list-style: none;
 
   li {
@@ -12,7 +12,7 @@
     border-top: 2px solid transparent;
     border-bottom: 2px solid transparent;
     padding: 0.75em 0.75em;
-    color: darken($gray, 10%);
+    color: $studio-gray-80;
     text-transform: capitalize;
     border-radius: 0;
 

--- a/lib/components/tab-panels/style.scss
+++ b/lib/components/tab-panels/style.scss
@@ -17,8 +17,8 @@
     border-radius: 0;
 
     &.is-active {
-      color: $blue;
-      border-bottom-color: $blue;
+      color: $studio-blue-50;
+      border-bottom-color: $studio-blue-50;
     }
   }
 }

--- a/lib/components/tag-chip/style.scss
+++ b/lib/components/tag-chip/style.scss
@@ -14,7 +14,7 @@
 
   &.selected,
   &:hover {
-    background: $gray;
+    background: $studio-gray-50;
     color: $white;
   }
 }

--- a/lib/components/tag-chip/style.scss
+++ b/lib/components/tag-chip/style.scss
@@ -25,7 +25,7 @@
     &.selected,
     &:hover {
       background: $studio-gray-70;
-      color: $white;
+      color: $studio-white;
     }
   }
 }

--- a/lib/components/tag-chip/style.scss
+++ b/lib/components/tag-chip/style.scss
@@ -6,27 +6,26 @@
   border-radius: 14px;
   line-height: 1.25em;
   white-space: nowrap;
-  background: lighten($gray, 30%);
-  color: darken($gray, 20%);
+  background: $studio-gray-5;
   text-decoration: none;
   font-size: 14px;
   -webkit-tap-highlight-color: transparent;
 
   &.selected,
   &:hover {
-    background: $studio-gray-50;
-    color: $white;
+    background: $studio-blue-5;
   }
 }
 
 .theme-dark {
   .tag-chip {
-    background: darken($gray, 25%);
-    color: lighten($gray, 10%);
+    background: $studio-gray-70;
+    color: $studio-gray-20;
 
-    &.selected {
-      background: lighten($gray, 10%);
-      color: darken($gray, 30%);
+    &.selected,
+    &:hover {
+      background: $studio-gray-70;
+      color: $white;
     }
   }
 }

--- a/lib/controls/checkbox/style.scss
+++ b/lib/controls/checkbox/style.scss
@@ -48,7 +48,7 @@
   }
 
   .checkbox-control-checked {
-    background: $green;
+    background: $studio-green-20;
     transition: all 0.15s ease;
     opacity: 0;
   }

--- a/lib/controls/checkbox/style.scss
+++ b/lib/controls/checkbox/style.scss
@@ -44,7 +44,7 @@
     pointer-events: none;
     border-radius: 50%;
     overflow: hidden;
-    border: 1px solid lighten($gray, 20%);
+    border: 1px solid $studio-gray-5;
   }
 
   .checkbox-control-checked {

--- a/lib/controls/toggle/style.scss
+++ b/lib/controls/toggle/style.scss
@@ -52,7 +52,7 @@ $toggle-control-knob-size: $toggle-control-height - $toggle-control-knob-margin 
   }
 
   .toggle-control-unchecked-color {
-    background: lighten($gray, 10%);
+    background: $studio-gray-10;
   }
 
   .toggle-control-checked-color {

--- a/lib/controls/toggle/style.scss
+++ b/lib/controls/toggle/style.scss
@@ -56,7 +56,7 @@ $toggle-control-knob-size: $toggle-control-height - $toggle-control-knob-margin 
   }
 
   .toggle-control-checked-color {
-    background: $green;
+    background: $studio-green-20;
     transition: $anim;
     opacity: 0;
   }

--- a/lib/dialog-renderer/style.scss
+++ b/lib/dialog-renderer/style.scss
@@ -7,7 +7,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba($white, .75);
+  background: rgba($studio-white, .75);
 }
 
 .theme-dark {

--- a/lib/dialog-renderer/style.scss
+++ b/lib/dialog-renderer/style.scss
@@ -12,7 +12,7 @@
 
 .theme-dark {
   .dialog-renderer__overlay {
-    background: rgba($gray-darkest, .75);
+    background: rgba($studio-gray-100, .75);
   }
 }
 

--- a/lib/dialog/style.scss
+++ b/lib/dialog/style.scss
@@ -8,12 +8,6 @@
   box-shadow: 0 2px 4px 2px rgba($studio-gray-90, 0.15);
 }
 
-.theme-dark {
-  .dialog {
-    box-shadow: 0 2px 4px 2px rgba($studio-gray-90, 0.5);
-  }
-}
-
 .dialog-title-bar {
   display: flex;
   border-bottom: 1px solid $studio-gray-5;

--- a/lib/dialog/style.scss
+++ b/lib/dialog/style.scss
@@ -4,19 +4,19 @@
   width: calc(100vw - 2rem);
   background: white;
   border-radius: $border-radius;
-  border: 1px solid lighten($gray, 30%);
-  box-shadow: 0 2px 4px 2px rgba($gray-darkest, 0.15);
+  border: 1px solid $studio-gray-5;
+  box-shadow: 0 2px 4px 2px rgba($studio-gray-90, 0.15);
 }
 
 .theme-dark {
   .dialog {
-    box-shadow: 0 2px 4px 2px rgba(darken($gray, 45%), 0.5);
+    box-shadow: 0 2px 4px 2px rgba($studio-gray-90, 0.5);
   }
 }
 
 .dialog-title-bar {
   display: flex;
-  border-bottom: 1px solid lighten($gray, 30%);
+  border-bottom: 1px solid $studio-gray-5;
 }
 
 .dialog-title-side {

--- a/lib/dialogs/about/style.scss
+++ b/lib/dialogs/about/style.scss
@@ -6,7 +6,7 @@
     // For overriding theme settings.
     // TODO: Improve theme management so this isn't necessary
     background: $studio-blue-50 !important;
-    color: $white !important;
+    color: $studio-white !important;
   }
 
   .dialog-content {
@@ -51,10 +51,10 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    border-bottom: 1px solid rgba($white, 0.25);
+    border-bottom: 1px solid rgba($studio-white, 0.25);
 
     &:first-child {
-      border-top: 1px solid rgba($white, 0.25);
+      border-top: 1px solid rgba($studio-white, 0.25);
     }
   }
 

--- a/lib/dialogs/about/style.scss
+++ b/lib/dialogs/about/style.scss
@@ -5,7 +5,7 @@
 
     // For overriding theme settings.
     // TODO: Improve theme management so this isn't necessary
-    background: $blue !important;
+    background: $studio-blue-50 !important;
     color: $white !important;
   }
 

--- a/lib/dialogs/import/dropzone/style.scss
+++ b/lib/dialogs/import/dropzone/style.scss
@@ -6,7 +6,7 @@
   padding: 24px;
   border-width: 2px;
   border-style: dashed;
-  background: lighten($gray, 45%);
+  background: $studio-blue-5;
   transition: padding .2s ease-out, background .2s ease-out;
 
   &:focus-within {
@@ -15,7 +15,7 @@
   }
 
   @at-root .theme-dark & {
-    background: darken($gray, 35%);
+    background: $studio-gray-70;
   }
 
   &.is-active {

--- a/lib/dialogs/import/source-importer/executor/style.scss
+++ b/lib/dialogs/import/source-importer/executor/style.scss
@@ -16,7 +16,7 @@
 
 .source-importer-executor__error {
   margin-bottom: .75em;
-  color: $red;
+  color: $studio-red-40;
   line-height: 1.3;
 }
 

--- a/lib/dialogs/settings/style.scss
+++ b/lib/dialogs/settings/style.scss
@@ -25,13 +25,12 @@
 
   p {
     line-height: normal;
-    color: darken($gray, 10%);
+    color: $studio-gray-80;
   }
 }
 
 .settings-items {
-  cursor: pointer;
-  border: 1px solid lighten($gray, 30%);
+  border: 1px solid $studio-gray-5;
 }
 
 .settings-item {
@@ -40,7 +39,7 @@
   height: 3em;
   padding-left: 18px;
   padding-right: 18px;
-  border-bottom: 1px solid lighten($gray, 30%);
+  border-bottom: 1px solid $studio-gray-5;
 
   &:last-child {
     border-bottom: none;

--- a/lib/dialogs/share/style.scss
+++ b/lib/dialogs/share/style.scss
@@ -1,5 +1,5 @@
 .share-collaborators-heading {
-  border-bottom: 1px solid lighten($gray, 30%);
+  border-bottom: 1px solid $studio-gray-5;
 }
 
 .share-collaborators {
@@ -21,7 +21,7 @@
     height: 34px;
     border-radius: 50%;
     overflow: hidden;
-    background: lighten($gray, 30%);
+    background: $studio-gray-5;
   }
 
   .share-collaborator-name {

--- a/lib/editable-list/style.scss
+++ b/lib/editable-list/style.scss
@@ -76,11 +76,11 @@
     margin-right: 4px;
 
     svg {
-      fill: $red;
+      fill: $studio-red-40;
     }
 
     &:focus svg {
-      fill: darken($red, 20%);
+      fill: darken($studio-red-40, 20%);
     }
   }
 

--- a/lib/editable-list/style.scss
+++ b/lib/editable-list/style.scss
@@ -91,7 +91,7 @@
     transform: translateX(24px);
 
     svg {
-      fill: $gray;
+      fill: $studio-gray-50;
     }
 
     &:focus svg {

--- a/lib/editable-list/style.scss
+++ b/lib/editable-list/style.scss
@@ -95,7 +95,7 @@
     }
 
     &:focus svg {
-      fill: darken($gray, 20%);
+      fill: $studio-gray-80;
     }
   }
 

--- a/lib/icon-button/style.scss
+++ b/lib/icon-button/style.scss
@@ -1,7 +1,7 @@
 .icon-button {
   width: 32px;
   height: 32px;
-  color: $blue;
+  color: $studio-blue-50;
 
   svg {
     transition: $anim-fast;
@@ -9,12 +9,6 @@
 
   &:disabled {
     opacity: .4;
-  }
-
-  &:active:not(:disabled) {
-    svg {
-      fill: darken($blue, 20%);
-    }
   }
 }
 

--- a/lib/icons/style.scss
+++ b/lib/icons/style.scss
@@ -7,5 +7,5 @@ svg[class^='icon-'] {
   fill: $studio-blue-50;
 }
 .logo circle {
-  fill: $white;
+  fill: $studio-white;
 }

--- a/lib/icons/style.scss
+++ b/lib/icons/style.scss
@@ -4,7 +4,7 @@ svg[class^='icon-'] {
 
 // Color for the Simplenote logo
 .logo path {
-  fill: $blue;
+  fill: $studio-blue-50;
 }
 .logo circle {
   fill: $white;

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -8,16 +8,12 @@
 
   &.is-selected {
     .button {
-      color: $blue;
+      color: $studio-blue-50;
     }
 
     svg[class^='icon-'] {
-      fill: $blue;
+      fill: $studio-blue-50;
     }
-  }
-
-  .button-borderless:active {
-    color: darken($blue, 20%);
   }
 }
 

--- a/lib/navigation-bar/style.scss
+++ b/lib/navigation-bar/style.scss
@@ -7,7 +7,7 @@
   width: $navigation-bar-width;
   height: 100%;
   overflow: hidden;
-  border-right: 1px solid lighten($gray, 30%);
+  border-right: 1px solid $studio-gray-5;
   background: white;
 }
 
@@ -24,7 +24,7 @@
   overflow: hidden;
   min-height: 9em;
   padding: 12px 0 0;
-  border-top: 1px solid lighten($gray, 30%);
+  border-top: 1px solid $studio-gray-5;
 
   .tag-list-title {
     padding: 8px 20px 0;
@@ -38,7 +38,7 @@
 .navigation-bar__tools {
   flex: 1 0 auto;
   padding: 10px 0;
-  border-top: 1px solid lighten($gray, 30%);
+  border-top: 1px solid $studio-gray-5;
 }
 
 .navigation-bar__footer {
@@ -47,7 +47,7 @@
   justify-content: flex-start;
   align-items: center;
   padding: 0 20px 20px 20px;
-  color: darken($gray, 20%);
+  color: $studio-gray-80;
 }
 
 .is-electron {
@@ -66,5 +66,5 @@
 }
 
 .navigation-bar__sync-status {
-  border-top: 1px solid lighten($gray, 30%);
+  border-top: 1px solid $studio-gray-5;
 }

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -59,7 +59,7 @@
   border: 0;
   line-height: 1.5em;
   font-size: 16px;
-  color: darken($gray, 20%);
+  color: $studio-gray-60;
   background: $white;
   resize: none;
   -webkit-tap-highlight-color: transparent;
@@ -177,18 +177,18 @@
   }
 
   code {
-    background: $gray-lightest;
+    background: $studio-gray-5;
   }
 
   pre {
-    border: 1px solid lighten($gray, 20%);
+    border: 1px solid $studio-gray-20;
     padding: 1em;
     border-radius: $border-radius;
     font-size: 85%;
   }
 
   pre code {
-    color: darken($gray, 10%);
+    color: $studio-gray-90;
     background: transparent;
   }
 
@@ -199,12 +199,12 @@
     width: 100%;
 
     tr:nth-child(2n) {
-      background-color: lighten($gray, 40%);
+      background-color: $studio-gray-5;
     }
 
     th,
     td {
-      border: 1px solid lighten($gray, 20%);
+      border: 1px solid $studio-gray-20;
       padding: 6px 13px;
     }
 

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -41,7 +41,7 @@
     opacity: .2;
 
     path {
-      fill: $gray;
+      fill: $studio-gray-50;
     }
   }
 

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -133,7 +133,7 @@
 
   hr {
     border: 0;
-    border-top: 1px solid lighten($gray, 20%);
+    border-top: 1px solid $studio-gray-5;
   }
 
   a {
@@ -142,7 +142,7 @@
 
   blockquote {
     font-style: italic;
-    border-left: 4px solid lighten($gray, 20%);
+    border-left: 4px solid $studio-gray-5;
     margin-left: 0;
     padding-left: 1em;
   }

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -60,7 +60,7 @@
   line-height: 1.5em;
   font-size: 16px;
   color: $studio-gray-60;
-  background: $white;
+  background: $studio-white;
   resize: none;
   -webkit-tap-highlight-color: transparent;
 

--- a/lib/note-info/style.scss
+++ b/lib/note-info/style.scss
@@ -6,7 +6,7 @@
   left: 100%;
   width: $note-info-width;
   height: 100%;
-  border-left: 1px solid lighten($gray, 30%);
+  border-left: 1px solid $studio-gray-5;
   overflow: auto;
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
@@ -15,7 +15,7 @@
   .note-info-panel {
     flex: none;
     padding: 20px;
-    border-bottom: 1px solid lighten($gray, 30%);
+    border-bottom: 1px solid $studio-gray-5;
 
     &:last-child {
       border: none;

--- a/lib/note-info/style.scss
+++ b/lib/note-info/style.scss
@@ -58,7 +58,7 @@
   }
 
   .note-info-detail {
-    color: $gray;
+    color: $studio-gray-50;
   }
 
   .note-info-link-text {

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -40,7 +40,7 @@
 .note-list-empty-trash {
   flex: none;
   padding: 10px 20px;
-  border-top: 1px solid lighten($gray, 30%);
+  border-top: 1px solid $studio-gray-5;
   text-align: center;
 }
 
@@ -64,19 +64,19 @@
   }
 
   &:hover .note-list-item-pinner {
-    box-shadow: inset 0 0 0 2px lighten($gray, 30%), inset 0 0 0 3px $white;
+    box-shadow: inset 0 0 0 2px $studio-gray-10, inset 0 0 0 3px $white;
 
     &:hover {
-      background: lighten($gray, 10%);
+      background: $studio-gray-50;
     }
   }
 
   &.note-list-item-pinned .note-list-item-pinner {
-    background: $gray-darkest;
-    box-shadow: inset 0 0 0 2px lighten($gray, 20%), inset 0 0 0 3px $white;
+    background: $studio-gray-80;
+    box-shadow: inset 0 0 0 2px $studio-gray-5, inset 0 0 0 3px $white;
 
     &:hover {
-      background: lighten($gray, 30%);
+      background: $studio-gray-10;
     }
   }
 
@@ -84,7 +84,7 @@
     flex: 1 1 auto;
     overflow: hidden;
     padding: 9px 0;
-    border-bottom: 1px solid lighten($gray, 30%);
+    border-bottom: 1px solid $studio-gray-5;
 
     &:focus {
       outline: none;
@@ -125,6 +125,6 @@
   }
 
   .note-list-item-excerpt {
-    color: $gray-darkest;
+    color: $studio-gray-80
   }
 }

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -64,7 +64,7 @@
   }
 
   &:hover .note-list-item-pinner {
-    box-shadow: inset 0 0 0 2px $studio-gray-10, inset 0 0 0 3px $white;
+    box-shadow: inset 0 0 0 2px $studio-gray-10, inset 0 0 0 3px $studio-white;
 
     &:hover {
       background: $studio-gray-50;
@@ -73,7 +73,7 @@
 
   &.note-list-item-pinned .note-list-item-pinner {
     background: $studio-gray-80;
-    box-shadow: inset 0 0 0 2px $studio-gray-5, inset 0 0 0 3px $white;
+    box-shadow: inset 0 0 0 2px $studio-gray-5, inset 0 0 0 3px $studio-white;
 
     &:hover {
       background: $studio-gray-10;

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -80,15 +80,6 @@
     }
   }
 
-  &.note-list-item-pinned.note-list-item-selected .note-list-item-pinner {
-    background: $blue;
-    box-shadow: inset 0 0 0 2px lighten($blue, 25%), inset 0 0 0 3px $white;
-
-    &:hover {
-      background: darken($blue, 10%);
-    }
-  }
-
   .note-list-item-text {
     flex: 1 1 auto;
     overflow: hidden;
@@ -108,7 +99,7 @@
   }
 
   &.note-list-item-selected {
-    background: lighten($blue, 30%);
+    background: $studio-blue-5;
   }
 
   .note-list-item-published-icon {

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -22,7 +22,7 @@
 }
 
 .note-list-placeholder {
-  color: $gray;
+  color: $studio-gray-50;
   font-size: 1.3em;
 }
 
@@ -107,7 +107,7 @@
     margin-right: 10px;
 
     & svg {
-      fill: $gray;
+      fill: $studio-gray-50;
       height: 12px;
       width: 12px;
     }

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -3,7 +3,7 @@
   justify-content: flex-end;
   flex: none;
   height: $toolbar-height;
-  border-bottom: 1px solid lighten($gray, 30%);
+  border-bottom: 1px solid $studio-gray-5;
 }
 
 .note-toolbar {
@@ -83,5 +83,5 @@
 .note-toolbar-placeholder {
   display: block;
   height: $toolbar-height;
-  border-bottom: 1px solid lighten($gray, 30%);
+  border-bottom: 1px solid $studio-gray-5;
 }

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -1,5 +1,5 @@
 .revision-selector {
-  background: $blue;
+  background: $studio-blue-50;
   padding: 10px 20px 20px 20px;
   color: $white;
   z-index: 1000;
@@ -24,21 +24,17 @@
 
     button {
       @extend %smart-focus-outline;
-
-      &:focus {
-        outline-color: lighten($blue, 20%);
-      }
     }
   }
 
   .button-primary {
     background: $white;
-    color: $blue;
+    color: $studio-blue-50;
     border-color: $white;
 
     &:active {
-      background: lighten($blue, 30%);
-      border-color: lighten($blue, 30%);
+      background: $studio-blue-5;
+      border-color: $studio-blue-5;
     }
   }
 
@@ -49,7 +45,7 @@
 
     &:active {
       background: $white;
-      color: $blue;
+      color: $studio-blue-50;
     }
   }
 

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -1,7 +1,7 @@
 .revision-selector {
   background: $studio-blue-50;
   padding: 10px 20px 20px 20px;
-  color: $white;
+  color: $studio-white;
   z-index: 1000;
   position: absolute;
   height: 114px;
@@ -28,9 +28,9 @@
   }
 
   .button-primary {
-    background: $white;
+    background: $studio-white;
     color: $studio-blue-50;
-    border-color: $white;
+    border-color: $studio-white;
 
     &:active {
       background: $studio-blue-5;
@@ -39,12 +39,12 @@
   }
 
   .button-secondary {
-    border-color: $white;
-    color: $white;
+    border-color: $studio-white;
+    color: $studio-white;
     margin-right: 10px;
 
     &:active {
-      background: $white;
+      background: $studio-white;
       color: $studio-blue-50;
     }
   }
@@ -58,7 +58,7 @@
 
   .revision-date {
     width: 100%;
-    color: $white;
+    color: $studio-white;
     text-align: center;
     margin-bottom: 10px;
   }

--- a/lib/search-bar/style.scss
+++ b/lib/search-bar/style.scss
@@ -1,7 +1,7 @@
 .search-bar {
   height: $toolbar-height;
   padding: 20px 15px;
-  border-bottom: 1px solid lighten($gray, 30%);
+  border-bottom: 1px solid $studio-gray-5;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/lib/search-field/style.scss
+++ b/lib/search-field/style.scss
@@ -6,7 +6,7 @@
   height: 1.75em;
   margin: 1px 12px 0;
   border-radius: 50px;
-  border: 1px solid $studio-gray-5;
+  border: 1px solid $studio-gray-10;
   padding: 0 8px 1px 15px;
 
   input {

--- a/lib/search-field/style.scss
+++ b/lib/search-field/style.scss
@@ -6,7 +6,7 @@
   height: 1.75em;
   margin: 1px 12px 0;
   border-radius: 50px;
-  border: 1px solid lighten($gray, 30%);
+  border: 1px solid $studio-gray-5;
   padding: 0 8px 1px 15px;
 
   input {

--- a/lib/search-field/style.scss
+++ b/lib/search-field/style.scss
@@ -23,6 +23,6 @@
 
   .icon-cross-small {
     transition: $anim-transition;
-    fill: $gray;
+    fill: $studio-gray-50;
   }
 }

--- a/lib/tag-input/style.scss
+++ b/lib/tag-input/style.scss
@@ -12,7 +12,7 @@
     min-width: 140px;
     outline: none;
     font: 14px/1.5 $sans;
-    color: darken($gray, 20%);
+    color: $studio-gray-80;
     background: transparent;
   }
 }
@@ -20,7 +20,7 @@
 .tag-input__placeholder {
   position: absolute;
   display: block;
-  color: lighten($gray, 10%);
+  color: $studio-gray-60;
   background: transparent;
   user-select: none;
 }
@@ -44,5 +44,5 @@
 }
 
 .tag-input__suggestion {
-  color: lighten($gray, 10%);
+  color: $studio-gray-40;
 }

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -53,7 +53,7 @@
     appearance: none;
 
     &.is-selected {
-      color: $blue;
+      color: $studio-blue-50;
     }
 
     &:focus {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,11 @@
         }
       }
     },
+    "@automattic/color-studio": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@automattic/color-studio/-/color-studio-2.1.0.tgz",
+      "integrity": "sha512-h1m7IRCz4UUQD8O568TKlCQDPyaEtNhzPs0TAP03dpOb/OIt/o8MBsa2gx9kwgcP/cpTLDEj0E5Z96YNBVDL4w=="
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,9 @@
       }
     },
     "@automattic/color-studio": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@automattic/color-studio/-/color-studio-2.1.0.tgz",
-      "integrity": "sha512-h1m7IRCz4UUQD8O568TKlCQDPyaEtNhzPs0TAP03dpOb/OIt/o8MBsa2gx9kwgcP/cpTLDEj0E5Z96YNBVDL4w=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@automattic/color-studio/-/color-studio-2.2.0.tgz",
+      "integrity": "sha512-ttIF8rPSRJ5hKkDxKESDXyGmbqV3Eg4WCVUmKJp5BQXlbQOtwZ1EqUHmZo+IofXXpO2ngn2GiFz+KGt56C5WMA=="
     },
     "@babel/code-frame": {
       "version": "7.5.5",
@@ -6918,8 +6918,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -6940,14 +6939,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6962,20 +6959,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7092,8 +7086,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
@@ -7105,7 +7098,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7120,7 +7112,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7128,14 +7119,12 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7154,7 +7143,6 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7235,8 +7223,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7248,7 +7235,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7334,8 +7320,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "optional": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7371,7 +7356,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7391,7 +7375,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7435,14 +7418,12 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "optional": true
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "webpack-dev-server": "3.8.0"
   },
   "dependencies": {
+    "@automattic/color-studio": "^2.2.0",
     "@material-ui/core": "4.4.3",
     "bottleneck": "2.19.5",
     "cookie": "0.4.0",

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -32,7 +32,7 @@ svg {
 }
 
 a {
-  color: $blue;
+  color: $studio-blue-50;
 }
 
 b,
@@ -109,7 +109,7 @@ optgroup {
 }
 
 .search-match {
-  background-color: $blue;
+  background-color: $studio-blue-50;
   border-radius: 3px;
   padding-left: 2px;
   padding-right: 2px;

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -113,5 +113,5 @@ optgroup {
   border-radius: 3px;
   padding-left: 2px;
   padding-right: 2px;
-  color: $white;
+  color: $studio-white;
 }

--- a/scss/_scrollbar.scss
+++ b/scss/_scrollbar.scss
@@ -11,7 +11,7 @@
 ::-webkit-scrollbar-thumb {
   background: $studio-gray-10;
   border-radius: 100px;
-  border: 4px solid $white;
+  border: 4px solid $studio-white;
 }
 // hover effect for scrollbar 'thumb'
 ::-webkit-scrollbar-thumb:hover {

--- a/scss/_scrollbar.scss
+++ b/scss/_scrollbar.scss
@@ -9,15 +9,15 @@
 }
 
 ::-webkit-scrollbar-thumb {
-  background: lighten($gray, 30%);
+  background: $studio-gray-10;
   border-radius: 100px;
   border: 4px solid $white;
 }
 // hover effect for scrollbar 'thumb'
 ::-webkit-scrollbar-thumb:hover {
-  background-color: lighten($gray, 20%);
+  background-color: $studio-gray-20;
 }
 ::-webkit-scrollbar-thumb:active {
-  background: lighten($gray, 10%);
+  background: $studio-gray-30;
   border-radius: 100px;
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,7 +1,6 @@
 // Grays
 $gray: #808080;
 
-$gray-lightest: lighten($gray, 38%);
 $gray-darkest: darken($gray, 38.5%);
 
 // Secondary

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,10 +1,3 @@
-// Secondary colors
-$yellow: #f0b849;
-$red: #d94f4f;
-$green: #4ab866;
-$black: #000;
-$white: #fff;
-
 $sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans',
   'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
 $normal: 400;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,26 +1,8 @@
-// Blues
-$blue: #4895d9; // old blue: #6da3d3
-$blue-lightest: lighten($blue, 33%);
-$blue-light: lighten($blue, 20%);
-
-$blue-active-highlight: lighten($blue, 10%);
-
-$blue-darkest: darken($blue, 20%);
-
 // Grays
 $gray: #808080;
 
 $gray-lightest: lighten($gray, 38%);
 $gray-darkest: darken($gray, 38.5%);
-
-// $gray color functions from light to dark:
-//
-// lighten($gray, 30%)
-// lighten($gray, 20%)
-// lighten($gray, 10%)
-// darken($gray, 10%)
-// darken($gray, 20%)
-// darken($gray, 30%)
 
 // Secondary
 $yellow: #f0b849;
@@ -43,7 +25,7 @@ $fade-alpha: 0.25;
 
 $border-radius: 3px;
 
-$focus-outline: 4px auto lighten($blue, 15%);
+$focus-outline: 4px auto $studio-blue-5;
 
 // Global Measurements
 $navigation-bar-width: 216px;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,13 +1,8 @@
-// Grays
-$gray: #808080;
-
-$gray-darkest: darken($gray, 38.5%);
-
-// Secondary
+// Secondary colors
 $yellow: #f0b849;
 $red: #d94f4f;
 $green: #4ab866;
-$black: #000; // use $gray-darkest instead
+$black: #000;
 $white: #fff;
 
 $sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans',

--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -28,10 +28,10 @@ button {
   transition: $anim-fast;
   -webkit-tap-highlight-color: transparent;
   background: transparent;
-  border-color: $blue;
+  border-color: $studio-blue-50;
   border-style: solid;
   border-width: 2px;
-  color: $blue;
+  color: $studio-blue-50;
   font-size: 14px;
   line-height: 1.5;
   font-weight: $bold;
@@ -40,7 +40,7 @@ button {
 
   &:active,
   &.active {
-    background: $blue;
+    background: $studio-blue-50;
     color: $white;
   }
   &[disabled],
@@ -51,14 +51,8 @@ button {
 
 // Primary buttons. Solid buttons.
 .button-primary {
-  background: $blue;
+  background: $studio-blue-50;
   color: white;
-
-  &:active,
-  &.active {
-    background: darken($blue, 10%);
-    border-color: darken($blue, 10%);
-  }
 }
 
 // Compact buttons. Use to make buttons smaller.
@@ -86,15 +80,6 @@ button {
 
   svg[class^='icon-'] {
     transition: $anim-fast;
-  }
-
-  &:active {
-    color: darken($blue, 20%);
-    background: transparent;
-
-    svg[class^='icon-'] {
-      fill: darken($blue, 20%);
-    }
   }
 }
 

--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -41,7 +41,7 @@ button {
   &:active,
   &.active {
     background: $studio-blue-50;
-    color: $white;
+    color: $studio-white;
   }
   &[disabled],
   &:disabled {
@@ -64,12 +64,12 @@ button {
 
 // Danger buttons
 .button-danger {
-  color: $red;
-  border-color: $red;
+  color: $studio-red-40;
+  border-color: $studio-red-40;
 
   &:active {
-    background: $red;
-    color: $white;
+    background: $studio-red-40;
+    color: $studio-white;
   }
 }
 
@@ -85,7 +85,7 @@ button {
 
 .button-borderless.button-danger {
   &:active {
-    color: darken($red, 20%);
+    color: darken($studio-red-40, 20%);
   }
 }
 

--- a/scss/inputs.scss
+++ b/scss/inputs.scss
@@ -11,7 +11,7 @@ input {
   -webkit-tap-highlight-color: transparent;
 
   &::placeholder {
-    color: $gray;
+    color: $studio-gray-50;
   }
 
   &::-ms-clear {

--- a/scss/print.scss
+++ b/scss/print.scss
@@ -23,10 +23,10 @@
   [class^="note-detail-"] {
     max-width: 100%;
     width: 100%;
-    color: $black;
+    color: $studio-black;
 
     &.theme-color-fg {
-      color: $black;
+      color: $studio-black;
     }
   }
 }

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -2,6 +2,8 @@
 @import 'normalize';
 @import '../node_modules/draft-js/dist/Draft.css';
 
+@import "~@automattic/color-studio/dist/color-variables";
+
 // Internal
 @import 'variables';
 @import 'mixins';

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -1,12 +1,12 @@
 .theme-light {
-  background-color: $white;
+  background-color: $studio-white;
   color: $studio-gray-60;
 
   .theme-color-bg {
-    background-color: $white;
+    background-color: $studio-white;
   }
   .theme-color-bg-lighter {
-    background-color: $white;
+    background-color: $studio-white;
   }
   .theme-color-fg {
     color: $studio-gray-80;
@@ -18,7 +18,7 @@
     border-color: $studio-gray-5;
   }
   .search-field {
-    border-color: $studio-gray-5;
+    border-color: $studio-gray-10;
   }
 }
 
@@ -33,7 +33,7 @@
     background-color: $studio-gray-90;
   }
   .theme-color-fg {
-    color: $white;
+    color: $studio-white;
   }
   .theme-color-fg-dim {
     color: $studio-gray-30;
@@ -115,7 +115,7 @@
 
   .note-list-item {
     &.note-list-item-pinned .note-list-item-pinner {
-      background: $white;
+      background: $studio-white;
       box-shadow: inset 0 0 0 2px $studio-gray-80,
         inset 0 0 0 3px $studio-gray-80;
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -96,7 +96,7 @@
     color: lighten($gray, 10%);
 
     &.is-active {
-      color: $blue;
+      color: $studio-blue-50;
     }
   }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -24,7 +24,7 @@
 
 .theme-dark {
   background-color: $gray-darkest;
-  color: $gray;
+  color: $studio-gray-50;
 
   .theme-color-bg {
     background-color: $gray-darkest;
@@ -54,7 +54,7 @@
     background-color: darken($gray, 10%);
   }
   ::-webkit-scrollbar-thumb:active {
-    background-color: $gray;
+    background-color: $studio-gray-50;
   }
 
   .button-borderless {
@@ -145,7 +145,7 @@
       border-color: darken($gray, 20%);
     }
     pre code {
-      color: $gray;
+      color: $studio-gray-50;
       background: transparent;
     }
     table {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -60,11 +60,11 @@
   }
 
   ::-webkit-scrollbar-thumb {
-    background-color: darken($gray, 20%);
-    border-color: $gray-darkest;
+    background-color: $studio-gray-80;
+    border-color: $studio-gray-60;
   }
   ::-webkit-scrollbar-thumb:hover {
-    background-color: darken($gray, 10%);
+    background-color: $studio-gray-90;
   }
   ::-webkit-scrollbar-thumb:active {
     background-color: $studio-gray-50;
@@ -74,39 +74,39 @@
     &[disabled],
     &:disabled {
       svg[class^='icon-'] {
-        fill: darken($gray, 30%);
+        fill: $studio-gray-60;
       }
     }
   }
 
   input,
   textarea {
-    border-color: darken($gray, 25%);
+    border-color: $studio-gray-70;
     background-color: transparent;
   }
 
   .transparent-input::placeholder {
-    color: darken($gray, 10%);
+    color: $studio-gray-80;
   }
 
   .checkbox-control-base {
-    border-color: darken($gray, 20%);
+    border-color: $studio-gray-80;
   }
 
   .tag-field input {
     background: transparent;
 
     &::placeholder {
-      color: lighten($gray, 10%);
+      color: $studio-gray-20;
     }
   }
 
   .settings-group p {
-    color: lighten($gray, 45%);
+    color: $studio-gray-5;
   }
 
   .tab-panels__tab-list li {
-    color: lighten($gray, 10%);
+    color: $studio-gray-50;
 
     &.is-active {
       color: $studio-blue-30;
@@ -116,11 +116,11 @@
   .note-list-item {
     &.note-list-item-pinned .note-list-item-pinner {
       background: $white;
-      box-shadow: inset 0 0 0 2px darken($gray, 10%),
-        inset 0 0 0 3px $gray-darkest;
+      box-shadow: inset 0 0 0 2px $studio-gray-80,
+        inset 0 0 0 3px $studio-gray-80;
 
       &:hover {
-        background: darken($gray, 30%);
+        background: $studio-gray-80;
       }
     }
 
@@ -133,10 +133,10 @@
     }
   }
   &.note-list-item-selected .note-list-item-excerpt .note-list-item-pinner {
-    box-shadow: inset 0 0 0 2px $gray-darkest, inset 0 0 0 3px $gray-darkest;
+    box-shadow: inset 0 0 0 2px $studio-gray-80, inset 0 0 0 3px $studio-gray-90;
 
     &:hover {
-      background: $gray-darkest;
+      background: $studio-gray-80;
     }
   }
 
@@ -144,18 +144,18 @@
     @import '../node_modules/highlight.js/styles/solarized-dark.css';
 
     hr {
-      border-color: darken($gray, 20%);
+      border-color: $studio-gray-80;
     }
 
     blockquote {
-      border-color: darken($gray, 20%);
+      border-color: $studio-gray-80;
     }
 
     code {
-      background: darken($gray, 30%);
+      background: $studio-gray-60;
     }
     pre {
-      border-color: darken($gray, 20%);
+      border-color: $studio-gray-80;
     }
     pre code {
       color: $studio-gray-50;
@@ -164,10 +164,10 @@
     table {
       th,
       td {
-        border-color: darken($gray, 20%);
+        border-color: $studio-gray-60;
       }
       tr:nth-child(2n) {
-        background-color: darken($gray, 33%);
+        background-color: $studio-gray-80;
       }
     }
   }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -109,7 +109,7 @@
     color: lighten($gray, 10%);
 
     &.is-active {
-      color: $studio-blue-50;
+      color: $studio-blue-30;
     }
   }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -1,49 +1,62 @@
 .theme-light {
   background-color: $white;
-  color: $gray-darkest;
+  color: $studio-gray-60;
 
   .theme-color-bg {
     background-color: $white;
   }
   .theme-color-bg-lighter {
-    background-color: lighten($gray, 30%);
+    background-color: $white;
   }
   .theme-color-fg {
-    color: $gray-darkest;
+    color: $studio-gray-80;
   }
   .theme-color-fg-dim {
-    color: darken($gray, 20%);
+    color: $studio-gray-50;
   }
   .theme-color-border {
-    border-color: lighten($gray, 40%);
+    border-color: $studio-gray-5;
   }
   .search-field {
-    border-color: lighten($gray, 40%);
+    border-color: $studio-gray-5;
   }
 }
 
 .theme-dark {
-  background-color: $gray-darkest;
-  color: $studio-gray-50;
+  background-color: $studio-gray-90;
+  color: $studio-gray-20;
 
   .theme-color-bg {
-    background-color: $gray-darkest;
+    background-color: $studio-gray-90;
   }
   .theme-color-bg-lighter {
-    background-color: darken($gray, 20%);
+    background-color: $studio-gray-90;
   }
   .theme-color-fg {
-    color: lighten($gray, 45%);
+    color: $white;
   }
   .theme-color-fg-dim {
-    color: lighten($gray, 9.9%);
+    color: $studio-gray-30;
   }
   .theme-color-border {
-    border-color: darken($gray, 30%);
+    border-color: $studio-gray-80;
   }
 
   .search-field {
-    border-color: darken($gray, 30%);
+    border-color: $studio-gray-60;
+
+    ::-moz-placeholder { /* Firefox 19+ */
+      color: $studio-gray-30;
+    }
+    ::webkit-input-placeholder { /* IE 10+ */
+      color: $studio-gray-30;
+    }
+    :-ms-input-placeholder { /* IE 10+ */
+      color: $studio-gray-30;
+    }
+    :-moz-placeholder { /* Firefox 18- */
+      color: $studio-gray-30;
+    }
   }
 
   ::-webkit-scrollbar-thumb {


### PR DESCRIPTION
### Fix
Update CSS colors to use [color-studio.blog](https://color-studio.blog/) in line with the [new style guidelines](P2XJRt-11W-p2).

### Test
* Verify that the app works and the colors look pretty much the same :)
* Test in both light and dark modes

### Screenshots
Before:
<img width="1433" alt="Screen Shot 2019-09-25 at 10 44 46 PM" src="https://user-images.githubusercontent.com/52152/65661357-4be0b300-dfe6-11e9-81a7-e978b63669df.png">
        
After:      
<img width="1440" alt="Screen Shot 2019-09-25 at 10 30 52 PM" src="https://user-images.githubusercontent.com/52152/65661385-6155dd00-dfe6-11e9-9bf4-7373ac766096.png">

Before:
<img width="1440" alt="Screen Shot 2019-09-25 at 10 48 10 PM" src="https://user-images.githubusercontent.com/52152/65661468-96fac600-dfe6-11e9-9af0-2d154ee5e969.png">

After:
<img width="1440" alt="Screen Shot 2019-09-25 at 10 30 01 PM" src="https://user-images.githubusercontent.com/52152/65661540-c27db080-dfe6-11e9-9cfc-5fc7e4d56d16.png">

Before:
<img width="513" alt="Screen Shot 2019-09-25 at 10 50 46 PM" src="https://user-images.githubusercontent.com/52152/65661619-f6f16c80-dfe6-11e9-89df-5f3588dfe116.png">

After:
<img width="550" alt="Screen Shot 2019-09-25 at 10 30 10 PM" src="https://user-images.githubusercontent.com/52152/65661593-dfb27f00-dfe6-11e9-8714-4f562c8056e9.png">

Before:
<img width="774" alt="Screen Shot 2019-09-25 at 10 47 59 PM" src="https://user-images.githubusercontent.com/52152/65661734-420b7f80-dfe7-11e9-907c-cc3c0b723189.png">

After:
<img width="1437" alt="Screen Shot 2019-09-25 at 10 30 30 PM" src="https://user-images.githubusercontent.com/52152/65661751-4d5eab00-dfe7-11e9-9a2b-b2d08e7be96d.png">



### Release
`RELEASE-NOTES.txt` was updated with:
> Updated colors to use Color Studio, the color palette for Automattic products