### PR TITLE
Fix: Replace missing click handler in revision slider

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fixed tag rename functionality [#1834](https://github.com/Automattic/simplenote-electron/pull/1834)
+- Properly close revision/history view when clicking outside of slider [#1837](https://github.com/Automattic/simplenote-electron/pull/1837)
 - Only remove markdown syntax in note list if markdown enabled for note [#1839](https://github.com/Automattic/simplenote-electron/pull/1839)
 
 ## [v1.14.0]

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -71,6 +71,8 @@ export class RevisionSelector extends Component<Props, State> {
     }
   }
 
+  handleClickOutside = () => this.onCancelRevision();
+
   onAcceptRevision = () => {
     const { note, onUpdateContent, resetIsViewingRevisions } = this.props;
     const { revisions, selection } = this.state;


### PR DESCRIPTION
In paFIJd-8t it was reported that note corruption was occurring when viewing the history of one note when it gets updated remotely. Although this fix may or may not address that problem a code audit revealed that in #1792 I removed what appeared to be an unused function when it was in fact used by the component's `onClickOutside` wrapper.

The missing handler function closed out of the revision slider when clicking anywhere else. Without it, the thread handling the click crashed but since it was a callback it didn't crash the app. A message appeared in the developer console indicating that the handler was missing.

Because we haven't been closing the revision slider it has become possible to start editing a note while the revisions are still open, something prevented before by way of the click handler. Thus, if viewing a revision, clicking anywhere else, and continuing, then we fill the editor with what it thinks is a note (and not a revision) and then will respond to remote updates with the contents of that revision before accepting remote updates.

## Testing

This can be verified my making edit operations on multiple devices with the revision slider open.
It's also exposed if you open the revision slider and then click inside the note and make change.

### Before

![revisionSliderBroken mov](https://user-images.githubusercontent.com/5431237/72494751-16084a00-37e2-11ea-8c75-f138f1f74ddc.gif)

### After

![revisionSliderFixed mov](https://user-images.githubusercontent.com/5431237/72494873-76978700-37e2-11ea-8d9c-472ccb5fa60e.gif)
