### PR TITLE
Render headings as rich text in editor mode

### DIFF
--- a/lib/components/heading/index.jsx
+++ b/lib/components/heading/index.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Heading = ({ headingLevel, children }) => {
+  const elementType = `h${headingLevel}`;
+  const elementClass = `heading heading__${headingLevel}`;
+
+  return React.createElement(
+    elementType,
+    { className: elementClass },
+    children
+  );
+};
+
+Heading.propTypes = {
+  headingLevel: PropTypes.number.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default Heading;

--- a/lib/components/heading/style.scss
+++ b/lib/components/heading/style.scss
@@ -1,0 +1,7 @@
+/* .heading {} */
+/* .heading__h1 {} */
+/* .heading__h2 {} */
+/* .heading__h3 {} */
+/* .heading__h4 {} */
+/* .heading__h5 {} */
+/* .heading__h6 {} */

--- a/lib/components/heading/test.js
+++ b/lib/components/heading/test.js
@@ -1,0 +1,8 @@
+import Heading from './';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+test.each([1, 2, 3, 4, 5, 6])('renders h%d', level => {
+  const wrapped = shallow(<Heading headingLevel={level}>Test</Heading>);
+  expect(wrapped.type()).toBe(`h${level}`);
+});

--- a/lib/editor/heading-decorator.js
+++ b/lib/editor/heading-decorator.js
@@ -1,0 +1,26 @@
+import SimpleDecorator from 'draft-js-simpledecorator';
+
+import Heading from '../components/heading';
+
+const headingRegex = /^([#]{1,6})(\s+)([^\s]+)/g;
+
+const headingDecorator = () => {
+  const strategy = (contentBlock, callback) => {
+    const text = contentBlock.getText();
+    let match;
+
+    while ((match = headingRegex.exec(text)) !== null) {
+      const fullText = text;
+      const headingLevel = match[1].length;
+
+      const start = match.index;
+      const end = start + fullText.length;
+
+      callback(start, end, { headingLevel, children: fullText });
+    }
+  };
+
+  return new SimpleDecorator(strategy, Heading);
+};
+
+export default headingDecorator;

--- a/lib/editor/heading-decorator.test.js
+++ b/lib/editor/heading-decorator.test.js
@@ -1,0 +1,39 @@
+import headingDecorator from './heading-decorator';
+
+describe('headingDecorator', () => {
+  let contentBlock, callback;
+  let replaceRangeWithText;
+  let decorator;
+
+  beforeEach(() => {
+    contentBlock = {
+      getText: () => '# note title',
+      getKey: () => 'mock-key',
+    };
+    callback = jest.fn();
+    replaceRangeWithText = jest.fn();
+    decorator = headingDecorator(replaceRangeWithText);
+  });
+
+  it('passes the start and end offsets of the task prefix to the callback', () => {
+    decorator.strategy(contentBlock, callback);
+    expect(callback).toHaveBeenCalledWith(0, 12, expect.any(Object));
+
+    contentBlock.getText = () => '# updated note title';
+    decorator.strategy(contentBlock, callback);
+    expect(callback).toHaveBeenCalledWith(0, 20, expect.any(Object));
+  });
+
+  it('passes the heading level to the callback', () => {
+    decorator.strategy(contentBlock, callback);
+    expect(callback.mock.calls[0][2].headingLevel).toBe(1);
+
+    contentBlock.getText = () => '## h2';
+    decorator.strategy(contentBlock, callback);
+    expect(callback.mock.calls[1][2].headingLevel).toBe(2);
+
+    contentBlock.getText = () => '### h3';
+    decorator.strategy(contentBlock, callback);
+    expect(callback.mock.calls[2][2].headingLevel).toBe(3);
+  });
+});

--- a/lib/note-content-editor.jsx
+++ b/lib/note-content-editor.jsx
@@ -20,6 +20,7 @@ import {
 import { filterHasText, searchPattern } from './utils/filter-notes';
 import matchingTextDecorator from './editor/matching-text-decorator';
 import checkboxDecorator from './editor/checkbox-decorator';
+import headingDecorator from './editor/heading-decorator';
 import { removeCheckbox, shouldRemoveCheckbox } from './editor/checkbox-utils';
 import { taskRegex } from './note-detail/toggle-task/constants';
 import insertOrRemoveCheckboxes from './editor/insert-or-remove-checkboxes';
@@ -66,6 +67,7 @@ export default class NoteContentEditor extends Component {
       compact([
         filterHasText(filter) && matchingTextDecorator(searchPattern(filter)),
         checkboxDecorator(this.replaceRangeWithText),
+        headingDecorator(this.replaceRangeWithText),
       ])
     );
   };

--- a/lib/note-list/decorators.js
+++ b/lib/note-list/decorators.js
@@ -2,7 +2,10 @@ import React from 'react';
 import replaceToArray from 'string-replace-to-array';
 
 import Checkbox from '../components/checkbox';
+import Heading from '../components/heading';
 import { taskPrefixRegex } from '../note-detail/toggle-task/constants';
+
+const headingPrefixRegex = /^([#]{1,6)\s+[^\s]/g;
 
 export const decorateWith = (decorators, text) => {
   let output = text;
@@ -13,6 +16,14 @@ export const decorateWith = (decorators, text) => {
   });
 
   return output;
+};
+
+export const headingDecorator = {
+  filter: headingPrefixRegex,
+  replacer: key => match => {
+    const headingLevel = match[1].length;
+    return <Heading headingLevel={headingLevel} key={key} />;
+  },
 };
 
 export const checkboxDecorator = {

--- a/lib/note-list/index.jsx
+++ b/lib/note-list/index.jsx
@@ -26,6 +26,7 @@ import getNoteTitleAndPreview from './get-note-title-and-preview';
 import {
   decorateWith,
   checkboxDecorator,
+  headingDecorator,
   makeFilterDecorator,
 } from './decorators';
 
@@ -185,7 +186,11 @@ const renderNote = (
     'published-note': isPublished,
   });
 
-  const decorators = [checkboxDecorator, makeFilterDecorator(filter)];
+  const decorators = [
+    checkboxDecorator,
+    headingDecorator,
+    makeFilterDecorator(filter),
+  ];
 
   const selectNote = () => {
     onSelectNote(note.id);


### PR DESCRIPTION
![screenshot-20191117-011902](https://user-images.githubusercontent.com/57426891/69005541-59c0ff00-08d8-11ea-9741-e6a3c6fd5b38.png)

### Fix
Render headings as rich text in editor mode.  Bold headings are a helpful visual component and already implemented in the MacOS version of the app.

### Test
1. Type a heading such as `# h1` or `## h2` or `### h3`
2. The text should transform into that element: the font-size should increase and the font-weight should change to bold

### Review
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> Render headings as rich text in editor mode

### Related issues
* #944
* #418
* #1578
* https://github.com/facebook/draft-js/issues/1198

### Screenshots

#### Before/After
![screenshot-20191117-012853](https://user-images.githubusercontent.com/57426891/69005622-ae18ae80-08d9-11ea-8a6a-6e69efc4e977.png)
![screenshot-20191117-011902](https://user-images.githubusercontent.com/57426891/69005541-59c0ff00-08d8-11ea-9741-e6a3c6fd5b38.png)