### PR TITLE
Remove unneeded action declarations

### DIFF
--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -2,10 +2,6 @@ import * as T from '../types';
 
 import { AuthState } from './auth/constants';
 
-export const AUTH_SET = 'AUTH_SET';
-export const FILTER_NOTES = 'FILTER_NOTES';
-export const TAG_DRAWER_TOGGLE = 'TAG_DRAWER_TOGGLE';
-
 export type Action<
   T extends string,
   Args extends { [extraProps: string]: unknown } = {}


### PR DESCRIPTION
Removes unneeded action declarations.

We intended to remove them as part of this PR: https://github.com/Automattic/simplenote-electron/pull/1856/files#diff-aef681720de17f639e0032e4e0730d05R5

