### PR TITLE
Tools: Change icon for Export Notes from arrow to download icon

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,11 +13,9 @@
 
 ### Other Changes
 
-- Added types to state/ui/actions [#1849](https://github.com/Automattic/simplenote-electron/pull/1849)
-
-### Other Changes
-
 - Updated Dependencies [#1848](https://github.com/Automattic/simplenote-electron/pull/1848)
+- Added types to state/ui/actions [#1849](https://github.com/Automattic/simplenote-electron/pull/1849)
+- Changed Export Notes icon in Settings to indicate that it's a file download [#1874](https://github.com/Automattic/simplenote-electron/pull/1874)
 
 ## [v1.14.0]
 

--- a/lib/dialogs/button-group/index.tsx
+++ b/lib/dialogs/button-group/index.tsx
@@ -10,7 +10,7 @@ const ButtonGroup = props => {
         <li key={item.slug} className="button-group__item theme-color-border">
           <button type="button" onClick={() => onClickItem(item)}>
             {item.name}
-            <div class="icon">{item.icon ? <item.icon /> : '→'}</div>
+            <div className="icon">{item.icon ? <item.icon /> : '→'}</div>
           </button>
         </li>
       ))}

--- a/lib/dialogs/button-group/index.tsx
+++ b/lib/dialogs/button-group/index.tsx
@@ -10,6 +10,7 @@ const ButtonGroup = props => {
         <li key={item.slug} className="button-group__item theme-color-border">
           <button type="button" onClick={() => onClickItem(item)}>
             {item.name}
+            <div class="icon">{item.icon ? <item.icon /> : '→'}</div>
           </button>
         </li>
       ))}

--- a/lib/dialogs/button-group/style.scss
+++ b/lib/dialogs/button-group/style.scss
@@ -24,8 +24,7 @@
     text-align: left;
     font-size: 115%;
 
-    &::after {
-      content: '→';
+    .icon {
       display: block;
       width: 1em;
       height: 1em;

--- a/lib/dialogs/settings/panels/tools.tsx
+++ b/lib/dialogs/settings/panels/tools.tsx
@@ -9,6 +9,8 @@ import exportZipArchive from '../../../utils/export';
 import PanelTitle from '../../../components/panel-title';
 import ButtonGroup from '../../button-group';
 
+import DownloadIcon from '../../../icons/download';
+
 const ToolsPanel = ({ showImportDialog }) => {
   const onSelectItem = item => {
     if (item.slug === 'import') {
@@ -30,6 +32,7 @@ const ToolsPanel = ({ showImportDialog }) => {
           {
             name: 'Export Notes',
             slug: 'export',
+            icon: DownloadIcon,
           },
         ]}
         onClickItem={onSelectItem}

--- a/lib/icons/download.tsx
+++ b/lib/icons/download.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function ReorderIcon() {
+  return (
+    <svg
+      className="icon-download"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+    >
+      <rect x="0" fill="none" width="24" height="24" />
+      <g>
+        <path d="M15.29,10.88l1.42,1.41L12,17,7.29,12.29l1.42-1.41L11,13.17V3h2V13.17Z" />
+        <path d="M18,21H6a2,2,0,0,1-2-2V12H6v7H18V12h2v7A2,2,0,0,1,18,21Z" />
+      </g>
+    </svg>
+  );
+}


### PR DESCRIPTION
### Fix
To eliminate confusion about the Export Notes button triggering a file download, this PR changes the right pointing arrow icon to a download icon.

Fixes #1394 

### Test
1. Go to Settings -> Tools
2. Check out the new icon
3. Make sure you can still download the notes.zip

### Screenshots

**Before**
<img width="412" alt="Screen Shot 2020-01-29 at 8 52 26 PM" src="https://user-images.githubusercontent.com/52152/73421004-491a0580-42d9-11ea-9c49-43b4e719bf51.png">

**After**
<img width="417" alt="Screen Shot 2020-01-29 at 8 46 53 PM" src="https://user-images.githubusercontent.com/52152/73421011-4ddeb980-42d9-11ea-8fd0-c7293e0dd202.png">

### Review
❓ Should we also change the wording? Right now import/export has a nice symmetry, but I wonder if "Download notes" would be clearer?

### Release
`RELEASE-NOTES.txt` was updated in 758b7d0fbd99c73cfff779a8129c546e45bdad18 with:
 
> Changed Export Notes icon in Settings to indicate that it's a file download [#1874](https://github.com/Automattic/simplenote-electron/pull/1874)