### PR TITLE
Fix: Replace missing click handler in revision slider (#1837)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -19,6 +19,7 @@
 - Fix ol numbering in markdown preview [#1823](https://github.com/Automattic/simplenote-electron/pull/1823)
 - Prevents weird effects in live previews due to incomplete input [#1822](https://github.com/Automattic/simplenote-electron/pull/1822)
 - Fixed a bug where searching for a tag containing non-alphanumeric characters erroneously returned no notes [#1828](https://github.com/Automattic/simplenote-electron/pull/1828)
+- Properly close revision/history view when clicking outside of slider [#1837](https://github.com/Automattic/simplenote-electron/pull/1837)
 
 ### Other Changes
 

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -71,6 +71,8 @@ export class RevisionSelector extends Component<Props, State> {
     }
   }
 
+  handleClickOutside = () => this.onCancelRevision();
+
   onAcceptRevision = () => {
     const { note, onUpdateContent, resetIsViewingRevisions } = this.props;
     const { revisions, selection } = this.state;


### PR DESCRIPTION
In paFIJd-8t it was reported that note corruption was occurring when viewing the history of one note when it gets updated remotely. Although this fix may or may not address that problem a code audit revealed that in #1792 I removed what appeared to be an unused function when it was in fact used by the component's `onClickOutside` wrapper.

The missing handler function closed out of the revision slider when clicking anywhere else. Without it, the thread handling the click crashed but since it was a callback it didn't crash the app. A message appeared in the developer console indicating that the handler was missing.

Because we haven't been closing the revision slider it has become possible to start editing a note while the revisions are still open, something prevented before by way of the click handler. Thus, if viewing a revision, clicking anywhere else, and continuing, then we fill the editor with what it thinks is a note (and not a revision) and then will respond to remote updates with the contents of that revision before accepting remote updates.

(cherry picked from commit 43bc2a5ad279d43f817b056add67358ca0b41ee8)