### PR TITLE
Fix: Stop infinite duplication by correcting typo (and stuff)

### DIFF
--- a/lib/boot.js
+++ b/lib/boot.js
@@ -1,5 +1,5 @@
 import './utils/ensure-platform-support';
-import './utils/ensure-single-browser-tab-only';
+// import './utils/ensure-single-browser-tab-only';
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import 'unorm';

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -430,11 +430,21 @@ export const actionMap = new ActionMap({
     onNoteBeforeRemoteUpdate: {
       creator({ noteId }) {
         return (dispatch, getState) => {
-          const state = getState();
-          if (state.selectedNoteId !== noteId) {
-            return null;
+          const {
+            appState: { selectedNoteId, note, notes },
+          } = getState();
+
+          if ( selectedNoteId === noteId ) {
+            return note.data;
           }
-          return getState().note.data;
+
+          const match = (notes || []).find(({ id }) => noteId === id);
+
+          if (match) {
+            return match.data;
+          }
+
+          return null;
         };
       },
     },


### PR DESCRIPTION
Resolves #1690
Obviates session lock in: #1700, #1704, #1707, #1710, #1720
Resolves bug that uncovered signout/signin issue: #1664
Follows Simperium API change in: #1598, #1599, Simperium/node-simperium#61, Simperium/node-simperium#78

When we fixed some deep and underlying issues in `node-simperium` we
started a chain of operations which had to adjust to that change.
Remember that the core problem was an assumption that after we send out
a change that we could wait until it came back. That assumption was
wrong because changes from other remote clients could come in during
that time period while we're waiting. Simperium/node-simperium#61 fixed
that problem but because it was broken in the past we added some
work-arounds in #706; these work-arounds complicated the flow of data in
the corrected version so we had to remove them and change how we handle
remote updates in the Simplnote side.

A critical step in this flow is letting Simperium know what local
changes we may have in the app buffer. We introduced this step in #1598
but never noticed a typo:

```js
getState().selectedNoteId
```

That reference will always be wrong and so we'll never send the local
contents of the note. It should have been...

```js
getState().appState.selectedNoteId
```

The implication of this change is that we always told Simperium that
there are no local changes and so it would grab the currenty copy in the
bucket, which in our case is in shared `indexedDB` tables, and thus it
would occasionally get updated copies of the bucket that were updated in
another session. This would then appear as though we also made the same
change we were receiving, and thus we would prepare our own patch to
send out and start the cycle.

Further we were only sending local updates in the case that we had the
same note open as was updated in the remote change. However, since we
don't update Simperium with notes that we're not editing we were leaving
other notes behind by sending `null` for them. The outcome of this is
that edits to notes that aren't selected would have a modification in
the way they are applied, if otherwise they would have started the
infinite looping.

After this change we're always sending the current local copy. This is
still somewhat of a work-around but it's one that should reliably cover
over the larger problems in the system. Eventually we have to clear out
the data flow, remove local copies of our data, separate independent
clients or sessions so they don't share buckets, and simplify the
control flow to make things easier to debug.

**Behavior in `master`**

https://cloudup.com/imqA8MXKOZM

**Behavior in this branch**
https://cloudup.com/i_ey4VLRWbd

It looks like the bug in the video that remains comes from when we have
changes on a new note because there's no local copy of that note. It gets
the `null` response from the application and then uses the already-updated
`bucket` value. This isn't _caused_ by this PR and it's not solved by it, but
it's probably worth making this change even if we can't fix it because we
dramatically reduce the number of cases where the infinite duplication
slips in.