### PR TITLE
Move Search state to redux

### DIFF
--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -33,7 +33,6 @@ const toggleSystemTag = (
 };
 
 const initialState: AppState = {
-  filter: '',
   previousIndex: -1,
   notes: null,
   tags: [],
@@ -176,12 +175,6 @@ export const actionMap = new ActionMap({
     editTags(state: AppState) {
       return update(state, {
         editingTags: { $set: !state.editingTags },
-      });
-    },
-
-    search(state: AppState, { filter }: { filter: string }) {
-      return update(state, {
-        filter: { $set: filter },
       });
     },
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { ContentState, Editor, EditorState, Modifier } from 'draft-js';
 import MultiDecorator from 'draft-js-multidecorators';
 import { compact, get, invoke, noop } from 'lodash';
@@ -26,16 +27,23 @@ import insertOrRemoveCheckboxes from './editor/insert-or-remove-checkboxes';
 import { getIpcRenderer } from './utils/electron';
 import analytics from './analytics';
 
+import * as S from './state';
+
 const TEXT_DELIMITER = '\n';
 
-export default class NoteContentEditor extends Component {
+type StateProps = {
+  searchQuery: string;
+};
+
+type Props = StateProps;
+
+class NoteContentEditor extends Component<Props> {
   static propTypes = {
     content: PropTypes.shape({
       text: PropTypes.string.isRequired,
       hasRemoteUpdate: PropTypes.bool.isRequired,
       version: PropTypes.string,
     }),
-    filter: PropTypes.string.isRequired,
     noteId: PropTypes.string,
     onChangeContent: PropTypes.func.isRequired,
     spellCheckEnabled: PropTypes.bool.isRequired,
@@ -62,23 +70,24 @@ export default class NoteContentEditor extends Component {
     );
   };
 
-  generateDecorators = filter => {
+  generateDecorators = (searchQuery: string) => {
     return new MultiDecorator(
       compact([
-        filterHasText(filter) && matchingTextDecorator(searchPattern(filter)),
+        filterHasText(searchQuery) &&
+          matchingTextDecorator(searchPattern(searchQuery)),
         checkboxDecorator(this.replaceRangeWithText),
       ])
     );
   };
 
-  createNewEditorState = (text, filter) => {
+  createNewEditorState = (text: string, searchQuery: string) => {
     const newEditorState = EditorState.createWithContent(
       ContentState.createFromText(text, TEXT_DELIMITER),
-      this.generateDecorators(filter)
+      this.generateDecorators(searchQuery)
     );
 
     // Focus the editor for a new, empty note when not searching
-    if (text === '' && filter === '') {
+    if (text === '' && searchQuery === '') {
       return EditorState.moveFocusToEnd(newEditorState);
     }
     return newEditorState;
@@ -87,7 +96,7 @@ export default class NoteContentEditor extends Component {
   state = {
     editorState: this.createNewEditorState(
       this.props.content.text,
-      this.props.filter
+      this.props.searchQuery
     ),
   };
 
@@ -152,7 +161,7 @@ export default class NoteContentEditor extends Component {
   };
 
   componentDidUpdate(prevProps) {
-    const { content, filter, noteId, spellCheckEnabled } = this.props;
+    const { content, searchQuery, noteId, spellCheckEnabled } = this.props;
     const { editorState } = this.state;
 
     // To immediately reflect the changes to the spell check setting,
@@ -171,16 +180,16 @@ export default class NoteContentEditor extends Component {
       content.version !== prevProps.content.version
     ) {
       this.setState({
-        editorState: this.createNewEditorState(content.text, filter),
+        editorState: this.createNewEditorState(content.text, searchQuery),
       });
       return;
     }
 
-    // If filter changes, re-set decorators
-    if (filter !== prevProps.filter) {
+    // If searchQuery changes, re-set decorators
+    if (searchQuery !== prevProps.searchQuery) {
       this.setState({
         editorState: EditorState.set(editorState, {
-          decorator: this.generateDecorators(filter),
+          decorator: this.generateDecorators(searchQuery),
         }),
       });
     }
@@ -320,3 +329,9 @@ export default class NoteContentEditor extends Component {
     );
   }
 }
+
+const mapStateToProps: S.MapState<StateProps> = ({ ui: { searchQuery } }) => ({
+  searchQuery,
+});
+
+export default connect(mapStateToProps)(NoteContentEditor);

--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -17,7 +17,6 @@ export class NoteDetail extends Component {
 
   static propTypes = {
     dialogs: PropTypes.array.isRequired,
-    filter: PropTypes.string.isRequired,
     fontSize: PropTypes.number,
     onChangeContent: PropTypes.func.isRequired,
     syncNote: PropTypes.func.isRequired,
@@ -54,8 +53,6 @@ export class NoteDetail extends Component {
   }
 
   focusEditor = () => this.focusContentEditor && this.focusContentEditor();
-
-  saveEditorRef = ref => (this.editor = ref);
 
   isValidNote = note => note && note.id;
 
@@ -177,7 +174,6 @@ export class NoteDetail extends Component {
   render() {
     const {
       note,
-      filter,
       fontSize,
       previewingMarkdown,
       spellCheckEnabled,
@@ -214,13 +210,11 @@ export class NoteDetail extends Component {
                 style={divStyle}
               >
                 <NoteContentEditor
-                  ref={this.saveEditorRef}
                   spellCheckEnabled={spellCheckEnabled}
                   storeFocusEditor={this.storeFocusContentEditor}
                   storeHasFocus={this.storeEditorHasFocus}
                   noteId={get(note, 'id', null)}
                   content={content}
-                  filter={filter}
                   onChangeContent={this.saveNote}
                 />
               </div>
@@ -234,7 +228,6 @@ export class NoteDetail extends Component {
 
 const mapStateToProps = ({ appState: state, ui, settings }) => ({
   dialogs: state.dialogs,
-  filter: state.filter,
   note: state.revision || ui.note,
   showNoteInfo: state.showNoteInfo,
   spellCheckEnabled: settings.spellCheckEnabled,

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -28,7 +28,6 @@ export class NoteEditor extends Component<Props> {
     closeNote: PropTypes.func.isRequired,
     isEditorActive: PropTypes.bool.isRequired,
     isSmallScreen: PropTypes.bool.isRequired,
-    filter: PropTypes.string.isRequired,
     noteBucket: PropTypes.object.isRequired,
     fontSize: PropTypes.number,
     onNoteClosed: PropTypes.func.isRequired,
@@ -148,7 +147,6 @@ export class NoteEditor extends Component<Props> {
         <NoteDetail
           storeFocusEditor={this.storeFocusEditor}
           storeHasFocus={this.storeEditorHasFocus}
-          filter={this.props.filter}
           noteBucket={noteBucket}
           previewingMarkdown={this.markdownEnabled() && !editMode}
           onChangeContent={this.props.onUpdateContent}
@@ -175,7 +173,6 @@ const mapStateToProps: S.MapState<StateProps> = ({
   ui: { note, editMode },
 }) => ({
   allTags: state.tags,
-  filter: state.filter,
   fontSize: settings.fontSize,
   editMode,
   isEditorActive: !state.showNavigation,

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -192,7 +192,7 @@ const getRowHeight = rowHeightCache(computeRowHeight);
  * @see react-virtual/list
  *
  * @param {Object[]} notes list of filtered notes
- * @param {String} filter search filter
+ * @param {String} searchQuery search searchQuery
  * @param {String} noteDisplay list view style: comfy, condensed, expanded
  * @param {Number} selectedNoteId id of currently selected note
  * @param {Function} onSelectNote used to change the current note selection
@@ -202,7 +202,7 @@ const getRowHeight = rowHeightCache(computeRowHeight);
 const renderNote = (
   notes,
   {
-    filter,
+    searchQuery,
     noteDisplay,
     selectedNoteId,
     onNoteOpened,
@@ -244,7 +244,7 @@ const renderNote = (
     'published-note': isPublished,
   });
 
-  const decorators = [checkboxDecorator, makeFilterDecorator(filter)];
+  const decorators = [checkboxDecorator, makeFilterDecorator(searchQuery)];
 
   const selectNote = () => {
     onSelectNote(note.id);
@@ -288,12 +288,12 @@ const renderNote = (
  * @see renderNote
  *
  * @param {Object[]} notes list of filtered notes
- * @param {String} filter search filter
+ * @param {String} searchQuery search filter
  * @param {Number} tagResultsFound number of tag matches to display
  * @returns {Object[]} modified notes list
  */
-const createCompositeNoteList = (notes, filter, tagResultsFound) => {
-  if (filter.length === 0 || tagResultsFound === 0) {
+const createCompositeNoteList = (notes, searchQuery, tagResultsFound) => {
+  if (searchQuery.length === 0 || tagResultsFound === 0) {
     return notes;
   }
 
@@ -311,7 +311,6 @@ export class NoteList extends Component<Props> {
 
   static propTypes = {
     closeNote: PropTypes.func.isRequired,
-    filter: PropTypes.string.isRequired,
     tagResultsFound: PropTypes.number.isRequired,
     isSmallScreen: PropTypes.bool.isRequired,
     notes: PropTypes.array.isRequired,
@@ -339,31 +338,15 @@ export class NoteList extends Component<Props> {
   }
 
   componentDidUpdate(prevProps) {
-    const {
-      closeNote,
-      filter,
-      notes,
-      onSelectNote,
-      selectedNoteId,
-    } = this.props;
+    const { searchQuery, notes } = this.props;
 
     if (
-      prevProps.filter !== this.props.filter ||
+      prevProps.searchQuery !== searchQuery ||
       prevProps.noteDisplay !== this.props.noteDisplay ||
       prevProps.notes !== notes ||
       prevProps.selectedNoteContent !== this.props.selectedNoteContent
     ) {
       this.recomputeHeights();
-    }
-
-    // Deselect the currently selected note if it doesn't match the search query
-    if (filter !== prevProps.filter) {
-      const selectedNotePassesFilter = notes.some(
-        note => note.id === selectedNoteId
-      );
-      if (!selectedNotePassesFilter) {
-        closeNote();
-      }
     }
   }
 
@@ -413,7 +396,7 @@ export class NoteList extends Component<Props> {
 
   render() {
     const {
-      filter,
+      searchQuery,
       hasLoaded,
       selectedNoteId,
       onNoteOpened,
@@ -429,7 +412,7 @@ export class NoteList extends Component<Props> {
     const listItemsClasses = classNames('note-list-items', noteDisplay);
 
     const renderNoteRow = renderNote(notes, {
-      filter,
+      searchQuery,
       noteDisplay,
       onNoteOpened,
       onSelectNote,
@@ -474,7 +457,7 @@ export class NoteList extends Component<Props> {
                     notes={notes}
                     rowCount={notes.length}
                     rowHeight={getRowHeight(notes, {
-                      filter,
+                      searchQuery,
                       noteDisplay,
                       tagResultsFound,
                       width,
@@ -506,10 +489,10 @@ const { recordEvent } = tracks;
 
 const mapStateToProps: S.MapState<StateProps> = ({
   appState: state,
-  ui: { filteredNotes, note },
+  ui: { filteredNotes, note, searchQuery },
   settings: { noteDisplay },
 }) => {
-  const tagResultsFound = getMatchingTags(state.tags, state.filter).length;
+  const tagResultsFound = getMatchingTags(state.tags, searchQuery).length;
   const selectedNote = note;
   const selectedNoteId = selectedNote?.id;
   const selectedNoteIndex = filteredNotes.findIndex(
@@ -524,7 +507,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
 
   const compositeNoteList = createCompositeNoteList(
     filteredNotes,
-    state.filter,
+    searchQuery,
     tagResultsFound
   );
 
@@ -552,12 +535,12 @@ const mapStateToProps: S.MapState<StateProps> = ({
     selectedNote && getNoteTitleAndPreview(selectedNote).preview;
 
   return {
-    filter: state.filter,
     hasLoaded: state.notes !== null,
     nextNote,
     noteDisplay,
     notes: compositeNoteList,
     prevNote,
+    searchQuery,
     selectedNotePreview,
     selectedNoteContent: get(selectedNote, 'data.content'),
     selectedNoteId,

--- a/lib/search-bar/index.tsx
+++ b/lib/search-bar/index.tsx
@@ -14,22 +14,29 @@ import NewNoteIcon from '../icons/new-note';
 import SearchField from '../search-field';
 import MenuIcon from '../icons/menu';
 import { withoutTags } from '../utils/filter-notes';
-import { createNote } from '../state/ui/actions';
+import { createNote, search } from '../state/ui/actions';
 
-const { newNote, search, toggleNavigation } = appState.actionCreators;
+import * as S from '../state';
+
+const { newNote, toggleNavigation } = appState.actionCreators;
 const { recordEvent } = tracks;
 
-type Props = {
+type OwnProps = {
   onNewNote: Function;
   onToggleNavigation: Function;
-  query: string;
+};
+
+type StateProps = {
+  searchQuery: string;
   showTrash: boolean;
 };
+
+type Props = OwnProps & StateProps;
 
 export const SearchBar: FunctionComponent<Props> = ({
   onNewNote,
   onToggleNavigation,
-  query,
+  searchQuery,
   showTrash,
 }) => (
   <div className="search-bar theme-color-border">
@@ -38,21 +45,24 @@ export const SearchBar: FunctionComponent<Props> = ({
     <IconButton
       disabled={showTrash}
       icon={<NewNoteIcon />}
-      onClick={() => onNewNote(withoutTags(query))}
+      onClick={() => onNewNote(withoutTags(searchQuery))}
       title="New Note"
     />
   </div>
 );
 
-const mapStateToProps = ({ appState: state }) => ({
-  query: state.filter,
-  showTrash: state.showTrash,
+const mapStateToProps: S.MapState<StateProps> = ({
+  appState: { showTrash },
+  ui: { searchQuery },
+}) => ({
+  searchQuery,
+  showTrash,
 });
 
 const mapDispatchToProps = (dispatch, { noteBucket, onNoteOpened }) => ({
   onNewNote: (content: string) => {
     dispatch(createNote());
-    dispatch(search({ filter: '' }));
+    dispatch(search(''));
     dispatch(newNote({ noteBucket, content }));
     onNoteOpened();
     recordEvent('list_note_created');

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -76,7 +76,10 @@ export class SearchField extends Component<ConnectedProps> {
   }
 }
 
-const mapStateToProps = ({ appState: state, ui: { listTitle, searchQuery } }: State) => ({
+const mapStateToProps = ({
+  appState: state,
+  ui: { listTitle, searchQuery },
+}: State) => ({
   isTagSelected: !!state.tag,
   placeholder: listTitle,
   searchFocus: state.searchFocus,

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -4,8 +4,9 @@ import SmallCrossIcon from '../icons/cross-small';
 import appState from '../flux/app-state';
 import { tracks } from '../analytics';
 import { State } from '../state';
+import { search } from '../state/ui/actions';
 
-const { search, setSearchFocus } = appState.actionCreators;
+const { setSearchFocus } = appState.actionCreators;
 const { recordEvent } = tracks;
 const KEY_ESC = 27;
 
@@ -29,7 +30,7 @@ export class SearchField extends Component<ConnectedProps> {
 
   interceptEsc = (event: KeyboardEvent) => {
     if (KEY_ESC === event.keyCode) {
-      if (this.props.filter === '' && this.inputField.current) {
+      if (this.props.searchQuery === '' && this.inputField.current) {
         this.inputField.current.blur();
       }
       this.clearQuery();
@@ -37,16 +38,16 @@ export class SearchField extends Component<ConnectedProps> {
   };
 
   update = ({
-    currentTarget: { value: filter },
+    currentTarget: { value: query },
   }: FormEvent<HTMLInputElement>) => {
-    this.props.onSearch(filter);
+    this.props.onSearch(query);
   };
 
   clearQuery = () => this.props.onSearch('');
 
   render() {
-    const { filter, isTagSelected, placeholder } = this.props;
-    const hasQuery = filter.length > 0;
+    const { searchQuery, isTagSelected, placeholder } = this.props;
+    const hasQuery = searchQuery.length > 0;
 
     const screenReaderLabel =
       'Search ' + (isTagSelected ? 'notes with tag ' : '') + placeholder;
@@ -60,7 +61,7 @@ export class SearchField extends Component<ConnectedProps> {
           placeholder={placeholder}
           onChange={this.update}
           onKeyUp={this.interceptEsc}
-          value={filter}
+          value={searchQuery}
           spellCheck={false}
         />
         <button
@@ -75,16 +76,16 @@ export class SearchField extends Component<ConnectedProps> {
   }
 }
 
-const mapStateToProps = ({ appState: state, ui: { listTitle } }: State) => ({
-  filter: state.filter,
+const mapStateToProps = ({ appState: state, ui: { listTitle, searchQuery } }: State) => ({
   isTagSelected: !!state.tag,
   placeholder: listTitle,
   searchFocus: state.searchFocus,
+  searchQuery,
 });
 
 const mapDispatchToProps = dispatch => ({
-  onSearch: (filter: string) => {
-    dispatch(search({ filter }));
+  onSearch: (query: string) => {
+    dispatch(search(query));
     recordEvent('list_notes_searched');
   },
   onSearchFocused: () => dispatch(setSearchFocus({ searchFocus: false })),

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -53,6 +53,7 @@ export type SetWPToken = Action<'setWPToken', { token: string }>;
  */
 export type CreateNote = Action<'CREATE_NOTE'>;
 export type FilterNotes = Action<'FILTER_NOTES', { notes: T.NoteEntity[] }>;
+export type Search = Action<'SEARCH', { searchQuery: string }>;
 export type SetAuth = Action<'AUTH_SET', { status: AuthState }>;
 export type SetUnsyncedNoteIds = Action<
   'SET_UNSYNCED_NOTE_IDS',
@@ -70,6 +71,7 @@ export type ActionType =
   | CreateNote
   | LegacyAction
   | FilterNotes
+  | Search
   | SelectNote
   | SetAccountName
   | SetAuth
@@ -178,7 +180,6 @@ type LegacyAction =
   | Action<'App.notesLoaded', { notes: T.NoteEntity[] }>
   | Action<'App.onNoteBeforeRemoteUpdate', { noteId: T.EntityId }>
   | Action<'App.preferencesLoaded', { analyticsEnabled: boolean }>
-  | Action<'App.search', { filter: string }>
   | Action<'App.selectNote', { note: T.NoteEntity; hasRemoteUpdate: boolean }>
   | Action<'App.selectTag', { tag: T.TagEntity }>
   | Action<'App.selectTagAndSElectFirstNote'>

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -5,6 +5,8 @@
  */
 
 import {
+  Dispatch as ReduxDispatch,
+  Middleware as ReduxMiddleware,
   Store as ReduxStore,
   compose,
   createStore,
@@ -29,7 +31,6 @@ import * as T from '../types';
 export type AppState = {
   dialogs: unknown[];
   editingTags: boolean;
-  filter: string;
   isViewingRevisions: boolean;
   nextDialogKey: number;
   notes: T.NoteEntity[] | null;
@@ -93,5 +94,12 @@ export type MapDispatch<
         ...args: Parameters<DispatchProps[P]>
       ) => A.ActionType;
     };
+
+export type Dispatch = ReduxDispatch<A.ActionType>;
+export type Middleware<Extension = {}> = ReduxMiddleware<
+  Extension,
+  State,
+  Dispatch
+>;
 
 export default store;

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -26,6 +26,11 @@ export const toggleSimperiumConnectionStatus: A.ActionCreator<A.ToggleSimperiumC
   simperiumConnected,
 });
 
+export const search: A.ActionCreator<A.Search> = (searchQuery: string) => ({
+  type: 'SEARCH',
+  searchQuery,
+});
+
 export const selectNote: A.ActionCreator<A.SelectNote> = (
   note: T.NoteEntity
 ) => ({ type: 'SELECT_NOTE', note });

--- a/lib/state/ui/middleware.ts
+++ b/lib/state/ui/middleware.ts
@@ -1,16 +1,16 @@
-import { AnyAction, Dispatch, Middleware } from 'redux';
 import { filterNotes as filterAction } from './actions';
 import filterNotes from '../../utils/filter-notes';
 
+import * as A from '../action-types';
 import * as S from '../';
 
 let searchTimeout: NodeJS.Timeout;
 
-export const middleware: Middleware<{}, S.State, Dispatch> = store => {
+export const middleware: S.Middleware = store => {
   const updateNotes = () =>
-    store.dispatch(filterAction(filterNotes(store.getState().appState)));
+    store.dispatch(filterAction(filterNotes(store.getState())));
 
-  return next => (action: AnyAction) => {
+  return next => (action: A.ActionType) => {
     const result = next(action);
 
     switch (action.type) {
@@ -30,9 +30,9 @@ export const middleware: Middleware<{}, S.State, Dispatch> = store => {
 
       // on updating the search field we should delay the update
       // so we don't waste our CPU time and lose responsiveness
-      case 'App.search':
+      case 'SEARCH':
         clearTimeout(searchTimeout);
-        if ('App.search' === action.type && !action.filter) {
+        if (!action.searchQuery) {
           // if we just cleared out the search bar then immediately update
           updateNotes();
         } else {

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -1,6 +1,5 @@
 import { difference, union } from 'lodash';
-import { AnyAction, combineReducers } from 'redux';
-
+import { combineReducers } from 'redux';
 import * as A from '../action-types';
 import * as T from '../../types';
 
@@ -44,6 +43,9 @@ const unsyncedNoteIds: A.Reducer<T.EntityId[]> = (
   state = emptyList as T.EntityId[],
   action
 ) => ('SET_UNSYNCED_NOTE_IDS' === action.type ? action.noteIds : state);
+
+const searchQuery: A.Reducer<string> = (state = '', action) =>
+  'SEARCH' === action.type ? action.searchQuery : state;
 
 const simperiumConnected: A.Reducer<boolean> = (state = false, action) =>
   'SIMPERIUM_CONNECTION_STATUS_TOGGLE' === action.type
@@ -89,6 +91,7 @@ export default combineReducers({
   filteredNotes,
   listTitle,
   note,
+  searchQuery,
   simperiumConnected,
   unsyncedNoteIds,
   visiblePanes,

--- a/lib/utils/filter-notes.ts
+++ b/lib/utils/filter-notes.ts
@@ -2,12 +2,15 @@
  * External dependencies
  */
 import { difference, escapeRegExp, get } from 'lodash';
-import { NoteEntity, TagEntity } from '../types';
+
+import * as S from '../state';
+import * as T from '../types';
 
 const tagPattern = () => /(?:\btag:)([^\s,]+)/g;
 
 export const withoutTags = (s: string) => s.replace(tagPattern(), '').trim();
-export const filterHasText = (filter: string) => !!withoutTags(filter);
+export const filterHasText = (searchQuery: string) =>
+  !!withoutTags(searchQuery);
 
 const getTerms = (filterText: string) => {
   if (!filterText) {
@@ -44,8 +47,8 @@ const getTerms = (filterText: string) => {
   return [...literals, ...terms];
 };
 
-export const searchPattern = (filter: string) => {
-  const terms = getTerms(withoutTags(filter));
+export const searchPattern = (searchQuery: string) => {
+  const terms = getTerms(withoutTags(searchQuery));
 
   if (!terms.length) {
     return new RegExp('.+', 'g');
@@ -57,15 +60,17 @@ export const searchPattern = (filter: string) => {
   );
 };
 
-const matchesTrashView = (isViewingTrash: boolean) => (note: NoteEntity) =>
+const matchesTrashView = (isViewingTrash: boolean) => (note: T.NoteEntity) =>
   isViewingTrash === !!get(note, 'data.deleted', false);
 
-const makeMatchesTag = (tag: TagEntity, filter = '') => (note: NoteEntity) => {
+const makeMatchesTag = (tag: T.TagEntity | undefined, searchQuery = '') => (
+  note: T.NoteEntity
+) => {
   let filterTags = [];
   let match;
   const matcher = tagPattern();
 
-  while ((match = matcher.exec(filter)) !== null) {
+  while ((match = matcher.exec(searchQuery)) !== null) {
     filterTags.push(match[1]);
 
     if (filterTags.length > 100) {
@@ -82,8 +87,8 @@ const makeMatchesTag = (tag: TagEntity, filter = '') => (note: NoteEntity) => {
   return missingTags.length === 0;
 };
 
-const makeMatchesSearch = (filter = '') => (content: string) => {
-  if (!filter) {
+const makeMatchesSearch = (searchQuery = '') => (content: string) => {
+  if (!searchQuery) {
     return true;
   }
 
@@ -91,7 +96,7 @@ const makeMatchesSearch = (filter = '') => (content: string) => {
     return false;
   }
 
-  return getTerms(filter).every(term =>
+  return getTerms(searchQuery).every(term =>
     new RegExp(escapeRegExp(term), 'gi').test(content)
   );
 };
@@ -105,37 +110,35 @@ const emptyList = Object.freeze([]);
  * @TODO: Pre-index note title in domains/note
  */
 export default function filterNotes(
-  state,
-  notesArray: NoteEntity[] | null = null
+  state: S.State,
+  notesArray: T.NoteEntity[] | null = null
 ) {
   const {
-    filter, // {string} search query from input
-    notes, // {[note]} list of all available notes
-    showTrash, // {bool} whether we are looking at the trashed notes
-    tag, // {tag|null} whether we are looking at a specific tag
+    appState: { notes, showTrash, tag },
+    ui: { searchQuery },
   } = state;
 
   const notesToFilter = notesArray ? notesArray : notes;
 
   if (null === notesToFilter) {
     // share the reference so the app doesn't re-render on shallow-compare
-    return (emptyList as unknown) as NoteEntity[];
+    return (emptyList as unknown) as T.NoteEntity[];
   }
 
   // skip into some imperative code for performance-critical code
-  const titleMatches: NoteEntity[] = [];
-  const otherMatches: NoteEntity[] = [];
+  const titleMatches: T.NoteEntity[] = [];
+  const otherMatches: T.NoteEntity[] = [];
 
   // reuse these functions for each note
   const matchesTrash = matchesTrashView(showTrash);
-  const matchesTag = makeMatchesTag(tag, filter);
-  const matchesSearch = makeMatchesSearch(filter);
-  const matchesFilter = (note: NoteEntity) =>
+  const matchesTag = makeMatchesTag(tag, searchQuery);
+  const matchesSearch = makeMatchesSearch(searchQuery);
+  const matchesFilter = (note: T.NoteEntity) =>
     matchesTrash(note) &&
     matchesTag(note) &&
     matchesSearch(get(note, ['data', 'content']));
 
-  notesToFilter.forEach((note: NoteEntity) => {
+  notesToFilter.forEach((note: T.NoteEntity) => {
     if (!matchesFilter(note)) {
       return;
     }


### PR DESCRIPTION
### Fix
This moves the search state to Redux from flux.

- Removed [ref](https://github.com/Automattic/simplenote-electron/pull/1881/files#diff-911dea0a0678832102ff0b94927cddc8L225) prop that wasn't being used
- Renamed filter to searchQuery which better describes what it is and increases the ability to find instances of where it is used in the future.
- Removed props from components that only pass them through

### Test
1. Tests search very heavily.
