### PR TITLE
Note list: Make decorator for search result highlighting case insensitive

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -18,6 +18,7 @@
 - Fix ol numbering in markdown preview [#1823](https://github.com/Automattic/simplenote-electron/pull/1823)
 - Prevents weird effects in live previews due to incomplete input [#1822](https://github.com/Automattic/simplenote-electron/pull/1822)
 - Fixed a bug where searching for a tag containing non-alphanumeric characters erroneously returned no notes [#1828](https://github.com/Automattic/simplenote-electron/pull/1828)
+- Fixed a bug causing the search result highlighting in the sidebar to be case sensitive [#1831](https://github.com/Automattic/simplenote-electron/pull/1831)
 
 ### Other Changes
 

--- a/lib/note-list/decorators.tsx
+++ b/lib/note-list/decorators.tsx
@@ -12,7 +12,7 @@ export const decorateWith = (decorators, text) =>
       const searchText = 'string' === typeof filter && withoutTags(filter);
       const pattern =
         searchText && searchText.length > 0
-          ? new RegExp(escapeRegExp(searchText), 'g')
+          ? new RegExp(escapeRegExp(searchText), 'gi')
           : filter;
 
       return replaceToArray(output, pattern, replacer);


### PR DESCRIPTION
### Fix
This is a single-character fix for #1830.

### Test
1. Search for a single character that exists in both lower and uppercase form in your note titles
2. Verify that, whether you enter it in lower or uppercase, both lowercase and uppercase results are highlighted in the notes list, as well as in the note content.

### Review
I'm curious why we're not using [the same decorator as the note-editor is using](https://github.com/Automattic/simplenote-electron/blob/develop/lib/editor/matching-text-decorator.ts).

### Release
`RELEASE-NOTES.txt` was updated in 7aa698e0ab182e0949b0c1873049b0ab5a633c63 with:

> Fixed a bug causing the search result highlighting in the sidebar to be case sensitive [#1831](https://github.com/Automattic/simplenote-electron/pull/1831)