### PR TITLE
Fix focus-mode transition to small screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 ## [v1.13.0]
 
 ### Enhancements
+- Keep note open when transitioning to small screen in focus mode [#1763](https://github.com/Automattic/simplenote-electron/pull/1763)
 
 ### Fixes
 

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -208,7 +208,7 @@ export const App = connect(
 
       if (isSmallScreen !== prevProps.isSmallScreen) {
         this.setState({
-          isNoteOpen: Boolean(!isSmallScreen && this.props.appState.note),
+          isNoteOpen: Boolean(this.props.appState.note && (settings.focusModeEnabled || !isSmallScreen)),
         });
       }
     }


### PR DESCRIPTION
### Fix
Closes https://github.com/Automattic/simplenote-electron/issues/1760

When resizing to small screen, if focus mode is enabled, keep the note open

### Test
> 1. Open a note in full screen
> 2. Enable focus mode
> 3. Resize window small enough that `isSmallScreen` is true. See that note is still open, instead of switching to note-list

### Review
See steps above

### Release
> `RELEASE-NOTES.txt` was updated in 9a15ac1 with:
> 
> > Keep note open when transitioning to small screen in focus mode
