### PR TITLE
Fix spacing on markdown nested lists

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - Open new note automatically upon creation
 - Open new note automatically upon creation [1566](https://github.com/Automattic/simplenote-electron/issues/1566)
 - Updated colors to use Color Studio, the color palette for Automattic products
+- Fixes vertical spacing with nested markdown lists
 
 ## [v1.7.0](https://github.com/Automattic/simplenote-electron/releases/tag/v1.7.0) (2019-08-12)
 

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -17,7 +17,7 @@
   display: flex;
   flex-direction: row;
   justify-content: center;
-  transition: all .3s ease-in-out;
+  transition: all 0.3s ease-in-out;
 
   &.is-viewing-revisions {
     padding-top: 51px;
@@ -38,7 +38,7 @@
   .logo {
     width: 140px;
     height: 140px;
-    opacity: .2;
+    opacity: 0.2;
 
     path {
       fill: $studio-gray-50;
@@ -70,7 +70,6 @@
 }
 
 .is-line-length-full {
-
   .note-detail-textarea,
   .note-detail-markdown {
     max-width: none;
@@ -97,6 +96,10 @@
 
   p {
     margin: 0 0 1.5em;
+  }
+
+  ul p {
+    margin: 0;
   }
 
   a {
@@ -163,13 +166,13 @@
     // there will be a slight delay until the checkbox actually toggles
     &:active {
       input {
-        transform: scale(.9);
+        transform: scale(0.9);
       }
     }
 
     input {
       position: relative;
-      bottom: .0625em;
+      bottom: 0.0625em;
       margin-right: 4px;
       height: 1em;
       vertical-align: middle;


### PR DESCRIPTION
### Fix
When you have a nested Markdown list the spacing is incorrect. This fixes that issue. The issue occurs when an item is rendered inside a paragraph tag.

Prettier also caused a bunch of other changes.

Here is a test markdown snippet:
```
* Fruit
  * Apple
  * Orange
  * Banana
* Dairy
  * Milk
  * Cheese
```

### Test
1. Add snippet from above to a note with markdown
2. Observe note on prod
3. Observe note on this branch
4. There should not be extra space in the lists.

After:
<img width="196" alt="Screen Shot 2019-09-30 at 11 56 57 AM" src="https://user-images.githubusercontent.com/6817400/65896485-54851080-e37b-11e9-8dc0-cfc5782946f2.png">

Before:
<img width="160" alt="Screen Shot 2019-09-30 at 11 57 44 AM" src="https://user-images.githubusercontent.com/6817400/65896486-54851080-e37b-11e9-868b-7868e751d265.png">

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Fixes vertical spacing with nested markdown lists