### PR TITLE
App-state: Remove unused `indexCtr`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -23,6 +23,7 @@
 - Added git hooks to run format, lints, and tests [#1790](https://github.com/Automattic/simplenote-electron/pull/1790)
 - Added React Hooks ESLint Plugin [#1789](https://github.com/Automattic/simplenote-electron/pull/1789)
 - Added end-to-end testing with Spectron [#1773](https://github.com/Automattic/simplenote-electron/pull/1773)
+- Maintenance cleanups [#1796](https://github.com/Automattic/simplenote-electron/pull/1796)
 
 ## [v1.13.0]
 

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -725,6 +725,4 @@ export const actionMap = new ActionMap({
   },
 });
 
-actionMap.indexCtr = 0;
-
 export default actionMap;


### PR DESCRIPTION
In the earlier stages of the app we relied on counting index operations
to defer updating the internal note list. This was to prevent thrashing
in the app when receiving updates for an account with lots of notes.

In #89 we moved the `indexCtr` value out of the controlled app state and
turned it into an instance variable on the `actionMap` object. This
change was made because we couldn't wait for a Redux update cycle to
update that value - the instance property updated immediately and
imperatively.

In #987 we removed the index-counting operation entirely and instead
relied on a more natural `debounce()` on `bucket.on('index')`. This
removed the need for the work-around but didn't remove the `indexCtr`
property.

In this patch we're finally removing it to finish the work from #987.
The property is currently unused and unreferenced in the app.

## Testing

There should be no functional or visual changes in this patch.