### PR TITLE
Fixes markdown code styles

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- Fixed markdown code styles [#1702](https://github.com/Automattic/simplenote-electron/pull/1702)
+
 ### Other Changes
 
 - Updated dependencies [#1693](https://github.com/Automattic/simplenote-electron/pull/1693)

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -114,7 +114,7 @@
 }
 
 .note-detail-markdown {
-  @import '../node_modules/highlight.js/styles/solarized-light.css';
+  @import '../node_modules/highlight.js/scss/solarized-light.scss';
 
   h1,
   h2,
@@ -179,20 +179,11 @@
     }
   }
 
-  code {
-    background: $studio-gray-5;
-  }
-
   pre {
     border: 1px solid $studio-gray-20;
     padding: 1em;
     border-radius: $border-radius;
     font-size: 85%;
-  }
-
-  pre code {
-    color: $studio-gray-90;
-    background: transparent;
   }
 
   table {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -72,7 +72,8 @@
     background-color: transparent;
   }
 
-  .transparent-input::placeholder, input::placeholder {
+  .transparent-input::placeholder,
+  input::placeholder {
     color: $studio-gray-20;
   }
 
@@ -128,7 +129,7 @@
   }
 
   .note-detail-markdown {
-    @import '../node_modules/highlight.js/styles/solarized-dark.css';
+    @import '../node_modules/highlight.js/scss/solarized-dark.scss';
 
     hr {
       border-color: $studio-gray-80;
@@ -138,16 +139,10 @@
       border-color: $studio-gray-80;
     }
 
-    code {
-      background: $studio-gray-60;
-    }
     pre {
       border-color: $studio-gray-80;
     }
-    pre code {
-      color: $studio-gray-50;
-      background: transparent;
-    }
+
     table {
       th,
       td {


### PR DESCRIPTION
### Fix
Closes #1701 

We were importing the highlight.js styles but only using parts of them. Solarized-light and dark were both imported but only dark was being used as the styles were being made global. We covered this up by modifying the background color and text color to match the theme. This removes those cover-ups and uses the scss so the resulting css is not scoped globally.

After:
<img width="463" alt="Screen Shot 2019-11-08 at 1 22 56 PM" src="https://user-images.githubusercontent.com/6817400/68500951-edd0fd80-022a-11ea-95c5-ce71a9fb1686.png">
<img width="464" alt="Screen Shot 2019-11-08 at 1 22 41 PM" src="https://user-images.githubusercontent.com/6817400/68500952-edd0fd80-022a-11ea-883f-dc536ece62de.png">

Before:
<img width="457" alt="Screen Shot 2019-11-08 at 1 22 04 PM" src="https://user-images.githubusercontent.com/6817400/68500953-edd0fd80-022a-11ea-9de2-52ab819ac7d7.png">
<img width="460" alt="Screen Shot 2019-11-08 at 1 22 31 PM" src="https://user-images.githubusercontent.com/6817400/68500954-edd0fd80-022a-11ea-8406-af512f371859.png">


### Test
1. Have code snippet below in a note
2. View light and dark modes in markdown view mode
3. Are the code snippets readable?

```
\```
import simperium from './simperium';

let client;

export const initClient = config => {
  client = simperium(config);
  return client;
};

export default () => client;
```\
```

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:
- Fixed markdown code styles [#1702](https://github.com/Automattic/simplenote-electron/pull/1702)