### PR TITLE
Refactor(NoteList): Use numbers for tabIndex instead of strings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -25,7 +25,7 @@
 - Added React Hooks ESLint Plugin [#1789](https://github.com/Automattic/simplenote-electron/pull/1789)
 - Added end-to-end testing with Spectron [#1773](https://github.com/Automattic/simplenote-electron/pull/1773)
 - Removed a workaround for indexing note pinned status [#1795](https://github.com/Automattic/simplenote-electron/pull/1795)
-- Maintenance cleanups [#1796](https://github.com/Automattic/simplenote-electron/pull/1796), [#1797](https://github.com/Automattic/simplenote-electron/pull/1797), [#1808](https://github.com/Automattic/simplenote-electron/pull/1808)
+- Maintenance cleanups [#1796](https://github.com/Automattic/simplenote-electron/pull/1796), [#1797](https://github.com/Automattic/simplenote-electron/pull/1797), [#1808](https://github.com/Automattic/simplenote-electron/pull/1808), [#1809](https://github.com/Automattic/simplenote-electron/pull/1809) 
 - Updated dependencies [#1802](https://github.com/Automattic/simplenote-electron/pull/1802)
 
 ## [v1.13.0]

--- a/lib/note-list/index.jsx
+++ b/lib/note-list/index.jsx
@@ -247,12 +247,12 @@ const renderNote = (
     <div key={key} style={style} className={classes}>
       <div
         className="note-list-item-pinner"
-        tabIndex="0"
+        tabIndex={0}
         onClick={onPinNote.bind(null, note)}
       />
       <div
         className="note-list-item-text theme-color-border"
-        tabIndex="0"
+        tabIndex={0}
         onClick={selectNote}
       >
         <div className="note-list-item-title">


### PR DESCRIPTION
Previously we have been (successfully) passing string values of `0` into the `tabIndex` property on parts of the note list preview. While acceptible this is the wrong datatype. In this patch we're passing the `{0}` value instead through React so that the types unify.

This is part of broader work to separate modifying the search parameters from
actually filtering the notes and was originally created as part of an
exploratory PR #1807.

## Testing

Open Simplenote and make sure that when tabbing you don't stop on the note
pinner or the div surrounding the preview. Confirm that the behavior matches
that in `develop`

This is a very minor change and should be able to be confirmed
through code inspection and auditing.