### PR TITLE
Filter notes: Make tag match inclusive of unicode characters

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -17,6 +17,7 @@
 - Show all checkboxes and search results in note list [#1814](https://github.com/Automattic/simplenote-electron/pull/1814)
 - Fix ol numbering in markdown preview [#1823](https://github.com/Automattic/simplenote-electron/pull/1823)
 - Prevents weird effects in live previews due to incomplete input [#1822](https://github.com/Automattic/simplenote-electron/pull/1822)
+- Fixed a bug where searching for a tag containing non-alphanumeric characters erroneously returned no notes [#1828](https://github.com/Automattic/simplenote-electron/pull/1828)
 
 ### Other Changes
 

--- a/lib/utils/filter-notes.ts
+++ b/lib/utils/filter-notes.ts
@@ -4,7 +4,7 @@
 import { difference, escapeRegExp, get } from 'lodash';
 import { NoteEntity, TagEntity } from '../types';
 
-const tagPattern = () => /(?:\btag:)([\w-]+)(?!\B)/g;
+const tagPattern = () => /(?:\btag:)([^\s,]+)/g;
 
 export const withoutTags = (s: string) => s.replace(tagPattern(), '').trim();
 export const filterHasText = (filter: string) => !!withoutTags(filter);


### PR DESCRIPTION
### Fix
This fixes #1770, a bug where tags with non-alphanumeric characters (other languages, emoji, etc) showed "No Notes" when typed into the search bar or chosen from tag suggestions, even when there were matching notes.

### Test
1. Follow the testing instructions at #1770 and confirm that non-alphanumeric tags properly filter the note results. 
2. Confirm that you can still search for multiple tags (e.g. `tag:one tag:two`).

### Release
`RELEASE-NOTES.txt` was updated in 46a0dfc726a7f8717f39f0e790ec15ccff8eca9d with:
> Fixed a bug where searching for a tag containing non-alphanumeric characters erroneously returned no notes [#1828](https://github.com/Automattic/simplenote-electron/pull/1828)