### PR TITLE
Allow unselecting tags by keyboard

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 ### Enhancements
 - Stop erasing the copy buffer if copying empty editor selections [#1847](https://github.com/Automattic/simplenote-electron/pull/1847)
+- Allow for unselecting a tag by pressing right arrow [#1853](https://github.com/Automattic/simplenote-electron/pull/1853)
 
 ### Fixes
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 ### Enhancements
 - Stop erasing the copy buffer if copying empty editor selections [#1847](https://github.com/Automattic/simplenote-electron/pull/1847)
-- Allow for unselecting a tag by tab or right arrow [#1853](https://github.com/Automattic/simplenote-electron/pull/1853)
+- Allow for unselecting a tag by tab or right arrow [#1853](https://github.com/Automattic/simplenote-electron/pull/1853) @qualitymanifest
 
 ### Fixes
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 ### Enhancements
 - Stop erasing the copy buffer if copying empty editor selections [#1847](https://github.com/Automattic/simplenote-electron/pull/1847)
-- Allow for unselecting a tag by pressing right arrow [#1853](https://github.com/Automattic/simplenote-electron/pull/1853)
+- Allow for unselecting a tag by tab or right arrow [#1853](https://github.com/Automattic/simplenote-electron/pull/1853)
 
 ### Fixes
 

--- a/lib/tag-field/index.tsx
+++ b/lib/tag-field/index.tsx
@@ -128,9 +128,13 @@ export class TagField extends Component {
       e.preventDefault();
     }
     // handle right arrow
-    if (39 === e.which && this.hasSelection()) {
+    else if (39 === e.which && this.hasSelection()) {
       this.unselect(e);
       this.focusTagField();
+    }
+    // handle tab
+    else if (9 === e.which && this.hasSelection()) {
+      this.unselect(e);
     }
   };
 

--- a/lib/tag-field/index.tsx
+++ b/lib/tag-field/index.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, KeyboardEventHandler } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Overlay } from 'react-overlays';
@@ -17,6 +17,10 @@ import {
   noop,
   union,
 } from 'lodash';
+
+const KEY_BACKSPACE = 8;
+const KEY_TAB = 9;
+const KEY_RIGHT = 39;
 
 export class TagField extends Component {
   static displayName = 'TagField';
@@ -113,9 +117,8 @@ export class TagField extends Component {
 
   focusTagField = () => this.focusInput && this.focusInput();
 
-  interceptKeys = e => {
-    // handle backspace
-    if (8 === e.which) {
+  interceptKeys: KeyboardEventHandler<HTMLDivElement> = e => {
+    if (KEY_BACKSPACE === e.which) {
       if (this.hasSelection()) {
         this.deleteSelection();
       }
@@ -126,15 +129,16 @@ export class TagField extends Component {
 
       this.selectLastTag();
       e.preventDefault();
+      return;
     }
-    // handle right arrow
-    else if (39 === e.which && this.hasSelection()) {
+    if (KEY_RIGHT === e.which && this.hasSelection()) {
       this.unselect(e);
       this.focusTagField();
+      return;
     }
-    // handle tab
-    else if (9 === e.which && this.hasSelection()) {
+    if (KEY_TAB === e.which && this.hasSelection()) {
       this.unselect(e);
+      return;
     }
   };
 

--- a/lib/tag-field/index.tsx
+++ b/lib/tag-field/index.tsx
@@ -114,21 +114,24 @@ export class TagField extends Component {
   focusTagField = () => this.focusInput && this.focusInput();
 
   interceptKeys = e => {
-    // only handle backspace
-    if (8 !== e.which) {
-      return;
-    }
+    // handle backspace
+    if (8 === e.which) {
+      if (this.hasSelection()) {
+        this.deleteSelection();
+      }
 
-    if (this.hasSelection()) {
-      this.deleteSelection();
-    }
+      if ('' !== this.state.tagInput) {
+        return;
+      }
 
-    if ('' !== this.state.tagInput) {
-      return;
+      this.selectLastTag();
+      e.preventDefault();
     }
-
-    this.selectLastTag();
-    e.preventDefault();
+    // handle right arrow
+    if (39 === e.which && this.hasSelection()) {
+      this.unselect(e);
+      this.focusTagField();
+    }
   };
 
   updateTags = tags =>


### PR DESCRIPTION
### Fix
Closes https://github.com/Automattic/simplenote-electron/issues/1852
If a tag is selected and the right arrow key is pressed, the tag is unselected and the focus is moved back into the tag field.

### Test
See the issue for details to reproduce, but use right arrow to unselect

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
Release notes updated in bde11cf
