### PR TITLE
Search: Prioritize notes with search matches in their title

### DIFF
--- a/lib/utils/filter-notes.js
+++ b/lib/utils/filter-notes.js
@@ -59,7 +59,7 @@ export const searchPattern = filter => {
 const matchesTrashView = isViewingTrash => note =>
   isViewingTrash === !!get(note, 'data.deleted', false);
 
-const matchesTag = (tag, filter = '') => note => {
+const makeMatchesTag = (tag, filter = '') => note => {
   let filterTags = [];
   let match;
   const matcher = tagPattern();
@@ -81,12 +81,10 @@ const matchesTag = (tag, filter = '') => note => {
   return missingTags.length === 0;
 };
 
-const matchesSearch = (filter = '') => note => {
+const makeMatchesSearch = (filter = '') => content => {
   if (!filter) {
     return true;
   }
-
-  const content = get(note, 'data.content');
 
   if (!content) {
     return false;
@@ -97,6 +95,14 @@ const matchesSearch = (filter = '') => note => {
   );
 };
 
+const emptyList = Object.freeze([]);
+
+/**
+ * Filters notes with the current search criteria
+ *
+ * @TODO: Remove shadowing by renaming search functions
+ * @TODO: Pre-index note title in domains/note
+ */
 export default function filterNotes(state, notesArray = null) {
   const {
     filter, // {string} search query from input
@@ -107,15 +113,38 @@ export default function filterNotes(state, notesArray = null) {
 
   const notesToFilter = notesArray ? notesArray : notes;
 
-  if ( null === notesToFilter ) {
-    return [];
+  if (null === notesToFilter) {
+    return emptyList; // share the reference so the app doesn't re-render on shallow-compare
   }
 
-  return notesToFilter.filter(
-    overEvery([
-      matchesTrashView(showTrash),
-      matchesTag(tag, filter),
-      matchesSearch(filter),
-    ])
-  );
+  // skip into some imperative code for performance-critical code
+  const titleMatches = [];
+  const otherMatches = [];
+
+  // reuse these functions for each note
+  const matchesTrash = matchesTrashView(showTrash);
+  const matchesTag = makeMatchesTag(tag, filter);
+  const matchesSearch = makeMatchesSearch(filter);
+  const matchesFilter = note =>
+    matchesTrash(note) &&
+    matchesTag(note) &&
+    matchesSearch(get(note, ['data', 'content']));
+
+  notesToFilter.forEach( note => {
+    if (!matchesFilter(note)) {
+      return;
+    }
+
+    // the search matches the note but we want to prioritize
+    // results that match the search query in the "title"
+    const title = get(note, ['data', 'content'], '').split('\n')[0];
+
+    if (matchesSearch(title)) {
+      titleMatches.push(note);
+    } else {
+      otherMatches.push(note);
+    }
+  } );
+
+  return titleMatches.concat(otherMatches);
 }


### PR DESCRIPTION
We have been returning search results in no particular order. When we
get searches that return many notes though the noise can make the search
less valuable.

In this patch we're starting to prioritize search results where the
first line of the note contains the string searched for. This is in
effect saying that we're prioritizing the note title matches in
searches.

**Testing**

This is best tested on an account with many notes so that we can
compare the search results.

Find keywords that are both in the note titles of some notes and
also in the content of many notes.

In `develop` we'd expect that the search results will be muddled
by the prevalence of notes matching the query string, but in this
branch we'd expect title-matching notes to appear at the top.

**Before**
![UnprioritizedSearch mov](https://user-images.githubusercontent.com/5431237/68523913-1ede1c00-0285-11ea-9962-cb8a1c6a6312.gif)

**After**
![TitlePrioritizedSearch mov](https://user-images.githubusercontent.com/5431237/68523914-26052a00-0285-11ea-82c8-b06a93957113.gif)
