### PR TITLE
Show Notes Loading not No Notes when notes are loading

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - Updated colors to use Color Studio, the color palette for Automattic products
    - [#1565](https://github.com/Automattic/simplenote-electron/pull/1565)
    - [#1612](https://github.com/Automattic/simplenote-electron/pull/1612)
+- Display a notice that notes are loading when notes are loading
 
 ### Fixes
 

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -39,6 +39,7 @@ export const actionMap = new ActionMap({
     revision: null,
     showTrash: false,
     listTitle: 'All Notes',
+    notesLoaded: false,
     showNavigation: false,
     showNoteInfo: false,
     isViewingRevisions: false,
@@ -296,6 +297,7 @@ export const actionMap = new ActionMap({
         notes: { $set: pinSortedNotes },
         note: { $set: selectedNote },
         selectedNoteId: { $set: get(selectedNote, 'id', null) },
+        notesLoaded: { $set: true },
       });
     },
 

--- a/lib/note-list/index.jsx
+++ b/lib/note-list/index.jsx
@@ -334,6 +334,7 @@ export class NoteList extends Component {
       onSelectNote,
       onEmptyTrash,
       noteDisplay,
+      notesLoaded,
       showTrash,
       notes,
       isSmallScreen,
@@ -368,7 +369,7 @@ export class NoteList extends Component {
     return (
       <div className={classNames('note-list', { 'is-empty': isEmptyList })}>
         {isEmptyList ? (
-          <span className="note-list-placeholder">No Notes</span>
+          <span className="note-list-placeholder">{ notesLoaded ? 'No Notes' : 'Loading Notes'}</span>
         ) : (
           <Fragment>
             <div className={listItemsClasses}>
@@ -456,6 +457,7 @@ const mapStateToProps = ({ appState: state, settings: { noteDisplay } }) => {
     nextNote,
     noteDisplay,
     notes: filteredNotes,
+    notesLoaded: state.notesLoaded,
     prevNote,
     selectedNotePreview,
     selectedNoteContent: get(selectedNote, 'data.content'),


### PR DESCRIPTION
### Fix
When notes are loading we should not display the text "No Notes" as there may be notes but they have yet to load.  This PR makes the text "Notes Loading" until notes are loaded and then changes to "No Notes" if there are indeed no notes.

### Test
1. Have lots of notes and throttle your connection, load the app
2. Observe the text in the notes list no says "Notes Loading"
3. Have an account with no notes
4. Observe the text says "No Notes" once notes have loaded

### Review
Only one developer id required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Display a notice that notes are loading when notes are loading

