### PR TITLE
Fixes focus mode toggle

### DIFF
--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -3,16 +3,27 @@
   flex: 1 0 auto;
   width: 100%;
 
-  &.is-focus-mode.is-note-open {
+  &.is-focus-mode {
     .app-layout__source-column {
       overflow: hidden;
       opacity: $fade-alpha;
       width: 0;
-      transition: width .2s ease-in-out, opacity .2s ease-in-out;
+      transition: width 0.2s ease-in-out, opacity 0.2s ease-in-out;
     }
     .app-layout__note-column {
       border-left-width: 0px;
-      transition: border-left-width .2s;
+      transition: border-left-width 0.2s;
+    }
+
+    @media only screen and (max-width: $single-column) {
+      .app-layout__source-column {
+        overflow: inherit;
+        opacity: 1;
+        width: inherit;
+      }
+      .app-layout__note-column {
+        transition: inherit;
+      }
     }
   }
 
@@ -43,7 +54,7 @@
 
   &.is-note-open {
     .app-layout__source-column {
-      transition: opacity .2s ease-in-out;
+      transition: opacity 0.2s ease-in-out;
     }
 
     @media only screen and (max-width: $single-column) {


### PR DESCRIPTION
### Fix
Fixes: #1525

When the app loads there is potential for the `is-note-open` css class to be
missing on app-layout. This removes the reliance on isNoteOpen as it is note
needed and should be independent. Now focus mode class will remain on all
screen widths but will only change the layout for widths greater than 750px. We
should look at why `is-note-open` is not applied to app layout and how the layout
is set up in general.

### Test
This is hard to test since the original issue is hard to replicate. The best thing you can do is make the function that adds `is-note-open` not add it.

1. Open app on widescreen
2. Toggle focus mode several times
3. Open app
4. Toggle focus mode
5. Make width less than 750px
6. Click back and forth between note list and note view
7. Open menus etc.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Fixes focus mode toggle sometimes not functioning [#1819](https://github.com/Automattic/simplenote-electron/pull/1819)