### PR TITLE
Fixes error where having unsynced note ids but no notes can crash the app

### DIFF
--- a/lib/components/sync-status/get-note-titles.ts
+++ b/lib/components/sync-status/get-note-titles.ts
@@ -1,7 +1,7 @@
 import { compact } from 'lodash';
 import noteTitleAndPreview from '../../utils/note-utils';
 
-const getNoteTitles = (ids, notes, limit = Infinity) => {
+const getNoteTitles = (ids = [], notes = [], limit = Infinity) => {
   const matchedNotes = ids.map((id, i) => {
     if (i >= limit) {
       return;


### PR DESCRIPTION
### Fix
When you have 0 notes and have unsynced changes you can cause the function to
crash the app. In my testing, I was not able to create these test conditions.
You will see in the modified code that we ensure that we at very least have an
empty array before attempting array functions. This eliminates the existing
bug.

### Test
1. Have no notes in state but have unsynced note ids
2. Toggle the hamburger menu causing the popover to load

### Release
- Fixes error where having unsynced note ids but no notes can crash the app
