### PR TITLE
Login screen: Replace hardcoded CSS colors with Color Studio as per design guidelines

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,9 @@
 ### Enhancements
 
 - Open new note automatically upon creation [1582](https://github.com/Automattic/simplenote-electron/pull/1582)
-- Updated colors to use Color Studio, the color palette for Automattic products [#1565](https://github.com/Automattic/simplenote-electron/pull/1565)
+- Updated colors to use Color Studio, the color palette for Automattic products
+   - [#1565](https://github.com/Automattic/simplenote-electron/pull/1565)
+   - [#1612](https://github.com/Automattic/simplenote-electron/pull/1612)
 
 ### Fixes
 

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -105,7 +105,7 @@
   }
 
   .wpcc-button {
-    background-color: $studio-blue-50;
+    background-color: $studio-wordpress-blue-50;
     border-radius: 4px;
     box-sizing: border-box;
     color: $studio-white;

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -23,7 +23,7 @@
   }
 
   .login__auth-message.is-error {
-    color: #be2a31;
+    color: $studio-red-60;
     font-size: 16px;
     margin: 0 auto 16px;
     max-width: 347px;
@@ -37,8 +37,8 @@
 
   input,
   button[type='submit'] {
-    background-color: #ffffff;
-    border: solid 1px #e3e0e2;
+    background-color: $studio-white;
+    border: solid 1px $studio-gray-5;
     border-radius: 4px;
     box-sizing: border-box;
     display: block;
@@ -52,21 +52,21 @@
   }
 
   button[type='submit'] {
-    background-color: #3584c8;
+    background-color: $studio-blue-50;
     border: none;
-    color: #ffffff;
+    color: $studio-white;
     font-weight: 500;
     margin: 16px auto 8px;
     padding: 0px 15px 2px;
   }
 
   a.login__forgot {
-    color: #135d95;
+    color: $studio-gray-60;
     text-decoration: none;
   }
 
   .login__forgot, .login__signup, .terms {
-    color: #51565f;
+    color: $studio-gray-60;
     display: block;
     font-size: 14px;
     margin: 16px auto;
@@ -75,14 +75,14 @@
   }
 
   .login__signup a, .terms a {
-    color: #135d95;
+    color: $studio-blue-60;
     margin-left: 5px;
     text-decoration: none;
   }
 
   .or {
-    background: #ffffff;
-    color: #6f7780;
+    background: $studio-white;
+    color: $studio-gray-60;
     display: block;
     font-size: 15px;
     font-style: italic;
@@ -95,7 +95,7 @@
   }
 
   .or-line {
-    border-bottom: 1px solid #dbdee0;
+    border-bottom: 1px solid $studio-gray-5;
     margin: -20px auto;
     max-width: 320px;
     text-align: center;
@@ -105,10 +105,10 @@
   }
 
   .wpcc-button {
-    background-color: #006088;
+    background-color: $studio-blue-50;
     border-radius: 4px;
     box-sizing: border-box;
-    color: #ffffff;
+    color: $studio-white;
     display: block;
     font-size: 16px;
     font-weight: 500;
@@ -123,7 +123,30 @@
 }
 
 .theme-dark .login {
+  h1 {
+    color: $studio-white;
+  }
+  a.login__forgot {
+    color: $studio-gray-20;
+  }
+
+  .login__forgot, .login__signup, .terms {
+    color: $studio-gray-20;
+  }
+
+  .login__signup a, .terms a {
+    color: $studio-blue-20;
+  }
+
+  .login__auth-message.is-error {
+    color: $studio-red-20;
+  }
+
   .or {
-    background: #1e1e1e;
+    background: $studio-gray-90;
+    color: $studio-gray-20;
+  }
+  .or-line {
+    border-color: $studio-gray-80;
   }
 }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -42,23 +42,6 @@
     border-color: $studio-gray-80;
   }
 
-  .search-field {
-    border-color: $studio-gray-60;
-
-    ::-moz-placeholder { /* Firefox 19+ */
-      color: $studio-gray-30;
-    }
-    ::webkit-input-placeholder { /* IE 10+ */
-      color: $studio-gray-30;
-    }
-    :-ms-input-placeholder { /* IE 10+ */
-      color: $studio-gray-30;
-    }
-    :-moz-placeholder { /* Firefox 18- */
-      color: $studio-gray-30;
-    }
-  }
-
   ::-webkit-scrollbar-thumb {
     background-color: $studio-gray-80;
     border-color: $studio-gray-60;
@@ -79,14 +62,18 @@
     }
   }
 
+  input {
+    color: $studio-white;
+  }
+
   input,
   textarea {
     border-color: $studio-gray-70;
     background-color: transparent;
   }
 
-  .transparent-input::placeholder {
-    color: $studio-gray-80;
+  .transparent-input::placeholder, input::placeholder {
+    color: $studio-gray-20;
   }
 
   .checkbox-control-base {
@@ -129,7 +116,7 @@
     }
 
     .note-list-item-excerpt {
-      color: white;
+      color: $studio-gray-20;
     }
   }
   &.note-list-item-selected .note-list-item-excerpt .note-list-item-pinner {


### PR DESCRIPTION
The auth screen colors were mostly defined as pure CSS. This PR replaces them with Color Studio colors as per the design guidelines.

The changes are most drastic in dark mode.

### Screenshots

**Light Mode Before:**

<img width="542" alt="Screen Shot 2019-10-01 at 7 01 42 PM" src="https://user-images.githubusercontent.com/52152/66013133-dd38a500-e47e-11e9-8595-7924dd86672e.png">

<img width="469" alt="Screen Shot 2019-10-01 at 7 01 46 PM" src="https://user-images.githubusercontent.com/52152/66013141-e9bcfd80-e47e-11e9-8176-3501f03ec7ee.png">

**Light Mode After:**

<img width="463" alt="Screen Shot 2019-10-01 at 7 03 44 PM" src="https://user-images.githubusercontent.com/52152/66013148-f3466580-e47e-11e9-8aa6-11938eed2897.png">
    
<img width="475" alt="Screen Shot 2019-10-01 at 7 03 41 PM" src="https://user-images.githubusercontent.com/52152/66013163-02c5ae80-e47f-11e9-8f2f-1089160135be.png">


**Dark Mode Before:**

<img width="503" alt="Screen Shot 2019-10-01 at 7 01 54 PM" src="https://user-images.githubusercontent.com/52152/66013168-09542600-e47f-11e9-8ad0-dfc939525619.png">

  
<img width="473" alt="Screen Shot 2019-10-01 at 7 02 01 PM" src="https://user-images.githubusercontent.com/52152/66013173-0eb17080-e47f-11e9-9272-a8ef4e0b5769.png">

**Dark Mode After:**

    
<img width="437" alt="Screen Shot 2019-10-01 at 7 03 57 PM" src="https://user-images.githubusercontent.com/52152/66013181-16711500-e47f-11e9-8c4b-b85194571404.png">
    
<img width="480" alt="Screen Shot 2019-10-01 at 7 03 53 PM" src="https://user-images.githubusercontent.com/52152/66013187-1bce5f80-e47f-11e9-9a0d-19dd75ccdbf4.png">




### Test
> Build the Electron app and view its login/sign up screen.

### Release

> `RELEASE-NOTES.txt` was updated in 7b57bc6e1349ab0fcca3d464ae0c963c9b8e914f with a link to this PR.

