### PR TITLE
Conditionally watch event for unload to release session lock

### DIFF
--- a/lib/utils/ensure-single-browser-tab-only.js
+++ b/lib/utils/ensure-single-browser-tab-only.js
@@ -44,7 +44,6 @@ if (!foundElectron) {
     keepGoing = false;
     const [lastClient] =
       JSON.parse(localStorage.getItem('session-lock')) || emptyLock;
-    console.log('session lock removed');
     lastClient === clientId && localStorage.removeItem('session-lock');
   }
 }

--- a/lib/utils/ensure-single-browser-tab-only.js
+++ b/lib/utils/ensure-single-browser-tab-only.js
@@ -36,14 +36,15 @@ if (!foundElectron) {
     }
   });
 
-  window.addEventListener('pagehide', unload);
-  window.addEventListener('beforeunload', unload);
-
+  const eventName = /iPad|iPhone|iPod/.test(navigator.userAgent)
+    ? 'pagehide'
+    : 'beforeunload';
+  window.addEventListener(eventName, unload);
   function unload() {
     keepGoing = false;
     const [lastClient] =
       JSON.parse(localStorage.getItem('session-lock')) || emptyLock;
-
+    console.log('session lock removed');
     lastClient === clientId && localStorage.removeItem('session-lock');
   }
 }

--- a/lib/utils/ensure-single-browser-tab-only.js
+++ b/lib/utils/ensure-single-browser-tab-only.js
@@ -36,10 +36,11 @@ if (!foundElectron) {
     }
   });
 
-  const eventName = /iPad|iPhone|iPod/.test(navigator.userAgent)
-    ? 'pagehide'
-    : 'beforeunload';
-  window.addEventListener(eventName, unload);
+  if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
+    window.addEventListener('pagehide', unload);
+  } else {
+    window.addEventListener('beforeunload', unload);
+  }
   function unload() {
     keepGoing = false;
     const [lastClient] =

--- a/lib/utils/ensure-single-browser-tab-only.js
+++ b/lib/utils/ensure-single-browser-tab-only.js
@@ -8,7 +8,7 @@ const clientId = uuidv4();
 const emptyLock = [null, -Infinity];
 const foundElectron = window.process && window.process.type;
 
-if (!foundElectron) {
+if (!foundElectron && !/iPad|iPhone|iPod/.test(navigator.userAgent)) {
   if ('lock-acquired' !== grabSessionLock()) {
     ReactDOM.render(
       <BootWarning>
@@ -35,12 +35,7 @@ if (!foundElectron) {
         return false; // stop watching - the user can proceed at their own risk
     }
   });
-
-  if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
-    window.addEventListener('pagehide', unload);
-  } else {
-    window.addEventListener('beforeunload', unload);
-  }
+  window.addEventListener('beforeunload', unload);
   function unload() {
     keepGoing = false;
     const [lastClient] =
@@ -67,10 +62,9 @@ function grabSessionLock() {
   const now = Date.now();
   // easy case - someone else clearly has the lock
   // add some hysteresis to prevent fighting between sessions
-  if (lastClient !== clientId && now - lastBeat < HEARTBEAT_DELAY * 2) {
+  if (lastClient !== clientId && now - lastBeat < HEARTBEAT_DELAY * 3) {
     return 'lock-unavailable';
   }
-
   // maybe nobody clearly has the lock, let's try and set it
   localStorage.setItem('session-lock', JSON.stringify([clientId, now]));
 


### PR DESCRIPTION
iOS does not have a beforeunload event. The pagehide event for iOS causes
issues for Firefox. This conditionally watches the event based on if the
browser is iOS or not.

### Test
1. Open two tabs in Firefox, does the tab lock work correctly
2. Once this is merged and deployed to develop test on actual iPad

### Review
Only one developer is required to review these changes, but anyone can perform the review.
