### PR TITLE
Move print state from flux to redux

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -30,6 +30,7 @@ import {
   pick,
   values,
 } from 'lodash';
+import { toggleShouldPrint } from './state/ui/actions';
 
 import * as settingsActions from './state/settings/actions';
 
@@ -76,12 +77,12 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
     setSortType: thenReloadNotes(settingsActions.setSortType),
     toggleSortOrder: thenReloadNotes(settingsActions.toggleSortOrder),
     toggleSortTagsAlpha: thenReloadTags(settingsActions.toggleSortTagsAlpha),
-
     openTagList: () => dispatch(actionCreators.toggleNavigation()),
     resetAuth: () => dispatch(reduxActions.auth.reset()),
     setAuthorized: () => dispatch(reduxActions.auth.setAuthorized()),
     setSearchFocus: () =>
       dispatch(actionCreators.setSearchFocus({ searchFocus: true })),
+    setShouldPrint: () => dispatch(toggleShouldPrint(true)),
   };
 }
 
@@ -258,6 +259,15 @@ export const App = connect(
         } else {
           this.props.actions[command.action](command);
         }
+        return;
+      }
+
+      switch (command?.action) {
+        case 'setShouldPrintNote':
+          this.props.setShouldPrint();
+          break;
+        default:
+          break;
       }
     };
 

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -49,7 +49,6 @@ const initialState: AppState = {
   editingTags: false,
   dialogs: [],
   nextDialogKey: 0,
-  shouldPrint: false,
   searchFocus: false,
   unsyncedNoteIds: [], // note bucket only
   isOffline: true, // disconnected from Simperium server
@@ -351,12 +350,6 @@ export const actionMap = new ActionMap({
     setIsViewingRevisions(state: AppState, { isViewingRevisions }) {
       return update(state, {
         isViewingRevisions: { $set: isViewingRevisions },
-      });
-    },
-
-    setShouldPrintNote(state: AppState, { shouldPrint = true }) {
-      return update(state, {
-        shouldPrint: { $set: shouldPrint },
       });
     },
 

--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { get, debounce, noop } from 'lodash';
 import analytics from '../analytics';
-import appState from '../flux/app-state';
 import { viewExternalUrl } from '../utils/url-utils';
 import NoteContentEditor from '../note-content-editor';
 import SimplenoteCompactLogo from '../icons/simplenote-compact';
 import renderToNode from './render-to-node';
 import toggleTask from './toggle-task';
+import { toggleShouldPrint } from '../state/ui/actions';
 
 const syncDelay = 2000;
 
@@ -25,7 +25,7 @@ export class NoteDetail extends Component {
     note: PropTypes.object,
     noteBucket: PropTypes.object.isRequired,
     previewingMarkdown: PropTypes.bool,
-    shouldPrint: PropTypes.bool.isRequired,
+    print: PropTypes.bool.isRequired,
     showNoteInfo: PropTypes.bool.isRequired,
     spellCheckEnabled: PropTypes.bool.isRequired,
     storeFocusEditor: PropTypes.func,
@@ -72,10 +72,11 @@ export class NoteDetail extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { note, onNotePrinted, previewingMarkdown, shouldPrint } = this.props;
+    const { note, onNotePrinted, previewingMarkdown, print } = this.props;
 
-    // Immediately print once `shouldPrint` has been set
-    if (shouldPrint) {
+    // Immediately print once `print` has been set
+    console.log(print);
+    if (print) {
       window.print();
       onNotePrinted();
     }
@@ -240,18 +241,16 @@ export class NoteDetail extends Component {
   }
 }
 
-const mapStateToProps = ({ appState: state, settings }) => ({
+const mapStateToProps = ({ appState: state, settings, ui: { print } }) => ({
   dialogs: state.dialogs,
   filter: state.filter,
-  shouldPrint: state.shouldPrint,
+  print,
   showNoteInfo: state.showNoteInfo,
   spellCheckEnabled: settings.spellCheckEnabled,
 });
 
-const { setShouldPrintNote } = appState.actionCreators;
-
-const mapDispatchToProps = {
-  onNotePrinted: () => setShouldPrintNote({ shouldPrint: false }),
-};
+const mapDispatchToProps = dispatch => ({
+  onNotePrinted: () => dispatch(toggleShouldPrint(false)),
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteDetail);

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -53,6 +53,10 @@ export type SetWPToken = Action<'setWPToken', { token: string }>;
  */
 export type FilterNotes = Action<'FILTER_NOTES', { notes: T.NoteEntity[] }>;
 export type SetAuth = Action<'AUTH_SET', { status: AuthState }>;
+export type ToggleShouldPrint = Action<
+  'SHOULD_PRINT_TOGGLE',
+  { shouldPrint: boolean }
+>;
 export type ToggleTagDrawer = Action<'TAG_DRAWER_TOGGLE', { show: boolean }>;
 
 export type ActionType =
@@ -71,6 +75,7 @@ export type ActionType =
   | SetSpellCheck
   | SetTheme
   | SetWPToken
+  | ToggleShouldPrint
   | ToggleTagDrawer;
 
 export type ActionCreator<A extends ActionType> = (...args: any[]) => A;

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -42,7 +42,6 @@ export type AppState = {
   revision: T.NoteEntity | null;
   searchFocus: boolean;
   selectedNoteId: T.EntityId | null;
-  shouldPrint: boolean;
   showNavigation: boolean;
   showNoteInfo: boolean;
   showTrash: boolean;

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -8,6 +8,13 @@ export const filterNotes: A.ActionCreator<A.FilterNotes> = (
   notes,
 });
 
+export const toggleShouldPrint: A.ActionCreator<A.ToggleShouldPrint> = (
+  shouldPrint: boolean
+) => ({
+  type: 'SHOULD_PRINT_TOGGLE',
+  shouldPrint,
+});
+
 export const toggleTagDrawer: A.ActionCreator<A.ToggleTagDrawer> = (
   show: boolean
 ) => ({

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -12,6 +12,9 @@ const filteredNotes: A.Reducer<T.NoteEntity[]> = (
   action
 ) => ('FILTER_NOTES' === action.type ? action.notes : state);
 
+const print: A.Reducer<boolean> = (state = false, action) =>
+  'SHOULD_PRINT_TOGGLE' === action.type ? action.shouldPrint : state;
+
 const visiblePanes: A.Reducer<string[]> = (
   state = defaultVisiblePanes,
   action
@@ -25,4 +28,4 @@ const visiblePanes: A.Reducer<string[]> = (
   return state;
 };
 
-export default combineReducers({ filteredNotes, visiblePanes });
+export default combineReducers({ filteredNotes, print, visiblePanes });


### PR DESCRIPTION
### Fix
We use a shouldPrint boolean in AppState to determine if we should print. When shouldState becomes true we initiate a print command. This was all happening in AppState.

This PR moves this state to state/ui/print. Due to the way that Electron menu bar actions interact with the app I have included a switch statement on L265 of lib/app.tsx. This allows us to start routing actions to redux. This will eventually make the code preceding it obsolete.

### Test
1. Open electron app
2. Ensure the app is in focus not the dev tools
3. Under the file menu item click print
4. Does the print dialog come up?
5. Print
6. Follow steps again
7. Click cancel
8. Follow steps again
9. Does dialog pop up?

### Review
Only one developer is required to review these changes, but anyone can perform the review.