### PR TITLE
Refactor tag operations to stop directly mutating tag objects

### DIFF
--- a/lib/state/domain/tags.js
+++ b/lib/state/domain/tags.js
@@ -28,54 +28,47 @@ export const createTag = ({ name }) => {
   tagBucket().update(tagId, { name });
 };
 
-export const reorderTags = ({ tags }) => () => {
-  for (let i = 0; i < tags.length; i++) {
-    let tag = tags[i];
-    tag.data.index = i;
-    tagBucket().update(tag.id, tag.data);
-  }
-};
+export const reorderTags = ({ tags }) => () =>
+  tags.forEach((tag, index) =>
+    tagBucket().update(tag.id, { ...tag.data, index })
+  );
 
-export const renameTag = ({ tag, name }) => (dispatch, getState) => {
-  let oldTagName = tag.data.name;
-  if (oldTagName === name) {
+export const renameTag = ({ tag, name: newName }) => (dispatch, getState) => {
+  const { notes } = getState().appState;
+  const tagName = tag.data.name;
+
+  if (tagName === newName) {
     return;
   }
 
-  let { notes } = getState().appState;
+  tagBucket().update(tag.id, { ...tag.data, name: newName });
 
-  tag.data.name = name;
-
-  tagBucket().update(tag.id, tag.data);
-
-  // Replace tags in notes
-  for (let i = 0; i < notes.length; i++) {
-    let note = notes[i];
-    let noteTags = note.data.tags || [];
-    let tagIndex = noteTags.indexOf(oldTagName);
-
-    if (tagIndex !== -1) {
-      noteTags.splice(tagIndex, 1, name);
-      note.data.tags = noteTags.filter(noteTag => noteTag !== oldTagName);
-      noteBucket().update(note.id, note.data);
-    }
-  }
+  notes
+    .filter(({ data: { tags } }) => (tags || []).includes(tagName))
+    .map(note => ({
+      ...note,
+      data: {
+        ...note.data,
+        tags: note.data.tags.map(tag => (tag === tagName ? name : tag)),
+      },
+    }))
+    .forEach(note => noteBucket().update(note.id, note.data));
 };
 
 export const trashTag = ({ tag }) => (dispatch, getState) => {
-  var { notes } = getState().appState;
-  var tagName = tag.data.name;
+  const { notes } = getState().appState;
+  const tagName = tag.data.name;
 
-  for (let i = 0; i < notes.length; i++) {
-    let note = notes[i];
-    let noteTags = note.data.tags || [];
-    let newTags = noteTags.filter(noteTag => noteTag !== tagName);
-
-    if (newTags.length !== noteTags.length) {
-      note.data.tags = newTags;
-      noteBucket().update(note.id, note.data);
-    }
-  }
+  notes
+    .filter(({ data: { tags } }) => (tags || []).includes(tagName))
+    .map(note => ({
+      ...note,
+      data: {
+        ...note.data,
+        tags: note.data.tags.filter(tag => tag !== tagName),
+      },
+    }))
+    .forEach(note => noteBucket().update(note.id, note.data));
 
   tagBucket().remove(tag.id, () => dispatch(loadTags()));
 };


### PR DESCRIPTION
See #1614

As part of a broader effort to resolve data-flow issues in the app this PR is a
first step in removing direct mutation where transactional atomic updates
should be occurring.

It's not clear if the existing code is the source of existing defects in the software
and this is part of why the code is problematic; we have created inherent
concurrency flaws that open up extremely-difficult-to-reproduce bugs.

Resolving this may or may not resolve any existing bugs but it will definitely
help guard us from introducing new ones.

---

Previously we have been directly mutating note and tag objects when
editing those tags. This mutation can lead to concurrency defects which
expose themselves as inconsistent UI state. This breaks our Redux model
which assumes that all UI updates happen atomically.

In this patch we're building new note objects and tag objects when we
make these updates in order to maintain our consistency.

---

There should be no significant visual or behavioral changes with this PR. We
are changing code related to removing tags, renaming tags, and
reordering tags.

In testing verify that with separate sessions the updates appear as expected.
Add, reorder, and remove tags to make sure the changes synchronize.