### PR TITLE
Refactor `trashNote` to stop directly mutating note object

### DIFF
--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -463,14 +463,11 @@ export const actionMap = new ActionMap({
 
     trashNote: {
       creator({ noteBucket, note, previousIndex }) {
-        return dispatch => {
-          if (note) {
-            note.data.deleted = true;
-            noteBucket.update(note.id, note.data);
+        if (note) {
+          noteBucket.update(note.id, { ...note.data, deleted: true });
+        }
 
-            dispatch(this.action('closeNote', { previousIndex }));
-          }
-        };
+        return this.action('closeNote', { previousIndex });
       },
     },
 


### PR DESCRIPTION
See #1614 

As part of a broader effort to resolve data-flow issues in the app this PR is a
first step in removing direct mutation where transactional atomic updates
should be occurring.

It's not clear if the existing code is the source of existing defects in the software
and this is part of why the code is problematic; we have created inherent
concurrency flaws that open up extremely-difficult-to-reproduce bugs.

Resolving this may or may not resolve any existing bugs but it will definitely
help guard us from introducing new ones.

---

Previously we have been directly mutating the note object in the
action creator when trashing a note.

This mutation can lead to concurrency defects which expose themselves as
inconsistent UI state. This breaks our Redux model which assumes that
all UI updates happen atomically.

In this patch we're building a new note object when trashing a note in
order to maintain our consistency.

At the same time I have removed the thunk from the action creator since
it wasn't doing anything and didn't need to exist. This shouldn't have
a noticeable impact on the application.

**Testing**

The goal of this PR is to refactor code without changing behaviors, so if we
notice any behavioral changes that will be problematic.

We're affecting note trashing, so build the app at this branch and attempt
to trash and untruth a note and make sure the app updates properly in
response to that.