### PR TITLE
Fix: Restore markdown preview button

### DIFF
--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -8,7 +8,7 @@ import SearchBar from '../search-bar';
 import SimplenoteCompactLogo from '../icons/simplenote-compact';
 import TransitionDelayEnter from '../components/transition-delay-enter';
 
-import { NoteEntity } from '../types';
+import * as T from '../types';
 
 const NoteList = React.lazy(() =>
   import(/* webpackChunkName: 'note-list' */ '../note-list')
@@ -24,9 +24,9 @@ type Props = {
   isNoteInfoOpen: boolean;
   isNoteOpen: boolean;
   isSmallScreen: boolean;
-  note: NoteEntity;
-  noteBucket: object;
-  revisions: NoteEntity[];
+  note: T.NoteEntity;
+  noteBucket: T.Bucket<T.Note>;
+  revisions: T.NoteEntity[];
   onNoteClosed: Function;
   onNoteOpened: Function;
   onUpdateContent: Function;

--- a/lib/note-toolbar-container.ts
+++ b/lib/note-toolbar-container.ts
@@ -6,19 +6,43 @@ import appState from './flux/app-state';
 import { toggleFocusMode } from './state/settings/actions';
 import DialogTypes from '../shared/dialog-types';
 
+import * as S from './state';
 import * as T from './types';
-import { State } from './state';
 
-type ExternalProps = {
+type OwnProps = {
   noteBucket: T.Bucket<T.Note>;
   onNoteClosed: Function;
   toolbar: ReactElement;
 };
 
-type ConnectedProps = ReturnType<typeof mapStateToProps> &
-  ReturnType<typeof mapDispatchToProps>;
+type StateProps = {
+  isViewingRevisions: boolean;
+  editorMode: T.EditorMode;
+  notes: T.NoteEntity[];
+  revisionOrNote: T.NoteEntity | null;
+};
 
-type Props = ExternalProps & ConnectedProps;
+type NoteChanger = {
+  noteBucket: T.Bucket<T.Note>;
+  note: T.NoteEntity;
+};
+
+type ListChanger = NoteChanger & { previousIndex: number };
+
+type DispatchProps = {
+  closeNote: () => any;
+  deleteNoteForever: (args: ListChanger) => any;
+  noteRevisions: (args: NoteChanger) => any;
+  restoreNote: (args: ListChanger) => any;
+  setEditorMode: ({ mode }: { mode: T.EditorMode }) => any;
+  setIsViewingRevisions: (isViewingRevisions: boolean) => any;
+  shareNote: () => any;
+  toggleFocusMode: () => any;
+  toggleNoteInfo: () => any;
+  trashNote: (args: ListChanger) => any;
+};
+
+type Props = OwnProps & StateProps & DispatchProps;
 
 export class NoteToolbarContainer extends Component<Props> {
   // Gets the index of the note located before the currently selected one
@@ -102,14 +126,14 @@ export class NoteToolbarContainer extends Component<Props> {
   }
 }
 
-const mapStateToProps = ({
-  appState: state,
-  ui: { filteredNotes },
-}: State) => ({
-  isViewingRevisions: state.isViewingRevisions,
-  editorMode: state.editorMode,
+const mapStateToProps: S.MapState<StateProps> = ({
+  appState,
+  ui: { filteredNotes, note },
+}) => ({
+  isViewingRevisions: appState.isViewingRevisions,
+  editorMode: appState.editorMode,
   notes: filteredNotes,
-  revisionOrNote: state.revision || state.note,
+  revisionOrNote: appState.revision || note,
 });
 
 const {
@@ -124,7 +148,7 @@ const {
   trashNote,
 } = appState.actionCreators;
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
   closeNote: () => dispatch(closeNote()),
   deleteNoteForever: args => dispatch(deleteNoteForever(args)),
   noteRevisions: args => dispatch(noteRevisions(args)),


### PR DESCRIPTION
In #1851 we refactored the selected note state but during testing
missed a reference to `state.appState.note` which should have been
updated to `state.ui.note`. Nothing crashed in the app because it
was being used for its truthiness but the result was that when
checking if Markdown was enabled for any given note the answer
would always end up as "no."

In this patch we're restoring the state reference which fixes that
bug and restores the preview button in the note toolbar.