### PR TITLE
Add types and reduce function context

### DIFF
--- a/lib/boot.ts
+++ b/lib/boot.ts
@@ -126,7 +126,7 @@ let props = {
   noteBucket: client.bucket('note'),
   preferencesBucket: client.bucket('preferences'),
   tagBucket: client.bucket('tag'),
-  isDevConfig: isDevConfig(config),
+  isDevConfig: isDevConfig(config?.development),
   onAuthenticate: (username, password) => {
     if (!(username && password)) {
       return;

--- a/lib/utils/is-dev-config/index.ts
+++ b/lib/utils/is-dev-config/index.ts
@@ -1,8 +1,7 @@
-const isDevConfig = config => {
-  const isDev = Boolean(config.development);
+const isDevConfig = (development: boolean = false) => {
+  const isDev = Boolean(development);
   const whichDB = isDev ? 'Development' : 'Production';
-  const shouldWarn =
-    process.env.NODE_ENV === 'production' && config.development;
+  const shouldWarn = process.env.NODE_ENV === 'production' && development;
   const consoleMode = shouldWarn ? 'warn' : 'info';
   console[consoleMode](`Simperium config: ${whichDB}`); // eslint-disable-line no-console
 

--- a/lib/utils/is-dev-config/test.ts
+++ b/lib/utils/is-dev-config/test.ts
@@ -15,16 +15,15 @@ describe('isDevConfig', () => {
     global.console = unmockedConsole;
   });
 
-  it('should return a boolean of whether config is dev or not', () => {
-    expect(isDevConfig({ development: true })).toBe(true);
-    expect(isDevConfig({})).toBe(false);
+  it('should return a boolean of whether it is given a value or not', () => {
+    expect(isDevConfig(true)).toBe(true);
+    expect(isDevConfig()).toBe(false);
   });
 
   it('should console.warn when NODE_ENV is production and Simperium is not', () => {
     global.process.env.NODE_ENV = 'production';
     global.console.warn = jest.fn();
-    const config = { development: true };
-    isDevConfig(config);
+    isDevConfig(true);
     expect(global.console.warn).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Fix
We pass an object to a isDevConfig but it only uses the one property.  This changes the function to only accept that property and types it as a boolean. I updated the one place where the function is called. I also updated the tests.

### Test
1. Run Simplenote with console open.
2. In dev you should see: `Simperium config: Development`
3. In prod you should see: `Simperium config: Production`
