### PR TITLE
Fix titlePattern removing leading s

### DIFF
--- a/lib/utils/note-utils.js
+++ b/lib/utils/note-utils.js
@@ -31,7 +31,7 @@ const removeMarkdownWithFix = inputString => {
 };
 
 const getTitle = content => {
-  const titlePattern = new RegExp(`\s*([^\n]{1,${maxTitleChars}})`, 'g');
+  const titlePattern = new RegExp(`\\s*([^\n]{1,${maxTitleChars}})`, 'g');
   const titleMatch = titlePattern.exec(content);
   if (!titleMatch) {
     return 'New Note…';


### PR DESCRIPTION
Closes https://github.com/Automattic/simplenote-electron/issues/1746

### Fix
Escapes the `\s` at the beginning of `titlePattern`. In a regex created like `/pattern/` this isn't necessary but since it is being built from a string it is.

### Test
1. Write a title starting with a lower case `s`
2. All characters, including the s, should appear in the `note-list-item-title`

### Review
It would probably be worth checking to see if related changes should be made to the other regular expressions in that file. I left them alone since if they are having similar problems, I don't know what kind of behavior was built to work around that.

### Release
These changes do not require release notes.
