### PR TITLE
Refactor: Remove "pinned" exceptions

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -23,6 +23,7 @@
 - Added git hooks to run format, lints, and tests [#1790](https://github.com/Automattic/simplenote-electron/pull/1790)
 - Added React Hooks ESLint Plugin [#1789](https://github.com/Automattic/simplenote-electron/pull/1789)
 - Added end-to-end testing with Spectron [#1773](https://github.com/Automattic/simplenote-electron/pull/1773)
+- Removed a workaround for indexing note pinned status [#1795](https://github.com/Automattic/simplenote-electron/pull/1795)
 - Maintenance cleanups [#1796](https://github.com/Automattic/simplenote-electron/pull/1796)
 
 ## [v1.13.0]

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -67,13 +67,11 @@ const client = initClient({
   bucketConfig: {
     note: {
       beforeIndex: function(note) {
-        var systemTags = (note.data && note.data.systemTags) || [];
         var content = (note.data && note.data.content) || '';
 
         return {
           ...note,
           contentKey: normalizeForSorting(content),
-          pinned: systemTags.indexOf('pinned') !== -1,
         };
       },
       configure: function(objectStore) {

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -291,7 +291,9 @@ export const actionMap = new ActionMap({
     },
 
     notesLoaded(state: AppState, { notes }: { notes: T.NoteEntity[] }) {
-      const [pinned, notPinned] = partition(notes, note => note.pinned);
+      const [pinned, notPinned] = partition(notes, note =>
+        note.data.systemTags.includes('pinned')
+      );
       const pinSortedNotes = [...pinned, ...notPinned];
 
       let selectedNote = null;

--- a/lib/flux/test.js
+++ b/lib/flux/test.js
@@ -51,9 +51,9 @@ describe('appState action reducers', () => {
       it('should load the newest version of the selected note', () => {
         const oldState = {
           notes: [{}],
-          note: { id: 'foo', data: 'old' },
+          note: { id: 'foo', data: { content: 'old', systemTags: [] } },
         };
-        const newNote = { id: 'foo', data: 'new' };
+        const newNote = { id: 'foo', data: { content: 'new', systemTags: [] } };
         const newNoteArray = [newNote];
         const newState = notesLoaded(oldState, {
           notes: newNoteArray,
@@ -70,8 +70,14 @@ describe('appState action reducers', () => {
           note: null,
           previousIndex: -1,
         };
-        const firstNote = { id: 'foo', data: 'first' };
-        const newNoteArray = [firstNote, {}];
+        const firstNote = {
+          id: 'foo',
+          data: { content: 'first', systemTags: [] },
+        };
+        const newNoteArray = [
+          firstNote,
+          { id: 'bar', data: { content: 'boo', systemTags: [] } },
+        ];
         const newState = notesLoaded(oldState, {
           notes: newNoteArray,
         });
@@ -85,8 +91,14 @@ describe('appState action reducers', () => {
           note: null,
           previousIndex: 1,
         };
-        const previousIndexNote = { id: 'foo', data: 'previous' };
-        const newNoteArray = [{}, previousIndexNote];
+        const previousIndexNote = {
+          id: 'foo',
+          data: { content: 'previous', systemTags: [] },
+        };
+        const newNoteArray = [
+          { id: 'bar', data: { content: 'boo', systemTags: [] } },
+          previousIndexNote,
+        ];
         const newState = notesLoaded(oldState, {
           notes: newNoteArray,
         });

--- a/lib/note-list/index.jsx
+++ b/lib/note-list/index.jsx
@@ -232,7 +232,7 @@ const renderNote = (
 
   const classes = classNames('note-list-item', {
     'note-list-item-selected': !isSmallScreen && selectedNoteId === note.id,
-    'note-list-item-pinned': note.pinned,
+    'note-list-item-pinned': note.data.systemTags.includes('pinned'),
     'published-note': isPublished,
   });
 
@@ -491,7 +491,8 @@ export class NoteList extends Component {
     );
   }
 
-  onPinNote = note => this.props.onPinNote(note, !note.pinned);
+  onPinNote = note =>
+    this.props.onPinNote(note, !note.data.systemTags.includes('pinned'));
 }
 
 const {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,7 +19,6 @@ export type Note = {
   creationDate: SecondsEpoch;
   deleted: boolean;
   modificationDate: SecondsEpoch;
-  pinned?: boolean;
   publishURL?: string;
   shareURL?: string;
   systemTags: SystemTag[];

--- a/lib/utils/export/export-notes.js
+++ b/lib/utils/export/export-notes.js
@@ -27,7 +27,7 @@ const mapNote = note => {
       creationDate: new Date(note.data.creationDate * 1000).toISOString(),
       lastModified: new Date(note.data.modificationDate * 1000).toISOString(),
     },
-    get(note, 'pinned', false) && { pinned: true },
+    note.data.systemTags.includes('pinned') && { pinned: true },
     get(note, 'data.systemTags', []).includes('markdown') && { markdown: true },
     tags.length && { tags },
     get(note, 'data.systemTags', []).includes('published') &&


### PR DESCRIPTION
To understand this change we have to undestand some core data models in
the app and some of the app's history.

Most data structures are composed of two parts: the Simperium `Entity`
which includes Simperium information of id, version, and wrapped data;
and the app-specific `data` which comes from Simplenote. That is, a
`note` is composed of the `Note` type which includes things like
`content` and `tags` and the `NoteEntity` which is the wrapped version.

We store all of the Simperium entities in `indexedDB` and in the
inception of this app we told `indexedDB` to create a search index based
off of whether or not a note was pinned. This was to make it fast to
list the notes with pinned notes at the top.

In order to facilitate the `pinned` index we had to create a fake
top-level property called `pinned` becuase we can't tell the browser:
"build an index on whether the `"pinned"` value is in the
`data.systemTags` array."

However, in [229a76b] we removed this index and moved pinned-sorting
into the application itself. When we did that we left behind the relic
of this top-level `pinned` value.

In this patch we're removing that relic. Why? Because it creates another
level of complexity by special-casing the `pinned` value which we have
to know about and reference when looking at the pinned status of a note.
By undoing this exception we can rely on the more semantically-native
means to check if or set whether a note is pinned.

This patch was triggered by what appeared to be an error when
introducing TypeScript types. We were looking at `note.pinned` which
shouldn't exist on the Simperium `Entity<Note>`. It _wasn't_ an error in
the app because the value existed but it wasn't clear that it _should_
exist.

I have preferred to undo the exception rather than to adjust the type.

## Testing

Since this change affects pinning we need to test the pinning flows:
 - Open the app and make sure that pinned notes are at the top
 - Pin a note and make sure that it jumps to the top
 - Unpin a note and make sure that it returns to its former spot in the list
 - Pin a note from a remote device and make sure that it updates accordingly here
 - Do the same as the previous step but for unpinning
 - Export the notes and make sure that the `pinned` property comes through to the exported format appropriately.
 - Import notes with `pinned` properties and make sure that they import properly.

[229a76b]: 229a76b4e6992728c20746cb5b6d0d3d32d27571