### PR TITLE
Render unfinished lists correctly

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,7 +16,7 @@
 - When system theme is selected in Settings, changing the system theme is now immediately reflected in the app [#1801](https://github.com/Automattic/simplenote-electron/pull/1801)
 - Show all checkboxes and search results in note list [#1814](https://github.com/Automattic/simplenote-electron/pull/1814)
 - Fix ol numbering in markdown preview [#1823](https://github.com/Automattic/simplenote-electron/pull/1823)
-- Fixed markdown render issue with lists with hypehn only on new line [#1822](https://github.com/Automattic/simplenote-electron/pull/1822)
+- Prevents weird effects in live previews due to incomplete input [#1822](https://github.com/Automattic/simplenote-electron/pull/1822)
 
 ### Other Changes
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@
 - When system theme is selected in Settings, changing the system theme is now immediately reflected in the app [#1801](https://github.com/Automattic/simplenote-electron/pull/1801)
 - Show all checkboxes and search results in note list [#1814](https://github.com/Automattic/simplenote-electron/pull/1814)
 - Fix ol numbering in markdown preview [#1823](https://github.com/Automattic/simplenote-electron/pull/1823)
+- Fixed markdown render issue with lists with hypehn only on new line [#1822](https://github.com/Automattic/simplenote-electron/pull/1822)
 
 ### Other Changes
 

--- a/lib/utils/render-note-to-html.ts
+++ b/lib/utils/render-note-to-html.ts
@@ -16,6 +16,7 @@ export const renderNoteToHtml = content => {
       markdownConverter.setFlavor('github');
       markdownConverter.setOption('simpleLineBreaks', false); // override GFM
       markdownConverter.setOption('ghMentions', false);
+      markdownConverter.setOption('smoothLivePreview', true);
 
       return sanitizeHtml(markdownConverter.makeHtml(content));
     }


### PR DESCRIPTION
### Fix

Fixes: #676

When a list has a trailing `-` the markdown renderer (showdown) will make the
previous list element an h2. Technically this is valid markdown and is doing
what it should but this is usually not the intention of the user. Because we
auto-add  a `-` after a carriage return users run into this issue regularly.

This issue is resolved by enabling the `smoothLivePreview` option in showdown.

You can replicate this with the following markdown:

```
- test 1
- test 2
- test 3
-
```
Currently, this will output:

```
<ul>
<li>test 1</li>
<li>test 2</li>
</ul>
<h2 id="test3">- test 3</h2>
```
After the addition of the `smoothLivePreview` option it will return:
```
<ul>
<li>test 1</li>
<li>test 2</li>
<li>test 3</li>
-
</ul>
```

### Test
1. Use the sample markdown from above
2. Toggle preview to ensure output is correct

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Fixed markdown render issue with lists with hypehn only on new line [#1822](https://github.com/Automattic/simplenote-electron/pull/1822)