### PR TITLE
Note Updates: Resequence async calls to match execution flow

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -413,40 +413,46 @@ export const actionMap = new ActionMap({
             return;
           }
 
-          let working = note.data;
-
           // diff of working and original will produce the modifications the client has currently made
-          let working_diff = simperiumUtil.change.diff(original, working);
+          const working_diff = simperiumUtil.change.diff(original, note.data);
 
           // Check for equal diffs so we don't duplicate changes
           const diffsAreEqual =
             get(working_diff, 'content.v', '') === get(patch, 'content.v', '');
 
-          if (!diffsAreEqual) {
-            // generate a patch that composes both the working changes and upstream changes
-            const newPatch = simperiumUtil.change.transform(
-              working_diff,
-              patch,
-              original
+          if (diffsAreEqual) {
+            return dispatch(
+              this.action('loadAndSelectNote', {
+                noteBucket,
+                noteId,
+                hasRemoteUpdate: true,
+              })
             );
-            // apply the new patch to the upstream data
-            let rebased = simperiumUtil.change.apply(newPatch, data);
-
-            // TODO: determine where the cursor is and put it in the correct place
-            // when applying the rebased content
-
-            state.note.data = rebased;
-
-            // update the bucket and sync
-            noteBucket.update(noteId, rebased);
           }
 
-          dispatch(
-            this.action('loadAndSelectNote', {
-              noteBucket,
-              noteId,
-              hasRemoteUpdate: true,
-            })
+          // generate a patch that composes both the working changes and upstream changes
+          const newPatch = simperiumUtil.change.transform(
+            working_diff,
+            patch,
+            original
+          );
+          // apply the new patch to the upstream data
+          const rebased = simperiumUtil.change.apply(newPatch, data);
+
+          // TODO: determine where the cursor is and put it in the correct place when applying the rebased content
+
+          // TODO: remove this direct state mutation - cause of data races with React components and note data
+          state.note.data = rebased;
+
+          // update the bucket and sync
+          noteBucket.update(noteId, rebased).then(() =>
+            dispatch(
+              this.action('loadAndSelectNote', {
+                noteBucket,
+                noteId,
+                hasRemoteUpdate: true,
+              })
+            )
           );
         };
       },

--- a/lib/simperium/bucket-store.js
+++ b/lib/simperium/bucket-store.js
@@ -38,26 +38,30 @@ class BucketStore {
       .catch(e => console.log('Failed', e)); // eslint-disable-line no-console
 
   get = (id, callback) =>
-    this.withBucket((db, bucket) => {
-      const req = db
-        .transaction(bucket)
-        .objectStore(bucket)
-        .get(id);
+    new Promise( ( resolve, reject ) => {
+        this.withBucket((db, bucket) => {
+            const req = db
+                .transaction(bucket)
+                .objectStore(bucket)
+                .get(id);
 
-      req.onsuccess = ({ target: { result } }) => callback(null, result);
-      req.onerror = e => callback(e);
-    });
+            req.onsuccess = ({target: {result}}) => callback ? callback(null, result) : resolve(result);
+            req.onerror = e => callback ? callback(e) : reject(e);
+        });
+    } );
 
   update = (id, data, isIndexing, callback) =>
-    this.withBucket((db, bucket) => {
-      const req = db
-        .transaction(bucket, 'readwrite')
-        .objectStore(bucket)
-        .put(this.beforeIndex({ id, data }));
+    new Promise( ( resolve, reject ) => {
+        this.withBucket((db, bucket) => {
+            const req = db
+                .transaction(bucket, 'readwrite')
+                .objectStore(bucket)
+                .put(this.beforeIndex({id, data}));
 
-      req.onsuccess = () => this.get(id, callback);
-      req.onerror = e => callback(e);
-    });
+            req.onsuccess = () => callback ? this.get(id, callback) : this.get(id).then(() => resolve(id));
+            req.onerror = e => callback ? callback(e) : reject(e);
+        });
+    } );
 
   remove = (id, callback) =>
     this.withBucket(


### PR DESCRIPTION
The `noteUpdateRemotely` action will attempt to update a note's contents
in the `noteBucket` if there are changes in the local copy that need to
rebase against updates from the remote server.

The code as written has made it appear as though this update occurs
before calling `loadAndSelectNote` but because of the asynchronous
behavior of the `noteBucket` the update occurs after that action is
dispatched. The `loadAndSelectNote` action further complicates things by
calling `noteBucket.get()` which is itself asynchronous and so ordering
of events is even more dubious.

In this change I'm rearranging some of the control flow and performing
an early-abort in the case where we have no rebasing to apply. This
should hopefully make it slightly clearer in what sequence the events
are occurring. This exists to clear up the code so we can more easily find
a source of data loss and/or synchronization issues and resolve them.

**Likely this will have no impact on the application**: the change is mostly
duplicating some code in a way which shouldn't actually change the
runtime operation.

**Testing**

Smoke testing should confirm that nothing major is broken.
Testing the actual changes are harder because the purpose here is
to track down data races and untangle them. Nonetheless, the code
in question runs when we receive external updates from Simperium.

Thus, to test we can try a few primary scenarios:
 - open a note and disconnect from the network
 - make changes to that note in another network-connected device
 - reconnect this version of the app and ensure that the update is received and applied
 - repeat, but make changes locally while offline that represent the same changes applied on the connected device
 - repeat, but make changes locally while offline that don't conflict with the remote updates
 - repeat, but make changes locally while offline that do conflict with the remote updates

In the following tests I'm using `AC` as a start version and adding `B` remotely and `D` locally where necessary.

| Change | Behavior in `develop` | Behavior in Branch |
|---|---|---|
| Remote change, no local changes | ✅ `ABC` | |
| Remote change, matching local change | ⭕️ crash - `ABBC` | |
| Remote change, non-conflicting local change | ⭕️ crash - `ACDD` | |
| Remote change, conflicting local change  | ⭕️ crash - `ADC` | |

In summary I guess this means that the changes in this branch do not introduce the errors; they are present in `develop` already.