### PR TITLE
Notes list: Fix console error when there are no matching notes

### DIFF
--- a/lib/note-list/index.jsx
+++ b/lib/note-list/index.jsx
@@ -505,11 +505,7 @@ const { recordEvent } = tracks;
 const mapStateToProps = ({ appState: state, settings: { noteDisplay } }) => {
   const tagResultsFound = getMatchingTags(state.tags, state.filter).length;
 
-  const filteredNotes = createCompositeNoteList(
-    filterNotes(state),
-    state.filter,
-    tagResultsFound
-  );
+  const filteredNotes = filterNotes(state);
 
   const noteIndex = Math.max(state.previousIndex, 0);
   const selectedNote = state.note ? state.note : filteredNotes[noteIndex];
@@ -523,6 +519,12 @@ const mapStateToProps = ({ appState: state, settings: { noteDisplay } }) => {
 
   const nextNote = filteredNotes[nextNoteId];
   const prevNote = filteredNotes[prevNoteId];
+
+  const compositeNoteList = createCompositeNoteList(
+    filteredNotes,
+    state.filter,
+    tagResultsFound
+  );
 
   /**
    * Although not used directly in the React component this value
@@ -552,7 +554,7 @@ const mapStateToProps = ({ appState: state, settings: { noteDisplay } }) => {
     hasLoaded: state.notes !== null,
     nextNote,
     noteDisplay,
-    notes: filteredNotes,
+    notes: compositeNoteList,
     prevNote,
     selectedNotePreview,
     selectedNoteContent: get(selectedNote, 'data.content'),
@@ -566,13 +568,12 @@ const mapDispatchToProps = (dispatch, { noteBucket }) => ({
   closeNote: () => dispatch(closeNote()),
   onEmptyTrash: () => dispatch(emptyTrash({ noteBucket })),
   onSelectNote: noteId => {
-    dispatch(loadAndSelectNote({ noteBucket, noteId }));
-    recordEvent('list_note_opened');
+    if (noteId) {
+      dispatch(loadAndSelectNote({ noteBucket, noteId }));
+      recordEvent('list_note_opened');
+    }
   },
   onPinNote: (note, pin) => dispatch(pinNote({ noteBucket, note, pin })),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(NoteList);
+export default connect(mapStateToProps, mapDispatchToProps)(NoteList);


### PR DESCRIPTION
### Fix
If you search for a string that matches no notes, this error appears in the console: `Failed DOMException: "No key or key range specified."`. This was introduced in #1648 and is due to the fake notes being added to the notes list as placeholders. In this PR we properly guard against the selected note ID being null.

This was happening in two ways:
1. If no notes nor tag matches were returned, we'd get `null` for the selected note ID, and `onSelectNote` wasn't checking for that. Now it does.
2. If tag matches are returned but no notes, we'd try to set the selected note ID to the fake placeholder note, which didn't have an ID. Instead we want to select the first actual note, which requires moving the code that determines which note should be selected *before* the code that adds the placeholders to the notes list.

### Test
> 1. Open the app and development console
> 2. Search for a string that has no matches in either tags or notes
> 3. Verify that no errors appear in the console log
> 4. Search for a string that matches tags but no notes text
> 5. Verify that no errors appear
> 4. Select different notes and make sure they correctly stay selected

### Release
> These changes do not require release notes.
