### PR TITLE
Types: Add types to analytics module, fix module syntax

### DIFF
--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -3,11 +3,23 @@ const debug = require('debug')('analytics');
 /**
  * Internal dependencies
  */
-var user;
-require('./tracks');
+import './tracks';
+import { TKQItem } from './tracks';
+let user: string;
+
+import * as T from '../types';
+
+declare global {
+  interface Window {
+    analyticsEnabled: boolean;
+    _tkq: TKQItem[];
+  }
+}
+
+declare const config: { version: string };
 
 const analytics = {
-  initialize: function(initUser) {
+  initialize: function(initUser: string) {
     analytics.setUser(initUser);
     analytics.identifyUser();
   },
@@ -28,12 +40,15 @@ const analytics = {
     return null;
   },
 
-  setUser: function(newUser) {
+  setUser: function(newUser: string) {
     user = newUser;
   },
 
   tracks: {
-    recordEvent: function(eventName, eventProperties) {
+    recordEvent: function(
+      eventName: string,
+      eventProperties: T.JSONSerializable = {}
+    ) {
       const prefix = analytics.getPlatformPrefix();
 
       const fullEventName = `${prefix}_${eventName}`;
@@ -53,7 +68,10 @@ const analytics = {
         window._tkq.push(['recordEvent', fullEventName, fullEventProperties]);
       }
     },
-    validateEvent: function(fullEventName, fullEventProperties) {
+    validateEvent: function(
+      fullEventName: string,
+      fullEventProperties: T.JSONSerializable
+    ) {
       if (process.env.NODE_ENV !== 'development') {
         return;
       }
@@ -76,7 +94,7 @@ const analytics = {
 
   identifyUser: function() {
     // Don't identify the user if we don't have one
-    if (user) {
+    if (undefined !== user) {
       window._tkq.push(['identifyUser', user, user]);
     }
   },
@@ -89,4 +107,4 @@ const analytics = {
 // Load tracking script
 window._tkq = window._tkq || [];
 
-module.exports = analytics;
+export default analytics;

--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -9,7 +9,7 @@ import SearchBar from '../search-bar';
 import SimplenoteCompactLogo from '../icons/simplenote-compact';
 import TransitionDelayEnter from '../components/transition-delay-enter';
 
-import * as S from './state';
+import * as S from '../state';
 import * as T from '../types';
 
 const NoteList = React.lazy(() =>

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -20,7 +20,7 @@ import classNames from 'classnames';
 import { debounce, get, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
 import appState from '../flux/app-state';
-import { tracks } from '../analytics';
+import analytics from '../analytics';
 import getNoteTitleAndPreview from './get-note-title-and-preview';
 import {
   decorateWith,
@@ -476,7 +476,6 @@ export class NoteList extends Component<Props> {
 }
 
 const { emptyTrash, loadAndSelectNote, pinNote } = appState.actionCreators;
-const { recordEvent } = tracks;
 
 const mapStateToProps: S.MapState<StateProps> = ({
   appState: state,
@@ -546,7 +545,7 @@ const mapDispatchToProps = (dispatch, { noteBucket }) => ({
   onSelectNote: noteId => {
     if (noteId) {
       dispatch(loadAndSelectNote({ noteBucket, noteId }));
-      recordEvent('list_note_opened');
+      analytics.tracks.recordEvent('list_note_opened');
     }
   },
   onPinNote: (note, pin) => dispatch(pinNote({ noteBucket, note, pin })),

--- a/lib/search-bar/index.tsx
+++ b/lib/search-bar/index.tsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import appState from '../flux/app-state';
-import { tracks } from '../analytics';
+import analytics from '../analytics';
 import IconButton from '../icon-button';
 import NewNoteIcon from '../icons/new-note';
 import SearchField from '../search-field';
@@ -20,7 +20,6 @@ import * as S from '../state';
 import * as T from '../types';
 
 const { newNote } = appState.actionCreators;
-const { recordEvent } = tracks;
 
 type OwnProps = {
   onNewNote: Function;
@@ -72,7 +71,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (
     dispatch(createNote());
     dispatch(search(''));
     dispatch(newNote({ noteBucket, content }));
-    recordEvent('list_note_created');
+    analytics.tracks.recordEvent('list_note_created');
   },
   toggleNavigation: () => {
     dispatch(toggleNavigation());

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -1,13 +1,12 @@
 import React, { Component, createRef, FormEvent, KeyboardEvent } from 'react';
 import { connect } from 'react-redux';
 import SmallCrossIcon from '../icons/cross-small';
-import { tracks } from '../analytics';
+import analytics from '../analytics';
 import { State } from '../state';
 import { search } from '../state/ui/actions';
 
 import { registerSearchField } from '../state/ui/search-field-middleware';
 
-const { recordEvent } = tracks;
 const KEY_ESC = 27;
 
 type ConnectedProps = ReturnType<typeof mapStateToProps> &
@@ -101,7 +100,7 @@ const mapStateToProps = ({
 const mapDispatchToProps = dispatch => ({
   onSearch: (query: string) => {
     dispatch(search(query));
-    recordEvent('list_notes_searched');
+    analytics.tracks.recordEvent('list_notes_searched');
   },
 });
 

--- a/lib/tag-list/index.tsx
+++ b/lib/tag-list/index.tsx
@@ -9,10 +9,9 @@ import TagListInput from './input';
 import appState from '../flux/app-state';
 import { renameTag, reorderTags, trashTag } from '../state/domain/tags';
 import { toggleTagEditing } from '../state/ui/actions';
-import { tracks } from '../analytics';
+import analytics from '../analytics';
 
 const { selectTagAndSelectFirstNote } = appState.actionCreators;
-const { recordEvent } = tracks;
 
 export class TagList extends Component {
   static displayName = 'TagList';
@@ -57,7 +56,7 @@ export class TagList extends Component {
 
   onTrashTag = tag => {
     this.props.trashTag({ tag });
-    recordEvent('list_tag_deleted');
+    analytics.tracks.recordEvent('list_tag_deleted');
   };
 
   render() {
@@ -102,7 +101,7 @@ const mapDispatchToProps = dispatch => ({
   onEditTags: () => dispatch(toggleTagEditing()),
   onSelectTag: tag => {
     dispatch(selectTagAndSelectFirstNote({ tag }));
-    recordEvent('list_tag_viewed');
+    analytics.tracks.recordEvent('list_tag_viewed');
   },
   renameTag: arg => dispatch(renameTag(arg)),
   reorderTags: arg => dispatch(reorderTags(arg)),

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -1,13 +1,11 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { tracks } from '../analytics';
+import analytics from '../analytics';
 import { search } from '../state/ui/actions';
 import filterAtMost from '../utils/filter-at-most';
 
 import * as S from '../state';
 import * as T from '../types';
-
-const { recordEvent } = tracks;
 
 type StateProps = {
   filteredTags: T.TagEntity[];
@@ -118,7 +116,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
   onSearch: query => {
     dispatch(search(query));
-    recordEvent('list_notes_searched');
+    analytics.tracks.recordEvent('list_notes_searched');
   },
 });
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -71,6 +71,16 @@ export type TranslatableString = string;
 // Language and Platform
 ///////////////////////////////////////
 
+export type JSONValue =
+  | null
+  | boolean
+  | number
+  | string
+  | Array<JSONValue>
+  | { [key: string]: JSONValue };
+
+export type JSONSerializable = { [key: string]: JSONValue };
+
 // Returns a type with the properties in T not also present in U
 export type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
 


### PR DESCRIPTION
The analytics module has been using a commonJS format and has been working "by accident"
because `webpack` properly translates the import/export syntax.

```js
// moduleA.js
const stuff = {
	thing: 5;
}

module.exports = stuff;

// moduleB.js
import { thing } from 'moduleA'
```

^^^ that shouldn't work but it has been. This has been resolved in this commit.

## Testing

There should be no functional or visual changes in this PR. Some code will likely
change but only in the exports. It may not change once through `webpack`.