### PR TITLE
Add Types to state ui actions

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,10 @@
 - Fixed tag rename functionality [#1834](https://github.com/Automattic/simplenote-electron/pull/1834)
 - Only remove markdown syntax in note list if markdown enabled for note [#1839](https://github.com/Automattic/simplenote-electron/pull/1839)
 
+### Other Changes
+
+- Added types to state/ui/actions [#1849](https://github.com/Automattic/simplenote-electron/pull/1849)
+
 ## [v1.14.0]
 
 ### Enhancements

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -1,11 +1,13 @@
 import { FILTER_NOTES, TAG_DRAWER_TOGGLE } from '../action-types';
 
-export const filterNotes = notes => ({
+import * as T from '../../types';
+
+export const filterNotes = (notes: T.NoteEntity[]) => ({
   type: FILTER_NOTES,
   notes,
 });
 
-export const toggleTagDrawer = show => ({
+export const toggleTagDrawer = (show: boolean) => ({
   type: TAG_DRAWER_TOGGLE,
   show,
 });


### PR DESCRIPTION
### Fix
Adds types to state/ui/actions

### Test
1. Does the app build?

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated with:

- Added types to state/ui/actions [#1849](https://github.com/Automattic/simplenote-electron/pull/1849)