### PR TITLE
In Dev mode, open Chrome Deve Tools in detached mode

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
  - Add ability to select system as a theme option and make it the default
  - Added support for the unicode bullet • in list items
  - Display a notice that notes are loading when notes are loading
+ - In dev mode open Chrome Dev Tools in a separate window
 
 ### Fixes
 

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -74,7 +74,7 @@ module.exports = function main() {
     }
 
     if (isDev || process.argv.includes('--devtools')) {
-      mainWindow.openDevTools();
+      mainWindow.openDevTools({ mode: 'detach' });
     }
 
     // Configure and set the application menu


### PR DESCRIPTION
### Fix
When you run `npm run dev` Chrome dev tools for the Electron app should open in detached mode (in a separate window). There are some interaction bugs that seem only to occur when dev tools are open.

### Test
1. `npm run dev`
2. Observe dev tools open in a window separate from the app

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

 - In dev mode open Chrome Dev Tools in a separate window

