### PR TITLE
[WIP] Search: Add dropdown with search suggestions

### DIFF
--- a/lib/icons/tag.jsx
+++ b/lib/icons/tag.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
 
-// TODO we need a single tag icon
 export default function TagIcon() {
   return (
     <svg
       className="icon-tag"
       xmlns="http://www.w3.org/2000/svg"
-      width="22"
-      height="22"
-      viewBox="0 0 22 22"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
     >
-      <path d="M20 5v5.172l-7 7L7.828 12l7-7H20m2-2h-8l-9 9 8 8 9-9V3zM3.763 13.237L2.525 12l1.237-1.237L11.525 3H9l-9 9 8 8 1.263-1.263-5.5-5.5zM17.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z" />
+      <rect x="0" fill="none" width="24" height="24" />
+      <path d="M18.29,5.71v5.17l-7,7L6.12,12.71l7-7h5.17m2-2h-8L4,12a1,1,0,0,0,0,1.41L10.59,20A1,1,0,0,0,12,20l8.29-8.29v-8Zm-4.5,5.5a1,1,0,1,0-1-1A1,1,0,0,0,15.79,9.21Z" />
     </svg>
   );
 }

--- a/lib/icons/tag.jsx
+++ b/lib/icons/tag.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+// TODO we need a single tag icon
+export default function TagIcon() {
+  return (
+    <svg
+      className="icon-tag"
+      xmlns="http://www.w3.org/2000/svg"
+      width="22"
+      height="22"
+      viewBox="0 0 22 22"
+    >
+      <path d="M20 5v5.172l-7 7L7.828 12l7-7H20m2-2h-8l-9 9 8 8 9-9V3zM3.763 13.237L2.525 12l1.237-1.237L11.525 3H9l-9 9 8 8 1.263-1.263-5.5-5.5zM17.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z" />
+    </svg>
+  );
+}

--- a/lib/search-field/style.scss
+++ b/lib/search-field/style.scss
@@ -1,5 +1,6 @@
 .search-field {
   display: flex;
+  position: relative;
   flex-direction: row;
   align-items: center;
   width: 100%;

--- a/lib/search-suggestions/index.jsx
+++ b/lib/search-suggestions/index.jsx
@@ -24,16 +24,20 @@ export class SearchSuggestions extends Component {
           <SmallSearchIcon />
           {query}
         </div>
-        {tags.map(tag => (
-          <div
-            key={tag.id}
-            className="search-suggestion-row"
-            onClick={() => onSearch(`tag:${tag.id}`)}
-          >
-            <TagIcon />
-            {tag.id}
-          </div>
-        ))}
+        {tags
+          .filter(function(tag) {
+            return tag.id.includes(query);
+          })
+          .map(tag => (
+            <div
+              key={tag.id}
+              className="search-suggestion-row"
+              onClick={() => onSearch(`tag:${tag.id}`)}
+            >
+              <TagIcon />
+              {tag.id}
+            </div>
+          ))}
       </div>
     );
   }

--- a/lib/search-suggestions/index.jsx
+++ b/lib/search-suggestions/index.jsx
@@ -1,0 +1,49 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import SmallSearchIcon from '../icons/search-small';
+import TagIcon from '../icons/tag';
+
+export class SearchSuggestions extends Component {
+  static displayName = 'SearchSuggestions';
+
+  static propTypes = {
+    onSearch: PropTypes.func.isRequired,
+    query: PropTypes.string.isRequired,
+    tags: PropTypes.array.isRequired,
+  };
+
+  render() {
+    const { query, onSearch, tags } = this.props;
+    // const screenReaderLabel =
+    //   'Search ' + (isTagSelected ? 'notes with tag ' : '') + placeholder;
+
+    return (
+      <div className="search-suggestions">
+        <div className="search-suggestion-row" onClick={() => onSearch(query)}>
+          <SmallSearchIcon />
+          {query}
+        </div>
+        {tags.map(tag => (
+          <div
+            key={tag.id}
+            className="search-suggestion-row"
+            onClick={() => onSearch(`tag:${tag.id}`)}
+          >
+            <TagIcon />
+            {tag.id}
+          </div>
+        ))}
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = ({ appState: state }) => ({
+  tags: state.tags,
+});
+
+export default connect(
+  mapStateToProps,
+  null
+)(SearchSuggestions);

--- a/lib/search-suggestions/style.scss
+++ b/lib/search-suggestions/style.scss
@@ -1,0 +1,25 @@
+.search-suggestions {
+  /* interim styles */
+  position: absolute;
+  top: 32px;
+  left: 0;
+  z-index: 10;
+  background: $studio-white;
+  width: 100%;
+  border-radius: 5px;
+  border: 1px solid $studio-gray-10;
+
+  .search-suggestion-row {
+    cursor: pointer;
+
+    &:hover {
+      background: $studio-blue-5;
+    }
+  }
+
+  .icon-search-small, .icon-tag {
+    transition: $anim-transition;
+    fill: $studio-gray-50;
+    width: 28px;
+  }
+}

--- a/lib/search-suggestions/style.scss
+++ b/lib/search-suggestions/style.scss
@@ -20,6 +20,6 @@
   .icon-search-small, .icon-tag {
     transition: $anim-transition;
     fill: $studio-gray-50;
-    width: 28px;
+    width: 24px;
   }
 }

--- a/scss/_components.scss
+++ b/scss/_components.scss
@@ -36,6 +36,7 @@
 @import 'revision-selector/style';
 @import 'search-bar/style';
 @import 'search-field/style';
+@import 'search-suggestions/style';
 @import 'tag-email-tooltip/style';
 @import 'tag-field/style';
 @import 'tag-input/style';


### PR DESCRIPTION
### Fix
This PR removes the "filter as you type" behavior from the search box in favor of a dropdown suggestion list that includes matching tags.

The first suggestion in the dropdown preserves the existing search behavior and can also be accessed by pressing "enter" on the search field.

Clicking a suggested tag fills in the search field with the `tag:` syntax.

I removed the debounce from searching since it no longer searches as you type, but we'll probably need to add it back to the tag suggestions.

Todo:
* ~Filter tag suggestions for those that match search string~
* Make tag suggestion search a littttttle less broad probably (e.g. don't search in the middle of words)
* Debounce tag searching / performance test overall
* A11y (screen reader labels and keyboard navigation)
* Clean up styles for the suggestion popup

Fixes #1624

### Test
TBD

### Review
TBD

### Release
> TBD - `RELEASE-NOTES.txt` will be updated with:
> 
> > Added suggested tags to the search field