### PR TITLE
Updates the prettier command and applies prettier fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,14 +1,16 @@
 {
   "version": "0.2.0",
-  "configurations": [{
-    "name": "Debug Main Process",
-    "type": "node",
-    "request": "launch",
-    "cwd": "${workspaceRoot}",
-    "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
-    "windows": {
-      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
-    },
-    "args": ["."]
-  }]
+  "configurations": [
+    {
+      "name": "Debug Main Process",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+      "windows": {
+        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+      },
+      "args": ["."]
+    }
+  ]
 }

--- a/Makefile
+++ b/Makefile
@@ -163,8 +163,8 @@ rebuild-deps:
 
 .PHONY: format
 format:
-	@npx prettier --write {desktop,lib,sass}/{**/,*}.{js,json,jsx,sass}
+	@npx prettier --ignore-path .gitignore --write "**/*.{js,jsx,json,sass}"
 
 .PHONY: lint
 lint:
-	@npx eslint --ext .js --ext .jsx lib
+	@npx eslint --ignore-path .gitignore --ext .js --ext .jsx lib

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,7 @@
 ### Other Changes
 
 - Updated dependencies [#1759](https://github.com/Automattic/simplenote-electron/pull/1759)
+- Applied prettier formattig to all files [#1780](https://github.com/Automattic/simplenote-electron/pull/1780)
 
 ## [v1.13.0]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,7 +14,7 @@
 ### Other Changes
 
 - Updated dependencies [#1759](https://github.com/Automattic/simplenote-electron/pull/1759)
-- Applied prettier formattig to all files [#1780](https://github.com/Automattic/simplenote-electron/pull/1780)
+- Applied prettier formatting to all files [#1780](https://github.com/Automattic/simplenote-electron/pull/1780)
 
 ## [v1.13.0]
 

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -5,11 +5,7 @@
     "output": "release",
     "buildResources": "resources"
   },
-  "files": [
-    "desktop",
-    "dist",
-    "shared"
-  ],
+  "files": ["desktop", "dist", "shared"],
   "mac": {
     "icon": "./resources/images/app-icon.icns",
     "category": "public.app-category.social-networking",
@@ -24,7 +20,8 @@
     "icon": "./resources/images/dmg-icon.icns",
     "iconSize": 150,
     "background": "./resources/images/dmg-background.png",
-    "contents": [{
+    "contents": [
+      {
         "x": 480,
         "y": 240,
         "type": "link",
@@ -40,12 +37,10 @@
   "win": {
     "icon": "resources/images/simplenote.ico",
     "artifactName": "Simplenote-win-${version}-${arch}.${ext}",
-    "target": [{
+    "target": [
+      {
         "target": "nsis",
-        "arch": [
-          "ia32",
-          "x64"
-        ]
+        "arch": ["ia32", "x64"]
       }
     ]
   },
@@ -60,31 +55,19 @@
     "target": [
       {
         "target": "AppImage",
-        "arch": [
-          "x64",
-          "ia32"
-        ]
+        "arch": ["x64", "ia32"]
       },
       {
         "target": "deb",
-        "arch": [
-          "x64",
-          "ia32"
-        ]
+        "arch": ["x64", "ia32"]
       },
       {
         "target": "rpm",
-        "arch": [
-          "x64",
-          "ia32"
-        ]
+        "arch": ["x64", "ia32"]
       },
       {
         "target": "tar.gz",
-        "arch": [
-          "x64",
-          "ia32"
-        ]
+        "arch": ["x64", "ia32"]
       }
     ],
     "synopsis": "The simplest way to keep notes",

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -208,7 +208,10 @@ export const App = connect(
 
       if (isSmallScreen !== prevProps.isSmallScreen) {
         this.setState({
-          isNoteOpen: Boolean(this.props.appState.note && (settings.focusModeEnabled || !isSmallScreen)),
+          isNoteOpen: Boolean(
+            this.props.appState.note &&
+              (settings.focusModeEnabled || !isSmallScreen)
+          ),
         });
       }
     }

--- a/lib/auth/index.jsx
+++ b/lib/auth/index.jsx
@@ -348,7 +348,4 @@ const mapStateToProps = state => ({
   hasLoginError: hasLoginError(state),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Auth);
+export default connect(mapStateToProps, mapDispatchToProps)(Auth);

--- a/lib/dialogs/settings/index.jsx
+++ b/lib/dialogs/settings/index.jsx
@@ -161,7 +161,4 @@ const mapDispatchToProps = dispatch => ({
   },
 });
 
-export default connect(
-  null,
-  mapDispatchToProps
-)(SettingsDialog);
+export default connect(null, mapDispatchToProps)(SettingsDialog);

--- a/lib/dialogs/settings/panels/display.jsx
+++ b/lib/dialogs/settings/panels/display.jsx
@@ -167,7 +167,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(DisplayPanel);
+export default connect(mapStateToProps, mapDispatchToProps)(DisplayPanel);

--- a/lib/dialogs/settings/panels/tools.jsx
+++ b/lib/dialogs/settings/panels/tools.jsx
@@ -49,7 +49,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(
-  null,
-  mapDispatchToProps
-)(ToolsPanel);
+export default connect(null, mapDispatchToProps)(ToolsPanel);

--- a/lib/flux/app-state.js
+++ b/lib/flux/app-state.js
@@ -434,7 +434,7 @@ export const actionMap = new ActionMap({
             appState: { selectedNoteId, note, notes },
           } = getState();
 
-          if ( selectedNoteId === noteId ) {
+          if (selectedNoteId === noteId) {
             return note.data;
           }
 

--- a/lib/note-detail/index.jsx
+++ b/lib/note-detail/index.jsx
@@ -207,7 +207,7 @@ export class NoteDetail extends Component {
             <SimplenoteCompactLogo />
           </div>
         ) : (
-          <div className='note-detail'>
+          <div className="note-detail">
             {previewingMarkdown && (
               <div
                 ref={this.storePreview}
@@ -256,7 +256,4 @@ const mapDispatchToProps = {
   onNotePrinted: () => setShouldPrintNote({ shouldPrint: false }),
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(NoteDetail);
+export default connect(mapStateToProps, mapDispatchToProps)(NoteDetail);

--- a/lib/note-editor/index.jsx
+++ b/lib/note-editor/index.jsx
@@ -168,7 +168,4 @@ const mapDispatchToProps = dispatch => ({
   setEditorMode: args => dispatch(setEditorMode(args)),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(NoteEditor);
+export default connect(mapStateToProps, mapDispatchToProps)(NoteEditor);

--- a/lib/search-bar/index.jsx
+++ b/lib/search-bar/index.jsx
@@ -53,7 +53,4 @@ const mapDispatchToProps = (dispatch, { noteBucket, onNoteOpened }) => ({
 
 SearchBar.displayName = 'SearchBar';
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(SearchBar);
+export default connect(mapStateToProps, mapDispatchToProps)(SearchBar);

--- a/lib/search-field/index.jsx
+++ b/lib/search-field/index.jsx
@@ -113,7 +113,4 @@ const mapDispatchToProps = dispatch => ({
   onSearchFocused: () => dispatch(setSearchFocus({ searchFocus: false })),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(SearchField);
+export default connect(mapStateToProps, mapDispatchToProps)(SearchField);

--- a/lib/tag-email-tooltip/index.jsx
+++ b/lib/tag-email-tooltip/index.jsx
@@ -28,7 +28,4 @@ EmailToolTip.propTypes = {
   openShareDialog: PropTypes.func.isRequired,
 };
 
-export default connect(
-  null,
-  mapDispatchToProps
-)(EmailToolTip);
+export default connect(null, mapDispatchToProps)(EmailToolTip);

--- a/lib/tag-field/index.jsx
+++ b/lib/tag-field/index.jsx
@@ -238,7 +238,4 @@ export class TagField extends Component {
   }
 }
 
-export default connect(
-  null,
-  { updateNoteTags }
-)(TagField);
+export default connect(null, { updateNoteTags })(TagField);

--- a/lib/tag-list/index.jsx
+++ b/lib/tag-list/index.jsx
@@ -111,7 +111,4 @@ const mapDispatchToProps = dispatch => ({
   trashTag: arg => dispatch(trashTag(arg)),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TagList);
+export default connect(mapStateToProps, mapDispatchToProps)(TagList);

--- a/lib/tag-suggestions/index.jsx
+++ b/lib/tag-suggestions/index.jsx
@@ -116,7 +116,4 @@ const mapDispatchToProps = dispatch => ({
   },
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TagSuggestions);
+export default connect(mapStateToProps, mapDispatchToProps)(TagSuggestions);

--- a/lib/utils/filter-notes.js
+++ b/lib/utils/filter-notes.js
@@ -130,7 +130,7 @@ export default function filterNotes(state, notesArray = null) {
     matchesTag(note) &&
     matchesSearch(get(note, ['data', 'content']));
 
-  notesToFilter.forEach( note => {
+  notesToFilter.forEach(note => {
     if (!matchesFilter(note)) {
       return;
     }
@@ -144,7 +144,7 @@ export default function filterNotes(state, notesArray = null) {
     } else {
       otherMatches.push(note);
     }
-  } );
+  });
 
   return titleMatches.concat(otherMatches);
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,3 @@
 {
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["config:base"]
 }


### PR DESCRIPTION
### Fix
The prettier command was not properly checking all files under code revision.
It was only checking files that were one layer deep. This updates the command
so that it runs on all files and applies formatting to those files

### Test
Does app run?

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Applied prettier formatting to all files [#1780](https://github.com/Automattic/simplenote-electron/pull/1780)
