### PR TITLE
Fix: Stop rebasing updates after they come in

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -396,8 +396,8 @@ export const actionMap = new ActionMap({
     noteUpdatedRemotely: {
       creator({ noteBucket, noteId, data, remoteUpdateInfo = {} }) {
         return (dispatch, getState) => {
-          var state = getState().appState;
-          const { original, patch } = remoteUpdateInfo;
+          const state = getState().appState;
+          const { patch } = remoteUpdateInfo;
 
           debug('noteUpdatedRemotely: %O', data);
 
@@ -405,41 +405,7 @@ export const actionMap = new ActionMap({
             return;
           }
 
-          // working is the state of the note in the editor
-          const note = state.notes.find(n => n.id === noteId);
-
-          if (!note) {
-            console.error(`Cannot find note (id=${noteId})!`); // eslint-disable-line no-console
-            return;
-          }
-
-          let working = note.data;
-
-          // diff of working and original will produce the modifications the client has currently made
-          let working_diff = simperiumUtil.change.diff(original, working);
-
-          // Check for equal diffs so we don't duplicate changes
-          const diffsAreEqual =
-            get(working_diff, 'content.v', '') === get(patch, 'content.v', '');
-
-          if (!diffsAreEqual) {
-            // generate a patch that composes both the working changes and upstream changes
-            const newPatch = simperiumUtil.change.transform(
-              working_diff,
-              patch,
-              original
-            );
-            // apply the new patch to the upstream data
-            let rebased = simperiumUtil.change.apply(newPatch, data);
-
-            // TODO: determine where the cursor is and put it in the correct place
-            // when applying the rebased content
-
-            state.note.data = rebased;
-
-            // update the bucket and sync
-            noteBucket.update(noteId, rebased);
-          }
+          state.note.data = data;
 
           dispatch(
             this.action('loadAndSelectNote', {


### PR DESCRIPTION
See #1579, #1598
See Simperium/node-simperium#78
See Simperium/node-simperium#61

When we receive an update from a remote client we have been listening
for it and adjusting our local app state to account for that change.
Unfortunately in cases where we also have local or pending changes we
have been erroneously transforming or _rebasing_ the change before
applying it. The underlying `node-simperium` library has already
performd that transform, however, and when the client application
does that too it leads to double-writes and misapplied patches,
producing note corruption.

In this change we're stopping the rebase operation we have been
performing and that will remove this particular bug from the
application. This change does not solve all of the problem however
because we also have to make sure that the `node-simperium` library is
aware of our local state when it receives those updates.

Further work is taking place in Simperium/node-simperium#61 and #1598 to
close the loop on that but these changes are important enough on their
own to warrant a change.

This will close one bug while opening another but this is a dependent
part of the process in closing the broader issue.

**Testing**

This is going to be hard to test. It would be good to document the before/after
bugs and I will try to do that after I get back to where I have two computers on
which to test.

We're expecting bugs when we are crossing paths between local and remote
updates: that involves a couple of stages of "queues." One queue is text in the
editor component, another is the debounced-update from the same, another is
the local queue in `node-simperium`, and the final (major) queue is the "wait"
queue in `node-simperium`.