### PR TITLE
Search / Tag suggestions: Escape regex characters in user input

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -17,6 +17,7 @@
 - Show all checkboxes and search results in note list [#1814](https://github.com/Automattic/simplenote-electron/pull/1814)
 - Fix ol numbering in markdown preview [#1823](https://github.com/Automattic/simplenote-electron/pull/1823)
 - Prevents weird effects in live previews due to incomplete input [#1822](https://github.com/Automattic/simplenote-electron/pull/1822)
+- Properly escape special characters from the search field when matching tags [#1826](https://github.com/Automattic/simplenote-electron/pull/1826)
 
 ### Other Changes
 

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import appState from '../flux/app-state';
 import { tracks } from '../analytics';
+import { escapeRegExp } from 'lodash';
 
 const { search, setSearchFocus } = appState.actionCreators;
 const { recordEvent } = tracks;
@@ -68,7 +69,7 @@ const filterTags = (tags, query) =>
           // we'll only suggest matches for the last word
           // ...this is possibly naive if the user has moved back and is editing,
           // but without knowing where the cursor is it's maybe the best we can do
-          let testQuery = queryWords[queryWords.length - 1];
+          let testQuery = escapeRegExp(queryWords[queryWords.length - 1]);
 
           // prefix tag ID with "tag:"; this allows us to match if the user typed the prefix
           // n.b. doing it in this direction instead of stripping off any "tag:" prefix allows support


### PR DESCRIPTION
### Fix
Typing a regex special character into the search field messed up the tag suggestions. At best this would show irrelevant suggestions. At worst it would crash the app.

### Test
1. Type `?` into the search field. Note that it shows only tags and notes that actually contain "?"s.
2. Type `??`. Note that the app does not crash and also shows only tags and notes that match.
3. Try other regex special characters, such as `* / \ ( ) $ ^ ~ { } + &` and verify nothing weird happens.

### Release
`RELEASE-NOTES.txt` was updated in 03b0ab93536de41e5e634ef89afecf70c550a049 with:
> Properly escape special characters from the search field when matching tags [#1826](https://github.com/Automattic/simplenote-electron/pull/1826)