### PR TITLE
Search: Add sort order to search results

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 ### Enhancements
 
  - Added matching tags to the notes list on search [#1648](https://github.com/Automattic/simplenote-electron/pull/1648)
+ - Added sort order to search results [#1726](https://github.com/Automattic/simplenote-electron/pull/1726)
 
 ### Fixes
 

--- a/lib/app-layout/index.js
+++ b/lib/app-layout/index.js
@@ -58,7 +58,7 @@ export const AppLayout = ({
             isSmallScreen={isSmallScreen}
             onNoteOpened={onNoteOpened}
           />
-          <SortOrderSelector />
+          <SortOrderSelector noteBucket={noteBucket} />
         </div>
         <div className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border">
           <RevisionSelector

--- a/lib/app-layout/index.js
+++ b/lib/app-layout/index.js
@@ -8,6 +8,7 @@ import NoteToolbar from '../note-toolbar';
 import RevisionSelector from '../revision-selector';
 import SearchBar from '../search-bar';
 import SimplenoteCompactLogo from '../icons/simplenote-compact';
+import SortOrderSelector from '../sort-order-selector';
 import TransitionDelayEnter from '../components/transition-delay-enter';
 
 const NoteList = React.lazy(() =>
@@ -57,6 +58,7 @@ export const AppLayout = ({
             isSmallScreen={isSmallScreen}
             onNoteOpened={onNoteOpened}
           />
+          <SortOrderSelector />
         </div>
         <div className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border">
           <RevisionSelector

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -243,14 +243,31 @@ export const actionMap = new ActionMap({
       creator({ noteBucket }) {
         return (dispatch, getState) => {
           const settings = getState().settings;
-          const { sortType, sortReversed } = settings;
+          const state = getState().appState;
+          const {
+            sortType,
+            sortReversed,
+            searchSortType,
+            searchSortReversed,
+          } = settings;
+          const query = state.filter;
           var sortOrder;
+
+          let noteSortType = sortType;
+          let noteSortReversed = sortReversed;
+
           debug('loadNotes');
 
-          if (sortType === 'alphabetical') {
-            sortOrder = sortReversed ? 'prev' : 'next';
+          // if we have a search active, use the search sorting instead of the global preferences
+          if (query && query.length > 0) {
+            noteSortType = searchSortType;
+            noteSortReversed = searchSortReversed;
+          }
+
+          if (noteSortType === 'alphabetical') {
+            sortOrder = noteSortReversed ? 'prev' : 'next';
           } else {
-            sortOrder = sortReversed ? 'next' : 'prev';
+            sortOrder = noteSortReversed ? 'next' : 'prev';
           }
 
           noteBucket.query(db => {
@@ -258,7 +275,7 @@ export const actionMap = new ActionMap({
             db
               .transaction('note')
               .objectStore('note')
-              .index(sortType)
+              .index(noteSortType)
               .openCursor(null, sortOrder).onsuccess = e => {
               var cursor = e.target.result;
               if (cursor) {
@@ -434,7 +451,7 @@ export const actionMap = new ActionMap({
             appState: { selectedNoteId, note, notes },
           } = getState();
 
-          if ( selectedNoteId === noteId ) {
+          if (selectedNoteId === noteId) {
             return note.data;
           }
 

--- a/lib/sort-order-selector/index.jsx
+++ b/lib/sort-order-selector/index.jsx
@@ -22,6 +22,21 @@ export class SortOrderSelector extends Component {
     setSortType: PropTypes.func.isRequired,
   };
 
+  componentDidUpdate(prevProps) {
+    const { sortType, sortReversed, searchSortReversed, query } = this.props;
+    /* If there's a query and there wasn't before
+       (i.e., the search sort component is being newly displayed),
+       set the search sort to match the global setting.
+       This means whenever a user starts a new search, the notes will be filtered
+       in place, rather than being reordered to match the last selected search order. */
+    if (!prevProps.query && prevProps.query !== query) {
+      this.props.setSortType(sortType);
+      if (sortReversed !== searchSortReversed) {
+        this.props.toggleSortOrder();
+      }
+    }
+  }
+
   changeSort = event => {
     this.props.setSortType(event.currentTarget.value);
   };

--- a/lib/sort-order-selector/index.jsx
+++ b/lib/sort-order-selector/index.jsx
@@ -2,7 +2,10 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import appState from '../flux/app-state';
-import { toggleSortOrder, setSortType } from '../state/settings/actions';
+import {
+  toggleSearchSortOrder,
+  setSearchSortType,
+} from '../state/settings/actions';
 import classNames from 'classnames';
 import ArrowDownIcon from '../icons/arrow-down';
 
@@ -13,6 +16,8 @@ export class SortOrderSelector extends Component {
     query: PropTypes.string.isRequired,
     sortType: PropTypes.string.isRequired,
     sortReversed: PropTypes.bool.isRequired,
+    searchSortType: PropTypes.string.isRequired,
+    searchSortReversed: PropTypes.bool.isRequired,
     toggleSortOrder: PropTypes.func.isRequired,
     setSortType: PropTypes.func.isRequired,
   };
@@ -22,7 +27,7 @@ export class SortOrderSelector extends Component {
   };
 
   render() {
-    const { sortType, sortReversed, query } = this.props;
+    const { searchSortType, searchSortReversed, query } = this.props;
 
     const sortTypes = [
       {
@@ -45,14 +50,14 @@ export class SortOrderSelector extends Component {
           <div className="sort-order-selector">
             <div
               className={classNames('sort-order-reverse', {
-                'is-reversed': sortReversed,
+                'is-reversed': searchSortReversed,
               })}
               onClick={this.props.toggleSortOrder}
             >
               <ArrowDownIcon />
             </div>
             Sort by
-            <select value={sortType} onChange={this.changeSort}>
+            <select value={searchSortType} onChange={this.changeSort}>
               {sortTypes.map(type => (
                 <option key={type.id} value={type.id}>
                   {type.label}
@@ -69,6 +74,8 @@ export class SortOrderSelector extends Component {
 const mapStateToProps = ({ settings, appState: state }) => ({
   sortType: settings.sortType,
   sortReversed: settings.sortReversed,
+  searchSortType: settings.searchSortType,
+  searchSortReversed: settings.searchSortReversed,
   query: state.filter,
 });
 
@@ -80,8 +87,8 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
     dispatch(actionCreators.loadNotes({ noteBucket }));
   };
   return {
-    setSortType: thenReloadNotes(setSortType),
-    toggleSortOrder: thenReloadNotes(toggleSortOrder),
+    setSortType: thenReloadNotes(setSearchSortType),
+    toggleSortOrder: thenReloadNotes(toggleSearchSortOrder),
   };
 }
 

--- a/lib/sort-order-selector/index.jsx
+++ b/lib/sort-order-selector/index.jsx
@@ -1,7 +1,8 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { setSortType, toggleSortOrder } from '../state/settings/actions';
+import appState from '../flux/app-state';
+import { toggleSortOrder, setSortType } from '../state/settings/actions';
 import classNames from 'classnames';
 import ArrowDownIcon from '../icons/arrow-down';
 
@@ -65,10 +66,18 @@ const mapStateToProps = ({ settings }) => ({
   sortReversed: settings.sortReversed,
 });
 
-const mapDispatchToProps = {
-  setSortType,
-  toggleSortOrder,
-};
+function mapDispatchToProps(dispatch, { noteBucket }) {
+  const actionCreators = Object.assign({}, appState.actionCreators);
+
+  const thenReloadNotes = action => a => {
+    dispatch(action(a));
+    dispatch(actionCreators.loadNotes({ noteBucket }));
+  };
+  return {
+    setSortType: thenReloadNotes(setSortType),
+    toggleSortOrder: thenReloadNotes(toggleSortOrder),
+  };
+}
 
 export default connect(
   mapStateToProps,

--- a/lib/sort-order-selector/index.jsx
+++ b/lib/sort-order-selector/index.jsx
@@ -79,7 +79,4 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(SortOrderSelector);
+export default connect(mapStateToProps, mapDispatchToProps)(SortOrderSelector);

--- a/lib/sort-order-selector/index.jsx
+++ b/lib/sort-order-selector/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import appState from '../flux/app-state';
@@ -10,6 +10,7 @@ export class SortOrderSelector extends Component {
   static displayName = 'SortOrderSelector';
 
   static propTypes = {
+    query: PropTypes.string.isRequired,
     sortType: PropTypes.string.isRequired,
     sortReversed: PropTypes.bool.isRequired,
     toggleSortOrder: PropTypes.func.isRequired,
@@ -21,7 +22,7 @@ export class SortOrderSelector extends Component {
   };
 
   render() {
-    const { sortType, sortReversed } = this.props;
+    const { sortType, sortReversed, query } = this.props;
 
     const sortTypes = [
       {
@@ -39,31 +40,36 @@ export class SortOrderSelector extends Component {
     ];
 
     return (
-      <div className="sort-order-selector">
-        <div
-          className={classNames('sort-order-reverse', {
-            'is-reversed': sortReversed,
-          })}
-          onClick={this.props.toggleSortOrder}
-        >
-          <ArrowDownIcon />
-        </div>
-        Sort by
-        <select value={sortType} onChange={this.changeSort}>
-          {sortTypes.map(type => (
-            <option key={type.id} value={type.id}>
-              {type.label}
-            </option>
-          ))}
-        </select>
-      </div>
+      <Fragment>
+        {query.length > 0 && (
+          <div className="sort-order-selector">
+            <div
+              className={classNames('sort-order-reverse', {
+                'is-reversed': sortReversed,
+              })}
+              onClick={this.props.toggleSortOrder}
+            >
+              <ArrowDownIcon />
+            </div>
+            Sort by
+            <select value={sortType} onChange={this.changeSort}>
+              {sortTypes.map(type => (
+                <option key={type.id} value={type.id}>
+                  {type.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </Fragment>
     );
   }
 }
 
-const mapStateToProps = ({ settings }) => ({
+const mapStateToProps = ({ settings, appState: state }) => ({
   sortType: settings.sortType,
   sortReversed: settings.sortReversed,
+  query: state.filter,
 });
 
 function mapDispatchToProps(dispatch, { noteBucket }) {

--- a/lib/sort-order-selector/index.jsx
+++ b/lib/sort-order-selector/index.jsx
@@ -1,0 +1,76 @@
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { setSortType, toggleSortOrder } from '../state/settings/actions';
+import classNames from 'classnames';
+import ArrowDownIcon from '../icons/arrow-down';
+
+export class SortOrderSelector extends Component {
+  static displayName = 'SortOrderSelector';
+
+  static propTypes = {
+    sortType: PropTypes.string.isRequired,
+    sortReversed: PropTypes.bool.isRequired,
+    toggleSortOrder: PropTypes.func.isRequired,
+    setSortType: PropTypes.func.isRequired,
+  };
+
+  changeSort = event => {
+    this.props.setSortType(event.currentTarget.value);
+  };
+
+  render() {
+    const { sortType, sortReversed } = this.props;
+
+    const sortTypes = [
+      {
+        label: 'Date modified',
+        id: 'modificationDate',
+      },
+      {
+        label: 'Date created',
+        id: 'creationDate',
+      },
+      {
+        label: 'Alphabetical',
+        id: 'alphabetical',
+      },
+    ];
+
+    return (
+      <div className="sort-order-selector">
+        <div
+          className={classNames('sort-order-reverse', {
+            'is-reversed': sortReversed,
+          })}
+          onClick={this.props.toggleSortOrder}
+        >
+          <ArrowDownIcon />
+        </div>
+        Sort by
+        <select value={sortType} onChange={this.changeSort}>
+          {sortTypes.map(type => (
+            <option key={type.id} value={type.id}>
+              {type.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = ({ settings }) => ({
+  sortType: settings.sortType,
+  sortReversed: settings.sortReversed,
+});
+
+const mapDispatchToProps = {
+  setSortType,
+  toggleSortOrder,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(SortOrderSelector);

--- a/lib/sort-order-selector/style.scss
+++ b/lib/sort-order-selector/style.scss
@@ -8,16 +8,17 @@
 	text-align: center;
 
 	font-size: 14px;
+	line-height: 44px;
 	color: $studio-gray-80;
 
-	.is-reversed .icon-arrow-down {
-		transform: rotate(180deg);
-	}
-
-	.icon-arrow-down {
+	.sort-order-reverse {
 		width: 24px;
 		height: 24px;
 		position: absolute;
 		left: 8px;
+	}
+
+	.is-reversed .icon-arrow-down {
+		transform: rotate(180deg);
 	}
 }

--- a/lib/sort-order-selector/style.scss
+++ b/lib/sort-order-selector/style.scss
@@ -21,4 +21,31 @@
 	.is-reversed .icon-arrow-down {
 		transform: rotate(180deg);
 	}
+
+	select {
+		/* remove default dropdown styling */
+		appearance: none;
+		-webkit-appearance: none;
+		-moz-appearance: none;
+		border: none;
+		padding: 0 5px;
+
+		margin: 0;
+
+		color: $studio-blue-30;
+		background: transparent;
+	}
+
+	option {
+		/* fix for Firefox, which allows <options> to inherit styles from parents */
+		color: $studio-gray-80;
+	}
+}
+
+.theme-dark {
+	.sort-order-selector {
+		background-color: $studio-gray-90;
+		color: $studio-gray-20;
+		box-shadow: 0 -1px 0 0 $studio-gray-80;
+	}
 }

--- a/lib/sort-order-selector/style.scss
+++ b/lib/sort-order-selector/style.scss
@@ -1,0 +1,23 @@
+.sort-order-selector {
+	width: 328px;
+	height: 44px;
+	background-color: $studio-white;
+	box-shadow: 0 -1px 0 0 $studio-gray-5;
+	margin: 0;
+	padding: 0 15px;
+	text-align: center;
+
+	font-size: 14px;
+	color: $studio-gray-80;
+
+	.is-reversed .icon-arrow-down {
+		transform: rotate(180deg);
+	}
+
+	.icon-arrow-down {
+		width: 24px;
+		height: 24px;
+		position: absolute;
+		left: 8px;
+	}
+}

--- a/lib/state/settings/actions.js
+++ b/lib/state/settings/actions.js
@@ -52,6 +52,18 @@ export const setSortType = sortType => ({
   sortType,
 });
 
+export const setSearchSortType = searchSortType => ({
+  type: 'setSearchSortType',
+  searchSortType,
+});
+
+export const toggleSearchSortOrder = () => (dispatch, getState) => {
+  dispatch({
+    type: 'setSearchSortReversed',
+    searchSortReversed: !getState().settings.searchSortReversed,
+  });
+};
+
 export const toggleSortTagsAlpha = () => (dispatch, getState) => {
   dispatch({
     type: 'setSortTagsAlpha',

--- a/lib/state/settings/reducer.js
+++ b/lib/state/settings/reducer.js
@@ -37,16 +37,16 @@ function reducer(state = initialState, action) {
       return { ...state, markdownEnabled: action.markdownEnabled };
     case 'setNoteDisplay':
       return { ...state, noteDisplay: action.noteDisplay };
-    case 'setSortReversed':
-      return { ...state, sortReversed: action.sortReversed };
     case 'setSearchSortReversed':
       return { ...state, searchSortReversed: action.searchSortReversed };
+    case 'setSearchSortType':
+      return { ...state, searchSortType: action.searchSortType };
+    case 'setSortReversed':
+      return { ...state, sortReversed: action.sortReversed };
     case 'setSortTagsAlpha':
       return { ...state, sortTagsAlpha: action.sortTagsAlpha };
     case 'setSortType':
       return { ...state, sortType: action.sortType };
-    case 'setSearchSortType':
-      return { ...state, searchSortType: action.searchSortType };
     case 'setSpellCheck':
       return { ...state, spellCheckEnabled: action.spellCheckEnabled };
     case 'setTheme':

--- a/lib/state/settings/reducer.js
+++ b/lib/state/settings/reducer.js
@@ -8,6 +8,8 @@ export const initialState = {
   lineLength: 'narrow',
   markdownEnabled: false,
   noteDisplay: 'comfy',
+  searchSortReversed: false,
+  searchSortType: 'modificationDate',
   sortReversed: false,
   sortTagsAlpha: false,
   sortType: 'modificationDate',
@@ -37,10 +39,14 @@ function reducer(state = initialState, action) {
       return { ...state, noteDisplay: action.noteDisplay };
     case 'setSortReversed':
       return { ...state, sortReversed: action.sortReversed };
+    case 'setSearchSortReversed':
+      return { ...state, searchSortReversed: action.searchSortReversed };
     case 'setSortTagsAlpha':
       return { ...state, sortTagsAlpha: action.sortTagsAlpha };
     case 'setSortType':
       return { ...state, sortType: action.sortType };
+    case 'setSearchSortType':
+      return { ...state, searchSortType: action.searchSortType };
     case 'setSpellCheck':
       return { ...state, spellCheckEnabled: action.spellCheckEnabled };
     case 'setTheme':

--- a/scss/_components.scss
+++ b/scss/_components.scss
@@ -36,6 +36,7 @@
 @import 'revision-selector/style';
 @import 'search-bar/style';
 @import 'search-field/style';
+@import 'sort-order-selector/style';
 @import 'tag-email-tooltip/style';
 @import 'tag-field/style';
 @import 'tag-input/style';


### PR DESCRIPTION
### Enhancement
This PR adds an ordering toggle to the bottom of the notes list when a search is active:

<img width="327" alt="Screen Shot 2019-11-27 at 10 38 23 PM" src="https://user-images.githubusercontent.com/52152/69782717-acb37580-1166-11ea-865a-be6ab4e76564.png">

Will fix #1625

### Test
1. Enter a search
2. Use the toggle to change the sort type and direction of the results.
3. Clear the search and verify that your global sort settings haven't been changed.
4. Start a new search and note that the sorting resets to the global setting.
5. Try in different browsers/OSes to make sure the dropdown styling is okay

*NOTE:* Title matches will get sorted to the top of the list as per #1705. So there's basically two separate sections: title and content. Within each section the notes should get sorted as per preferences. It's out of scope but I'd like to make this clearer in a separate PR.

### Dark Mode screenshots
<img width="321" alt="Screen Shot 2019-11-27 at 10 37 51 PM" src="https://user-images.githubusercontent.com/52152/69782884-20ee1900-1167-11ea-8d03-bae1e115f607.png">
<img width="316" alt="Screen Shot 2019-11-27 at 10 37 56 PM" src="https://user-images.githubusercontent.com/52152/69782897-25b2cd00-1167-11ea-8e76-58d9b72beffb.png">

### Release

> `RELEASE-NOTES.txt` was updated in 
932676d  with:
> 
> > Added sort order to search results [#1726](https://github.com/Automattic/simplenote-electron/pull/1726)
