### PR TITLE
Fix ol numbering in markdown preview

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 - Fixed an issue where typing a comma in the tag input would insert an empty tag [#1798](https://github.com/Automattic/simplenote-electron/pull/1798)
 - When system theme is selected in Settings, changing the system theme is now immediately reflected in the app [#1801](https://github.com/Automattic/simplenote-electron/pull/1801)
 - Show all checkboxes and search results in note list [#1814](https://github.com/Automattic/simplenote-electron/pull/1814)
+- Fix ol numbering in markdown preview [#1823](https://github.com/Automattic/simplenote-electron/pull/1823)
 
 ### Other Changes
 

--- a/lib/utils/sanitize-html.ts
+++ b/lib/utils/sanitize-html.ts
@@ -134,6 +134,14 @@ const isAllowedAttr = (tagName, attrName, value) => {
           return false;
       }
 
+    case 'ol':
+      switch (attrName) {
+        case 'start':
+          return true;
+        default:
+          return false;
+      }
+
     default:
       return false;
   }


### PR DESCRIPTION
### Fix

Fixes: #676

The numbering of ol lists is currently broken when you have a list that is
interrupted with a line of text that is not part of the list.

This PR whitelists the `start` attribute on `ol` tags which fixes the issue.

For example:
```
1. One
1. Two
1. Three
some_text some_text
1. Four
```

The above example should number the list 1 to 4. It, however, orders the list 1
to 3 and then after the interrupt starts over at 1.

The output from showdown, the markdown to html processor, is:
```
<ol>
<li>One</li>
<li>Two</li>
<li>Three</li>
</ol>
<p>some_text some_text</p>
<ol start="4">
<li>Four</li>
</ol>
```

Notice the second ol has a `start` attribute `<ol start="4">`.

When we pass the html into the `sanitizeHtml` function that attribute is
stripped. This PR whitelists that attribute so it is not stripped.

### Test
1. Use the sample markdown from above
2. Toggle preview to ensure output is correct

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Fix ol numbering in markdown preview [#1823](https://github.com/Automattic/simplenote-electron/pull/1823)