### PR TITLE
Refactors closeNote to Redux

### DIFF
--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -22,13 +22,10 @@ type Props = {
   isFocusMode: boolean;
   isNavigationOpen: boolean;
   isNoteInfoOpen: boolean;
-  isNoteOpen: boolean;
   isSmallScreen: boolean;
   note: T.NoteEntity;
   noteBucket: T.Bucket<T.Note>;
   revisions: T.NoteEntity[];
-  onNoteClosed: Function;
-  onNoteOpened: Function;
   onUpdateContent: Function;
   syncNote: Function;
 };
@@ -37,19 +34,16 @@ export const AppLayout: FunctionComponent<Props> = ({
   isFocusMode = false,
   isNavigationOpen,
   isNoteInfoOpen,
-  isNoteOpen,
   isSmallScreen,
   noteBucket,
   revisions,
-  onNoteClosed,
-  onNoteOpened,
   onUpdateContent,
   syncNote,
 }) => {
   const mainClasses = classNames('app-layout', {
     'is-focus-mode': isFocusMode,
     'is-navigation-open': isNavigationOpen,
-    'is-note-open': isNoteOpen,
+    'is-note-open': true,
     'is-showing-note-info': isNoteInfoOpen,
   });
 
@@ -65,12 +59,8 @@ export const AppLayout: FunctionComponent<Props> = ({
     <div className={mainClasses}>
       <Suspense fallback={placeholder}>
         <div className="app-layout__source-column theme-color-bg theme-color-fg">
-          <SearchBar noteBucket={noteBucket} onNoteOpened={onNoteOpened} />
-          <NoteList
-            noteBucket={noteBucket}
-            isSmallScreen={isSmallScreen}
-            onNoteOpened={onNoteOpened}
-          />
+          <SearchBar noteBucket={noteBucket} />
+          <NoteList noteBucket={noteBucket} isSmallScreen={isSmallScreen} />
         </div>
         <div className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border">
           <RevisionSelector
@@ -78,14 +68,12 @@ export const AppLayout: FunctionComponent<Props> = ({
             onUpdateContent={onUpdateContent}
           />
           <NoteToolbarContainer
-            onNoteClosed={onNoteClosed}
             noteBucket={noteBucket}
             toolbar={<NoteToolbar />}
           />
           <NoteEditor
             isSmallScreen={isSmallScreen}
             noteBucket={noteBucket}
-            onNoteClosed={onNoteClosed}
             onUpdateContent={onUpdateContent}
             syncNote={syncNote}
           />

--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, Suspense } from 'react';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 
 import NoteToolbarContainer from '../note-toolbar-container';
 import NoteToolbar from '../note-toolbar';
@@ -8,6 +9,7 @@ import SearchBar from '../search-bar';
 import SimplenoteCompactLogo from '../icons/simplenote-compact';
 import TransitionDelayEnter from '../components/transition-delay-enter';
 
+import * as S from './state';
 import * as T from '../types';
 
 const NoteList = React.lazy(() =>
@@ -18,7 +20,7 @@ const NoteEditor = React.lazy(() =>
   import(/* webpackChunkName: 'note-editor' */ '../note-editor')
 );
 
-type Props = {
+type OwnProps = {
   isFocusMode: boolean;
   isNavigationOpen: boolean;
   isNoteInfoOpen: boolean;
@@ -30,10 +32,17 @@ type Props = {
   syncNote: Function;
 };
 
+type StateProps = {
+  isNoteOpen: boolean;
+};
+
+type Props = OwnProps & StateProps;
+
 export const AppLayout: FunctionComponent<Props> = ({
   isFocusMode = false,
   isNavigationOpen,
   isNoteInfoOpen,
+  isNoteOpen,
   isSmallScreen,
   noteBucket,
   revisions,
@@ -43,7 +52,7 @@ export const AppLayout: FunctionComponent<Props> = ({
   const mainClasses = classNames('app-layout', {
     'is-focus-mode': isFocusMode,
     'is-navigation-open': isNavigationOpen,
-    'is-note-open': true,
+    'is-note-open': isNoteOpen,
     'is-showing-note-info': isNoteInfoOpen,
   });
 
@@ -83,4 +92,8 @@ export const AppLayout: FunctionComponent<Props> = ({
   );
 };
 
-export default AppLayout;
+const mapStateToProps: S.MapState<StateProps> = ({ ui: { visiblePanes } }) => ({
+  isNoteOpen: !visiblePanes.has('noteList'),
+});
+
+export default connect(mapStateToProps)(AppLayout);

--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -92,8 +92,8 @@ export const AppLayout: FunctionComponent<Props> = ({
   );
 };
 
-const mapStateToProps: S.MapState<StateProps> = ({ ui: { visiblePanes } }) => ({
-  isNoteOpen: !visiblePanes.has('noteList'),
+const mapStateToProps: S.MapState<StateProps> = ({ ui: { showNoteList } }) => ({
+  isNoteOpen: !showNoteList,
 });
 
 export default connect(mapStateToProps)(AppLayout);

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -32,6 +32,7 @@ import {
 } from 'lodash';
 import {
   createNote,
+  closeNote,
   setUnsyncedNoteIds,
   toggleSimperiumConnectionStatus,
 } from './state/ui/actions';
@@ -50,6 +51,7 @@ export type OwnProps = {
 
 export type DispatchProps = {
   createNote: () => any;
+  closeNote: () => any;
   selectNote: (note: T.NoteEntity) => any;
 };
 
@@ -95,6 +97,7 @@ const mapDispatchToProps: S.MapDispatch<
       ]),
       dispatch
     ),
+    closeNote: () => dispatch(closeNote()),
     loadTags: () => dispatch(loadTags()),
     setSortType: thenReloadNotes(settingsActions.setSortType),
     toggleSortOrder: thenReloadNotes(settingsActions.toggleSortOrder),
@@ -158,10 +161,6 @@ export const App = connect(
       onSignOut: () => {},
     };
 
-    state = {
-      isNoteOpen: false,
-    };
-
     UNSAFE_componentWillMount() {
       if (isElectron()) {
         this.initializeElectron();
@@ -217,24 +216,10 @@ export const App = connect(
     }
 
     componentDidUpdate(prevProps) {
-      const { settings, isSmallScreen } = this.props;
+      const { settings } = this.props;
 
       if (settings !== prevProps.settings) {
         ipc.send('settingsUpdate', settings);
-      }
-
-      // If note has just been loaded
-      if (prevProps.appState.note === undefined && this.props.appState.note) {
-        this.setState({ isNoteOpen: true });
-      }
-
-      if (isSmallScreen !== prevProps.isSmallScreen) {
-        this.setState({
-          isNoteOpen: Boolean(
-            this.props.appState.note &&
-              (settings.focusModeEnabled || !isSmallScreen)
-          ),
-        });
       }
     }
 
@@ -305,7 +290,7 @@ export const App = connect(
       actions.authChanged();
 
       if (!client.isAuthorized()) {
-        actions.closeNote();
+        this.props.closeNote();
         return resetAuth();
       }
 
@@ -482,13 +467,10 @@ export const App = connect(
               <AppLayout
                 isFocusMode={settings.focusModeEnabled}
                 isNavigationOpen={state.showNavigation}
-                isNoteOpen={this.state.isNoteOpen}
                 isNoteInfoOpen={showNoteInfo}
                 isSmallScreen={isSmallScreen}
                 noteBucket={noteBucket}
                 revisions={state.revisions}
-                onNoteClosed={() => this.setState({ isNoteOpen: false })}
-                onNoteOpened={() => this.setState({ isNoteOpen: true })}
                 onUpdateContent={this.onUpdateContent}
                 syncNote={this.syncNote}
               />

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -347,12 +347,6 @@ export const actionMap = new ActionMap({
       });
     },
 
-    closeNote(state: AppState, { previousIndex = -1 }) {
-      return update(state, {
-        previousIndex: { $set: previousIndex },
-      });
-    },
-
     /**
      * A note is being changed from somewhere else! If the same
      * note is also open and being edited, we need to make sure
@@ -395,12 +389,10 @@ export const actionMap = new ActionMap({
         note: T.NoteEntity;
         previousIndex: number;
       }) {
-        return dispatch => {
+        return () => {
           if (note) {
             note.data.deleted = true;
             noteBucket.update(note.id, note.data);
-
-            dispatch(this.action('closeNote', { previousIndex }));
           }
         };
       },
@@ -420,8 +412,6 @@ export const actionMap = new ActionMap({
           if (note) {
             note.data.deleted = false;
             noteBucket.update(note.id, note.data);
-
-            dispatch(this.action('closeNote', { previousIndex }));
           }
         };
       },
@@ -439,8 +429,6 @@ export const actionMap = new ActionMap({
       }) {
         return dispatch => {
           noteBucket.remove(note.id);
-
-          dispatch(this.action('closeNote', { previousIndex }));
           dispatch(this.action('loadNotes', { noteBucket }));
         };
       },
@@ -474,8 +462,6 @@ export const actionMap = new ActionMap({
             state.notes,
             note => note.data.deleted
           );
-
-          dispatch(this.action('closeNote'));
           deleted.forEach(note => noteBucket.remove(note.id));
           dispatch(this.action('notesLoaded', { notes }));
         };

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -7,6 +7,8 @@ import { property } from 'lodash';
 import NoteDetail from '../note-detail';
 import { toggleEditMode } from '../state/ui/actions';
 
+import { closeNote } from '../state/ui/actions';
+
 import * as S from '../state';
 import * as T from '../types';
 
@@ -25,12 +27,10 @@ export class NoteEditor extends Component<Props> {
 
   static propTypes = {
     allTags: PropTypes.array.isRequired,
-    closeNote: PropTypes.func.isRequired,
     isEditorActive: PropTypes.bool.isRequired,
     isSmallScreen: PropTypes.bool.isRequired,
     noteBucket: PropTypes.object.isRequired,
     fontSize: PropTypes.number,
-    onNoteClosed: PropTypes.func.isRequired,
     onUpdateContent: PropTypes.func.isRequired,
     revision: PropTypes.object,
     syncNote: PropTypes.func.isRequired,
@@ -88,8 +88,6 @@ export class NoteEditor extends Component<Props> {
       'n' === key.toLowerCase()
     ) {
       this.props.closeNote();
-      this.props.onNoteClosed();
-
       event.stopPropagation();
       event.preventDefault();
       return false;
@@ -179,8 +177,6 @@ const mapStateToProps: S.MapState<StateProps> = ({
   note,
   revision: state.revision,
 });
-
-const { closeNote } = appState.actionCreators;
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
   closeNote: () => dispatch(closeNote()),

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -29,6 +29,8 @@ import {
 } from './decorators';
 import TagSuggestions, { getMatchingTags } from '../tag-suggestions';
 
+import { closeNote } from '../state/ui/actions';
+
 import * as S from '../state';
 import * as T from '../types';
 
@@ -205,7 +207,6 @@ const renderNote = (
     searchQuery,
     noteDisplay,
     selectedNoteId,
-    onNoteOpened,
     onSelectNote,
     onPinNote,
     isSmallScreen,
@@ -248,7 +249,6 @@ const renderNote = (
 
   const selectNote = () => {
     onSelectNote(note.id);
-    onNoteOpened();
   };
 
   return (
@@ -310,11 +310,9 @@ export class NoteList extends Component<Props> {
   list = createRef();
 
   static propTypes = {
-    closeNote: PropTypes.func.isRequired,
     tagResultsFound: PropTypes.number.isRequired,
     isSmallScreen: PropTypes.bool.isRequired,
     notes: PropTypes.array.isRequired,
-    onNoteOpened: PropTypes.func.isRequired,
     onSelectNote: PropTypes.func.isRequired,
     onPinNote: PropTypes.func.isRequired,
     noteDisplay: PropTypes.string.isRequired,
@@ -399,7 +397,6 @@ export class NoteList extends Component<Props> {
       searchQuery,
       hasLoaded,
       selectedNoteId,
-      onNoteOpened,
       onSelectNote,
       onEmptyTrash,
       noteDisplay,
@@ -414,7 +411,6 @@ export class NoteList extends Component<Props> {
     const renderNoteRow = renderNote(notes, {
       searchQuery,
       noteDisplay,
-      onNoteOpened,
       onSelectNote,
       onPinNote: this.onPinNote,
       selectedNoteId,
@@ -479,12 +475,7 @@ export class NoteList extends Component<Props> {
     this.props.onPinNote(note, !note.data.systemTags.includes('pinned'));
 }
 
-const {
-  closeNote,
-  emptyTrash,
-  loadAndSelectNote,
-  pinNote,
-} = appState.actionCreators;
+const { emptyTrash, loadAndSelectNote, pinNote } = appState.actionCreators;
 const { recordEvent } = tracks;
 
 const mapStateToProps: S.MapState<StateProps> = ({

--- a/lib/note-toolbar-container.ts
+++ b/lib/note-toolbar-container.ts
@@ -29,6 +29,7 @@ type NoteChanger = {
 type ListChanger = NoteChanger & { previousIndex: number };
 
 type DispatchProps = {
+  closeNote: () => any;
   deleteNoteForever: (args: ListChanger) => any;
   noteRevisions: (args: NoteChanger) => any;
   restoreNote: (args: ListChanger) => any;

--- a/lib/note-toolbar-container.ts
+++ b/lib/note-toolbar-container.ts
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 
 import analytics from './analytics';
 import appState from './flux/app-state';
+import { closeNote } from './state/ui/actions';
 import { toggleFocusMode } from './state/settings/actions';
 import DialogTypes from '../shared/dialog-types';
 
@@ -50,6 +51,7 @@ export class NoteToolbarContainer extends Component<Props> {
   onTrashNote = (note: T.NoteEntity) => {
     const { noteBucket } = this.props;
     const previousIndex = this.getPreviousNoteIndex(note);
+    this.props.closeNote();
     this.props.trashNote({ noteBucket, note, previousIndex });
     analytics.tracks.recordEvent('editor_note_deleted');
   };
@@ -122,6 +124,7 @@ const {
 } = appState.actionCreators;
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
+  closeNote: () => dispatch(closeNote()),
   deleteNoteForever: args => dispatch(deleteNoteForever(args)),
   noteRevisions: args => dispatch(noteRevisions(args)),
   restoreNote: args => dispatch(restoreNote(args)),

--- a/lib/note-toolbar-container.ts
+++ b/lib/note-toolbar-container.ts
@@ -11,7 +11,6 @@ import * as T from './types';
 
 type OwnProps = {
   noteBucket: T.Bucket<T.Note>;
-  onNoteClosed: Function;
   toolbar: ReactElement;
 };
 
@@ -29,7 +28,6 @@ type NoteChanger = {
 type ListChanger = NoteChanger & { previousIndex: number };
 
 type DispatchProps = {
-  closeNote: () => any;
   deleteNoteForever: (args: ListChanger) => any;
   noteRevisions: (args: NoteChanger) => any;
   restoreNote: (args: ListChanger) => any;
@@ -49,16 +47,10 @@ export class NoteToolbarContainer extends Component<Props> {
     return Math.max(noteIndex - 1, 0);
   };
 
-  onCloseNote = () => {
-    this.props.closeNote();
-    this.props.onNoteClosed();
-  };
-
   onTrashNote = (note: T.NoteEntity) => {
     const { noteBucket } = this.props;
     const previousIndex = this.getPreviousNoteIndex(note);
     this.props.trashNote({ noteBucket, note, previousIndex });
-    this.props.onNoteClosed();
     analytics.tracks.recordEvent('editor_note_deleted');
   };
 
@@ -66,14 +58,12 @@ export class NoteToolbarContainer extends Component<Props> {
     const { noteBucket } = this.props;
     const previousIndex = this.getPreviousNoteIndex(note);
     this.props.deleteNoteForever({ noteBucket, note, previousIndex });
-    this.props.onNoteClosed();
   };
 
   onRestoreNote = (note: T.NoteEntity) => {
     const { noteBucket } = this.props;
     const previousIndex = this.getPreviousNoteIndex(note);
     this.props.restoreNote({ noteBucket, note, previousIndex });
-    this.props.onNoteClosed();
     analytics.tracks.recordEvent('editor_note_restored');
   };
 
@@ -92,7 +82,6 @@ export class NoteToolbarContainer extends Component<Props> {
     const { isViewingRevisions, toolbar, revisionOrNote } = this.props;
 
     const handlers = {
-      onCloseNote: this.onCloseNote,
       onDeleteNoteForever: this.onDeleteNoteForever,
       onRestoreNote: this.onRestoreNote,
       onShowRevisions: this.onShowRevisions,
@@ -124,7 +113,6 @@ const mapStateToProps: S.MapState<StateProps> = ({
 });
 
 const {
-  closeNote,
   deleteNoteForever,
   noteRevisions,
   restoreNote,
@@ -134,7 +122,6 @@ const {
 } = appState.actionCreators;
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
-  closeNote: () => dispatch(closeNote()),
   deleteNoteForever: args => dispatch(deleteNoteForever(args)),
   noteRevisions: args => dispatch(noteRevisions(args)),
   restoreNote: args => dispatch(restoreNote(args)),

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -13,13 +13,13 @@ import TrashIcon from '../icons/trash';
 import ShareIcon from '../icons/share';
 import SidebarIcon from '../icons/sidebar';
 
-import { toggleEditMode } from '../state/ui/actions';
-import { toggleNoteInfo } from '../state/ui/actions';
+import { closeNote, toggleEditMode, toggleNoteInfo } from '../state/ui/actions';
 
 import * as S from '../state';
 import * as T from '../types';
 
 type DispatchProps = {
+  closeNote: () => any;
   toggleEditMode: () => any;
   toggleNoteInfo: () => any;
 };
@@ -40,14 +40,12 @@ export class NoteToolbar extends Component<Props> {
     onDeleteNoteForever: PropTypes.func,
     onShowRevisions: PropTypes.func,
     onShareNote: PropTypes.func,
-    onCloseNote: PropTypes.func,
     setIsViewingRevisions: PropTypes.func,
     toggleFocusMode: PropTypes.func.isRequired,
     markdownEnabled: PropTypes.bool,
   };
 
   static defaultProps = {
-    onCloseNote: noop,
     onDeleteNoteForever: noop,
     onRestoreNote: noop,
     onShowRevisions: noop,
@@ -92,7 +90,7 @@ export class NoteToolbar extends Component<Props> {
           <div className="note-toolbar__button note-toolbar-back">
             <IconButton
               icon={<BackIcon />}
-              onClick={this.props.onCloseNote}
+              onClick={this.props.closeNote}
               title="Back"
             />
           </div>
@@ -146,7 +144,7 @@ export class NoteToolbar extends Component<Props> {
         <div className="note-toolbar__column-left">
           <IconButton
             icon={<BackIcon />}
-            onClick={this.props.onCloseNote}
+            onClick={this.props.closeNote}
             title="Back"
           />
         </div>
@@ -182,9 +180,10 @@ const mapStateToProps: S.MapState<StateProps> = ({
   note,
 });
 
-const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
-  toggleEditMode,
-  toggleNoteInfo,
-};
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
+  closeNote: () => dispatch(closeNote()),
+  toggleEditMode: () => dispatch(toggleEditMode()),
+  toggleNoteInfo: () => dispatch(toggleNoteInfo()),
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteToolbar);

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -180,10 +180,10 @@ const mapStateToProps: S.MapState<StateProps> = ({
   note,
 });
 
-const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
-  closeNote: () => dispatch(closeNote()),
-  toggleEditMode: () => dispatch(toggleEditMode()),
-  toggleNoteInfo: () => dispatch(toggleNoteInfo()),
-});
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
+  closeNote,
+  toggleEditMode,
+  toggleNoteInfo,
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteToolbar);

--- a/lib/search-bar/index.tsx
+++ b/lib/search-bar/index.tsx
@@ -59,12 +59,11 @@ const mapStateToProps: S.MapState<StateProps> = ({
   showTrash,
 });
 
-const mapDispatchToProps = (dispatch, { noteBucket, onNoteOpened }) => ({
+const mapDispatchToProps = (dispatch, { noteBucket }) => ({
   onNewNote: (content: string) => {
     dispatch(createNote());
     dispatch(search(''));
     dispatch(newNote({ noteBucket, content }));
-    onNoteOpened();
     recordEvent('list_note_created');
   },
   onToggleNavigation: () => dispatch(toggleNavigation()),

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -66,7 +66,6 @@ export type ToggleSimperiumConnectionStatus = Action<
   { simperiumConnected: boolean }
 >;
 export type ToggleEditMode = Action<'TOGGLE_EDIT_MODE'>;
-export type ToggleNoteList = Action<'NOTE_LIST_TOGGLE', { show: boolean }>;
 export type ToggleTagDrawer = Action<'TAG_DRAWER_TOGGLE', { show: boolean }>;
 export type SelectNote = Action<'SELECT_NOTE', { note: T.NoteEntity }>;
 
@@ -94,7 +93,6 @@ export type ActionType =
   | SetWPToken
   | ToggleEditMode
   | ToggleNoteInfo
-  | ToggleNoteList
   | ToggleSimperiumConnectionStatus
   | ToggleTagDrawer;
 

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -177,7 +177,6 @@ type LegacyAction =
     >
   | Action<'App.authChanged'>
   | Action<'App.closeDialog', { key: unknown }>
-  | Action<'App.closeNote', { previousIndex: number }>
   | Action<'App.editTags'>
   | Action<'App.emptyTrash', { noteBucket: T.Bucket<T.Note> }>
   | Action<'App.loadNotes', { noteBucket: T.Bucket<T.Note> }>

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -66,6 +66,7 @@ export type ToggleSimperiumConnectionStatus = Action<
   { simperiumConnected: boolean }
 >;
 export type ToggleEditMode = Action<'TOGGLE_EDIT_MODE'>;
+export type ToggleNoteList = Action<'NOTE_LIST_TOGGLE', { show: boolean }>;
 export type ToggleTagDrawer = Action<'TAG_DRAWER_TOGGLE', { show: boolean }>;
 export type SelectNote = Action<'SELECT_NOTE', { note: T.NoteEntity }>;
 
@@ -93,6 +94,7 @@ export type ActionType =
   | SetWPToken
   | ToggleEditMode
   | ToggleNoteInfo
+  | ToggleNoteList
   | ToggleSimperiumConnectionStatus
   | ToggleTagDrawer;
 

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -52,6 +52,7 @@ export type SetWPToken = Action<'setWPToken', { token: string }>;
  * Normal action types
  */
 export type CreateNote = Action<'CREATE_NOTE'>;
+export type CloseNote = Action<'CLOSE_NOTE'>;
 export type FilterNotes = Action<'FILTER_NOTES', { notes: T.NoteEntity[] }>;
 export type Search = Action<'SEARCH', { searchQuery: string }>;
 export type SetAuth = Action<'AUTH_SET', { status: AuthState }>;
@@ -70,6 +71,7 @@ export type SelectNote = Action<'SELECT_NOTE', { note: T.NoteEntity }>;
 
 export type ActionType =
   | CreateNote
+  | CloseNote
   | LegacyAction
   | FilterNotes
   | Search

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -5,6 +5,10 @@ export const createNote: A.ActionCreator<A.CreateNote> = () => ({
   type: 'CREATE_NOTE',
 });
 
+export const closeNote: A.ActionCreator<A.CloseNote> = () => ({
+  type: 'CLOSE_NOTE',
+});
+
 export const filterNotes: A.ActionCreator<A.FilterNotes> = (
   notes: T.NoteEntity[]
 ) => ({

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -53,10 +53,3 @@ export const toggleTagDrawer: A.ActionCreator<A.ToggleTagDrawer> = (
   type: 'TAG_DRAWER_TOGGLE',
   show,
 });
-
-export const toggleNoteList: A.ActionCreator<A.ToggleNoteList> = (
-  show: boolean
-) => ({
-  type: 'NOTE_LIST_TOGGLE',
-  show,
-});

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -53,3 +53,10 @@ export const toggleTagDrawer: A.ActionCreator<A.ToggleTagDrawer> = (
   type: 'TAG_DRAWER_TOGGLE',
   show,
 });
+
+export const toggleNoteList: A.ActionCreator<A.ToggleNoteList> = (
+  show: boolean
+) => ({
+  type: 'NOTE_LIST_TOGGLE',
+  show,
+});

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -55,7 +55,6 @@ const visiblePanes: A.Reducer<Set<string>> = (
   state = defaultVisiblePanes,
   action
 ) => {
-  console.log(action.type);
   switch (action.type) {
     case 'CLOSE_NOTE': {
       return new Set(state).add('noteList');

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -1,9 +1,8 @@
-import { difference, union } from 'lodash';
 import { combineReducers } from 'redux';
 import * as A from '../action-types';
 import * as T from '../../types';
 
-const defaultVisiblePanes = ['editor', 'noteList'];
+const defaultVisiblePanes = new Set(['editor', 'noteList']);
 const emptyList: unknown[] = [];
 
 const editMode: A.Reducer<boolean> = (state = true, action) => {
@@ -52,19 +51,37 @@ const simperiumConnected: A.Reducer<boolean> = (state = false, action) =>
     ? action.simperiumConnected
     : state;
 
-const visiblePanes: A.Reducer<string[]> = (
+const visiblePanes: A.Reducer<Set<string>> = (
   state = defaultVisiblePanes,
   action
 ) => {
+  console.log(action.type);
   switch (action.type) {
+    case 'CLOSE_NOTE': {
+      return new Set(state).add('noteList');
+    }
+    case 'App.selectNote': {
+      const newSet = new Set(state);
+      newSet.delete('noteList');
+      return newSet;
+    }
     case 'NOTE_LIST_TOGGLE':
-      return action.show
-        ? new Set(state).add('noteList')
-        : new Set(state).delete('noteList');
-    case 'TAG_DRAWER_TOGGLE':
-      return action.show
-        ? new Set(state).add('tagDrawer')
-        : new Set(state).delete('tagDrawer');
+      if (action.show) {
+        return new Set(state).add('noteList');
+      } else {
+        const newSet = new Set(state);
+        newSet.delete('noteList');
+        return newSet;
+      }
+    case 'TAG_DRAWER_TOGGLE': {
+      if (action.show) {
+        return new Set(state).add('tagDrawer');
+      } else {
+        const newSet = new Set(state);
+        newSet.delete('tagDrawer');
+        return newSet;
+      }
+    }
     default:
       return state;
   }

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -2,7 +2,6 @@ import { combineReducers } from 'redux';
 import * as A from '../action-types';
 import * as T from '../../types';
 
-const defaultVisiblePanes = new Set(['editor', 'noteList']);
 const emptyList: unknown[] = [];
 
 const editMode: A.Reducer<boolean> = (state = true, action) => {
@@ -38,6 +37,22 @@ const listTitle: A.Reducer<T.TranslatableString> = (
   }
 };
 
+const showNoteList: A.Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'CLOSE_NOTE': {
+      return true;
+    }
+    case 'NOTE_LIST_TOGGLE':
+      return !state;
+
+    case 'App.selectNote':
+      return false;
+
+    default:
+      return state;
+  }
+};
+
 const unsyncedNoteIds: A.Reducer<T.EntityId[]> = (
   state = emptyList as T.EntityId[],
   action
@@ -50,41 +65,6 @@ const simperiumConnected: A.Reducer<boolean> = (state = false, action) =>
   'SIMPERIUM_CONNECTION_STATUS_TOGGLE' === action.type
     ? action.simperiumConnected
     : state;
-
-const visiblePanes: A.Reducer<Set<string>> = (
-  state = defaultVisiblePanes,
-  action
-) => {
-  switch (action.type) {
-    case 'CLOSE_NOTE': {
-      return new Set(state).add('noteList');
-    }
-    case 'App.selectNote': {
-      const newSet = new Set(state);
-      newSet.delete('noteList');
-      return newSet;
-    }
-    case 'NOTE_LIST_TOGGLE':
-      if (action.show) {
-        return new Set(state).add('noteList');
-      } else {
-        const newSet = new Set(state);
-        newSet.delete('noteList');
-        return newSet;
-      }
-    case 'TAG_DRAWER_TOGGLE': {
-      if (action.show) {
-        return new Set(state).add('tagDrawer');
-      } else {
-        const newSet = new Set(state);
-        newSet.delete('tagDrawer');
-        return newSet;
-      }
-    }
-    default:
-      return state;
-  }
-};
 
 const showNoteInfo: A.Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
@@ -129,7 +109,7 @@ export default combineReducers({
   note,
   searchQuery,
   showNoteInfo,
+  showNoteList,
   simperiumConnected,
   unsyncedNoteIds,
-  visiblePanes,
 });

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -82,7 +82,9 @@ const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
   switch (action.type) {
     case 'App.selectNote':
       return { ...action.note, hasRemoteUpdate: action.hasRemoteUpdate };
-    case 'App.closeNote':
+    case 'CLOSE_NOTE':
+    case 'App.trashNote':
+    case 'App.emptyTrash':
     case 'App.showAllNotes':
     case 'App.selectTrash':
     case 'App.selectTag':

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -56,13 +56,18 @@ const visiblePanes: A.Reducer<string[]> = (
   state = defaultVisiblePanes,
   action
 ) => {
-  if ('TAG_DRAWER_TOGGLE' === action.type) {
-    return action.show
-      ? union(state, ['tagDrawer'])
-      : difference(state, ['tagDrawer']);
+  switch (action.type) {
+    case 'NOTE_LIST_TOGGLE':
+      return action.show
+        ? new Set(state).add('noteList')
+        : new Set(state).delete('noteList');
+    case 'TAG_DRAWER_TOGGLE':
+      return action.show
+        ? new Set(state).add('tagDrawer')
+        : new Set(state).delete('tagDrawer');
+    default:
+      return state;
   }
-
-  return state;
 };
 
 const showNoteInfo: A.Reducer<boolean> = (state = false, action) => {

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -42,9 +42,6 @@ const showNoteList: A.Reducer<boolean> = (state = false, action) => {
     case 'CLOSE_NOTE': {
       return true;
     }
-    case 'NOTE_LIST_TOGGLE':
-      return !state;
-
     case 'App.selectNote':
       return false;
 


### PR DESCRIPTION
### Fix

Refactors `closeNote` moving the function from the flux actions to Redux. In doing this it required the removal of the note list open/closed that was being stored in the component state of app.tsx.

### Test
1. Have SImplenote open with a small width so only the note list appears
2. Click a note
3. Click the back button at the top
4. Click note again
5. Trash it, does note list appear?
6. Open Trashed note list
7. Click into note
8. Click back button at top
9. Permanently trash note, should go back to trashed note list
10. Empty trash, should see blank note editor
11. Go back to all notes
12. Create new note
13. Play with search
