### PR TITLE
Allow width attribute on img tags

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 ### Enhancements
 - Keep note open when transitioning to small screen in focus mode [#1763](https://github.com/Automattic/simplenote-electron/pull/1763)
 - Added GenericName (description) field for app on Linux [#1761](https://github.com/Automattic/simplenote-electron/pull/1761)
+- Allow width attribute on img tags [#1833](https://github.com/Automattic/simplenote-electron/pull/1833)
 
 ### Fixes
 - Makes settings scrollable on shorter smaller view ports [#1767](https://github.com/Automattic/simplenote-electron/pull/1767)

--- a/lib/utils/sanitize-html.ts
+++ b/lib/utils/sanitize-html.ts
@@ -105,6 +105,7 @@ const isAllowedAttr = (tagName, attrName, value) => {
         case 'alt':
         case 'src':
         case 'title':
+        case 'width':
           return true;
         default:
           return false;


### PR DESCRIPTION
Closes https://github.com/Automattic/simplenote-electron/issues/1832

### Fix
Allow width attribute on `img` elements

### Test
1. Create an `img` element
2. Give it a width attribute
3. Success

### Review
Only one developer is required to review these changes

### Release
Updated release notes in bdfd05c
