### PR TITLE
Filter notes in state vs. on `render()`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -32,6 +32,7 @@
 - Updated dependencies [#1802](https://github.com/Automattic/simplenote-electron/pull/1802)
 - Updated dependencies [#1821](https://github.com/Automattic/simplenote-electron/pull/1821)
 - Fixed build warning [#1806](https://github.com/Automattic/simplenote-electron/pull/1806)
+- Refactor how notes are filtered for better performance and maintainability [#1812](https://github.com/Automattic/simplenote-electron/pull/1812)
 
 ## [v1.13.0]
 

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -33,8 +33,6 @@ import {
 
 import * as settingsActions from './state/settings/actions';
 
-import filterNotes from './utils/filter-notes';
-
 const ipc = getIpcRenderer();
 
 const mapStateToProps = state => ({
@@ -361,13 +359,11 @@ export const App = connect(
 
     // gets the index of the note located before the currently selected one
     getPreviousNoteIndex = note => {
-      const filteredNotes = filterNotes(this.props.appState);
+      const noteIndex = this.props.ui.filteredNotes.findIndex(
+        ({ id }) => note.id === id
+      );
 
-      const noteIndex = function(filteredNote) {
-        return note.id === filteredNote.id;
-      };
-
-      return Math.max(filteredNotes.findIndex(noteIndex) - 1, 0);
+      return Math.max(noteIndex - 1, 0);
     };
 
     syncActivityHooks = data => {

--- a/lib/note-info/index.tsx
+++ b/lib/note-info/index.tsx
@@ -9,7 +9,6 @@ import CrossIcon from '../icons/cross';
 import { connect } from 'react-redux';
 import appState from '../flux/app-state';
 import { setMarkdown } from '../state/settings/actions';
-import filterNotes from '../utils/filter-notes';
 
 export class NoteInfo extends Component {
   static propTypes = {
@@ -189,8 +188,7 @@ function characterCount(content) {
 
 const { markdownNote, pinNote, toggleNoteInfo } = appState.actionCreators;
 
-const mapStateToProps = ({ appState: state }) => {
-  const filteredNotes = filterNotes(state);
+const mapStateToProps = ({ appState: state, ui: { filteredNotes } }) => {
   const noteIndex = Math.max(state.previousIndex, 0);
   const note = state.note ? state.note : filteredNotes[noteIndex];
   return {

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -21,7 +21,6 @@ import { debounce, get, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
 import appState from '../flux/app-state';
 import { tracks } from '../analytics';
-import filterNotes from '../utils/filter-notes';
 import getNoteTitleAndPreview from './get-note-title-and-preview';
 import {
   decorateWith,
@@ -341,6 +340,7 @@ export class NoteList extends Component {
     } = this.props;
 
     if (
+      prevProps.filter !== this.props.filter ||
       prevProps.noteDisplay !== this.props.noteDisplay ||
       prevProps.notes !== notes ||
       prevProps.selectedNoteContent !== this.props.selectedNoteContent
@@ -494,10 +494,12 @@ const {
 } = appState.actionCreators;
 const { recordEvent } = tracks;
 
-const mapStateToProps = ({ appState: state, settings: { noteDisplay } }) => {
+const mapStateToProps = ({
+  appState: state,
+  ui: { filteredNotes },
+  settings: { noteDisplay },
+}) => {
   const tagResultsFound = getMatchingTags(state.tags, state.filter).length;
-
-  const filteredNotes = filterNotes(state);
 
   const noteIndex = Math.max(state.previousIndex, 0);
   const selectedNote = state.note ? state.note : filteredNotes[noteIndex];

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -1,2 +1,3 @@
 export const AUTH_SET = 'AUTH_SET';
+export const FILTER_NOTES = 'FILTER_NOTES';
 export const TAG_DRAWER_TOGGLE = 'TAG_DRAWER_TOGGLE';

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -11,6 +11,8 @@ import { omit } from 'lodash';
 
 import appState from '../flux/app-state';
 
+import uiMiddleware from './ui/middleware';
+
 import auth from './auth/reducer';
 import settings from './settings/reducer';
 import ui from './ui/reducer';
@@ -66,7 +68,7 @@ export const store = createStore(
         [path]: omit(state[path], 'focusModeEnabled'),
       }),
     }),
-    applyMiddleware(thunk)
+    applyMiddleware(thunk, uiMiddleware)
   )
 );
 

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -1,4 +1,9 @@
-import { TAG_DRAWER_TOGGLE } from '../action-types';
+import { FILTER_NOTES, TAG_DRAWER_TOGGLE } from '../action-types';
+
+export const filterNotes = notes => ({
+  type: FILTER_NOTES,
+  notes,
+});
 
 export const toggleTagDrawer = show => ({
   type: TAG_DRAWER_TOGGLE,

--- a/lib/state/ui/middleware.ts
+++ b/lib/state/ui/middleware.ts
@@ -1,0 +1,37 @@
+import { AnyAction } from 'redux';
+import { filterNotes as filterAction } from './actions';
+import filterNotes from '../../utils/filter-notes';
+
+let searchTimeout: NodeJS.Timeout;
+
+export default store => {
+  const updateNotes = () =>
+    store.dispatch(filterAction(filterNotes(store.getState().appState)));
+
+  return next => (action: AnyAction) => {
+    const result = next(action);
+
+    switch (action.type) {
+      case 'App.authChanged':
+      case 'App.deleteNoteForever':
+      case 'App.notesLoaded':
+      case 'App.restoreNote':
+      case 'App.showAllNotes':
+      case 'App.selectTag':
+      case 'App.selectTrash':
+      case 'App.tagsLoaded':
+      case 'App.trashNote':
+        clearTimeout(searchTimeout);
+        searchTimeout = setTimeout(updateNotes, 50);
+        break;
+
+      case 'App.noteUpdatedRemotely':
+      case 'App.search':
+        clearTimeout(searchTimeout);
+        searchTimeout = setTimeout(updateNotes, 500);
+        break;
+    }
+
+    return result;
+  };
+};

--- a/lib/state/ui/middleware.ts
+++ b/lib/state/ui/middleware.ts
@@ -12,23 +12,31 @@ export default store => {
     const result = next(action);
 
     switch (action.type) {
+      // on clicks re-filter "immediately"
       case 'App.authChanged':
       case 'App.deleteNoteForever':
       case 'App.notesLoaded':
       case 'App.restoreNote':
-      case 'App.showAllNotes':
       case 'App.selectTag':
       case 'App.selectTrash':
+      case 'App.showAllNotes':
       case 'App.tagsLoaded':
       case 'App.trashNote':
         clearTimeout(searchTimeout);
         searchTimeout = setTimeout(updateNotes, 50);
         break;
 
+      // on updating the search field we should delay the update
+      // so we don't waste our CPU time and lose responsiveness
       case 'App.noteUpdatedRemotely':
       case 'App.search':
         clearTimeout(searchTimeout);
-        searchTimeout = setTimeout(updateNotes, 500);
+        if ('App.search' === action.type && !action.filter) {
+          // if we just cleared out the search bar then immediately update
+          updateNotes();
+        } else {
+          searchTimeout = setTimeout(updateNotes, 500);
+        }
         break;
     }
 

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -1,8 +1,16 @@
 import { difference, union } from 'lodash';
 import { combineReducers } from 'redux';
-import { TAG_DRAWER_TOGGLE } from '../action-types';
+import { FILTER_NOTES, TAG_DRAWER_TOGGLE } from '../action-types';
+
+import * as T from '../../types';
 
 const defaultVisiblePanes = ['editor', 'noteList'];
+const emptyList: unknown[] = [];
+
+const filteredNotes = (
+  state = emptyList as T.NoteEntity[],
+  { type, notes }: { type: string; notes: T.NoteEntity[] }
+) => (FILTER_NOTES === type ? notes : state);
 
 const visiblePanes = (state = defaultVisiblePanes, { type, show }) => {
   if (TAG_DRAWER_TOGGLE === type) {
@@ -14,4 +22,4 @@ const visiblePanes = (state = defaultVisiblePanes, { type, show }) => {
   return state;
 };
 
-export default combineReducers({ visiblePanes });
+export default combineReducers({ filteredNotes, visiblePanes });

--- a/lib/utils/filter-notes.ts
+++ b/lib/utils/filter-notes.ts
@@ -3,6 +3,7 @@
  */
 import { difference, escapeRegExp, get } from 'lodash';
 import { NoteEntity, TagEntity } from '../types';
+import { AppState } from '../state';
 
 const tagPattern = () => /(?:\btag:)([\w-]+)(?!\B)/g;
 
@@ -105,7 +106,7 @@ const emptyList = Object.freeze([]);
  * @TODO: Pre-index note title in domains/note
  */
 export default function filterNotes(
-  state,
+  state: AppState,
   notesArray: NoteEntity[] | null = null
 ) {
   const {

--- a/lib/utils/filter-notes.ts
+++ b/lib/utils/filter-notes.ts
@@ -3,7 +3,6 @@
  */
 import { difference, escapeRegExp, get } from 'lodash';
 import { NoteEntity, TagEntity } from '../types';
-import { AppState } from '../state';
 
 const tagPattern = () => /(?:\btag:)([\w-]+)(?!\B)/g;
 
@@ -106,7 +105,7 @@ const emptyList = Object.freeze([]);
  * @TODO: Pre-index note title in domains/note
  */
 export default function filterNotes(
-  state: AppState,
+  state,
   notesArray: NoteEntity[] | null = null
 ) {
   const {


### PR DESCRIPTION
The `filterNotes()` function is relatively expensive, particularly for accounts
with many notes.  Previously we have been running this several times in a
normal app update because it gets called in `mapStateToProps` on `note-list`
and also in a couple of other components. When these all re-render we end up
filtering the notes multiple times in a row even though no changes could have
occurred during that window of time (due to the single-threaded nature of
JavaScript, not because of the unlikelihood of receiving remote changes).

In this patch we're separating out the filtered notes into a new place in
`state` and we're updating it via middleware that watches for any actions which
might impact the note list. This gives us more control over the update cycle
and lets us replace debounced logic with synchronous updates.

After this change the search field's input will immediately update to reflect
the changes being entered in on the keyboard or via the tag list panel but the
note list won't immediately update when only typing in the search field. It
will update immediately when changing tags or when performing "atomic" updates
like trashing or restoring a note. The decision to defer or operate
"immediately" was based on the expectations of how interactive each action
should be. When we're typing in a search field we are probably going to type
more before we need the results to update, but when we flip to another tag we
expect that to immediately reflect visually.

## Testing

This is a bigger commit. It touches a wide variety of interactions with the note list
and we need to be extra thorough in testing. Please smoke-test and record what
you tested.

Interactions we need to test include but are not limited to:
 - type in the search field, wait for the results
 - type in the search field, keep typing
 - select a tag
 - select a tag when there's a search filter already
 - with search results, create a new note matching the query from another device
 - with search results, trash a note in the results from another device
 - perform searches with and without tag suggestions
 - select/open a note, delete a note which is above it in the list
 - select/open a note, delete the note
 - select/open a note, edit the note

For example, during my own testing I found at one point that there was a blank gap above the notes
in the note list and this was due to the fact that we weren't recalculating the list heights
when the filter changed. Previously the `filteredNotes` was referentially different on every
render but now it only changes when the search results update, so I had to add in that
check in `componentDidUpdate()`.

There should be no visual or functional changes in this PR.