### PR TITLE
Move simperium connection state from flux to redux

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -175,12 +175,8 @@ export const App = connect(
         .on('message', setLastSyncedTime)
         .on('message', this.syncActivityHooks)
         .on('send', this.syncActivityHooks)
-        .on('connect', () => {
-          this.props.setSimperiumConnectionStatus(true);
-        })
-        .on('disconnect', () => {
-          this.props.setSimperiumConnectionStatus(false);
-        });
+        .on('connect', () => this.props.setSimperiumConnectionStatus(true))
+        .on('disconnect', () => this.props.setSimperiumConnectionStatus(false));
 
       this.onLoadPreferences(() =>
         // Make sure that tracking starts only after preferences are loaded

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -30,6 +30,7 @@ import {
   pick,
   values,
 } from 'lodash';
+import { toggleSimperiumConnectionStatus } from './state/ui/actions';
 
 import * as settingsActions from './state/settings/actions';
 
@@ -82,6 +83,8 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
     setAuthorized: () => dispatch(reduxActions.auth.setAuthorized()),
     setSearchFocus: () =>
       dispatch(actionCreators.setSearchFocus({ searchFocus: true })),
+    setSimperiumConnectionStatus: connected =>
+      dispatch(toggleSimperiumConnectionStatus(connected)),
   };
 }
 
@@ -166,18 +169,18 @@ export const App = connect(
         .on('update', debounce(this.props.loadTags, 200))
         .on('remove', this.props.loadTags);
 
-      const {
-        actions: { setConnectionStatus },
-      } = this.props;
-
       this.props.client
         .on('authorized', this.onAuthChanged)
         .on('unauthorized', this.onAuthChanged)
         .on('message', setLastSyncedTime)
         .on('message', this.syncActivityHooks)
         .on('send', this.syncActivityHooks)
-        .on('connect', () => setConnectionStatus({ isOffline: false }))
-        .on('disconnect', () => setConnectionStatus({ isOffline: true }));
+        .on('connect', () => {
+          this.props.setSimperiumConnectionStatus(true);
+        })
+        .on('disconnect', () => {
+          this.props.setSimperiumConnectionStatus(false);
+        });
 
       this.onLoadPreferences(() =>
         // Make sure that tracking starts only after preferences are loaded

--- a/lib/components/sync-status/index.tsx
+++ b/lib/components/sync-status/index.tsx
@@ -7,10 +7,11 @@ import SyncIcon from '../../icons/sync';
 import SyncStatusPopover from './popover';
 
 import * as S from '../../state';
+import * as T from '../../types';
 
 type StateProps = {
   simperiumConnected: boolean;
-  unsyncedNoteIds: string[];
+  unsyncedNoteIds: T.EntityId[];
 };
 
 class SyncStatus extends Component<StateProps> {

--- a/lib/components/sync-status/index.tsx
+++ b/lib/components/sync-status/index.tsx
@@ -1,16 +1,19 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 import AlertIcon from '../../icons/alert';
 import SyncIcon from '../../icons/sync';
 import SyncStatusPopover from './popover';
 
-class SyncStatus extends Component {
-  static propTypes = {
-    isOffline: PropTypes.bool.isRequired,
-    unsyncedNoteIds: PropTypes.array.isRequired,
-  };
+import * as S from '../../state';
 
+type StateProps = {
+  simperiumConnected: boolean;
+  unsyncedNoteIds: string[];
+};
+
+class SyncStatus extends Component<StateProps> {
   state = {
     anchorEl: null,
   };
@@ -24,7 +27,7 @@ class SyncStatus extends Component {
   };
 
   render() {
-    const { isOffline, unsyncedNoteIds } = this.props;
+    const { simperiumConnected, unsyncedNoteIds } = this.props;
     const { anchorEl } = this.state;
 
     const popoverId = 'sync-status__popover';
@@ -33,9 +36,9 @@ class SyncStatus extends Component {
     const unit = unsyncedChangeCount === 1 ? 'change' : 'changes';
     const text = unsyncedChangeCount
       ? `${unsyncedChangeCount} unsynced ${unit}`
-      : isOffline
-      ? 'No connection'
-      : 'All changes synced';
+      : simperiumConnected
+      ? 'All changes synced'
+      : 'No connection';
 
     return (
       <div>
@@ -49,7 +52,7 @@ class SyncStatus extends Component {
           tabIndex="0"
         >
           <span className="sync-status__icon">
-            {isOffline ? <AlertIcon /> : <SyncIcon />}
+            {simperiumConnected ? <SyncIcon /> : <AlertIcon />}
           </span>
           {text}
         </div>
@@ -65,4 +68,12 @@ class SyncStatus extends Component {
   }
 }
 
-export default SyncStatus;
+const mapStateToProps: S.MapState<StateProps> = ({
+  appState: state,
+  ui: { simperiumConnected },
+}) => ({
+  simperiumConnected,
+  unsyncedNoteIds: state.unsyncedNoteIds,
+});
+
+export default connect(mapStateToProps)(SyncStatus);

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -52,7 +52,6 @@ const initialState: AppState = {
   shouldPrint: false,
   searchFocus: false,
   unsyncedNoteIds: [], // note bucket only
-  isOffline: true, // disconnected from Simperium server
 };
 
 export const actionMap = new ActionMap({
@@ -716,15 +715,6 @@ export const actionMap = new ActionMap({
     ) {
       return update(state, {
         unsyncedNoteIds: { $set: noteIds },
-      });
-    },
-
-    setConnectionStatus(
-      state: AppState,
-      { isOffline }: { isOffline: boolean }
-    ) {
-      return update(state, {
-        isOffline: { $set: isOffline },
       });
     },
   },

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -21,7 +21,6 @@ export class NavigationBar extends Component {
     autoHideMenuBar: PropTypes.bool,
     dialogs: PropTypes.array.isRequired,
     isElectron: PropTypes.bool.isRequired,
-    isOffline: PropTypes.bool.isRequired,
     onAbout: PropTypes.func.isRequired,
     onOutsideClick: PropTypes.func.isRequired,
     onSettings: PropTypes.func.isRequired,
@@ -30,7 +29,6 @@ export class NavigationBar extends Component {
     selectedTag: PropTypes.object,
     showNavigation: PropTypes.bool.isRequired,
     showTrash: PropTypes.bool.isRequired,
-    unsyncedNoteIds: PropTypes.array.isRequired,
   };
 
   static defaultProps = {
@@ -69,13 +67,10 @@ export class NavigationBar extends Component {
     const {
       autoHideMenuBar,
       isElectron,
-      isOffline,
       onAbout,
       onSettings,
       onShowAllNotes,
-      unsyncedNoteIds,
     } = this.props;
-
     return (
       <div className="navigation-bar theme-color-bg theme-color-fg theme-color-border">
         <div className="navigation-bar__folders">
@@ -125,7 +120,7 @@ export class NavigationBar extends Component {
         )}
 
         <div className="navigation-bar__sync-status theme-color-fg-dim theme-color-border">
-          <SyncStatus isOffline={isOffline} unsyncedNoteIds={unsyncedNoteIds} />
+          <SyncStatus />
         </div>
       </div>
     );
@@ -135,11 +130,9 @@ export class NavigationBar extends Component {
 const mapStateToProps = ({ appState: state, settings }) => ({
   autoHideMenuBar: settings.autoHideMenuBar,
   dialogs: state.dialogs,
-  isOffline: state.isOffline,
   selectedTag: state.tag,
   showNavigation: state.showNavigation,
   showTrash: state.showTrash,
-  unsyncedNoteIds: state.unsyncedNoteIds,
 });
 
 const {

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -53,6 +53,10 @@ export type SetWPToken = Action<'setWPToken', { token: string }>;
  */
 export type FilterNotes = Action<'FILTER_NOTES', { notes: T.NoteEntity[] }>;
 export type SetAuth = Action<'AUTH_SET', { status: AuthState }>;
+export type ToggleSimperiumConnectionStatus = Action<
+  'SIMPERIUM_CONNECTION_STATUS_TOGGLE',
+  { simperiumConnected: boolean }
+>;
 export type ToggleTagDrawer = Action<'TAG_DRAWER_TOGGLE', { show: boolean }>;
 
 export type ActionType =
@@ -71,6 +75,7 @@ export type ActionType =
   | SetSpellCheck
   | SetTheme
   | SetWPToken
+  | ToggleSimperiumConnectionStatus
   | ToggleTagDrawer;
 
 export type ActionCreator<A extends ActionType> = (...args: any[]) => A;

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -31,7 +31,6 @@ export type AppState = {
   editorMode: T.EditorMode;
   editingTags: boolean;
   filter: string;
-  isOffline: boolean;
   isViewingRevisions: boolean;
   listTitle: T.TranslatableString;
   nextDialogKey: number;

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -8,6 +8,13 @@ export const filterNotes: A.ActionCreator<A.FilterNotes> = (
   notes,
 });
 
+export const toggleSimperiumConnectionStatus: A.ActionCreator<A.ToggleSimperiumConnectionStatus> = (
+  simperiumConnected: boolean
+) => ({
+  type: 'SIMPERIUM_CONNECTION_STATUS_TOGGLE',
+  simperiumConnected,
+});
+
 export const toggleTagDrawer: A.ActionCreator<A.ToggleTagDrawer> = (
   show: boolean
 ) => ({

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -12,6 +12,11 @@ const filteredNotes: A.Reducer<T.NoteEntity[]> = (
   action
 ) => ('FILTER_NOTES' === action.type ? action.notes : state);
 
+const simperiumConnected: A.Reducer<boolean> = (state = false, action) =>
+  'SIMPERIUM_CONNECTION_STATUS_TOGGLE' === action.type
+    ? action.simperiumConnected
+    : state;
+
 const visiblePanes: A.Reducer<string[]> = (
   state = defaultVisiblePanes,
   action
@@ -25,4 +30,8 @@ const visiblePanes: A.Reducer<string[]> = (
   return state;
 };
 
-export default combineReducers({ filteredNotes, visiblePanes });
+export default combineReducers({
+  filteredNotes,
+  simperiumConnected,
+  visiblePanes,
+});


### PR DESCRIPTION
### Fix
When Simperium connects and disconnects we display different text and a different icon in the sync status popover. This PR moves that state from flux to the redux state.

### Test
1. Observe the sync status in the hamburger menu
2. Does it say that it is connnected?

I have not been able to get the websocket to send a disconnection message. I am not sure how to test the disconnection.

### Review
Only one developer is required to review these changes, but anyone can perform the review.