### PR TITLE
Fix: Added change notes to wrong version

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,6 @@
 ### Fixes
 
 - Fixed tag rename functionality [#1834](https://github.com/Automattic/simplenote-electron/pull/1834)
-- Properly close revision/history view when clicking outside of slider [#1837](https://github.com/Automattic/simplenote-electron/pull/1837)
 - Only remove markdown syntax in note list if markdown enabled for note [#1839](https://github.com/Automattic/simplenote-electron/pull/1839)
 
 ### Other Changes
@@ -34,6 +33,7 @@
 - Fix ol numbering in markdown preview [#1823](https://github.com/Automattic/simplenote-electron/pull/1823)
 - Prevents weird effects in live previews due to incomplete input [#1822](https://github.com/Automattic/simplenote-electron/pull/1822)
 - Fixed a bug where searching for a tag containing non-alphanumeric characters erroneously returned no notes [#1828](https://github.com/Automattic/simplenote-electron/pull/1828)
+- Properly close revision/history view when clicking outside of slider [#1837](https://github.com/Automattic/simplenote-electron/pull/1837)
 - Fixed a bug causing the search result highlighting in the sidebar to be case sensitive [#1831](https://github.com/Automattic/simplenote-electron/pull/1831)
 
 ### Other Changes


### PR DESCRIPTION
In #1837 we added the change notes to v1.15.0's notes and it looked like it may
have not been able to get into v1.14.0; however, we cherry-picked it in to the
next release in #1850 and this needs to move back into the proper section.

The only change is in the release notes so there should be no need to test.