### PR TITLE
Fix: Possibly unknown note when creating note.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -24,7 +24,7 @@
 - Added React Hooks ESLint Plugin [#1789](https://github.com/Automattic/simplenote-electron/pull/1789)
 - Added end-to-end testing with Spectron [#1773](https://github.com/Automattic/simplenote-electron/pull/1773)
 - Removed a workaround for indexing note pinned status [#1795](https://github.com/Automattic/simplenote-electron/pull/1795)
-- Maintenance cleanups [#1796](https://github.com/Automattic/simplenote-electron/pull/1796)
+- Maintenance cleanups [#1796](https://github.com/Automattic/simplenote-electron/pull/1796), [#1797](https://github.com/Automattic/simplenote-electron/pull/1797)
 
 ## [v1.13.0]
 

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -241,6 +241,9 @@ export const actionMap = new ActionMap({
               ),
             },
             (e, note) => {
+              if (e) {
+                return debug(`newNote: could not create note - ${e.message}`);
+              }
               dispatch(
                 this.action('loadAndSelectNote', {
                   noteBucket,


### PR DESCRIPTION
When creating a new note we know that the operation might fail but we
keep on treating it as a success.

In this patch we send a debug message if the note bucket fails to create
our note and we don't continue processing as if it had.

## Testing

This is going to be a hard one to test unless you mangle Simperium, so
focus on auditing the change itself and consider the possible side-effects
of it. Make sure that we can still create notes and that those new notes
get synchronized with other devices.

This change is introducing a safety guard where none previously existed.