### PR TITLE
Fix ESLint Errors

### DIFF
--- a/lib/boot.js
+++ b/lib/boot.js
@@ -219,12 +219,12 @@ let props = {
 };
 
 // If we sign in with a different username, ensure storage is reset
-const resetStorageIfAccountChanged = newAccountName => {
+function resetStorageIfAccountChanged(newAccountName) {
   const accountName = get(store.getState(), 'settings.accountName', '');
   if (accountName !== newAccountName) {
     client.reset();
   }
-};
+}
 
 // Set account email if app engine provided it
 if (cookie.email && config.is_app_engine) {

--- a/lib/dialogs/import/dropzone/index.jsx
+++ b/lib/dialogs/import/dropzone/index.jsx
@@ -17,6 +17,23 @@ function ImporterDropzone({
   const [acceptedFile, setAcceptedFile] = useState();
   const [errorMessage, setErrorMessage] = useState();
 
+  const handleAccept = acceptedFiles => {
+    const fileCount = acceptedFiles.length;
+    const label = fileCount > 1 ? `${fileCount} files` : acceptedFiles[0].name;
+    setAcceptedFile(label);
+    onAccept(acceptedFiles);
+  };
+
+  const handleReject = rejectedFiles => {
+    if (!multiple && rejectedFiles.length > 1) {
+      setErrorMessage('Choose a single file');
+    } else {
+      setErrorMessage('File type is incorrect');
+    }
+    setAcceptedFile(undefined);
+    onReset();
+  };
+
   const onDrop = useCallback((acceptedFiles, rejectedFiles) => {
     if (acceptedFiles.length === 0) {
       handleReject(rejectedFiles);
@@ -32,13 +49,6 @@ function ImporterDropzone({
     onDrop,
   });
 
-  const handleAccept = acceptedFiles => {
-    const fileCount = acceptedFiles.length;
-    const label = fileCount > 1 ? `${fileCount} files` : acceptedFiles[0].name;
-    setAcceptedFile(label);
-    onAccept(acceptedFiles);
-  };
-
   useEffect(() => {
     if (!errorMessage) {
       return;
@@ -46,16 +56,6 @@ function ImporterDropzone({
     const timer = setTimeout(() => setErrorMessage(undefined), 2500);
     return () => clearTimeout(timer);
   }, [errorMessage]);
-
-  const handleReject = rejectedFiles => {
-    if (!multiple && rejectedFiles.length > 1) {
-      setErrorMessage('Choose a single file');
-    } else {
-      setErrorMessage('File type is incorrect');
-    }
-    setAcceptedFile(undefined);
-    onReset();
-  };
 
   const text = errorMessage ? errorMessage : 'Drag a file, or click to choose';
 

--- a/lib/simperium/bucket-store.js
+++ b/lib/simperium/bucket-store.js
@@ -1,31 +1,4 @@
-class StoreProvider {
-  constructor(config) {
-    this.setup = new Promise((resolve, reject) => config(resolve, reject));
-  }
-
-  provider = () => bucket => new BucketStore(bucket, this.setup);
-
-  reset = () =>
-    this.setup
-      .then(db =>
-        Promise.all(
-          Array.prototype.map.call(
-            db.objectStoreNames,
-            name =>
-              new Promise((resolve, reject) => {
-                const tx = db.transaction(name, 'readwrite');
-                const request = tx.objectStore(name).clear();
-
-                request.onsuccess = () => resolve(name);
-                request.onerror = e => reject(e);
-              })
-          )
-        )
-      )
-      .catch(e => console.error('Failed to reset stores', e)); // eslint-disable-line no-console
-}
-
-class BucketStore {
+export class BucketStore {
   constructor(bucket, setup) {
     this.bucket = bucket;
     this.setup = setup;
@@ -85,5 +58,3 @@ class BucketStore {
       request.onerror = e => callback(e);
     });
 }
-
-export default config => new StoreProvider(config);

--- a/lib/simperium/index.js
+++ b/lib/simperium/index.js
@@ -1,5 +1,5 @@
 import simperium, { Client } from 'simperium';
-import bucket_store from './bucket-store';
+import store_provider from './store-provider';
 import ghost_store from './ghost-store';
 import localQueueStore from './local-queue-store';
 import util from 'util';
@@ -27,7 +27,7 @@ function BrowserClient({ appID, token, bucketConfig, database, version }) {
   this.databaseName = database || 'simperium-objects';
   this.databaseVersion = version || 1;
   let config = (this.bucketConfig = bucketConfig);
-  this.bucketDB = bucket_store(this.configureDb.bind(this));
+  this.bucketDB = store_provider(this.configureDb.bind(this));
   this.buckets = {};
 
   let objectStoreProvider = this.bucketDB.provider();

--- a/lib/simperium/local-queue-store.js
+++ b/lib/simperium/local-queue-store.js
@@ -32,8 +32,13 @@ function restoreTo(bucket) {
   );
 }
 
-export const getKey = bucket => `localQueue:${bucket.name}`;
-export const getLocalQueue = bucket => bucket.channel.localQueue;
+export function getKey(bucket) {
+  return `localQueue:${bucket.name}`;
+}
+
+export function getLocalQueue(bucket) {
+  return bucket.channel.localQueue;
+}
 
 const localQueueStore = { persist, restoreTo };
 

--- a/lib/simperium/store-provider.js
+++ b/lib/simperium/store-provider.js
@@ -1,0 +1,30 @@
+import BucketStore from './bucket-store';
+
+export class StoreProvider {
+  constructor(config) {
+    this.setup = new Promise((resolve, reject) => config(resolve, reject));
+  }
+
+  provider = () => bucket => new BucketStore(bucket, this.setup);
+
+  reset = () =>
+    this.setup
+      .then(db =>
+        Promise.all(
+          Array.prototype.map.call(
+            db.objectStoreNames,
+            name =>
+              new Promise((resolve, reject) => {
+                const tx = db.transaction(name, 'readwrite');
+                const request = tx.objectStore(name).clear();
+
+                request.onsuccess = () => resolve(name);
+                request.onerror = e => reject(e);
+              })
+          )
+        )
+      )
+      .catch(e => console.error('Failed to reset stores', e)); // eslint-disable-line no-console
+}
+
+export default config => new StoreProvider(config);

--- a/lib/simperium/store-provider.js
+++ b/lib/simperium/store-provider.js
@@ -1,4 +1,4 @@
-import BucketStore from './bucket-store';
+import { BucketStore } from './bucket-store';
 
 export class StoreProvider {
   constructor(config) {

--- a/lib/utils/import/simplenote/index.js
+++ b/lib/utils/import/simplenote/index.js
@@ -61,7 +61,7 @@ class SimplenoteImporter extends EventEmitter {
   };
 }
 
-export const convertModificationDates = notes => {
+export function convertModificationDates(notes) {
   return notes.map(({ lastModified, ...note }) => {
     // Account for Simplenote's exported `lastModified` date
     let modificationDate = note.modificationDate || lastModified;
@@ -76,6 +76,6 @@ export const convertModificationDates = notes => {
     }
     return resultNote;
   });
-};
+}
 
 export default SimplenoteImporter;

--- a/lib/utils/note-utils.js
+++ b/lib/utils/note-utils.js
@@ -69,9 +69,9 @@ export const noteTitleAndPreview = note => {
   return { title, preview };
 };
 
-export const isMarkdown = note => {
+export function isMarkdown(note) {
   return note && note.data && note.data.systemTags.includes('markdown');
-};
+}
 
 /**
  * Clean the text so it is ready to be sorted alphabetically.

--- a/lib/utils/sync/nudge-unsynced.js
+++ b/lib/utils/sync/nudge-unsynced.js
@@ -29,7 +29,7 @@ const nudgeUnsynced = ({ noteBucket, notes, client }) => {
   });
 };
 
-const updateUnsyncedNotes = ({ noteBucket, notes }) => {
+function updateUnsyncedNotes({ noteBucket, notes }) {
   const noteHasSynced = note =>
     new Promise(resolve =>
       noteBucket.getVersion(note.id, (e, v) => {
@@ -48,6 +48,6 @@ const updateUnsyncedNotes = ({ noteBucket, notes }) => {
     debug(`${unsyncedNotes.length} unsynced notes`);
     unsyncedNotes.forEach(note => noteBucket.update(note.id, note.data));
   });
-};
+}
 
 export default nudgeUnsynced;


### PR DESCRIPTION
### Fix

- Fixes all ES Lint errors that exist in master, they were all `no-use-before-define`

Generally using the arrow function syntax is more concise, however it means the functions are defined as constants which means they aren't hoisted in the runtime, therefore we get a `no-use-before-define`.

In each case the arrow functions that caused this problem could be changed to boring old `functions`.

The one other case was use of the `BucketStore` constructor before the class definition. The `StoreProvider` and `BucketStore` have been split into their own modules and the import order has been fixed.

### Test

1. `make run`
2. If you can edit and sync a note all codepaths in this change have been executed.

To test the dropzone change

1. Open simplenote
2. Go to settings -> tools -> import -> plain text files
3. Drop a `.txt` file in the dropzone
4. You should see a new note

### Review

There should be no noticeable changes to the application.

### Release

These changes do not require release notes.
