### PR TITLE
Refactor `pinNote` to stop directly mutating note object

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -291,21 +291,27 @@ export const actionMap = new ActionMap({
     },
 
     pinNote: {
-      creator({ noteBucket, note, pin }) {
-        return dispatch => {
-          let systemTags = note.data.systemTags || [];
-          let pinnedTagIndex = systemTags.indexOf('pinned');
+      creator({ noteBucket, note, pin: shouldPin }) {
+        const { systemTags = [] } = note.data;
+        const isAlreadyPinned = systemTags.includes('pinned');
 
-          if (pin && pinnedTagIndex === -1) {
-            note.data.systemTags.push('pinned');
-            noteBucket.update(note.id, note.data);
-            dispatch(this.action('selectNote', { note }));
-          } else if (!pin && pinnedTagIndex !== -1) {
-            note.data.systemTags = systemTags.filter(tag => tag !== 'pinned');
-            noteBucket.update(note.id, note.data);
-            dispatch(this.action('selectNote', { note }));
-          }
+        if (shouldPin === isAlreadyPinned) {
+          return this.action('selectNote', { note });
+        }
+
+        const updatedNote = {
+          ...note,
+          data: {
+            ...note.data,
+            systemTags: shouldPin
+              ? [...systemTags, 'pinned']
+              : systemTags.filter(tag => tag !== 'pinned'),
+          },
         };
+
+        noteBucket.update(note.id, updatedNote.data);
+
+        return this.action('selectNote', { note: updatedNote });
       },
     },
 

--- a/lib/note-info/index.jsx
+++ b/lib/note-info/index.jsx
@@ -153,10 +153,10 @@ export class NoteInfo extends Component {
   }
 
   onPinChanged = event =>
-    this.props.onPinNote(this.props.note, event.currentTarget.checked);
+    this.props.onPinNote(this.props.note, !!event.currentTarget.checked);
 
   onMarkdownChanged = event =>
-    this.props.onMarkdownNote(this.props.note, event.currentTarget.checked);
+    this.props.onMarkdownNote(this.props.note, !!event.currentTarget.checked);
 }
 
 function formatTimestamp(unixTime) {


### PR DESCRIPTION
See #1614 

As part of a broader effort to resolve data-flow issues in the app this PR is a
first step in removing direct mutation where transactional atomic updates
should be occurring.

It's not clear if the existing code is the source of existing defects in the software
and this is part of why the code is problematic; we have created inherent
concurrency flaws that open up extremely-difficult-to-reproduce bugs.

Resolving this may or may not resolve any existing bugs but it will definitely
help guard us from introducing new ones.

---

Previously we have been directly mutating the `note` object in the
action creator when toggling a note's pinned status.

This mutation can lead to concurrency defects which expose themselves as
inconsistent UI state. This breaks our Redux model which assumes that
all UI updates happen atomically.

In this patch we're building a new `note` object when toggling the
pinned status in order to maintain our consistency.

At the same time I have removed the thunk from the action creator since
it wasn't doing anything and didn't need to exist. This shouldn't have
a noticeable impact on the application.

**Testing**
The goal of this PR is to refactor code without changing behaviors, so if we
notice any behavioral changes that will be problematic.

We're affecting pinning and unpinning, so build the app at this branch and
attempt to pin and unpin notes and make sure the app updates properly in
response to that.