### PR TITLE
Fix keyboard shortcuts on Windows Chrome

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -243,7 +243,11 @@ export const App = connect(
       const cmdOrCtrl = (ctrlKey || metaKey) && ctrlKey !== metaKey;
 
       // open tag list
-      if (cmdOrCtrl && 'T' === key && !this.state.showNavigation) {
+      if (
+        cmdOrCtrl &&
+        't' === key.toLowerCase() &&
+        !this.state.showNavigation
+      ) {
         this.props.openTagList();
 
         event.stopPropagation();

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -84,7 +84,12 @@ export class NoteEditor extends Component<Props> {
     }
 
     // open note list - shift + n
-    if (this.props.isSmallScreen && cmdOrCtrl && shiftKey && 'n' === key) {
+    if (
+      this.props.isSmallScreen &&
+      cmdOrCtrl &&
+      shiftKey &&
+      'n' === key.toLowerCase()
+    ) {
       this.props.closeNote();
       this.props.onNoteClosed();
 
@@ -94,7 +99,7 @@ export class NoteEditor extends Component<Props> {
     }
 
     // toggle between tag editor and note editor
-    if (cmdOrCtrl && 't' === key && this.props.isEditorActive) {
+    if (cmdOrCtrl && 't' === key.toLowerCase() && this.props.isEditorActive) {
       // prefer focusing the edit field first
       if (!this.editFieldHasFocus()) {
         this.focusNoteEditor && this.focusNoteEditor();

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -376,8 +376,11 @@ export class NoteList extends Component<Props> {
     const { ctrlKey, key, metaKey, shiftKey } = event;
 
     const cmdOrCtrl = ctrlKey || metaKey;
-
-    if (cmdOrCtrl && shiftKey && (key === 'ArrowUp' || key === 'k')) {
+    if (
+      cmdOrCtrl &&
+      shiftKey &&
+      (key === 'ArrowUp' || key.toLowerCase() === 'k')
+    ) {
       this.props.onSelectNote(this.props.nextNote.id);
 
       event.stopPropagation();
@@ -385,7 +388,11 @@ export class NoteList extends Component<Props> {
       return false;
     }
 
-    if (cmdOrCtrl && shiftKey && (key === 'ArrowDown' || key === 'j')) {
+    if (
+      cmdOrCtrl &&
+      shiftKey &&
+      (key === 'ArrowDown' || key.toLowerCase() === 'j')
+    ) {
       this.props.onSelectNote(this.props.prevNote.id);
 
       event.stopPropagation();


### PR DESCRIPTION
### Fix
Fixes the ctrl + shift + j/k keyboard shortcut on Windows Chrome and Windows Electron.

Adds the same logic to other shortcuts to ensure bugs of the same sort don't pop up:
- ctrl + shift + t - open tag list
- ctrl + shift + n - open note list
- ctrl + t - move between tag editor and note editor

### Test
1. In windows chrome
2. Click a note in the note list
3. Use ctrl + shift + j/k to navigate between notes
4. Use ctrl + shift + up/down arrow keys to navigate between notes
5. Use ctrl + shift + t to open close the tag list
6. In OSX Electron make Simplenote small so only note list or note is visible
7. Open a note
8. Use ctrl + shift + n to go back to note list
9. Open note
10. Use ctrl + t to move back and forth between tag editor and note editor

Note:
ctrl + shift + n and ctrl + t do not work in many places do to Chrome not allowing us to override the built in keyboard shortcuts. https://bugs.chromium.org/p/chromium/issues/detail?id=33056

### Release
- Fixes ctrl + shift + j/k keyboard shortcut on Windows [#1888](https://github.com/Automattic/simplenote-electron/pull/1888)