### PR TITLE
Fix to make macOS app movable on log in screen

### DIFF
--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -104,6 +104,14 @@ optgroup {
   }
 }
 
+.login__draggable-area {
+  height: 100px;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  -webkit-app-region: drag;
+}
+
 .gridicon {
   fill: currentColor;
 }


### PR DESCRIPTION
### Fix
Fixes: https://github.com/Automattic/simplenote-electron/issues/1654

This PR makes the macOS app movable when on the log in screen. With not title bar you must have an html element with: `-webkit-app-region: drag;` to make the window draggable. We have this once logged in but no on the login screen.

It appears that the element: `.login__draggable-area` was added for this purpose but the css was never implemented.

### Test
1. `npm run dev`
2. Close chrome dev tools
3. Is app draggable?
4. Run the same test on develop
5. App should not be draggable. 

### Review
Only one developer ais required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` To be added.


