### PR TITLE
Fix: Wrap a few calls safetly to prevent crashing on app boot

### DIFF
--- a/lib/components/sync-status/popover.jsx
+++ b/lib/components/sync-status/popover.jsx
@@ -29,10 +29,7 @@ class SyncStatusPopover extends React.Component {
       : [];
     const overflowCount = unsyncedNoteIds.length - noteTitles.length;
     const unit = overflowCount === 1 ? 'note' : 'notes';
-
-    const lastSyncedTime = formatDistanceToNow(getLastSyncedTime(), {
-      addSuffix: true,
-    });
+    const lastSyncedTime = getLastSyncedTime();
 
     return (
       <Popover
@@ -88,7 +85,11 @@ class SyncStatusPopover extends React.Component {
             </div>
           </div>
         )}
-        <span>Last synced: {lastSyncedTime}</span>
+        { lastSyncedTime > -Infinity ? (
+			<span>Last synced: {formatDistanceToNow(lastSyncedTime, { addSuffix: true })}</span>
+		) : (
+			<span>Unknown sync status</span>
+		) }
       </Popover>
     );
   }

--- a/lib/components/sync-status/popover.jsx
+++ b/lib/components/sync-status/popover.jsx
@@ -85,11 +85,14 @@ class SyncStatusPopover extends React.Component {
             </div>
           </div>
         )}
-        { lastSyncedTime > -Infinity ? (
-			<span>Last synced: {formatDistanceToNow(lastSyncedTime, { addSuffix: true })}</span>
-		) : (
-			<span>Unknown sync status</span>
-		) }
+        {lastSyncedTime > -Infinity ? (
+          <span>
+            Last synced:{' '}
+            {formatDistanceToNow(lastSyncedTime, { addSuffix: true })}
+          </span>
+        ) : (
+          <span>Unknown sync status</span>
+        )}
       </Popover>
     );
   }

--- a/lib/utils/sync/last-synced-time.js
+++ b/lib/utils/sync/last-synced-time.js
@@ -8,9 +8,18 @@ export const setLastSyncedTime = debounce(data => {
   if (startsWith(data, 'h:')) {
     return;
   }
-  window.localStorage.setItem(key, Date.now());
+  try {
+    window.localStorage.setItem(key, Date.now());
+  } catch (e) {
+    // must be missing localStorage
+  }
 }, debounceWait);
 
 export const getLastSyncedTime = () => {
-  return parseFloat(window.localStorage.getItem(key));
+  try {
+    return parseFloat(window.localStorage.getItem(key));
+  } catch (e) {
+    // missing localStorage or corruped value
+    return -Infinity;
+  }
 };

--- a/lib/utils/sync/nudge-unsynced.js
+++ b/lib/utils/sync/nudge-unsynced.js
@@ -30,6 +30,10 @@ const nudgeUnsynced = ({ noteBucket, notes, client }) => {
 };
 
 function updateUnsyncedNotes({ noteBucket, notes }) {
+  if ( ! notes ) {
+    return;
+  }
+
   const noteHasSynced = note =>
     new Promise(resolve =>
       noteBucket.getVersion(note.id, (e, v) => {

--- a/lib/utils/sync/nudge-unsynced.js
+++ b/lib/utils/sync/nudge-unsynced.js
@@ -30,7 +30,7 @@ const nudgeUnsynced = ({ noteBucket, notes, client }) => {
 };
 
 function updateUnsyncedNotes({ noteBucket, notes }) {
-  if ( ! notes ) {
+  if (!notes) {
     return;
   }
 


### PR DESCRIPTION
 - The note sync indicator was making a call to `localStorage` which
could fail and it was in the main thread
 - In #1650 we missed this reference to `notes` which now may be `null`
