### PR TITLE
Use name attribute not the deprecated getter function

### DIFF
--- a/desktop/menus/mac-app-menu.js
+++ b/desktop/menus/mac-app-menu.js
@@ -4,7 +4,7 @@ const menuItems = require('./menu-items');
 const build = require('../detect/build');
 
 const macAppMenu = {
-  label: app.getName(),
+  label: app.name,
   submenu: [
     menuItems.about,
     ...(build.isMAS() ? [] : [menuItems.checkForUpdates]),

--- a/desktop/menus/menu-items.js
+++ b/desktop/menus/menu-items.js
@@ -5,7 +5,7 @@ const updater = require('../updater');
 const DialogTypes = require('../../shared/dialog-types');
 
 const about = {
-  label: '&About ' + app.getName(),
+  label: '&About ' + app.name,
   click: appCommandSender({
     action: 'showDialog',
     dialog: DialogTypes.ABOUT,

--- a/desktop/updater/lib/Updater.js
+++ b/desktop/updater/lib/Updater.js
@@ -86,7 +86,7 @@ class Updater extends EventEmitter {
 
   expandMacros(originalText) {
     const macros = {
-      name: app.getName(),
+      name: app.name,
       currentVersion: app.getVersion(),
       newVersion: this._version,
     };


### PR DESCRIPTION
### Fix
https://electronjs.org/docs/all#appgetname is deprecated,
https://electronjs.org/docs/all#appname should be used instead. This PR
replaces uses of `.getName()` with `.name`.

### Test
Open built dmg from ci and ensure the App name in the context menu is correct.


