### PR TITLE
Removes renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
### Fix
We are no longer using renovate. This removes the config.

### Test
No testing needed

### Review
Only one developer is required to review these changes, but anyone can perform the review.