### PR TITLE
Note List: Replace custom height cache with one provided by react-virtualized

### DIFF
--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -100,11 +100,15 @@ const renderNote = (
 ): ListRowRenderer => ({ index, key, parent, style }) => {
   const note = notes[index];
 
-  if (
-    'tag-suggestions' === note ||
-    'notes-header' === note ||
-    'no-notes' === note
-  ) {
+  if ('no-notes' === note) {
+    return (
+      <div className="note-list is-empty" style={{ ...style, height: 200 }}>
+        <span className="note-list-placeholder">No Notes</span>
+      </div>
+    );
+  }
+
+  if ('tag-suggestions' === note || 'notes-header' === note) {
     return (
       <CellMeasurer
         cache={heightCache}
@@ -115,12 +119,8 @@ const renderNote = (
       >
         {'tag-suggestions' === note ? (
           <TagSuggestions />
-        ) : 'notes-header' === note ? (
-          <div className="note-list-header">Notes</div>
         ) : (
-          <div className="note-list is-empty">
-            <span className="note-list-placeholder">No Notes</span>
-          </div>
+          <div className="note-list-header">Notes</div>
         )}
       </CellMeasurer>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -2715,6 +2715,16 @@
         "@types/react": "*"
       }
     },
+    "@types/react-virtualized": {
+      "version": "9.21.8",
+      "resolved": "https://registry.npmjs.org/@types/react-virtualized/-/react-virtualized-9.21.8.tgz",
+      "integrity": "sha512-7fZoA0Azd2jLIE9XC37fMZgMqaJe3o3pfzGjvrzphoKjBCdT4oNl6wikvo4dDMESDnpkZ8DvVTc7aSe4DW86Ew==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/react": "*"
+      }
+    },
     "@types/redux": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@types/redux/-/redux-3.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/react-modal": "3.10.5",
     "@types/react-onclickoutside": "6.7.3",
     "@types/react-redux": "7.1.7",
+    "@types/react-virtualized": "9.21.8",
     "@types/redux": "3.6.0",
     "@types/redux-localstorage": "1.0.8",
     "@types/rimraf": "3.0.0",


### PR DESCRIPTION
Follows exploratory work in #1807

For a long time we have had our own custom note list height cache. This was
used to tell `react-virtualized` how tall each item in the list is so that it
can determine how many and which ones to render. That cache was complicated and
sensitive due to the caching and performance-oriented nature of the code.

Whether `CellMesurerCache` existed when we first put in `react-virtualized` I
don't know but it does do what we want it to do and with less guessing. It
keeps track of the heights for the rendered components and provides a clean API
to interface with the `AutoSizer`.

In this patch we're removing our custom height cache and instead relying on the
one provided by `react-virtualized`.

## Testing

Many app flows interact with the note list. Please vet as many of them as you can
find. A failure in this code would likely lead to skewed or obscured views in the list.

There are some existing quirks in the way that the tag suggestions and list filtering
interact; this patch does not attempt to address those.