### PR TITLE
Remove prop types warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,7 +46,6 @@
     "react/display-name": "warn",
     "react/no-deprecated": "warn",
     "react/no-string-refs": "warn",
-    "react/prop-types": "warn",
     "vars-on-top": "error"
   },
   "settings": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,6 +46,7 @@
     "react/display-name": "warn",
     "react/no-deprecated": "warn",
     "react/no-string-refs": "warn",
+    "react/prop-types": "off",
     "vars-on-top": "error"
   },
   "settings": {


### PR DESCRIPTION
### Fix
Remove prop types warnings from the linter as we will be removing them with the use of Typescript types

### Test
No testing needed

### Review
Only one developer is required to review these changes, but anyone can perform the review.