### PR TITLE
Update the link to the Release Notes in the updater config

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,7 +11,7 @@
 ### Fixes
 
  - Rework WordPress.com signin to prevent infinite looping and login failures [#1627](https://github.com/Automattic/simplenote-electron/pull/1627)
- - Fixed link to release notes in updater config
+ - Update link to release-notes in updater config: CHANGELOG -> RELEASE_NOTES
 
 ## [v1.9.1]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 ### Fixes
 
  - Rework WordPress.com signin to prevent infinite looping and login failures [#1627](https://github.com/Automattic/simplenote-electron/pull/1627)
+ - Fixed link to release notes in updater config
 
 ## [v1.9.1]
 

--- a/desktop/config-updater.json
+++ b/desktop/config-updater.json
@@ -1,7 +1,7 @@
 {
   "updater": {
     "downloadUrl": "https://github.com/Automattic/simplenote-electron/releases/latest",
-    "changelogUrl": "https://github.com/Automattic/simplenote-electron/blob/develop/RELEASE-NOTES.txt",
+    "changelogUrl": "https://github.com/Automattic/simplenote-electron/blob/master/RELEASE-NOTES.txt",
     "apiUrl": "https://api.github.com/repos/automattic/simplenote-electron/releases/latest",
     "delay": 2000,
     "interval": 600000

--- a/desktop/config-updater.json
+++ b/desktop/config-updater.json
@@ -1,7 +1,7 @@
 {
   "updater": {
     "downloadUrl": "https://github.com/Automattic/simplenote-electron/releases/latest",
-    "changelogUrl": "https://github.com/Automattic/simplenote-electron/blob/master/CHANGELOG.md",
+    "changelogUrl": "https://github.com/Automattic/simplenote-electron/blob/develop/RELEASE-NOTES.txt",
     "apiUrl": "https://api.github.com/repos/automattic/simplenote-electron/releases/latest",
     "delay": 2000,
     "interval": 600000


### PR DESCRIPTION
In (#1582) CHANGELOG.md was renamed to RELEASE-NOTES.txt. This caused the link to the release notes to break.

### Fix
Fixes https://github.com/Automattic/simplenote-electron/issues/1659

### Test
No testing required. Will need to test the release notes link on the Windows app on the next update.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

 - Fixed link to release notes in updater config
