### PR TITLE
Tags: Treat comma as a submit key

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - Added indication that publish url has been copied [#1743](https://github.com/Automattic/simplenote-electron/pull/1743)
 - Disallow partial emails and user's own email from being adding to collaborators email field [#1735](https://github.com/Automattic/simplenote-electron/pull/1735)
 - Fixed keyboard shortcut to toggle markdown preview [#1788](https://github.com/Automattic/simplenote-electron/pull/1788)
+- Fixed an issue where typing a comma in the tag input would insert an empty tag [#1798](https://github.com/Automattic/simplenote-electron/pull/1798)
 
 ### Other Changes
 

--- a/lib/tag-input/index.jsx
+++ b/lib/tag-input/index.jsx
@@ -5,6 +5,7 @@ import { get, identity, invoke, noop } from 'lodash';
 const KEY_TAB = 9;
 const KEY_ENTER = 13;
 const KEY_RIGHT = 39;
+const KEY_COMMA = 188;
 
 const startsWith = prefix => text =>
   text
@@ -101,6 +102,7 @@ export class TagInput extends Component {
     invoke(
       {
         [KEY_ENTER]: this.submitTag,
+        [KEY_COMMA]: this.submitTag,
         [KEY_TAB]: this.interceptTabPress,
         [KEY_RIGHT]: this.interceptRightArrow,
       },
@@ -149,9 +151,7 @@ export class TagInput extends Component {
       return;
     }
 
-    value.endsWith(',') && value.trim().length // commas should automatically insert non-zero tags
-      ? this.props.onSelect(value.slice(0, -1).trim())
-      : this.props.onChange(value.trim(), this.focusInput);
+    this.props.onChange(value.trim(), this.focusInput);
   };
 
   onCompositionEnd = e => {


### PR DESCRIPTION
In the tag input, typing a comma acts like a submit (it gets stripped out and the tag is submitted). This fixes an issue where you could type a single comma and have a blank tag added.

Fixes #1670 

### Fix
Having the comma act as a "submit" was the intent of the original code, but there were bugs with it. Instead of testing to see if the value `endsWith` a comma and then attempting to strip it out, let's just go all-in and intercept the comma as if it was an Enter.

### Test
1. Go to a note
2. Focus on the "Add a tag..." text input at the bottom
3. Type a comma by itself. Note that it does not appear.
4. Type a tag name followed by a comma. Verify that the tag is added to the note.

### Release
`RELEASE-NOTES.txt` was updated in 414beb22ec6f5a1aaae0b3e0a61a6fcb6f038a28 with:
 
> Fixed an issue where typing a comma in the tag input would insert an empty tag [#1798](https://github.com/Automattic/simplenote-electron/pull/1798)