### PR TITLE
Fix: Added change notes to wrong version (#1860)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 
 - Fixed tag rename functionality [#1834](https://github.com/Automattic/simplenote-electron/pull/1834)
 - Only remove markdown syntax in note list if markdown enabled for note [#1839](https://github.com/Automattic/simplenote-electron/pull/1839)
+- Fixed a bug causing the search result highlighting in the sidebar to be case sensitive [#1831](https://github.com/Automattic/simplenote-electron/pull/1831)
 
 ### Other Changes
 
@@ -34,7 +35,6 @@
 - Prevents weird effects in live previews due to incomplete input [#1822](https://github.com/Automattic/simplenote-electron/pull/1822)
 - Fixed a bug where searching for a tag containing non-alphanumeric characters erroneously returned no notes [#1828](https://github.com/Automattic/simplenote-electron/pull/1828)
 - Properly close revision/history view when clicking outside of slider [#1837](https://github.com/Automattic/simplenote-electron/pull/1837)
-- Fixed a bug causing the search result highlighting in the sidebar to be case sensitive [#1831](https://github.com/Automattic/simplenote-electron/pull/1831)
 
 ### Other Changes
 


### PR DESCRIPTION
In #1831 we added the change notes to v1.14.0's notes but this fix did not make
it into the v1.14.0 release. In this patch we're moving the notes into the
future v1.15.0 release's notes.

As this only touches the release notes there should be no need for testing.