### PR TITLE
Add eslint plugin for React Hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
     "prettier",
     "prettier/react"
   ],
-  "plugins": ["eslint-plugin-react", "jest", "prettier"],
+  "plugins": ["eslint-plugin-react", "jest", "prettier", "react-hooks"],
   "rules": {
     "eqeqeq": ["error", "always"],
     "no-console": "warn",

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -19,6 +19,7 @@
 - Applied prettier formatting to all files [#1780](https://github.com/Automattic/simplenote-electron/pull/1780)
 - Delete unused tab restriction util [#1783](https://github.com/Automattic/simplenote-electron/pull/1783)
 - Migrate TransitionDelayEnter to React hooks [#1784](https://github.com/Automattic/simplenote-electron/pull/1784)
+- Added React Hooks Eslinnt Plugin [#1789](https://github.com/Automattic/simplenote-electron/pull/1789)
 
 ## [v1.13.0]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7045,6 +7045,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.3.0.tgz",
+      "integrity": "sha512-gLKCa52G4ee7uXzdLiorca7JIQZPPXRAQDXV83J4bUEeUuc5pIEyZYAZ45Xnxe5IuupxEqHS+hUhSLIimK1EMw==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-plugin-jest": "23.1.1",
     "eslint-plugin-prettier": "3.1.2",
     "eslint-plugin-react": "7.17.0",
+    "eslint-plugin-react-hooks": "2.3.0",
     "fake-indexeddb": "3.0.0",
     "hard-source-webpack-plugin": "0.13.1",
     "html-webpack-plugin": "3.2.0",


### PR DESCRIPTION
### Fix
Add eslint plugin for React Hooks

### Test
1. `npm install` 
2. ` npm runn lint`

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Added React Hooks Eslinnt Plugin [#1789](https://github.com/Automattic/simplenote-electron/pull/1789)
