### PR TITLE
Re-render immediately when system theme is changed

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 - Disallow partial emails and user's own email from being adding to collaborators email field [#1735](https://github.com/Automattic/simplenote-electron/pull/1735)
 - Fixed keyboard shortcut to toggle markdown preview [#1788](https://github.com/Automattic/simplenote-electron/pull/1788)
 - Fixed an issue where typing a comma in the tag input would insert an empty tag [#1798](https://github.com/Automattic/simplenote-electron/pull/1798)
+- When system theme is selected in Settings, changing the system theme is now immediately reflected in the app [#1801](https://github.com/Automattic/simplenote-electron/pull/1801)
 
 ### Other Changes
 

--- a/lib/app.jsx
+++ b/lib/app.jsx
@@ -123,6 +123,7 @@ export const App = connect(
       preferencesBucket: PropTypes.object.isRequired,
       resetAuth: PropTypes.func.isRequired,
       setAuthorized: PropTypes.func.isRequired,
+      systemTheme: PropTypes.string.isRequired,
       tagBucket: PropTypes.object.isRequired,
     };
 
@@ -314,16 +315,12 @@ export const App = connect(
         preferencesBucket: this.props.preferencesBucket,
       });
 
-    getSystemColorMode = () =>
-      window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light';
-
     getTheme = () => {
       const {
         settings: { theme },
+        systemTheme,
       } = this.props;
-      return 'system' === theme ? this.getSystemColorMode() : theme;
+      return 'system' === theme ? systemTheme : theme;
     };
 
     initializeElectron = () => {

--- a/lib/app.test.js
+++ b/lib/app.test.js
@@ -3,6 +3,19 @@ import { shallow } from 'enzyme';
 
 import App from './app';
 
+window.matchMedia = jest.fn().mockImplementation(query => {
+  return {
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  };
+});
+
 describe('App', () => {
   it('should render', () => {
     const app = shallow(<App />);

--- a/lib/browser-shell.jsx
+++ b/lib/browser-shell.jsx
@@ -5,14 +5,20 @@ import React, { Component } from 'react';
  *
  * There is no need for `this` here; `window` is global
  *
- * @returns {{windowWidth: Number, isSmallScreen: boolean}} window attributes
+ * @returns {{windowWidth: Number, isSmallScreen: boolean, systemTheme: String }}
+ * window attributes
  */
 const getState = () => {
   const windowWidth = window.innerWidth;
 
+  const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+
   return {
     windowWidth,
     isSmallScreen: windowWidth <= 750, // Magic number here corresponds to $single-column value in variables.scss
+    systemTheme,
   };
 };
 
@@ -22,6 +28,7 @@ const getState = () => {
  * Passes:
  *   - viewport width (including scrollbar)
  *   - whether width is considered small
+ *   - system @media theme (dark or light)
  *
  * @param {Element} Wrapped React component dependent on window attributes
  * @returns {Component} wrapped React component with window attributes as props
@@ -34,13 +41,20 @@ export const browserShell = Wrapped =>
 
     componentDidMount() {
       window.addEventListener('resize', this.updateWindowSize);
+      window
+        .matchMedia('(prefers-color-scheme: dark)')
+        .addListener(this.updateSystemTheme);
     }
 
     componentWillUnmount() {
       window.removeEventListener('resize', this.updateWindowSize);
+      window
+        .matchMedia('(prefers-color-scheme: dark)')
+        .removeListener(this.updateSystemTheme);
     }
 
     updateWindowSize = () => this.setState(getState());
+    updateSystemTheme = () => this.setState(getState());
 
     render() {
       return <Wrapped {...this.state} {...this.props} />;


### PR DESCRIPTION
### Fix
In #1581 we added a setting for System theme, however the app currently only checks the system theme on load. This PR adds a listener to the browser shell that stores the system theme in app state, allowing the app to re-render immediately when the system theme is changed.

### Test
1. Load the app
2. Change the system theme
3. Observe that the theme changes without requiring a reload

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
 `RELEASE-NOTES.txt` was updated in ea483769292cace8825a2730ea0604b50c94c6ba with:
 
> When system theme is selected in Settings, changing the system theme is now immediately reflected in the app [#1801](https://github.com/Automattic/simplenote-electron/pull/1801)