### PR TITLE
Updates the menu icon

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,8 @@
 
 ### Enhancements
 
+ - Updated menu icon to use new icon set
+
 ### Fixes
 
  - Fixed bug that only shows the first line of text in note list preview [#1647](https://github.com/Automattic/simplenote-electron/pull/1647)

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+ - Updated menu icon to use the new icon set [#1694](https://github.com/Automattic/simplenote-electron/pull/1694)
+
 ### Fixes
 
 ### Other Changes
@@ -13,8 +15,6 @@
 ## [v1.11.0]
 
 ### Enhancements
-
- - Updated menu icon to use the new icon set [#1694](https://github.com/Automattic/simplenote-electron/pull/1694)
 
 ### Fixes
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,7 +14,7 @@
 
 ### Enhancements
 
- - Updated menu icon to use new icon set
+ - Updated menu icon to use the new icon set [#1694](https://github.com/Automattic/simplenote-electron/pull/1694)
 
 ### Fixes
 

--- a/lib/icons/menu.jsx
+++ b/lib/icons/menu.jsx
@@ -5,11 +5,12 @@ export default function MenuIcon() {
     <svg
       className="icon-menu"
       xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
       viewBox="0 0 24 24"
     >
-      <path d="M21 6v2H3V6h18zM3 18h18v-2H3v2zm0-5h18v-2H3v2z" />
+      <rect x="0" fill="none" width="24" height="24" />
+      <g>
+        <path d="M21,11H3v2H21Zm0-5H3V8H21Zm0,10H3v2H21Z" />
+      </g>
     </svg>
   );
 }


### PR DESCRIPTION
### Fix
We have a new icon set. This updates the menu icon to the new one.

This PR shows how the icons will be updated. In an additional PR, the remaining icons will be updated.  Would you make any changes to the icon components as we switch out the svg?

### Test
1. Open app
2. Does the menu icon in the top left render correctly?
3. Does it render correctly in the Dark theme?
4. Does it render correctly in Electron app

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Updated menu icon to use the new icon set [#1694](https://github.com/Automattic/simplenote-electron/pull/1694)
