### PR TITLE
Fix: Broken oAuth flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,11 @@
 # Changelog
 
+## Future release
+
+### Fixes
+
+ - Rework WordPress.com signin to prevent infinite looping and login failures [#1627](https://github.com/Automattic/simplenote-electron/pull/1627)
+
 ## [v1.9.0]
 
 ### Enhancements


### PR DESCRIPTION
Resolves #1229 

We have been experiencing problems when trying to login with the
WordPress.com signin. Something appears to have changed in Electron such
that the older versions of the app still work but newer versions are
failing.

In this patch we're rewriting the authentication flow to simplify it and
prepare ourselves for better handling of the failure cases.

In production we are seeing strange behaviors on failure and some on
success: unending re-requests to `simplenote://auth` which trigger full
CPU load; and no response after authentication.

After this patch we should be able to wrangle in errors and add a
timeout to better communicate when things are failing.

Additionally, the unending loop should be closed due to a replacement of
the old network intercept code with a single simplified model.

---

## Testing

This feature isn't currently working on the `history-analyst-dad` application
configured by default in this repository. In order to test the app you'll have to
build it with a custom `config-local.json` including the details to connect to
the actual production Simplenote system.

 - Logged in with my normal WordPress.com account ✅
 - Created a new WordPress.com account but didn't verify my email address, tried to login here and it failed, responding with a message indicating as much. ✅


 - Logging in to WordPress.com with a non-production app (`history-analyst-dad`) successfully authenticates via oAuth and returns my production-app Simperium token, but that fails when logging in but there's no message. ⭕️ (This is probably best scoped for a separate update as this has been the case before this PR existed and it's not a customer-facing issue, mostly for devs)