### PR TITLE
Transition TransitionDelayEnter to React hooks

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,7 +15,7 @@
 
 - Updated dependencies [#1759](https://github.com/Automattic/simplenote-electron/pull/1759)
 - Applied prettier formatting to all files [#1780](https://github.com/Automattic/simplenote-electron/pull/1780)
-- Transition TransitionDelayEnter to React hooks [#1784](https://github.com/Automattic/simplenote-electron/pull/1784)
+- Migrate TransitionDelayEnter to React hooks [#1784](https://github.com/Automattic/simplenote-electron/pull/1784)
 
 ## [v1.13.0]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 
 - Updated dependencies [#1759](https://github.com/Automattic/simplenote-electron/pull/1759)
 - Applied prettier formatting to all files [#1780](https://github.com/Automattic/simplenote-electron/pull/1780)
+- Transition TransitionDelayEnter to React hooks [#1784](https://github.com/Automattic/simplenote-electron/pull/1784)
 
 ## [v1.13.0]
 

--- a/lib/components/transition-delay-enter/index.jsx
+++ b/lib/components/transition-delay-enter/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { CSSTransition } from 'react-transition-group';
 
@@ -8,43 +8,33 @@ import { CSSTransition } from 'react-transition-group';
  * Useful for progress bars and spinners, that should generally have about a
  * 1000 ms delay before displaying to the user.
  */
-class TransitionDelayEnter extends React.Component {
-  static propTypes = {
-    delay: PropTypes.number,
-    children: PropTypes.node.isRequired,
-  };
+const TransitionDelayEnter = ({ children, delay = 1000 }) => {
+  const [shouldRender, setShouldRender] = useState(false);
 
-  static defaultProps = {
-    delay: 1000,
-  };
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setShouldRender(true);
+    }, delay);
 
-  state = {
-    shouldRender: false,
-  };
+    return () => window.clearTimeout(timer);
+  }, []);
 
-  componentDidMount() {
-    this.timer = window.setTimeout(() => {
-      this.setState({ shouldRender: true });
-    }, this.props.delay);
-  }
+  return (
+    <CSSTransition
+      classNames="transition-delay-enter"
+      in={shouldRender}
+      mountOnEnter={true}
+      timeout={200 /* fade-in speed */}
+      unmountOnExit={true}
+    >
+      {children}
+    </CSSTransition>
+  );
+};
 
-  componentWillUnmount() {
-    window.clearTimeout(this.timer);
-  }
-
-  render() {
-    return (
-      <CSSTransition
-        classNames="transition-delay-enter"
-        in={this.state.shouldRender}
-        mountOnEnter={true}
-        timeout={200 /* fade-in speed */}
-        unmountOnExit={true}
-      >
-        {this.props.children}
-      </CSSTransition>
-    );
-  }
-}
+TransitionDelayEnter.propTypes = {
+  delay: PropTypes.number,
+  children: PropTypes.node.isRequired,
+};
 
 export default TransitionDelayEnter;


### PR DESCRIPTION
### Fix
This is a good small example of how React hooks are used.  Nothing changes
except we are now using a functional component and using hooks over lifecycle
methods.

### Test
1. Clear site data, reload
2. Sign in
3. Observe Simplenote log appears then disappears

Note: The value of this component is really really low. I'm thinking about deleting it.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Transition TransitionDelayEnter to React hooks [#1784](https://github.com/Automattic/simplenote-electron/pull/1784)