### PR TITLE
Move editor mode to redux

### DIFF
--- a/desktop/menus/file-menu.js
+++ b/desktop/menus/file-menu.js
@@ -28,7 +28,7 @@ const submenu = [
   {
     label: '&Print…',
     accelerator: 'CommandOrControl+P',
-    click: appCommandSender({ action: 'setShouldPrintNote' }),
+    click: appCommandSender({ action: 'printNote' }),
   },
 ];
 

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -31,6 +31,7 @@ import {
   values,
 } from 'lodash';
 import {
+  createNote,
   setUnsyncedNoteIds,
   toggleSimperiumConnectionStatus,
 } from './state/ui/actions';
@@ -48,6 +49,7 @@ export type OwnProps = {
 };
 
 export type DispatchProps = {
+  createNote: () => any;
   selectNote: (note: T.NoteEntity) => any;
 };
 
@@ -97,7 +99,7 @@ const mapDispatchToProps: S.MapDispatch<
     setSortType: thenReloadNotes(settingsActions.setSortType),
     toggleSortOrder: thenReloadNotes(settingsActions.toggleSortOrder),
     toggleSortTagsAlpha: thenReloadTags(settingsActions.toggleSortTagsAlpha),
-
+    createNote: () => dispatch(createNote()),
     openTagList: () => dispatch(actionCreators.toggleNavigation()),
     resetAuth: () => dispatch(reduxActions.auth.reset()),
     selectNote: (note: T.NoteEntity) => dispatch(actions.ui.selectNote(note)),
@@ -259,6 +261,10 @@ export const App = connect(
         exportZipArchive();
       }
 
+      if ('printNote' === command.action) {
+        return window.print();
+      }
+
       const canRun = overEvery(
         isObject,
         o => o.action !== null,
@@ -268,6 +274,7 @@ export const App = connect(
       if (canRun(command)) {
         // newNote expects a bucket to be passed in, but the action method itself wouldn't do that
         if (command.action === 'newNote') {
+          this.props.createNote();
           this.props.actions.newNote({
             noteBucket: this.props.noteBucket,
           });

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -33,7 +33,6 @@ const toggleSystemTag = (
 };
 
 const initialState: AppState = {
-  editorMode: 'edit',
   filter: '',
   previousIndex: -1,
   notes: null,
@@ -47,7 +46,6 @@ const initialState: AppState = {
   editingTags: false,
   dialogs: [],
   nextDialogKey: 0,
-  shouldPrint: false,
   searchFocus: false,
   unsyncedNoteIds: [], // note bucket only
 };
@@ -137,12 +135,6 @@ export const actionMap = new ActionMap({
       });
     },
 
-    setEditorMode(state: AppState, { mode }: { mode: T.EditorMode }) {
-      return update(state, {
-        editorMode: { $set: mode },
-      });
-    },
-
     showDialog(state: AppState, { dialog }) {
       const { type, multiple = false, title, ...dialogProps } = dialog;
 
@@ -211,10 +203,6 @@ export const actionMap = new ActionMap({
 
           if (state.showTrash) {
             dispatch(this.action('showAllNotes'));
-          }
-
-          if (settings.markdownEnabled) {
-            dispatch(this.action('setEditorMode', { mode: 'edit' }));
           }
 
           // insert a new note into the store and select it
@@ -325,12 +313,6 @@ export const actionMap = new ActionMap({
     setIsViewingRevisions(state: AppState, { isViewingRevisions }) {
       return update(state, {
         isViewingRevisions: { $set: isViewingRevisions },
-      });
-    },
-
-    setShouldPrintNote(state: AppState, { shouldPrint = true }) {
-      return update(state, {
-        shouldPrint: { $set: shouldPrint },
       });
     },
 

--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -21,11 +21,9 @@ export class NoteDetail extends Component {
     fontSize: PropTypes.number,
     onChangeContent: PropTypes.func.isRequired,
     syncNote: PropTypes.func.isRequired,
-    onNotePrinted: PropTypes.func.isRequired,
     note: PropTypes.object,
     noteBucket: PropTypes.object.isRequired,
     previewingMarkdown: PropTypes.bool,
-    shouldPrint: PropTypes.bool.isRequired,
     showNoteInfo: PropTypes.bool.isRequired,
     spellCheckEnabled: PropTypes.bool.isRequired,
     storeFocusEditor: PropTypes.func,
@@ -72,13 +70,7 @@ export class NoteDetail extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { note, onNotePrinted, previewingMarkdown, shouldPrint } = this.props;
-
-    // Immediately print once `shouldPrint` has been set
-    if (shouldPrint) {
-      window.print();
-      onNotePrinted();
-    }
+    const { note, previewingMarkdown } = this.props;
 
     const prevContent = get(prevProps, 'note.data.content', '');
     const nextContent = get(this.props, 'note.data.content', '');
@@ -244,15 +236,8 @@ const mapStateToProps = ({ appState: state, ui, settings }) => ({
   dialogs: state.dialogs,
   filter: state.filter,
   note: state.revision || ui.note,
-  shouldPrint: state.shouldPrint,
   showNoteInfo: state.showNoteInfo,
   spellCheckEnabled: settings.spellCheckEnabled,
 });
 
-const { setShouldPrintNote } = appState.actionCreators;
-
-const mapDispatchToProps = {
-  onNotePrinted: () => setShouldPrintNote({ shouldPrint: false }),
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(NoteDetail);
+export default connect(mapStateToProps)(NoteDetail);

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -5,15 +5,20 @@ import appState from '../flux/app-state';
 import TagField from '../tag-field';
 import { property } from 'lodash';
 import NoteDetail from '../note-detail';
+import { toggleEditMode } from '../state/ui/actions';
 
 import * as S from '../state';
 import * as T from '../types';
+
+type DispatchProps = {
+  toggleEditMode: () => any;
+};
 
 type StateProps = {
   note: T.NoteEntity | null;
 };
 
-type Props = StateProps;
+type Props = DispatchProps & StateProps;
 
 export class NoteEditor extends Component<Props> {
   static displayName = 'NoteEditor';
@@ -21,7 +26,6 @@ export class NoteEditor extends Component<Props> {
   static propTypes = {
     allTags: PropTypes.array.isRequired,
     closeNote: PropTypes.func.isRequired,
-    editorMode: PropTypes.oneOf(['edit', 'markdown']),
     isEditorActive: PropTypes.bool.isRequired,
     isSmallScreen: PropTypes.bool.isRequired,
     filter: PropTypes.string.isRequired,
@@ -30,12 +34,10 @@ export class NoteEditor extends Component<Props> {
     onNoteClosed: PropTypes.func.isRequired,
     onUpdateContent: PropTypes.func.isRequired,
     revision: PropTypes.object,
-    setEditorMode: PropTypes.func.isRequired,
     syncNote: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
-    editorMode: 'edit',
     note: {
       data: {
         tags: [],
@@ -73,11 +75,7 @@ export class NoteEditor extends Component<Props> {
       'p' === key.toLowerCase() &&
       this.markdownEnabled
     ) {
-      const prevEditorMode = this.props.editorMode;
-      const nextEditorMode = prevEditorMode === 'edit' ? 'markdown' : 'edit';
-
-      this.props.setEditorMode({ mode: nextEditorMode });
-
+      this.props.toggleEditMode();
       event.stopPropagation();
       event.preventDefault();
       return false;
@@ -135,7 +133,7 @@ export class NoteEditor extends Component<Props> {
   };
 
   render() {
-    const { editorMode, note, noteBucket, fontSize } = this.props;
+    const { editMode, note, noteBucket, fontSize } = this.props;
     const revision = this.props.revision || note;
     const tags = (revision && revision.data && revision.data.tags) || [];
     const isTrashed = !!(note && note.data.deleted);
@@ -147,9 +145,7 @@ export class NoteEditor extends Component<Props> {
           storeHasFocus={this.storeEditorHasFocus}
           filter={this.props.filter}
           noteBucket={noteBucket}
-          previewingMarkdown={
-            this.markdownEnabled() && editorMode === 'markdown'
-          }
+          previewingMarkdown={this.markdownEnabled() && !editMode}
           onChangeContent={this.props.onUpdateContent}
           syncNote={this.props.syncNote}
           fontSize={fontSize}
@@ -171,22 +167,22 @@ export class NoteEditor extends Component<Props> {
 const mapStateToProps: S.MapState<StateProps> = ({
   appState: state,
   settings,
-  ui: { note },
+  ui: { note, editMode },
 }) => ({
   allTags: state.tags,
   filter: state.filter,
   fontSize: settings.fontSize,
-  editorMode: state.editorMode,
+  editMode,
   isEditorActive: !state.showNavigation,
   note,
   revision: state.revision,
 });
 
-const { closeNote, setEditorMode } = appState.actionCreators;
+const { closeNote } = appState.actionCreators;
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
   closeNote: () => dispatch(closeNote()),
-  setEditorMode: args => dispatch(setEditorMode(args)),
+  toggleEditMode: () => dispatch(toggleEditMode()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteEditor);

--- a/lib/note-toolbar-container.ts
+++ b/lib/note-toolbar-container.ts
@@ -17,7 +17,6 @@ type OwnProps = {
 
 type StateProps = {
   isViewingRevisions: boolean;
-  editorMode: T.EditorMode;
   notes: T.NoteEntity[];
   revisionOrNote: T.NoteEntity | null;
 };
@@ -34,7 +33,6 @@ type DispatchProps = {
   deleteNoteForever: (args: ListChanger) => any;
   noteRevisions: (args: NoteChanger) => any;
   restoreNote: (args: ListChanger) => any;
-  setEditorMode: ({ mode }: { mode: T.EditorMode }) => any;
   setIsViewingRevisions: (isViewingRevisions: boolean) => any;
   shareNote: () => any;
   toggleFocusMode: () => any;
@@ -91,21 +89,13 @@ export class NoteToolbarContainer extends Component<Props> {
     analytics.tracks.recordEvent('editor_share_dialog_viewed');
   };
 
-  onSetEditorMode = (mode: T.EditorMode) => this.props.setEditorMode({ mode });
-
   render() {
-    const {
-      editorMode,
-      isViewingRevisions,
-      toolbar,
-      revisionOrNote,
-    } = this.props;
+    const { isViewingRevisions, toolbar, revisionOrNote } = this.props;
 
     const handlers = {
       onCloseNote: this.onCloseNote,
       onDeleteNoteForever: this.onDeleteNoteForever,
       onRestoreNote: this.onRestoreNote,
-      onSetEditorMode: this.onSetEditorMode,
       onShowNoteInfo: this.props.toggleNoteInfo,
       onShowRevisions: this.onShowRevisions,
       onShareNote: this.onShareNote,
@@ -122,7 +112,7 @@ export class NoteToolbarContainer extends Component<Props> {
       ? revisionOrNote.data.systemTags.includes('markdown')
       : false;
 
-    return cloneElement(toolbar, { ...handlers, editorMode, markdownEnabled });
+    return cloneElement(toolbar, { ...handlers, markdownEnabled });
   }
 }
 
@@ -131,7 +121,6 @@ const mapStateToProps: S.MapState<StateProps> = ({
   ui: { filteredNotes, note },
 }) => ({
   isViewingRevisions: appState.isViewingRevisions,
-  editorMode: appState.editorMode,
   notes: filteredNotes,
   revisionOrNote: appState.revision || note,
 });
@@ -141,7 +130,6 @@ const {
   deleteNoteForever,
   noteRevisions,
   restoreNote,
-  setEditorMode,
   setIsViewingRevisions,
   showDialog,
   toggleNoteInfo,
@@ -153,7 +141,6 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
   deleteNoteForever: args => dispatch(deleteNoteForever(args)),
   noteRevisions: args => dispatch(noteRevisions(args)),
   restoreNote: args => dispatch(restoreNote(args)),
-  setEditorMode: args => dispatch(setEditorMode(args)),
   setIsViewingRevisions: (isViewingRevisions: boolean) => {
     dispatch(setIsViewingRevisions({ isViewingRevisions }));
   },

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -12,15 +12,21 @@ import RevisionsIcon from '../icons/revisions';
 import TrashIcon from '../icons/trash';
 import ShareIcon from '../icons/share';
 import SidebarIcon from '../icons/sidebar';
+import { toggleEditMode } from '../state/ui/actions';
 
 import * as S from '../state';
 import * as T from '../types';
 
+type DispatchProps = {
+  toggleEditMode: () => any;
+};
+
 type StateProps = {
+  editMode: boolean;
   note: T.NoteEntity | null;
 };
 
-type Props = StateProps;
+type Props = DispatchProps & StateProps;
 
 export class NoteToolbar extends Component<Props> {
   static displayName = 'NoteToolbar';
@@ -35,17 +41,13 @@ export class NoteToolbar extends Component<Props> {
     onShowNoteInfo: PropTypes.func,
     setIsViewingRevisions: PropTypes.func,
     toggleFocusMode: PropTypes.func.isRequired,
-    onSetEditorMode: PropTypes.func,
-    editorMode: PropTypes.string,
     markdownEnabled: PropTypes.bool,
   };
 
   static defaultProps = {
-    editorMode: 'edit',
     onCloseNote: noop,
     onDeleteNoteForever: noop,
     onRestoreNote: noop,
-    onSetEditorMode: noop,
     onShowNoteInfo: noop,
     onShowRevisions: noop,
     onShareNote: noop,
@@ -70,16 +72,8 @@ export class NoteToolbar extends Component<Props> {
     );
   }
 
-  setEditorMode = () => {
-    const { editorMode } = this.props;
-
-    this.props.onSetEditorMode(editorMode === 'markdown' ? 'edit' : 'markdown');
-  };
-
   renderNormal = () => {
-    const { note, editorMode, markdownEnabled } = this.props;
-    const isPreviewing = editorMode === 'markdown';
-
+    const { editMode, markdownEnabled, note } = this.props;
     return !note ? (
       <div className="note-toolbar-placeholder theme-color-border" />
     ) : (
@@ -104,8 +98,8 @@ export class NoteToolbar extends Component<Props> {
           {markdownEnabled && (
             <div className="note-toolbar__button">
               <IconButton
-                icon={isPreviewing ? <PreviewStopIcon /> : <PreviewIcon />}
-                onClick={this.setEditorMode}
+                icon={!editMode ? <PreviewStopIcon /> : <PreviewIcon />}
+                onClick={this.props.toggleEditMode}
                 title="Preview • Ctrl+Shift+P"
               />
             </div>
@@ -180,8 +174,15 @@ export class NoteToolbar extends Component<Props> {
   };
 }
 
-const mapStateToProps: S.MapState<StateProps> = ({ ui: { note } }) => ({
+const mapStateToProps: S.MapState<StateProps> = ({
+  ui: { note, editMode },
+}) => ({
+  editMode,
   note,
 });
 
-export default connect(mapStateToProps)(NoteToolbar);
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
+  toggleEditMode: () => dispatch(toggleEditMode()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(NoteToolbar);

--- a/lib/search-bar/index.tsx
+++ b/lib/search-bar/index.tsx
@@ -14,6 +14,7 @@ import NewNoteIcon from '../icons/new-note';
 import SearchField from '../search-field';
 import MenuIcon from '../icons/menu';
 import { withoutTags } from '../utils/filter-notes';
+import { createNote } from '../state/ui/actions';
 
 const { newNote, search, toggleNavigation } = appState.actionCreators;
 const { recordEvent } = tracks;
@@ -50,6 +51,7 @@ const mapStateToProps = ({ appState: state }) => ({
 
 const mapDispatchToProps = (dispatch, { noteBucket, onNoteOpened }) => ({
   onNewNote: (content: string) => {
+    dispatch(createNote());
     dispatch(search({ filter: '' }));
     dispatch(newNote({ noteBucket, content }));
     onNoteOpened();

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -51,6 +51,7 @@ export type SetWPToken = Action<'setWPToken', { token: string }>;
 /*
  * Normal action types
  */
+export type CreateNote = Action<'CREATE_NOTE'>;
 export type FilterNotes = Action<'FILTER_NOTES', { notes: T.NoteEntity[] }>;
 export type SetAuth = Action<'AUTH_SET', { status: AuthState }>;
 export type SetUnsyncedNoteIds = Action<
@@ -61,10 +62,12 @@ export type ToggleSimperiumConnectionStatus = Action<
   'SIMPERIUM_CONNECTION_STATUS_TOGGLE',
   { simperiumConnected: boolean }
 >;
+export type ToggleEditMode = Action<'TOGGLE_EDIT_MODE'>;
 export type ToggleTagDrawer = Action<'TAG_DRAWER_TOGGLE', { show: boolean }>;
 export type SelectNote = Action<'SELECT_NOTE', { note: T.NoteEntity }>;
 
 export type ActionType =
+  | CreateNote
   | LegacyAction
   | FilterNotes
   | SelectNote
@@ -83,6 +86,7 @@ export type ActionType =
   | SetTheme
   | SetUnsyncedNoteIds
   | SetWPToken
+  | ToggleEditMode
   | ToggleSimperiumConnectionStatus
   | ToggleTagDrawer;
 
@@ -179,7 +183,6 @@ type LegacyAction =
   | Action<'App.selectTag', { tag: T.TagEntity }>
   | Action<'App.selectTagAndSElectFirstNote'>
   | Action<'App.selectTrash'>
-  | Action<'App.setEditorMode', { mode: T.EditorMode }>
   | Action<'App.setIsViewingRevisions', { isReviewingRevisions: boolean }>
   | Action<'App.setRevision', { revision: T.NoteEntity }>
   | Action<'App.setSearchFocus', { searchFocus: boolean }>

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -28,7 +28,6 @@ import * as T from '../types';
 
 export type AppState = {
   dialogs: unknown[];
-  editorMode: T.EditorMode;
   editingTags: boolean;
   filter: string;
   isViewingRevisions: boolean;
@@ -39,7 +38,6 @@ export type AppState = {
   previousIndex: number;
   revision: T.NoteEntity | null;
   searchFocus: boolean;
-  shouldPrint: boolean;
   showNavigation: boolean;
   showNoteInfo: boolean;
   showTrash: boolean;

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -1,6 +1,10 @@
 import * as A from '../action-types';
 import * as T from '../../types';
 
+export const createNote: A.ActionCreator<A.CreateNote> = () => ({
+  type: 'CREATE_NOTE',
+});
+
 export const filterNotes: A.ActionCreator<A.FilterNotes> = (
   notes: T.NoteEntity[]
 ) => ({
@@ -25,6 +29,10 @@ export const toggleSimperiumConnectionStatus: A.ActionCreator<A.ToggleSimperiumC
 export const selectNote: A.ActionCreator<A.SelectNote> = (
   note: T.NoteEntity
 ) => ({ type: 'SELECT_NOTE', note });
+
+export const toggleEditMode: A.ActionCreator<A.ToggleEditMode> = () => ({
+  type: 'TOGGLE_EDIT_MODE',
+});
 
 export const toggleTagDrawer: A.ActionCreator<A.ToggleTagDrawer> = (
   show: boolean

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -1,10 +1,23 @@
 import { difference, union } from 'lodash';
 import { AnyAction, combineReducers } from 'redux';
+
 import * as A from '../action-types';
 import * as T from '../../types';
 
 const defaultVisiblePanes = ['editor', 'noteList'];
 const emptyList: unknown[] = [];
+
+const editMode: A.Reducer<boolean> = (state = true, action) => {
+  switch (action.type) {
+    case 'TOGGLE_EDIT_MODE': {
+      return !state;
+    }
+    case 'CREATE_NOTE':
+      return true;
+    default:
+      return state;
+  }
+};
 
 const filteredNotes: A.Reducer<T.NoteEntity[]> = (
   state = emptyList as T.NoteEntity[],
@@ -56,6 +69,7 @@ const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
 };
 
 export default combineReducers({
+  editMode,
   filteredNotes,
   note,
   simperiumConnected,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -61,8 +61,6 @@ export type Bucket<T> = {
 ///////////////////////////////////////
 // Application Types
 ///////////////////////////////////////
-
-export type EditorMode = 'edit' | 'markdown' | 'preview';
 export type LineLength = 'full' | 'narrow';
 export type ListDisplayMode = 'expanded' | 'comfy' | 'condensed';
 export type SortType = 'alphabetical' | 'creationDate' | 'modificationDate';


### PR DESCRIPTION
### Fix
This PR moves the editor mode state from flux to redux.

### Test
1. Open app
2. Click into note with markdown
3. Does the note display in edit mode?
4. Click preview button
5. Does note display in preview mode
6. Click between notes
7. Does preview mode remain enabled
8. Turn off preview mode
9. Does preview mode turn off
10. Turn preview back on
11. Turn off markdown in the info panel for a note
12. Does preview mode turn off?

### Review
Only one developer is required to review these changes, but anyone can perform the review.