### PR TITLE
Remove code that stops settings from scrolling on shorter screens

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - Keep note open when transitioning to small screen in focus mode [#1763](https://github.com/Automattic/simplenote-electron/pull/1763)
 
 ### Fixes
+- Makes settings scrollable on shorter smaller view ports [#1767](https://github.com/Automattic/simplenote-electron/pull/1767)
 
 ### Other Changes
 

--- a/lib/components/tab-panels/style.scss
+++ b/lib/components/tab-panels/style.scss
@@ -27,12 +27,6 @@
   height: 30.5em;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
-
-  // On small screens, the tab bar uses up too much space so it should
-  // move out of the way while scrolling.
-  @media only screen and (max-width: 720px) and (max-height: 640px) {
-    height: auto;
-  }
 }
 
 .tab-panels__column {
@@ -40,4 +34,3 @@
   margin: 0 auto;
   padding: 36px 10px 50px;
 }
-


### PR DESCRIPTION
### Fix
At some point, some code was added that allowed the tabs to scroll. In adding
this it caused the settings tab to display at full height and not be contained
by the scroll box in the modal. This fixes
https://href.li/?https://github.com/Automattic/simplenote-electron/issues/1268

This is not a long term solution as it is still not a great user experience.  We need to drop the modals for full-page settings.

### Test
1. Open app.simplenote.com with dev tools open
2. Open settings to the display tab
3. Enable mobile responsive mode
4. Set the height to less than 640px
5. See that it doesn't scroll
6. Do the same on this branch
7. Observe that it does scroll

Old, doesn't scroll:

![old](https://user-images.githubusercontent.com/6817400/70466003-30872f00-1a90-11ea-9122-8cad5a756533.gif)

After, scrolls:

![Dec-09-2019 14-28-09](https://user-images.githubusercontent.com/6817400/70466014-37ae3d00-1a90-11ea-97c1-facc32585160.gif)

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Makes settings scrollable on shorter smaller view ports [#1767](https://github.com/Automattic/simplenote-electron/pull/1767)