### PR TITLE
Refactor(NoteList): Use already assigned list iterator

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -25,7 +25,7 @@
 - Added React Hooks ESLint Plugin [#1789](https://github.com/Automattic/simplenote-electron/pull/1789)
 - Added end-to-end testing with Spectron [#1773](https://github.com/Automattic/simplenote-electron/pull/1773)
 - Removed a workaround for indexing note pinned status [#1795](https://github.com/Automattic/simplenote-electron/pull/1795)
-- Maintenance cleanups [#1796](https://github.com/Automattic/simplenote-electron/pull/1796), [#1797](https://github.com/Automattic/simplenote-electron/pull/1797)
+- Maintenance cleanups [#1796](https://github.com/Automattic/simplenote-electron/pull/1796), [#1797](https://github.com/Automattic/simplenote-electron/pull/1797), [#1808](https://github.com/Automattic/simplenote-electron/pull/1808)
 - Updated dependencies [#1802](https://github.com/Automattic/simplenote-electron/pull/1802)
 
 ## [v1.13.0]

--- a/lib/note-list/index.jsx
+++ b/lib/note-list/index.jsx
@@ -126,7 +126,7 @@ const rowHeightCache = f => (
 
   const { preview } = getNoteTitleAndPreview(note);
 
-  const key = notes[index].id;
+  const key = note.id;
   const cached = previewCache.get(key);
 
   if ('undefined' !== typeof cached) {


### PR DESCRIPTION
In the existing code we're recomputing the current list item in the note list
when we've already assigned it above. In this patch we're using the
already-assigned value.

This is part of broader work to separate modifying the search parameters from
actually filtering the notes and was originally created as part of an
exploratory PR #1807.

## Testing

Smoke test with some note searches.
Open the settings panel and change the list display mode.
Make sure that the notes list displays correctly.

This is a very minor change and should be able to be confirmed
through code inspection and auditing.