### PR TITLE
Adds a Clipboard Button component

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,8 @@
 
 ### Fixes
 
+- Added indication that publish url has been copied [#1743](https://github.com/Automattic/simplenote-electron/pull/1743)
+
 ### Other Changes
 
 - Updated dependencies [#1759](https://github.com/Automattic/simplenote-electron/pull/1759)
@@ -16,7 +18,6 @@
 ### Enhancements
 
 - Added matching tags to the notes list on search [#1648](https://github.com/Automattic/simplenote-electron/pull/1648)
-- Added indication that publish url has been copied [#1743](https://github.com/Automattic/simplenote-electron/pull/1743)
 
 ### Fixes
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,7 +15,8 @@
 
 ### Enhancements
 
- - Added matching tags to the notes list on search [#1648](https://github.com/Automattic/simplenote-electron/pull/1648)
+- Added matching tags to the notes list on search [#1648](https://github.com/Automattic/simplenote-electron/pull/1648)
+- Added indication that publish url has been copied [#1743](https://github.com/Automattic/simplenote-electron/pull/1743)
 
 ### Fixes
 

--- a/lib/components/clipboard-button/index.jsx
+++ b/lib/components/clipboard-button/index.jsx
@@ -1,22 +1,21 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import ReactDom from 'react-dom';
 import Clipboard from 'clipboard';
 
-function ClipboardButton({ text, disabled }) {
-  const buttonRef = React.useRef();
-
-  const textCallback = React.useRef();
-  const successCallback = React.useRef();
+function ClipboardButton({ text }) {
+  const buttonRef = useRef();
+  const textCallback = useRef();
+  const successCallback = useRef();
 
   const onCopy = () => {
     setCopied(true);
   };
 
-  const [isCopied, setCopied] = React.useState(false);
+  const [isCopied, setCopied] = useState(false);
 
   // toggle the `isCopied` flag back to `false` after 4 seconds
-  React.useEffect(() => {
+  useEffect(() => {
     if (isCopied) {
       const confirmationTimeout = setTimeout(() => setCopied(false), 4000);
       return () => clearTimeout(confirmationTimeout);
@@ -24,15 +23,14 @@ function ClipboardButton({ text, disabled }) {
   }, [isCopied]);
 
   // update the callbacks on rerenders that change `text` or `onCopy`
-  React.useEffect(() => {
+  useEffect(() => {
     textCallback.current = () => text;
     successCallback.current = onCopy;
   }, [text, onCopy]);
 
   // create the `Clipboard` object on mount and destroy on unmount
-  React.useEffect(() => {
-    const buttonEl = ReactDom.findDOMNode(buttonRef.current);
-    const clipboard = new Clipboard(buttonEl, {
+  useEffect(() => {
+    const clipboard = new Clipboard(buttonRef.current, {
       text: () => textCallback.current(),
     });
     clipboard.on('success', () => successCallback.current());
@@ -41,12 +39,7 @@ function ClipboardButton({ text, disabled }) {
   }, []);
 
   return (
-    <button
-      ref={buttonRef}
-      disabled={disabled}
-      type="button"
-      className="button button-borderless"
-    >
+    <button ref={buttonRef} type="button" className="button button-borderless">
       {isCopied ? 'Copied!' : 'Copy'}
     </button>
   );

--- a/lib/components/clipboard-button/index.jsx
+++ b/lib/components/clipboard-button/index.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactDom from 'react-dom';
+import Clipboard from 'clipboard';
+
+function ClipboardButton({ text, disabled }) {
+  const buttonRef = React.useRef();
+
+  const textCallback = React.useRef();
+  const successCallback = React.useRef();
+
+  const onCopy = () => {
+    setCopied(true);
+  };
+
+  const [isCopied, setCopied] = React.useState(false);
+
+  // toggle the `isCopied` flag back to `false` after 4 seconds
+  React.useEffect(() => {
+    if (isCopied) {
+      const confirmationTimeout = setTimeout(() => setCopied(false), 4000);
+      return () => clearTimeout(confirmationTimeout);
+    }
+  }, [isCopied]);
+
+  // update the callbacks on rerenders that change `text` or `onCopy`
+  React.useEffect(() => {
+    textCallback.current = () => text;
+    successCallback.current = onCopy;
+  }, [text, onCopy]);
+
+  // create the `Clipboard` object on mount and destroy on unmount
+  React.useEffect(() => {
+    const buttonEl = ReactDom.findDOMNode(buttonRef.current);
+    const clipboard = new Clipboard(buttonEl, {
+      text: () => textCallback.current(),
+    });
+    clipboard.on('success', () => successCallback.current());
+
+    return () => clipboard.destroy();
+  }, []);
+
+  return (
+    <button
+      ref={buttonRef}
+      disabled={disabled}
+      type="button"
+      className="button button-borderless"
+    >
+      {isCopied ? 'Copied!' : 'Copy'}
+    </button>
+  );
+}
+
+ClipboardButton.propTypes = {
+  disbaled: PropTypes.bool,
+  text: PropTypes.string,
+};
+
+export default ClipboardButton;

--- a/lib/dialogs/settings/style.scss
+++ b/lib/dialogs/settings/style.scss
@@ -45,10 +45,6 @@
     border-bottom: none;
   }
 
-  .button-borderless {
-    padding-right: 0;
-  }
-
   .settings-item-label {
     flex: 1 1 auto;
     align-items: center;

--- a/lib/dialogs/share/index.jsx
+++ b/lib/dialogs/share/index.jsx
@@ -5,6 +5,7 @@ import { includes, isEmpty } from 'lodash';
 import MD5 from 'md5.js';
 
 import analytics from '../../analytics';
+import ClipboardButton from '../../components/clipboard-button';
 import isEmailTag from '../../utils/is-email-tag';
 import { updateNoteTags } from '../../state/domain/notes';
 import Dialog from '../../dialog';
@@ -31,18 +32,6 @@ export class ShareDialog extends Component {
       note: this.props.appState.note,
       publish: event.currentTarget.checked,
     });
-  };
-
-  copyPublishURL = () => {
-    this.publishUrlElement.select();
-
-    try {
-      document.execCommand('copy');
-    } catch (err) {
-      return;
-    }
-
-    this.copyUrlElement.focus();
   };
 
   getPublishURL = url => (isEmpty(url) ? undefined : `http://simp.ly/p/${url}`);
@@ -200,15 +189,10 @@ export class ShareDialog extends Component {
                       spellCheck={false}
                     />
                     <div className="settings-item-control">
-                      <button
-                        ref={e => (this.copyUrlElement = e)}
+                      <ClipboardButton
                         disabled={!publishURL}
-                        type="button"
-                        className="button button-borderless"
-                        onClick={this.copyPublishURL}
-                      >
-                        Copy
-                      </button>
+                        text={publishURL}
+                      />
                     </div>
                   </div>
                 </div>
@@ -222,7 +206,4 @@ export class ShareDialog extends Component {
   }
 }
 
-export default connect(
-  null,
-  { updateNoteTags }
-)(ShareDialog);
+export default connect(null, { updateNoteTags })(ShareDialog);

--- a/lib/dialogs/share/index.jsx
+++ b/lib/dialogs/share/index.jsx
@@ -189,10 +189,7 @@ export class ShareDialog extends Component {
                       spellCheck={false}
                     />
                     <div className="settings-item-control">
-                      <ClipboardButton
-                        disabled={!publishURL}
-                        text={publishURL}
-                      />
+                      {publishURL && <ClipboardButton text={publishURL} />}
                     </div>
                   </div>
                 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4957,6 +4957,16 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "clipboard": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
+      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -5881,6 +5891,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -8763,6 +8778,14 @@
             "path-is-absolute": "^1.0.0"
           }
         }
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "got": {
@@ -14623,6 +14646,11 @@
         }
       }
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -16004,6 +16032,11 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tiny-warning": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@automattic/color-studio": "2.2.0",
     "@material-ui/core": "4.7.1",
     "bottleneck": "2.19.5",
+    "clipboard": "2.0.4",
     "cookie": "0.4.0",
     "core-js": "3.4.7",
     "date-fns": "2.8.1",


### PR DESCRIPTION
### Fix

Closes: https://github.com/Automattic/simplenote-electron/issues/232

The inline button component to copy the publish url was lacking an inidcation
that the text was copied. Additionally, the current setup was using a copy
method that can have issue in some browsers. This commit switches to use of the
clipboard npm repo, moves code into a component, and adds an indication that
the text was copied.

### Test
1. Build project
2. Have note that is published
3. Click copy button
4. Observe that text is copied
5. Observe that text of button changes to: "Copied!" for 4000ms

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Added indication that publish url has been copied [#1743](https://github.com/Automattic/simplenote-electron/pull/1743)