### PR TITLE
Fixes thrashing between notes

### DIFF
--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -206,6 +206,19 @@ export const actionMap = new ActionMap({
       });
     },
 
+    searchAndSelectFirstNote: {
+      creator({ filter }: { filter: T.TagEntity }) {
+        return (dispatch, getState) => {
+          dispatch(this.action('search', { filter }));
+          dispatch(
+            this.action('notesLoaded', {
+              notes: getState().appState.notes,
+            })
+          );
+        };
+      },
+    },
+
     newNote: {
       creator({
         noteBucket,

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -348,11 +348,6 @@ export class NoteList extends Component {
       this.recomputeHeights();
     }
 
-    // Ensure that the note selected here is also selected in the editor
-    if (selectedNoteId !== prevProps.selectedNoteId) {
-      onSelectNote(selectedNoteId);
-    }
-
     // Deselect the currently selected note if it doesn't match the search query
     if (filter !== prevProps.filter) {
       const selectedNotePassesFilter = notes.some(

--- a/lib/search-bar/index.tsx
+++ b/lib/search-bar/index.tsx
@@ -15,7 +15,11 @@ import SearchField from '../search-field';
 import MenuIcon from '../icons/menu';
 import { withoutTags } from '../utils/filter-notes';
 
-const { newNote, search, toggleNavigation } = appState.actionCreators;
+const {
+  newNote,
+  searchAndSelectFirstNote,
+  toggleNavigation,
+} = appState.actionCreators;
 const { recordEvent } = tracks;
 
 type Props = {
@@ -50,7 +54,7 @@ const mapStateToProps = ({ appState: state }) => ({
 
 const mapDispatchToProps = (dispatch, { noteBucket, onNoteOpened }) => ({
   onNewNote: (content: string) => {
-    dispatch(search({ filter: '' }));
+    dispatch(searchAndSelectFirstNote({ filter: '' }));
     dispatch(newNote({ noteBucket, content }));
     onNoteOpened();
     recordEvent('list_note_created');

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -6,7 +6,7 @@ import SmallCrossIcon from '../icons/cross-small';
 import appState from '../flux/app-state';
 import { tracks } from '../analytics';
 
-const { search, setSearchFocus } = appState.actionCreators;
+const { searchAndSelectFirstNote, setSearchFocus } = appState.actionCreators;
 const { recordEvent } = tracks;
 const KEY_ESC = 27;
 const SEARCH_DELAY = 500;
@@ -108,7 +108,7 @@ const mapStateToProps = ({ appState: state }) => ({
 
 const mapDispatchToProps = dispatch => ({
   onSearch: filter => {
-    dispatch(search({ filter }));
+    dispatch(searchAndSelectFirstNote({ filter }));
     recordEvent('list_notes_searched');
   },
   onSearchFocused: () => dispatch(setSearchFocus({ searchFocus: false })),

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import appState from '../flux/app-state';
 import { tracks } from '../analytics';
 
-const { search, setSearchFocus } = appState.actionCreators;
+const { searchAndSelectFirstNote, setSearchFocus } = appState.actionCreators;
 const { recordEvent } = tracks;
 
 export class TagSuggestions extends Component {
@@ -111,7 +111,7 @@ const mapStateToProps = ({ appState: state }) => ({
 
 const mapDispatchToProps = dispatch => ({
   onSearch: filter => {
-    dispatch(search({ filter }));
+    dispatch(searchAndSelectFirstNote({ filter }));
     recordEvent('list_notes_searched');
     dispatch(setSearchFocus({ searchFocus: true }));
   },


### PR DESCRIPTION
### Fix
Fixes: #1531

We have reports of users who has seen the web and desktop apps thrashing
between two notes. What happens is that the user will get into a state where
for some reason, the selected note is repeatedly changing back and forth between
two notes.

I believe that this was happening because the componentDidUpdate on the note
list was setting the selected note id if the note id was different than
previous props. My suspicion is that it was putting the selected note id into
an infinite loop of changing back and forth between two notes.

I have not been able to replicate this bug but this seems like the proper
solution.

### Test
1. Click around app
2. Make sure the note editor is displaying the note you think it should
3. Do search
4. Open trash
5. Trash a note
6. Restore a note

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:
