### PR TITLE
Add missing decorators in note list previews

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,7 @@
 - Fixed keyboard shortcut to toggle markdown preview [#1788](https://github.com/Automattic/simplenote-electron/pull/1788)
 - Fixed an issue where typing a comma in the tag input would insert an empty tag [#1798](https://github.com/Automattic/simplenote-electron/pull/1798)
 - When system theme is selected in Settings, changing the system theme is now immediately reflected in the app [#1801](https://github.com/Automattic/simplenote-electron/pull/1801)
+- Show all checkboxes and search results in note list [#1814](https://github.com/Automattic/simplenote-electron/pull/1814)
 
 ### Other Changes
 

--- a/lib/note-detail/toggle-task/constants.ts
+++ b/lib/note-detail/toggle-task/constants.ts
@@ -3,6 +3,6 @@ export const selectors = {
   markdownRoot: '[data-markdown-root]',
 };
 
-export const taskPrefixRegex = /^(\s*)(-[ \t]+\[[xX\s]?\])/g;
+export const taskPrefixRegex = /^(\s*)(-[ \t]+\[[xX\s]?\])/gm;
 
 export const taskRegex = /^(\s*)(-[ \t]+\[[xX\s]?\])(.+)/gm;

--- a/lib/note-list/decorators.tsx
+++ b/lib/note-list/decorators.tsx
@@ -1,37 +1,41 @@
 import React from 'react';
+import { escapeRegExp } from 'lodash';
 import replaceToArray from 'string-replace-to-array';
 
 import Checkbox from '../components/checkbox';
+import { withoutTags } from '../utils/filter-notes';
 import { taskPrefixRegex } from '../note-detail/toggle-task/constants';
 
-export const decorateWith = (decorators, text) => {
-  let output = text;
-  let i = 0;
+export const decorateWith = (decorators, text) =>
+  decorators
+    .reduce((output, { filter, replacer }) => {
+      const searchText = 'string' === typeof filter && withoutTags(filter);
+      const pattern =
+        searchText && searchText.length > 0
+          ? new RegExp(escapeRegExp(searchText), 'g')
+          : filter;
 
-  decorators.forEach(({ filter, replacer }) => {
-    output = replaceToArray(output, filter, replacer(i++));
-  });
-
-  return output;
-};
+      return replaceToArray(output, pattern, replacer);
+    }, text)
+    .map((chunk, key) =>
+      chunk && 'string' !== typeof chunk
+        ? React.cloneElement(chunk, { key })
+        : chunk
+    );
 
 export const checkboxDecorator = {
   filter: taskPrefixRegex,
-  replacer: key => match => {
+  replacer: match => {
     const isChecked = /x/i.test(match);
-    return <Checkbox checked={isChecked} key={key} />;
+    return <Checkbox checked={isChecked} />;
   },
 };
 
 export const makeFilterDecorator = filter => ({
   filter,
-  replacer: key => match => {
+  replacer: match => {
     if (match.length) {
-      return (
-        <span className="search-match" key={key}>
-          {match}
-        </span>
-      );
+      return <span className="search-match">{match}</span>;
     }
   },
 });


### PR DESCRIPTION
When showing each item in the note list we run the content decorators on them
in order to show checkboxes instead of the markdown syntax for a checkbox and
we also highlight the matching text from the search box.

Previously we have only been showing the first match for each decorator because
of a couple small bugs:
 - the task prefix matcher wasn't using the `m` multi-line flag in its RegExp
   pattern
 - the search filter text was only replacing the first occurrance, see JS
   "replaceAll()" proposal

In this patch we're rewritten `decorateWith` to automatically create a global
RegExp pattern for the search text and the task prefix RegExp pattern has been
corrected.

After this patch you can now see all of the decorated items in the note list;
for example, if you had two checklist items in a note then you can now see
multiple checkboxes in the note list whereas before you'd only see the first
one and then the second one would appear as ` - [ ]` or `- [x]`

## Testing

Open an account with notes having multiple repeated text in the first few lines.

For example…(`one` appears in each line)
```
# A short poem
One river,
Two stones,
In the zone.
```

Search for the repeated pattern, such as `one`

You should find that in **develop** you'll only see the first result highlighted
but in this branch all of the `one`s should be highlighted.

Repeat the experiment with a checklist…
```
# Groceries
 - [ ] Eggs
 - [ ] Chicken
 - [ ] Milk
```

In **develop** only the first item will render as a checklist but in this branch
all three should, if they are visible in the preview.

Verify that if you search for regular-expression-y patterns then you'll only
get results matching the literal text and not the pattern itself.

```
Patterns I use:

4 a number - /\d/
```

If you search for `\d` then the `\d` in the note should be highlighted, not the `4`

## Before
![missing-decorators mov](https://user-images.githubusercontent.com/5431237/71762939-3efc1700-2e93-11ea-88da-aeda9641f8ea.gif)


## After
![all-the-decorators mov](https://user-images.githubusercontent.com/5431237/71762928-225fdf00-2e93-11ea-8c3b-9dd7fbdb0b45.gif)
