### PR TITLE
Fix: Cursors over UI elements should indicate clickable or text entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## Future Release
 
 - Updated Log in and Sign up form to match current styling
+- Fixed cursors to use the proper type
 
 ## [v1.7.0](https://github.com/Automattic/simplenote-electron/releases/tag/v1.7.0) (2019-08-12)
 
 ### Fixes
+
 - Updates to dark mode styling [#1452](https://github.com/Automattic/simplenote-electron/pull/1452)
 - Updated several dependencies
 

--- a/lib/components/checkbox/style.scss
+++ b/lib/components/checkbox/style.scss
@@ -1,4 +1,9 @@
+input[type="checkbox"] {
+  cursor: pointer;
+}
+
 .checkbox {
+  cursor: pointer;
   line-height: inherit;
 
   &[aria-checked="true"] {

--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -1,6 +1,7 @@
 .slider {
   @extend %smart-focus-outline;
 
+  cursor: pointer;
   width: 100%;
   max-width: $max-content-width;
   padding: 0; // IE11

--- a/lib/components/tag-chip/style.scss
+++ b/lib/components/tag-chip/style.scss
@@ -1,4 +1,5 @@
 .tag-chip {
+  cursor: pointer;
   flex: none;
   margin: 2px 8px 6px 0;
   padding: 1px 14px 3px 14px;

--- a/lib/dialogs/settings/style.scss
+++ b/lib/dialogs/settings/style.scss
@@ -1,6 +1,10 @@
 .settings {
   max-width: 630px;
 
+  input[type="radio"] {
+    cursor: pointer;
+  }
+
   .settings-account-name {
     font-size: 115%;
     text-align: center;

--- a/lib/dialogs/settings/style.scss
+++ b/lib/dialogs/settings/style.scss
@@ -26,6 +26,7 @@
 }
 
 .settings-items {
+  cursor: pointer;
   border: 1px solid lighten($gray, 30%);
 }
 

--- a/lib/editable-list/style.scss
+++ b/lib/editable-list/style.scss
@@ -56,6 +56,7 @@
 
   .editable-list-trash,
   .editable-list-reorder {
+    cursor: pointer;
     flex: none;
     opacity: 0;
     pointer-events: none;

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -45,6 +45,7 @@
 }
 
 .note-list-item {
+  cursor: pointer;
   display: flex;
   padding-left: 8px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);

--- a/lib/tag-input/style.scss
+++ b/lib/tag-input/style.scss
@@ -1,4 +1,5 @@
 .tag-input {
+  cursor: text;
   position: relative;
   display: flex;
   flex: 1 0 auto;

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -38,6 +38,7 @@
   }
 
   .tag-list-input {
+    cursor: pointer;
     flex: 1 1 auto;
     display: block;
     width: 50px;

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -1,7 +1,6 @@
 *,
 *:before,
 *:after {
-  cursor: default; // Make everything use default cursor
   box-sizing: border-box;
 }
 

--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -1,19 +1,23 @@
 // Resets button styles
 button {
   @extend %smart-focus-outline;
-
   background: transparent;
   border: none;
   padding: 0;
-  cursor: default;
+  cursor: pointer;
   font-size: 14px;
   appearance: none;
   vertical-align: baseline;
+
+  svg {
+    cursor: pointer;
+  }
 }
 
 // Generic button base class
 // Can be used by itself, or in conjunction with the .button-* modifier classes
 .button {
+  cursor: pointer;
   display: inline-block;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -101,8 +101,6 @@
   }
 
   .note-list-item {
-    cursor: pointer;
-
     &.note-list-item-pinned .note-list-item-pinner {
       background: $white;
       box-shadow: inset 0 0 0 2px darken($gray, 10%),
@@ -113,24 +111,21 @@
       }
     }
 
-    &.note-list-item-selected{
+    &.note-list-item-selected {
       background: #2c3338;
     }
 
     .note-list-item-excerpt {
       color: white;
     }
-
-
   }
-    &.note-list-item-selected .note-list-item-excerpt .note-list-item-pinner {
-      box-shadow: inset 0 0 0 2px $gray-darkest,
-        inset 0 0 0 3px $gray-darkest;
+  &.note-list-item-selected .note-list-item-excerpt .note-list-item-pinner {
+    box-shadow: inset 0 0 0 2px $gray-darkest, inset 0 0 0 3px $gray-darkest;
 
-      &:hover {
-        background: $gray-darkest;
-      }
+    &:hover {
+      background: $gray-darkest;
     }
+  }
 
   .note-detail-markdown {
     @import '../node_modules/highlight.js/styles/solarized-dark.css';
@@ -154,7 +149,8 @@
       background: transparent;
     }
     table {
-      th, td {
+      th,
+      td {
         border-color: darken($gray, 20%);
       }
       tr:nth-child(2n) {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -101,6 +101,8 @@
   }
 
   .note-list-item {
+    cursor: pointer;
+
     &.note-list-item-pinned .note-list-item-pinner {
       background: $white;
       box-shadow: inset 0 0 0 2px darken($gray, 10%),


### PR DESCRIPTION
### Fix
Cursors in the UI do not use the proper type to indicate when elements are clickable or editable. This PR fixes those issue across the app.

### Test
1. Run the branch
2. Step through app hovering over anything that is clickable and verify that the cursor changes to "pointer"
3. Hover over anything that allows text entry and verify that the cursor changes to "text"

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Hovering over a clickable or editable UI element now show the correct cursor for its type
