### PR TITLE
Bump node version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ references:
 jobs:
   build:
     docker:
-      - image: circleci/node:10.16.3
+      - image: circleci/node:10.15.0
     shell: /bin/bash --login
     working_directory: ~/simplenote
     steps:
@@ -52,7 +52,7 @@ jobs:
 
   linux:
     docker:
-      - image: circleci/node:10.16.3
+      - image: circleci/node:10.15.0
     working_directory: ~/simplenote
     steps:
       - checkout

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  CSC_ENC_KEY: 
+  CSC_ENC_KEY:
     secure: ef2yQX3A9dZPQzS6r7oY7pUtzK/ICiUUDZZsh/K7eT59a4BVdxqCfIZU812MmqQHK/iC4cYLdTW+tWHrq9bJquzQgHGjgB0cTBwS9KUjyOg=
   CSC_KEY_PASSWORD:
     secure: Sz53shy7P4kPzBKa9shHTw==
@@ -17,7 +17,7 @@ configuration:
   - AppX-Testing
 
 install:
-  - ps: Install-Product node 10
+  - ps: Install-Product node 11.15.0
   - cinst make
   - npm ci
   - patch -p1 < ./resources/macos/macPackager-patch.diff
@@ -28,7 +28,7 @@ for:
   - matrix:
       only:
         - configuration: Default
-    before_build: 
+    before_build:
       - openssl aes-256-cbc -d -in .\resources\certificates\win.p12.enc -out %CSC_LINK% -k "%CSC_ENC_KEY%"
       - openssl aes-256-cbc -d -in .\resources\secrets\config.json.enc -out .\config.json -k "%CSC_ENC_KEY%"
     build_script:
@@ -44,7 +44,7 @@ for:
       - openssl aes-256-cbc -d -in .\resources\secrets\config.json.enc -out .\config.json -k "%CSC_ENC_KEY%"
     skip_non_tags: true
     environment:
-      CSC_LINK: ""
+      CSC_LINK: ''
     build_script:
       - make build
       - make test
@@ -54,7 +54,7 @@ for:
   - matrix:
       only:
         - configuration: AppX-Testing
-    before_build: 
+    before_build:
       - openssl aes-256-cbc -d -in .\resources\certificates\win.p12.enc -out %CSC_LINK% -k "%CSC_ENC_KEY%"
       - openssl aes-256-cbc -d -in .\resources\secrets\config.json.enc -out .\config.json -k "%CSC_ENC_KEY%"
     build_script:
@@ -72,7 +72,6 @@ cache:
   - '%APPDATA%\npm-cache'
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
-
 # RDP Debug mode
 # on_finish:
 #   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "url": "git://github.com/Automattic/simplenote-electron.git"
   },
   "engines": {
-    "node": ">= 7.9.0",
-    "npm": ">= 6.4.0"
+    "node": ">= 10.15.0",
+    "npm": ">= 6.7.0"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
Our AppVeyor builds have been failing due to an issue with `node-gyp`.  In this
patch we're updating the version of node run in the CI environments.  This not
only addresses the `node-gyp` issue but it also keeps us more up to date with
node.

## Testing

Most affected by these changes will be the packaged apps.
Once CI finishes, download the built binaries and make sure they run fine.
Any problem would likely result in catastrophic failure - failure to build.