### PR TITLE
Stop running lint and tests on pre-push git hook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
       - run: patch -p1 < ./resources/macos/macPackager-patch.diff
       - run: patch -p1 < ./resources/macos/scheme-patch.diff
       - run: make build
+      - run: make lint
       - run: make test
       - persist_to_workspace:
           root: ~/simplenote

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "npm test && npm run lint",
       "pre-commit": "pretty-quick --staged"
     }
   },


### PR DESCRIPTION
These tests already run in CI after pushing changes and before pushing
they add considerable delay. Many of the issues the tests reveal aren't
completely relevant for work-in-progress branches.
