### PR TITLE
WIP: Search: Offload processing to WebWorker and free up main thread

### DIFF
--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -191,14 +191,6 @@ export class NoteList extends Component {
       selectedNoteId,
     } = this.props;
 
-    if (
-      prevProps.noteDisplay !== this.props.noteDisplay ||
-      prevProps.notes !== this.props.notes ||
-      prevProps.selectedNoteContent !== this.props.selectedNoteContent
-    ) {
-      heightCache.clearAll();
-    }
-
     // Ensure that the note selected here is also selected in the editor
     if (selectedNoteId !== prevProps.selectedNoteId) {
       onSelectNote(selectedNoteId);

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -1,3 +1,3 @@
 export const AUTH_SET = 'AUTH_SET';
-export const FILTER_NOTES = 'FILTER_NOTES';
+export const APPLY_SEARCH = 'APPLY_SEARCH';
 export const TAG_DRAWER_TOGGLE = 'TAG_DRAWER_TOGGLE';

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -1,8 +1,16 @@
-import { FILTER_NOTES, TAG_DRAWER_TOGGLE } from '../action-types';
+import { APPLY_SEARCH, TAG_DRAWER_TOGGLE } from '../action-types';
 
-export const filterNotes = notes => ({
-  type: FILTER_NOTES,
+import * as T from '../../types';
+
+export const applySearch = (
+  filter: string,
+  notes: T.NoteEntity[],
+  tags: T.TagEntity[]
+) => ({
+  type: APPLY_SEARCH,
+  filter,
   notes,
+  tags,
 });
 
 export const toggleTagDrawer = show => ({

--- a/lib/state/ui/middleware.ts
+++ b/lib/state/ui/middleware.ts
@@ -1,12 +1,22 @@
 import { AnyAction } from 'redux';
-import { filterNotes as filterAction } from './actions';
+import { applySearch } from './actions';
 import filterNotes from '../../utils/filter-notes';
+import { filterTags } from '../../tag-suggestions';
+
+import { State } from '../';
 
 let searchTimeout: NodeJS.Timeout;
 
 export default store => {
-  const updateNotes = () =>
-    store.dispatch(filterAction(filterNotes(store.getState().appState)));
+  const updateNotes = () => {
+    const { appState } = store.getState() as State;
+    const { filter, tags } = appState;
+
+    const filteredNotes = filterNotes(appState);
+    const filteredTags = filterTags(filter, filteredNotes, tags);
+
+    store.dispatch(applySearch(filter, filteredNotes, filteredTags));
+  };
 
   return next => (action: AnyAction) => {
     const result = next(action);
@@ -26,13 +36,17 @@ export default store => {
         searchTimeout = setTimeout(updateNotes, 50);
         break;
 
+      case 'App.noteUpdatedRemotely':
+        clearTimeout(searchTimeout);
+        searchTimeout = setTimeout(updateNotes, 500);
+        break;
+
       // on updating the search field we should delay the update
       // so we don't waste our CPU time and lose responsiveness
-      case 'App.noteUpdatedRemotely':
+      // but there are some cases where we do want an immediate response
       case 'App.search':
         clearTimeout(searchTimeout);
-        if ('App.search' === action.type && !action.filter) {
-          // if we just cleared out the search bar then immediately update
+        if (!action.filter || action.sync) {
           updateNotes();
         } else {
           searchTimeout = setTimeout(updateNotes, 500);

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -1,8 +1,9 @@
 import { difference, union } from 'lodash';
 import { combineReducers } from 'redux';
-import { FILTER_NOTES, TAG_DRAWER_TOGGLE } from '../action-types';
+import { APPLY_SEARCH, TAG_DRAWER_TOGGLE } from '../action-types';
 
 import * as T from '../../types';
+import { NoteListItem } from '../../note-list';
 
 const defaultVisiblePanes = ['editor', 'noteList'];
 const emptyList: unknown[] = [];
@@ -10,7 +11,41 @@ const emptyList: unknown[] = [];
 const filteredNotes = (
   state = emptyList as T.NoteEntity[],
   { type, notes }: { type: string; notes: T.NoteEntity[] }
-) => (FILTER_NOTES === type ? notes : state);
+) => (APPLY_SEARCH === type ? notes : state);
+
+const filteredTags = (
+  state = emptyList as T.TagEntity[],
+  { type, tags }: { type: string; tags: T.TagEntity[] }
+): T.TagEntity[] => (APPLY_SEARCH === type ? tags : state);
+
+const noteListItems = (
+  state = emptyList as NoteListItem[],
+  {
+    type,
+    filter,
+    notes,
+    tags,
+  }: {
+    type: string;
+    filter: string;
+    notes: T.NoteEntity[];
+    tags: T.TagEntity[];
+  }
+): NoteListItem[] => {
+  if (APPLY_SEARCH !== type) {
+    return state;
+  }
+
+  if (filter.length === 0 || tags.length === 0) {
+    return notes;
+  }
+
+  return [
+    'tag-suggestions',
+    'notes-header',
+    ...(notes.length > 0 ? notes : (['no-notes'] as NoteListItem[])),
+  ];
+};
 
 const visiblePanes = (state = defaultVisiblePanes, { type, show }) => {
   if (TAG_DRAWER_TOGGLE === type) {
@@ -22,4 +57,9 @@ const visiblePanes = (state = defaultVisiblePanes, { type, show }) => {
   return state;
 };
 
-export default combineReducers({ filteredNotes, visiblePanes });
+export default combineReducers({
+  filteredNotes,
+  filteredTags,
+  noteListItems,
+  visiblePanes,
+});

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -67,69 +67,6 @@ export class TagSuggestions extends Component<Props> {
   }
 }
 
-/**
- * Return the first maxResults matching items in the list
- *
- * This is like items.filter(predicate).slice(0,maxResults)
- * but it early-aborts as soon as we find our max results.
- * If we were filtering thousands of tags, for example, there'd
- * be no reason to iterate through all of them and only prune
- * the list after computing whether each one matches.
- *
- * @param items items to filter
- * @param predicate filtering function
- * @param maxResults maximum number of returned matching items
- */
-const filterAtMost = function<I>(
-  items: I[],
-  predicate: (item: I) => boolean,
-  maxResults: number
-): I[] {
-  const results = [];
-  for (const item of items) {
-    if (predicate(item)) {
-      results.push(item);
-    }
-
-    if (results.length === maxResults) {
-      break;
-    }
-  }
-  return results;
-};
-
-const emptyTagList: T.TagEntity[] = [];
-
-export const filterTags = (
-  query: string,
-  notes: T.NoteEntity[],
-  tags: T.TagEntity[]
-): T.TagEntity[] => {
-  // we'll only suggest matches for the last word
-  // ...this is possibly naive if the user has moved back and is editing,
-  // but without knowing where the cursor is it's maybe the best we can do
-  const tagTerm = query
-    .trim()
-    .split(' ')
-    .pop();
-
-  if (!tagTerm) {
-    return emptyTagList;
-  }
-
-  // with `tag:` we don't want to suggest tags which have already been added
-  // to the search bar, so we make it an explicit prefix match, meaning we
-  // don't match inside the tag and we don't match full-text matches
-  const isPrefixMatch = tagTerm.startsWith('tag:') && tagTerm.length > 4;
-  const term = isPrefixMatch ? tagTerm.slice(4) : tagTerm;
-
-  const matcher: (tag: T.TagEntity) => boolean = isPrefixMatch
-    ? ({ data: { name } }) => name !== term && name.startsWith(term)
-    : ({ data: { name } }) => name.includes(term);
-
-  return filterAtMost(tags, matcher, 5);
-};
-
 const mapStateToProps: MapStateToProps<
   StateProps,
   OwnProps,

--- a/lib/tag-suggestions/test.tsx
+++ b/lib/tag-suggestions/test.tsx
@@ -1,4 +1,4 @@
-import { filterTags } from './';
+import { filterTags } from '../utils/filter-tags';
 
 import { TagEntity as T } from '../types';
 

--- a/lib/tag-suggestions/test.tsx
+++ b/lib/tag-suggestions/test.tsx
@@ -8,69 +8,75 @@ const prefixen: T[] = ['do', 'doo', 'door', 'doort', 'doorth'].map(t);
 const infixen: T[] = ['unicode', 'sourcecode', 'codewars'].map(t);
 const taggers: T[] = ['atag', 'atag:what?', 'tag'].map(t);
 
-it('only filters if given a query', () => {
+it('returns an empty result for an empty query', () => {
   const tags = ['a', 'b'].map(t);
 
-  expect(filterTags(tags, '')).toBe(tags);
-  expect(filterTags(tags, ' \t ')).toBe(tags);
-  expect(filterTags(tags, '    ')).toBe(tags);
+  expect(filterTags('', [], tags)).toEqual([]);
+  expect(filterTags(' \t ', [], tags)).toEqual([]);
+  expect(filterTags('    ', [], tags)).toEqual([]);
 });
 
 it.each(animals)('finds full-tag matches', animal => {
-  expect(filterTags(animals, animal.data.name)).toEqual([animal]);
+  expect(filterTags(animal.data.name, [], animals)).toEqual([animal]);
 });
 
 it('finds all prefix-matching tags', () => {
-  expect(filterTags(prefixen, 'd')).toEqual(prefixen);
-  expect(filterTags(prefixen, 'do')).toEqual(prefixen);
-  expect(filterTags(prefixen, 'doo')).toEqual(prefixen.slice(1));
-  expect(filterTags(prefixen, 'door')).toEqual(prefixen.slice(2));
-  expect(filterTags(prefixen, 'doort')).toEqual(prefixen.slice(3));
+  expect(filterTags('d', [], prefixen)).toEqual(prefixen);
+  expect(filterTags('do', [], prefixen)).toEqual(prefixen);
+  expect(filterTags('doo', [], prefixen)).toEqual(prefixen.slice(1));
+  expect(filterTags('door', [], prefixen)).toEqual(prefixen.slice(2));
+  expect(filterTags('doort', [], prefixen)).toEqual(prefixen.slice(3));
 });
 
 it('finds mid-tag matches', () => {
   // all but the first prefixen has a double-oo
-  expect(filterTags(prefixen, 'oo')).toEqual(prefixen.slice(1));
-  expect(filterTags(animals, 'at')).toEqual(['bat', 'cat'].map(t));
-  expect(filterTags(infixen, 'rce')).toEqual(['sourcecode'].map(t));
-  expect(filterTags(infixen, 'code')).toEqual(infixen);
+  expect(filterTags('oo', [], prefixen)).toEqual(prefixen.slice(1));
+  expect(filterTags('at', [], animals)).toEqual(['bat', 'cat'].map(t));
+  expect(filterTags('rce', [], infixen)).toEqual(['sourcecode'].map(t));
+  expect(filterTags('code', [], infixen)).toEqual(infixen);
 });
 
 it('uses the last space-separated segment in the query for search', () => {
-  expect(filterTags(infixen, 'code bug')).toEqual([]);
-  expect(filterTags(infixen, 'bug code')).toEqual(infixen);
-  expect(filterTags(animals, 'bat cat dog owl')).toEqual(['owl'].map(t));
-  expect(filterTags(animals, 'bat owl dog cat')).toEqual(['cat'].map(t));
+  expect(filterTags('code bug', [], infixen)).toEqual([]);
+  expect(filterTags('bug code', [], infixen)).toEqual(infixen);
+  expect(filterTags('bat cat dog owl', [], animals)).toEqual(['owl'].map(t));
+  expect(filterTags('bat owl dog cat', [], animals)).toEqual(['cat'].map(t));
 });
 
 it('returns at-most five results', () => {
-  expect(filterTags([...infixen, ...infixen, ...infixen], 'd')).toHaveLength(5);
+  expect(
+    filterTags('d', [], [...infixen, ...infixen, ...infixen])
+  ).toHaveLength(5);
 });
 
 it.each(animals)('ignores full matches with the tag: prefix', animal => {
-  expect(filterTags(animals, `tag:${animal.data.name}`)).toEqual([]);
+  expect(filterTags(`tag:${animal.data.name}`, [], animals)).toEqual([]);
 });
 
 it('ignores full matches with the tag: prefix (round 2)', () => {
-  expect(filterTags(infixen, 'tag:sourcecod')).toEqual(['sourcecode'].map(t));
-  expect(filterTags(infixen, 'tag:sourcecode')).toEqual([]);
+  expect(filterTags('tag:sourcecod', [], infixen)).toEqual(
+    ['sourcecode'].map(t)
+  );
+  expect(filterTags('tag:sourcecode', [], infixen)).toEqual([]);
 });
 
 it('matches with the tag: prefix (only prefixes)', () => {
-  expect(filterTags(animals, 'tag:ba')).toEqual(['bat'].map(t));
-  expect(filterTags(prefixen, 'tag:door')).toEqual(['doort', 'doorth'].map(t));
-  expect(filterTags(prefixen, 'tag:oor')).toEqual([]);
-  expect(filterTags(infixen, 'tag:code')).toEqual(['codewars'].map(t));
+  expect(filterTags('tag:ba', [], animals)).toEqual(['bat'].map(t));
+  expect(filterTags('tag:door', [], prefixen)).toEqual(
+    ['doort', 'doorth'].map(t)
+  );
+  expect(filterTags('tag:oor', [], prefixen)).toEqual([]);
+  expect(filterTags('tag:code', [], infixen)).toEqual(['codewars'].map(t));
 });
 
 it('falls-back to plain text matching if the tag: prefix is incomplete', () => {
-  expect(filterTags(animals, 't')).toEqual(['bat', 'cat'].map(t));
-  expect(filterTags(animals, 'ta')).toEqual([]);
-  expect(filterTags(animals, 'tag')).toEqual([]);
-  expect(filterTags(animals, 'tag:')).toEqual([]);
+  expect(filterTags('t', [], animals)).toEqual(['bat', 'cat'].map(t));
+  expect(filterTags('ta', [], animals)).toEqual([]);
+  expect(filterTags('tag', [], animals)).toEqual([]);
+  expect(filterTags('tag:', [], animals)).toEqual([]);
 
-  expect(filterTags(taggers, 't')).toEqual(taggers);
-  expect(filterTags(taggers, 'ta')).toEqual(taggers);
-  expect(filterTags(taggers, 'tag')).toEqual(taggers);
-  expect(filterTags(taggers, 'tag:')).toEqual(['atag:what?'].map(t));
+  expect(filterTags('t', [], taggers)).toEqual(taggers);
+  expect(filterTags('ta', [], taggers)).toEqual(taggers);
+  expect(filterTags('tag', [], taggers)).toEqual(taggers);
+  expect(filterTags('tag:', [], taggers)).toEqual(['atag:what?'].map(t));
 });

--- a/lib/utils/filter-tags.ts
+++ b/lib/utils/filter-tags.ts
@@ -1,0 +1,64 @@
+import * as T from '../types';
+
+/**
+ * Return the first maxResults matching items in the list
+ *
+ * This is like items.filter(predicate).slice(0,maxResults)
+ * but it early-aborts as soon as we find our max results.
+ * If we were filtering thousands of tags, for example, there'd
+ * be no reason to iterate through all of them and only prune
+ * the list after computing whether each one matches.
+ *
+ * @param items items to filter
+ * @param predicate filtering function
+ * @param maxResults maximum number of returned matching items
+ */
+const filterAtMost = function<I>(
+  items: I[],
+  predicate: (item: I) => boolean,
+  maxResults: number
+): I[] {
+  const results = [];
+  for (const item of items) {
+    if (predicate(item)) {
+      results.push(item);
+    }
+
+    if (results.length === maxResults) {
+      break;
+    }
+  }
+  return results;
+};
+
+const emptyTagList: T.TagEntity[] = [];
+
+export const filterTags = (
+  query: string,
+  notes: T.NoteEntity[],
+  tags: T.TagEntity[]
+): T.TagEntity[] => {
+  // we'll only suggest matches for the last word
+  // ...this is possibly naive if the user has moved back and is editing,
+  // but without knowing where the cursor is it's maybe the best we can do
+  const tagTerm = query
+    .trim()
+    .split(' ')
+    .pop();
+
+  if (!tagTerm) {
+    return emptyTagList;
+  }
+
+  // with `tag:` we don't want to suggest tags which have already been added
+  // to the search bar, so we make it an explicit prefix match, meaning we
+  // don't match inside the tag and we don't match full-text matches
+  const isPrefixMatch = tagTerm.startsWith('tag:') && tagTerm.length > 4;
+  const term = isPrefixMatch ? tagTerm.slice(4) : tagTerm;
+
+  const matcher: (tag: T.TagEntity) => boolean = isPrefixMatch
+    ? ({ data: { name } }) => name !== term && name.startsWith(term)
+    : ({ data: { name } }) => name.includes(term);
+
+  return filterAtMost(tags, matcher, 5);
+};

--- a/lib/utils/search-processor.worker.ts
+++ b/lib/utils/search-processor.worker.ts
@@ -1,0 +1,56 @@
+import filterNotes from './filter-notes';
+import { filterTags } from './filter-tags';
+
+import * as T from '../types';
+
+type ApplySearchCommand = {
+  action: 'applySearch';
+  delay: number;
+  filter: string;
+  notes: T.NoteEntity[] | null;
+  showTrash: boolean;
+  tag?: T.TagEntity;
+  tags: T.TagEntity[];
+};
+
+type SearchCommand = ApplySearchCommand;
+
+export interface SearchPort extends MessagePort {
+  postMessage: (message: SearchCommand) => void;
+}
+
+const ctx: Worker = self as any;
+
+let searchTimeout: NodeJS.Timeout;
+
+ctx.onmessage = bootEvent => {
+  const mainApp = bootEvent.ports[0];
+
+  mainApp.onmessage = event => {
+    switch (event.data.action) {
+      case 'applySearch': {
+        const { delay, filter, notes, showTrash, tag, tags } = event.data;
+
+        clearTimeout(searchTimeout);
+        const go = () => {
+          const filteredNotes = filterNotes({ filter, notes, showTrash, tag });
+          const filteredTags = filterTags(filter, notes, tags);
+
+          mainApp.postMessage({
+            action: 'applySearch',
+            filter,
+            notes: filteredNotes,
+            tags: filteredTags,
+          });
+        };
+
+        if (delay) {
+          searchTimeout = setTimeout(go, delay);
+        } else {
+          go();
+        }
+        break;
+      }
+    }
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3367,8 +3367,7 @@
     "ajv-keywords": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-      "dev": true
+      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
     },
     "amdefine": {
       "version": "1.0.1",
@@ -4182,8 +4181,7 @@
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "binary-extensions": {
       "version": "1.13.1",
@@ -6722,8 +6720,7 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -11514,7 +11511,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
       "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-      "dev": true,
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^2.0.0",
@@ -11525,7 +11521,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -11533,8 +11528,7 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
@@ -17953,6 +17947,26 @@
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
+      }
+    },
+    "worker-loader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
+      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
+      "requires": {
+        "loader-utils": "^1.0.0",
+        "schema-utils": "^0.4.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
       }
     },
     "wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2922,6 +2922,16 @@
         "@types/react": "*"
       }
     },
+    "@types/react-virtualized": {
+      "version": "9.21.7",
+      "resolved": "https://registry.npmjs.org/@types/react-virtualized/-/react-virtualized-9.21.7.tgz",
+      "integrity": "sha512-Go+r3xz6TLUHwmRsyEHfo7UvikVbR0L1HUxe/otBgFEUx8aLrTQeblY8r9UbnSmAsynU0KtJTQErS907GM4lQw==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/react": "*"
+      }
+    },
     "@types/redux": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@types/redux/-/redux-3.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/react-modal": "3.10.1",
     "@types/react-onclickoutside": "6.7.3",
     "@types/react-redux": "7.1.5",
+    "@types/react-virtualized": "9.21.7",
     "@types/redux": "3.6.0",
     "@types/redux-localstorage": "1.0.8",
     "@types/rimraf": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "string-replace-to-array": "1.0.3",
     "turndown": "5.0.3",
     "unorm": "1.6.0",
-    "valid-url": "1.0.9"
+    "valid-url": "1.0.9",
+    "worker-loader": "2.0.0"
   }
 }


### PR DESCRIPTION
Compare against #1829 (off of which it's based) instead of using the "Files changed" tab here.

[Real files changed in this branch ⑂](https://github.com/Automattic/simplenote-electron/compare/refactor/remove-custom-note-list-height-cache...search/offload-filtering)

## Status

 - the app is notably more interactive in this branch while searching than in `develop`
 - the "thrashing note" (being worked on in #1825) appears to be even more frequently triggered here and I'm not sure why. there is a lifecycle-method loop in the `NoteList` and also in the `NoteContentEditor`. In the `NoteList` it's changing the selected note when that should happen in the middleware when filtering notes. ⭕️ Move `closeNote()` into the middleware
 - Apart from testing to make sure this doesn't break things it seems fairly robust and there's nothing I would be strongly opposed to merging
 - **DO NOT MERGE** and definitely not before #1829 is merged. Since this is a branch on a branch it's likely to be that we'll have to rebase and update and resolve conflicts before this is ready to be considered for inclusion.

## Description

As long as our `NoteList` has been bound up in re-computing the fitlered notes on every render and on every call to `mapStateToProps` and as long as it has been calculating note indices based on that list it calculates we have been in a pickle when it comes to rendering performance whil searching.

We have taken a few steps towards mitigating the CPU bottleneck:
 - debounced the search filter
 - debounced searching when updating the filter
 - moved the filtered notes and tags into Redux and only
   compute them when a debounce times out after events change
   the filtering: e.g. a search or a remote update

In this patch we're doing what we've long waited to do which is move the search filtering out of the main thread and into a WebWorker. By doing this we not only eliminate one of the biggest performance bottlenecks for accounts with lots of data but we have opened ourselves up to dramatically increasing the quality of our search results since the costs of performing the searching and indexing can be overlooked as the main UI thread remains responsive.

This specific patch only takes the first step which is reproducing the search as-is. It also trades some of the performance gain by passing all of the notes and tags in the account to the WebWorker on every update. However, as this is a relatively fast operation it shouldn't pose any significant obstacle.

If we develop this design for search indexing one area we can start improving is to stop sending the full contents of all the notes and tags on every fitlering event. It's enough to pass the search filter, whether the trash is open, and if there's a selected tag. We can do this by trapping more actions in the middleware and maintaining a copy of the notes in the WebWorker.

We can probably do even better by maintaining our copy of the notes independently, by pulling from `indexedDB`, though that may carry with it the higher risk of further coupling our Ghost and Bucket implementations to a shared-state system we are trying to avoid.

Once the data-passing and synchronization is figured out we can start to perform more robust indexing of the notes and rank search results.