### PR TITLE
Fix lint command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,4 +167,4 @@ format:
 
 .PHONY: lint
 lint:
-	@npx eslint --ignore-path .gitignore --ext .js --ext .jsx lib
+	@npx eslint --ignore-path .gitignore "**/*.{js,jsx}"


### PR DESCRIPTION
### Fix
Fixes the lint command

### Test
1. run `npm run lint`
2. Does it lint all js/jsx files under revision control?

### Review
Only one developer is required to review these changes, but anyone can perform the review.

