### PR TITLE
Stop erasing the copy buffer if copying empty editor selections

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,9 @@
 
 ## [v1.15.0]
 
+### Enhancements
+- Stop erasing the copy buffer if copying empty editor selections [#1847](https://github.com/Automattic/simplenote-electron/pull/1847)
+
 ### Fixes
 
 - Fixed tag rename functionality [#1834](https://github.com/Automattic/simplenote-electron/pull/1834)

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -292,6 +292,9 @@ export default class NoteContentEditor extends Component {
    */
   copyPlainText = event => {
     const textToCopy = getSelectedText(this.state.editorState);
+    if (!textToCopy) {
+      return;
+    }
     event.clipboardData.setData('text/plain', textToCopy);
     event.preventDefault();
   };


### PR DESCRIPTION
Resolves #1843

Previously it has been the case that if you attempt to copy something in
the note editor but there is no selection then it will wipe out the
system's copy buffer. This is because we implement our own copy handler
which strips away the visual formatting of elements in the note editor.

 1. Copy anything in any app, suppose you copy "test"
 2. Paste that "test" anywhere, it pastes
 3. Click in the note editor but don't select anything.
 4. "Copy" by hitting the copy shortcut or by using a menu option
 5. Paste anywhere

Although we'd expect that "test" is still in our copy buffer we get the
empty string pasted in and "test" is gone.

While not really _wrong_ or _broken_ this is a bit jarring and it's
probably better in most cases to preserve the previous copy buffer if
we're not copying anything. We've turned the copy command into a "clear
the copy buffer" command if there's no content.

In this patch we're aborting the copy if our selection is empty and that
will preserve the existing buffer and the expected behavior.

## Testing

Follow the procedure above before and after applying this patch.

### Before
![copyBroken mov](https://user-images.githubusercontent.com/5431237/72650581-26cdd280-393e-11ea-858b-5b090725962e.gif)

### After
![copyWorking mov](https://user-images.githubusercontent.com/5431237/72650490-ed956280-393d-11ea-9dfc-3977e97b4570.gif)
