### PR TITLE
Fix typo from #1792 preventing filtering by tag

### DIFF
--- a/lib/utils/filter-notes.ts
+++ b/lib/utils/filter-notes.ts
@@ -73,7 +73,7 @@ const makeMatchesTag = (tag: TagEntity, filter = '') => (note: NoteEntity) => {
     }
   }
 
-  const givenTag = tag ? [get(tag, 'data.namer', '')] : [];
+  const givenTag = tag ? [get(tag, 'data.name', '')] : [];
 
   const noteTags = get(note, 'data.tags', []);
 


### PR DESCRIPTION
In #1792 I introduced a typo from `name` to `namer` and this prevented the tag
drawer from working properly. That is, when trying to filter by tag it was
looking for matches on `tag.data.namer` instead of on `tag.data.name` and
unsuprisingly there were no matches.

After this patch things are restored to normal working order.

## Testing

Confirm that in `develop` if you select a tag in the tag drawer then no notes will show in the note list.
![tagDrawerNotWorking mov](https://user-images.githubusercontent.com/5431237/71859667-5a466c80-30b5-11ea-81ae-fa8a401c9f8d.gif)

In this branch, however, they should filter as usual.
![workingTagList mov](https://user-images.githubusercontent.com/5431237/71859683-6b8f7900-30b5-11ea-81f5-fc86a0b60286.gif)
