### PR TITLE
Stop requiring cookie support to boot.

### DIFF
--- a/lib/utils/ensure-platform-support.js
+++ b/lib/utils/ensure-platform-support.js
@@ -52,7 +52,6 @@ const hasCookies = () => {
 const deps = [
   ['localStorage', hasLocalStorage()],
   ['indexedDB', hasIndexedDB()],
-  ['cookies', hasCookies()],
 ];
 
 const missingDeps = deps.filter(([, hasIt]) => !hasIt).map(([name]) => name);


### PR DESCRIPTION
Although we read cookies to get the auth token for a user we do not
depend on our ability to read them in order to work, so in this patch
we're removing that constraint from our platform support.

@SylvesterWilmott found that the cookie requirement broke the `.dmg` binary.
We need to make sure we can boot up in that.