### PR TITLE
Remove print state and call print directly

### DIFF
--- a/desktop/menus/file-menu.js
+++ b/desktop/menus/file-menu.js
@@ -28,7 +28,7 @@ const submenu = [
   {
     label: '&Print…',
     accelerator: 'CommandOrControl+P',
-    click: appCommandSender({ action: 'setShouldPrintNote' }),
+    click: appCommandSender({ action: 'printNote' }),
   },
 ];
 

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -30,7 +30,6 @@ import {
   pick,
   values,
 } from 'lodash';
-import { setEditorMode } from './state/ui/actions';
 import { toggleSimperiumConnectionStatus } from './state/ui/actions';
 
 import * as settingsActions from './state/settings/actions';
@@ -40,7 +39,6 @@ const ipc = getIpcRenderer();
 const mapStateToProps = state => ({
   ...state,
   authIsPending: selectors.auth.authIsPending(state),
-  editorMode: state?.ui?.editorMode,
   isAuthorized: selectors.auth.isAuthorized(state),
 });
 
@@ -87,7 +85,6 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
       dispatch(actionCreators.setSearchFocus({ searchFocus: true })),
     setSimperiumConnectionStatus: connected =>
       dispatch(toggleSimperiumConnectionStatus(connected)),
-    setEditorMode: mode => dispatch(setEditorMode(mode)),
   };
 }
 
@@ -241,16 +238,7 @@ export const App = connect(
       }
 
       if ('printNote' === command.action) {
-        const { editorMode, setEditorMode } = this.props;
-
-        setTimeout(() => {
-          setEditorMode('markdown');
-          setTimeout(() => {
-            window.print();
-            // setEditorMode(editorMode);
-          }, 0);
-        }, 0);
-        return;
+        return window.print();
       }
 
       const canRun = overEvery(

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -30,6 +30,7 @@ import {
   pick,
   values,
 } from 'lodash';
+import { setEditorMode } from './state/ui/actions';
 import { toggleSimperiumConnectionStatus } from './state/ui/actions';
 
 import * as settingsActions from './state/settings/actions';
@@ -39,6 +40,7 @@ const ipc = getIpcRenderer();
 const mapStateToProps = state => ({
   ...state,
   authIsPending: selectors.auth.authIsPending(state),
+  editorMode: state?.ui?.editorMode,
   isAuthorized: selectors.auth.isAuthorized(state),
 });
 
@@ -85,6 +87,7 @@ function mapDispatchToProps(dispatch, { noteBucket }) {
       dispatch(actionCreators.setSearchFocus({ searchFocus: true })),
     setSimperiumConnectionStatus: connected =>
       dispatch(toggleSimperiumConnectionStatus(connected)),
+    setEditorMode: mode => dispatch(setEditorMode(mode)),
   };
 }
 
@@ -235,6 +238,19 @@ export const App = connect(
     onAppCommand = (event, command) => {
       if ('exportZipArchive' === get(command, 'action')) {
         exportZipArchive();
+      }
+
+      if ('printNote' === command.action) {
+        const { editorMode, setEditorMode } = this.props;
+
+        setTimeout(() => {
+          setEditorMode('markdown');
+          setTimeout(() => {
+            window.print();
+            // setEditorMode(editorMode);
+          }, 0);
+        }, 0);
+        return;
       }
 
       const canRun = overEvery(

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -48,7 +48,6 @@ const initialState: AppState = {
   editingTags: false,
   dialogs: [],
   nextDialogKey: 0,
-  shouldPrint: false,
   searchFocus: false,
   unsyncedNoteIds: [], // note bucket only
 };
@@ -345,12 +344,6 @@ export const actionMap = new ActionMap({
     setIsViewingRevisions(state: AppState, { isViewingRevisions }) {
       return update(state, {
         isViewingRevisions: { $set: isViewingRevisions },
-      });
-    },
-
-    setShouldPrintNote(state: AppState, { shouldPrint = true }) {
-      return update(state, {
-        shouldPrint: { $set: shouldPrint },
       });
     },
 

--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -21,11 +21,9 @@ export class NoteDetail extends Component {
     fontSize: PropTypes.number,
     onChangeContent: PropTypes.func.isRequired,
     syncNote: PropTypes.func.isRequired,
-    onNotePrinted: PropTypes.func.isRequired,
     note: PropTypes.object,
     noteBucket: PropTypes.object.isRequired,
     previewingMarkdown: PropTypes.bool,
-    shouldPrint: PropTypes.bool.isRequired,
     showNoteInfo: PropTypes.bool.isRequired,
     spellCheckEnabled: PropTypes.bool.isRequired,
     storeFocusEditor: PropTypes.func,
@@ -72,13 +70,7 @@ export class NoteDetail extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { note, onNotePrinted, previewingMarkdown, shouldPrint } = this.props;
-
-    // Immediately print once `shouldPrint` has been set
-    if (shouldPrint) {
-      window.print();
-      onNotePrinted();
-    }
+    const { note, previewingMarkdown } = this.props;
 
     const prevContent = get(prevProps, 'note.data.content', '');
     const nextContent = get(this.props, 'note.data.content', '');
@@ -243,15 +235,8 @@ export class NoteDetail extends Component {
 const mapStateToProps = ({ appState: state, settings }) => ({
   dialogs: state.dialogs,
   filter: state.filter,
-  shouldPrint: state.shouldPrint,
   showNoteInfo: state.showNoteInfo,
   spellCheckEnabled: settings.spellCheckEnabled,
 });
 
-const { setShouldPrintNote } = appState.actionCreators;
-
-const mapDispatchToProps = {
-  onNotePrinted: () => setShouldPrintNote({ shouldPrint: false }),
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(NoteDetail);
+export default connect(mapStateToProps)(NoteDetail);

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -40,7 +40,6 @@ export type AppState = {
   revision: T.NoteEntity | null;
   searchFocus: boolean;
   selectedNoteId: T.EntityId | null;
-  shouldPrint: boolean;
   showNavigation: boolean;
   showNoteInfo: boolean;
   showTrash: boolean;


### PR DESCRIPTION
### Fix
This PR calls the print function directly from app.tsx rather than setting up state. By not having to set editor/preview mode we decrease the complexity of this functionality while giving the user the option to print the editor view OR the markdown styled mode.  

Before this change, the print function was intended to only print the formatted markdown mode but the functionality is broken. This PR removes the broken code.

### Test
1. Open electron
2. From file menu click print
3. Observe it prints the note
4. Turn on markdown mode
5. Print
6. Observe that it prints formatted markdown

### Review
Only one developer is required to review these changes, but anyone can perform the review.