### PR TITLE
Sets babel compact option to false is development

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -31,6 +31,7 @@
 - Maintenance cleanups [#1796](https://github.com/Automattic/simplenote-electron/pull/1796), [#1797](https://github.com/Automattic/simplenote-electron/pull/1797), [#1808](https://github.com/Automattic/simplenote-electron/pull/1808), [#1809](https://github.com/Automattic/simplenote-electron/pull/1809), [#1810](https://github.com/Automattic/simplenote-electron/pull/1810), [#1811](https://github.com/Automattic/simplenote-electron/pull/1811)
 - Updated dependencies [#1802](https://github.com/Automattic/simplenote-electron/pull/1802)
 - Updated dependencies [#1821](https://github.com/Automattic/simplenote-electron/pull/1821)
+- Fixed build warning [#1806](https://github.com/Automattic/simplenote-electron/pull/1806)
 
 ## [v1.13.0]
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -18,6 +18,9 @@ module.exports = function(api) {
     '@babel/plugin-syntax-dynamic-import',
   ];
   const env = {
+    development: {
+      compact: false,
+    },
     test: {
       plugins: ['dynamic-import-node'],
     },


### PR DESCRIPTION
### Fix
Babel was outputting warnings about lodash and react-dom that it wasn't
removing white space. This sets babel compact to false in order to stop those
warnings. We also don't need babel to compact in development.
https://babeljs.io/docs/en/options#compact

### Test
Does the app build from `npm run dev`?

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Fixed build warning [#1806](https://github.com/Automattic/simplenote-electron/pull/1806)