### PR TITLE
Fix: Actually reset auth when authorizing without acess token

### DIFF
--- a/lib/boot.ts
+++ b/lib/boot.ts
@@ -169,7 +169,7 @@ let props = {
       .then(user => {
         resetStorageIfAccountChanged(username);
         if (!user.access_token) {
-          return store.dispatch(resetAuth);
+          return store.dispatch(resetAuth());
         }
 
         store.dispatch(setAccountName(username));

--- a/lib/boot.ts
+++ b/lib/boot.ts
@@ -135,7 +135,7 @@ let props = {
       .then(user => {
         resetStorageIfAccountChanged(username);
         if (!user.access_token) {
-          return store.dispatch(resetAuth);
+          return store.dispatch(resetAuth());
         }
 
         store.dispatch(setAccountName(username));


### PR DESCRIPTION
Discovered via TypeScript in #1884

Previously when authorizing an account which yields no `access_token`
we have been attempting to reset the authorization state by dispatching
`resetAuth`. Unfortunately we haven't been dispatching the function
call but rather the function/action-creator itself leading to no
actionable dispatch.

In this patch we're fixing the call by calling `resetAuth()` which
then passes a real action to the dispatcher.

This should fix an unsurfaced but during invalid authentication flows.

## Testing

It would be good to recreate the initial login bug in order to reproduce this
and confirm the fix. We know that the code is wrong but I'm not sure _how_
that impacts the app's behavior or what defects surface because of it.