### PR TITLE
Refactor: Use direct comparison of note id when receiving remote upates

### DIFF
--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -451,10 +451,10 @@ export const actionMap = new ActionMap({
       creator({ noteId }: { noteId: T.EntityId }) {
         return (dispatch, getState: () => State) => {
           const {
-            appState: { selectedNoteId, note, notes },
+            appState: { note, notes },
           } = getState();
 
-          if (selectedNoteId === noteId) {
+          if (note && note.id === noteId) {
             return note.data;
           }
 


### PR DESCRIPTION
In `onNoteBeforeRemoteUpdate` we give ourselves a chance to rebase local edits
on a note before remote changes are applied. Although we haven't identified any
problem related to this refactor, we have been using indirect measures to check
if the note we are working with is the note we think it is. That is, we were
checking against `selectedNoteId` as a proxy for `note.id` when relying on
`note.id` works and eliminates the possibility that `selectedNoteId` doesn't
match `note.id`

In this patch we're simplifying to rely solely on that direct measure and
eliminting one possible bug.

## Testing

Since I'm not sure that this has been causing any issues I don't know how to test it.
Please smoke-test the app.

Verify that remote updates correctly "rebase" local changes when they come in.
You'll need to sequence a change on another device to occur before local changes
flush and send their updates to the server.