### PR TITLE
Fix/only run notes loaded when notes loaded

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,7 +13,7 @@
 
  - Rework WordPress.com signin to prevent infinite looping and login failures [#1627](https://github.com/Automattic/simplenote-electron/pull/1627)
  - Update link to release-notes in updater config: CHANGELOG -> RELEASE_NOTES
- - Don't update notes state with an empty array causing notes to be considered loaded
+ - Stop showing that there are no notes when initially loading notes from the server. [#1680](https://github.com/Automattic/simplenote-electron/pull/1680)
 
 ## [v1.9.1]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 
  - Rework WordPress.com signin to prevent infinite looping and login failures [#1627](https://github.com/Automattic/simplenote-electron/pull/1627)
  - Update link to release-notes in updater config: CHANGELOG -> RELEASE_NOTES
+ - Don't update notes state with an empty array causing notes to be considered loaded
 
 ## [v1.9.1]
 

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -266,7 +266,9 @@ export const actionMap = new ActionMap({
                 cursor.continue();
               } else {
                 debug(`noteCount: ${notes.length}`);
-                dispatch(this.action('notesLoaded', { notes: notes }));
+                if (notes.length) {
+                  dispatch(this.action('notesLoaded', { notes: notes }));
+                }
               }
             };
           });


### PR DESCRIPTION
After querying the noteBucket we run `notesLoaded` with an empty notes array. This causes havoc because we rely on notes being null until notes are loaded. This commit adds a check to ensure there is at least one note before running notesLoaded

Before this change "Loading Notes" is shown for a split second before "No Notes" is shown until notes are loaded.

### Fix
Fixes: https://github.com/Automattic/simplenote-electron/issues/1678

### Test
1. Have lots of notes
2. Clear application state
3. Observe that `Loading Notes` is displayed until notes are loaded

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in e848f1b with:

- Stop showing that there are no notes when initially loading notes from the server.