### PR TITLE
Add pagehide to make page unload code work on iOS and iPad

### DIFF
--- a/lib/utils/ensure-single-browser-tab-only.js
+++ b/lib/utils/ensure-single-browser-tab-only.js
@@ -30,13 +30,16 @@ if (!foundElectron) {
     }
   });
 
-  window.addEventListener('beforeunload', function() {
+  window.addEventListener('pagehide', unload);
+  window.addEventListener('beforeunload', unload);
+
+  function unload() {
     keepGoing = false;
     const [lastClient] =
       JSON.parse(localStorage.getItem('session-lock')) || emptyLock;
 
     lastClient === clientId && localStorage.removeItem('session-lock');
-  });
+  }
 }
 
 function uuidv4() {
@@ -57,7 +60,7 @@ function grabSessionLock() {
   const now = Date.now();
   // easy case - someone else clearly has the lock
   // add some hysteresis to prevent fighting between sessions
-  if (lastClient !== clientId && now - lastBeat < HEARTBEAT_DELAY * 5) {
+  if (lastClient !== clientId && now - lastBeat < HEARTBEAT_DELAY * 2) {
     return 'lock-unavailable';
   }
 


### PR DESCRIPTION
### Fix
The pageunload event no longer exists on Safari mobile. This fix adds the
pagehide event to ensure things get cleaned up as the browser closes or
refreshes.

### Test
1. Bring app up in the iOS simulator
2. Bring it up in another tab
3. Refresh a couple of times in each tab
4. Does the app only come up in one and the warning message in other tabs?

### Review
Only one developer is required to review these changes, but anyone can perform the review.
