### PR TITLE
Fix tag rename functionality

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.15.0]
+
+### Fixes
+
+- Fixed tag rename functionality [#1834](https://github.com/Automattic/simplenote-electron/pull/1834)
+
 ## [v1.14.0]
 
 ### Enhancements

--- a/lib/state/domain/tags.ts
+++ b/lib/state/domain/tags.ts
@@ -50,7 +50,7 @@ export const renameTag = ({ tag, name: newName }) => (dispatch, getState) => {
       data: {
         ...note.data,
         tags: note.data.tags.map(noteTag =>
-          noteTag === tagName ? name : noteTag
+          noteTag === tagName ? newName : noteTag
         ),
       },
     }))


### PR DESCRIPTION
### Fix

There is a typo in the variable rename function that is causing tags to be set
as undefined on tag rename.

### Test
1. Add tag to a site
2. Change the tag name
3. Observe that tag is renamed o the ote

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Fixed tag rename functionality [#1834](https://github.com/Automattic/simplenote-electron/pull/1834)