### PR TITLE
Update Release notes to fix merge

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v1.11.0]
+
+### Enhancements
+
+### Fixes
+
+ - Fixed bug that only shows the first line of text in note list preview [#1647](https://github.com/Automattic/simplenote-electron/pull/1647)
+
+### Other Changes
+
 ## [v1.10.0]
 
 ### Enhancements
@@ -12,7 +22,6 @@
 ### Fixes
 
  - Rework WordPress.com signin to prevent infinite looping and login failures [#1627](https://github.com/Automattic/simplenote-electron/pull/1627)
- - Fixed bug that only shows the first line of text in note list preview [#1647](https://github.com/Automattic/simplenote-electron/pull/1647)
  - Update link to release-notes in updater config: CHANGELOG -> RELEASE_NOTES
  - Stop showing that there are no notes when initially loading notes from the server. [#1680](https://github.com/Automattic/simplenote-electron/pull/1680)
 


### PR DESCRIPTION
When 1.10.0 was merged back into develop it incorrectly merged the Release Notes. This fixes that.
