### PR TITLE
Refactor state: Move editorMode into a separate reducer

### DIFF
--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -7,6 +7,7 @@ import analytics from '../analytics';
 
 import { AppState, State } from '../state';
 import * as T from '../types';
+import actions from '../state/actions';
 
 const debug = Debug('appState');
 
@@ -34,7 +35,6 @@ const toggleSystemTag = (
 };
 
 const initialState: AppState = {
-  editorMode: 'edit',
   filter: '',
   selectedNoteId: null,
   previousIndex: -1,
@@ -146,12 +146,6 @@ export const actionMap = new ActionMap({
       });
     },
 
-    setEditorMode(state: AppState, { mode }: { mode: T.EditorMode }) {
-      return update(state, {
-        editorMode: { $set: mode },
-      });
-    },
-
     showDialog(state: AppState, { dialog }) {
       const { type, multiple = false, title, ...dialogProps } = dialog;
 
@@ -223,7 +217,7 @@ export const actionMap = new ActionMap({
           }
 
           if (settings.markdownEnabled) {
-            dispatch(this.action('setEditorMode', { mode: 'edit' }));
+            dispatch(actions.ui.setEditorMode('edit'));
           }
 
           // insert a new note into the store and select it

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -1,33 +1,30 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import appState from '../flux/app-state';
 import TagField from '../tag-field';
 import { property } from 'lodash';
 import NoteDetail from '../note-detail';
 
-export class NoteEditor extends Component {
+import { State } from '../state';
+import { setEditorMode } from '../state/ui/actions';
+import * as T from '../types';
+
+type Props = {
+  isSmallScreen: boolean;
+  note: T.NoteEntity;
+  noteBucket: T.Bucket<T.Note>;
+  onNoteClosed: Function;
+  onUpdateContent: Function;
+  syncNote: Function;
+};
+
+type ConnectedProps = ReturnType<typeof mapStateToProps> &
+  typeof mapDispatchToProps;
+
+export class NoteEditor extends Component<Props & ConnectedProps> {
   static displayName = 'NoteEditor';
 
-  static propTypes = {
-    allTags: PropTypes.array.isRequired,
-    closeNote: PropTypes.func.isRequired,
-    editorMode: PropTypes.oneOf(['edit', 'markdown']),
-    isEditorActive: PropTypes.bool.isRequired,
-    isSmallScreen: PropTypes.bool.isRequired,
-    filter: PropTypes.string.isRequired,
-    note: PropTypes.object,
-    noteBucket: PropTypes.object.isRequired,
-    fontSize: PropTypes.number,
-    onNoteClosed: PropTypes.func.isRequired,
-    onUpdateContent: PropTypes.func.isRequired,
-    revision: PropTypes.object,
-    setEditorMode: PropTypes.func.isRequired,
-    syncNote: PropTypes.func.isRequired,
-  };
-
   static defaultProps = {
-    editorMode: 'edit',
     note: {
       data: {
         tags: [],
@@ -68,7 +65,7 @@ export class NoteEditor extends Component {
       const prevEditorMode = this.props.editorMode;
       const nextEditorMode = prevEditorMode === 'edit' ? 'markdown' : 'edit';
 
-      this.props.setEditorMode({ mode: nextEditorMode });
+      this.props.setEditorMode(nextEditorMode);
 
       event.stopPropagation();
       event.preventDefault();
@@ -118,7 +115,7 @@ export class NoteEditor extends Component {
 
   tagFieldHasFocus = () => this.tagFieldHasFocus && this.tagFieldHasFocus();
 
-  toggleShortcuts = doEnable => {
+  toggleShortcuts = (doEnable: boolean) => {
     if (doEnable) {
       window.addEventListener('keydown', this.handleShortcut, true);
     } else {
@@ -161,20 +158,24 @@ export class NoteEditor extends Component {
   }
 }
 
-const mapStateToProps = ({ appState: state, settings }) => ({
-  allTags: state.tags,
-  filter: state.filter,
+const mapStateToProps = ({
+  appState: { filter, revision, showNavigation, tags },
+  settings,
+  ui: { editorMode },
+}: State) => ({
+  allTags: tags,
+  filter: filter,
   fontSize: settings.fontSize,
-  editorMode: state.editorMode,
-  isEditorActive: !state.showNavigation,
-  revision: state.revision,
+  editorMode,
+  isEditorActive: !showNavigation,
+  revision: revision,
 });
 
-const { closeNote, setEditorMode } = appState.actionCreators;
+const { closeNote } = appState.actionCreators;
 
-const mapDispatchToProps = dispatch => ({
-  closeNote: () => dispatch(closeNote()),
-  setEditorMode: args => dispatch(setEditorMode(args)),
-});
+const mapDispatchToProps = {
+  closeNote,
+  setEditorMode,
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteEditor);

--- a/lib/note-toolbar-container.ts
+++ b/lib/note-toolbar-container.ts
@@ -67,8 +67,6 @@ export class NoteToolbarContainer extends Component<Props> {
     analytics.tracks.recordEvent('editor_share_dialog_viewed');
   };
 
-  onSetEditorMode = (mode: T.EditorMode) => this.props.setEditorMode({ mode });
-
   render() {
     const {
       editorMode,
@@ -81,7 +79,6 @@ export class NoteToolbarContainer extends Component<Props> {
       onCloseNote: this.onCloseNote,
       onDeleteNoteForever: this.onDeleteNoteForever,
       onRestoreNote: this.onRestoreNote,
-      onSetEditorMode: this.onSetEditorMode,
       onShowNoteInfo: this.props.toggleNoteInfo,
       onShowRevisions: this.onShowRevisions,
       onShareNote: this.onShareNote,
@@ -98,7 +95,7 @@ export class NoteToolbarContainer extends Component<Props> {
       ? revisionOrNote.data.systemTags.includes('markdown')
       : false;
 
-    return cloneElement(toolbar, { ...handlers, editorMode, markdownEnabled });
+    return cloneElement(toolbar, { ...handlers, markdownEnabled });
   }
 }
 
@@ -117,7 +114,6 @@ const {
   deleteNoteForever,
   noteRevisions,
   restoreNote,
-  setEditorMode,
   setIsViewingRevisions,
   showDialog,
   toggleNoteInfo,
@@ -129,7 +125,6 @@ const mapDispatchToProps = dispatch => ({
   deleteNoteForever: args => dispatch(deleteNoteForever(args)),
   noteRevisions: args => dispatch(noteRevisions(args)),
   restoreNote: args => dispatch(restoreNote(args)),
-  setEditorMode: args => dispatch(setEditorMode(args)),
   setIsViewingRevisions: (isViewingRevisions: boolean) => {
     dispatch(setIsViewingRevisions({ isViewingRevisions }));
   },

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { noop } from 'lodash';
 
+import actions from '../state/actions';
 import IconButton from '../icon-button';
 import BackIcon from '../icons/back';
 import InfoIcon from '../icons/info';
@@ -12,31 +13,33 @@ import TrashIcon from '../icons/trash';
 import ShareIcon from '../icons/share';
 import SidebarIcon from '../icons/sidebar';
 
-export class NoteToolbar extends Component {
+import * as T from '../types';
+import { State } from '../state';
+
+type Props = {
+  note: T.NoteEntity;
+  onRestoreNote: Function;
+  onTrashNote: Function;
+  onDeleteNoteForever: Function;
+  onShowRevisions: Function;
+  onShareNote: Function;
+  onCloseNote: Function;
+  onShowNoteInfo: Function;
+  setIsViewingRevisions: Function;
+  toggleFocusMode: Function;
+  markdownEnabled: boolean;
+};
+
+type ConnectedProps = ReturnType<typeof mapStateToProps> &
+  typeof mapDispatchToProps;
+
+export class NoteToolbar extends Component<Props & ConnectedProps> {
   static displayName = 'NoteToolbar';
 
-  static propTypes = {
-    note: PropTypes.object,
-    onRestoreNote: PropTypes.func,
-    onTrashNote: PropTypes.func,
-    onDeleteNoteForever: PropTypes.func,
-    onShowRevisions: PropTypes.func,
-    onShareNote: PropTypes.func,
-    onCloseNote: PropTypes.func,
-    onShowNoteInfo: PropTypes.func,
-    setIsViewingRevisions: PropTypes.func,
-    toggleFocusMode: PropTypes.func.isRequired,
-    onSetEditorMode: PropTypes.func,
-    editorMode: PropTypes.string,
-    markdownEnabled: PropTypes.bool,
-  };
-
   static defaultProps = {
-    editorMode: 'edit',
     onCloseNote: noop,
     onDeleteNoteForever: noop,
     onRestoreNote: noop,
-    onSetEditorMode: noop,
     onShowNoteInfo: noop,
     onShowRevisions: noop,
     onShareNote: noop,
@@ -64,7 +67,7 @@ export class NoteToolbar extends Component {
   setEditorMode = () => {
     const { editorMode } = this.props;
 
-    this.props.onSetEditorMode(editorMode === 'markdown' ? 'edit' : 'markdown');
+    this.props.setEditorMode(editorMode === 'markdown' ? 'edit' : 'markdown');
   };
 
   renderNormal = () => {
@@ -171,4 +174,12 @@ export class NoteToolbar extends Component {
   };
 }
 
-export default NoteToolbar;
+const mapStateToProps = (state: State) => ({
+  editorMode: state.ui.editorMode,
+});
+
+const mapDispatchToProps = {
+  setEditorMode: actions.ui.setEditorMode,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(NoteToolbar);

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -1,3 +1,4 @@
 export const AUTH_SET = 'AUTH_SET';
 export const FILTER_NOTES = 'FILTER_NOTES';
+export const EDITOR_MODE_SET = 'EDITOR_MODE_SET';
 export const TAG_DRAWER_TOGGLE = 'TAG_DRAWER_TOGGLE';

--- a/lib/state/actions.ts
+++ b/lib/state/actions.ts
@@ -1,7 +1,9 @@
 import * as auth from './auth/actions';
 import * as settings from './settings/actions';
+import * as ui from './ui/actions';
 
 export default {
   auth,
   settings,
+  ui,
 };

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -21,7 +21,6 @@ import * as T from '../types';
 
 export type AppState = {
   dialogs: unknown[];
-  editorMode: T.EditorMode;
   editingTags: boolean;
   filter: string;
   isOffline: boolean;

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -1,11 +1,22 @@
-import { FILTER_NOTES, TAG_DRAWER_TOGGLE } from '../action-types';
+import {
+  EDITOR_MODE_SET,
+  FILTER_NOTES,
+  TAG_DRAWER_TOGGLE,
+} from '../action-types';
+
+import * as T from '../../types';
 
 export const filterNotes = notes => ({
   type: FILTER_NOTES,
   notes,
 });
 
-export const toggleTagDrawer = show => ({
+export const setEditorMode = (mode: T.EditorMode) => ({
+  type: EDITOR_MODE_SET,
+  mode,
+});
+
+export const toggleTagDrawer = (show: boolean) => ({
   type: TAG_DRAWER_TOGGLE,
   show,
 });

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -1,11 +1,29 @@
 import { difference, union } from 'lodash';
 import { combineReducers } from 'redux';
-import { FILTER_NOTES, TAG_DRAWER_TOGGLE } from '../action-types';
+import {
+  EDITOR_MODE_SET,
+  FILTER_NOTES,
+  TAG_DRAWER_TOGGLE,
+} from '../action-types';
 
 import * as T from '../../types';
 
 const defaultVisiblePanes = ['editor', 'noteList'];
 const emptyList: unknown[] = [];
+
+const editorMode = (
+  state: T.EditorMode = 'edit',
+  { type, mode }: { type: string; mode: T.EditorMode }
+): T.EditorMode => {
+  switch (type) {
+    case 'App.newNote':
+      return 'edit';
+    case EDITOR_MODE_SET:
+      return mode;
+    default:
+      return state;
+  }
+};
 
 const filteredNotes = (
   state = emptyList as T.NoteEntity[],
@@ -22,4 +40,4 @@ const visiblePanes = (state = defaultVisiblePanes, { type, show }) => {
   return state;
 };
 
-export default combineReducers({ filteredNotes, visiblePanes });
+export default combineReducers({ editorMode, filteredNotes, visiblePanes });


### PR DESCRIPTION
**Status**: This is a collector branch where I have been exploring. After several derivative patches have been applied I'll come back and trim this down and request a real review on it.

Working on making the smallest change to move functionality out of the complicated `app-state` and into separate reducers.

This will drive towards two ends:
 - clarify the update sequence to that updates are atomic and predictable
 - focus Redux actions on app semantics

Maybe more. Either way it should help us predict and eliminate a number of bugs associated with immutable update sequences that get interrupted and are non atomic.

Even in `editorMode` we have a strange situation where the call to `dispatch(newNote(…))` then calls a nested `dispatch('setEditorMode')` and a few other `dispatch` calls that may end up out of sequence based on the network activity in Simperium.