### PR TITLE
Moves Tag Editing state from flux to redux

### DIFF
--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -40,7 +40,6 @@ const initialState: AppState = {
   showTrash: false,
   showNavigation: false,
   isViewingRevisions: false,
-  editingTags: false,
   dialogs: [],
   nextDialogKey: 0,
   searchFocus: false,
@@ -63,7 +62,6 @@ export const actionMap = new ActionMap({
       if (state.showNavigation) {
         return update(state, {
           showNavigation: { $set: false },
-          editingTags: { $set: false },
         });
       }
 
@@ -88,7 +86,6 @@ export const actionMap = new ActionMap({
     showAllNotes(state: AppState) {
       return update(state, {
         showNavigation: { $set: false },
-        editingTags: { $set: false },
         showTrash: { $set: false },
         tag: { $set: null },
         previousIndex: { $set: -1 },
@@ -98,7 +95,6 @@ export const actionMap = new ActionMap({
     selectTrash(state: AppState) {
       return update(state, {
         showNavigation: { $set: false },
-        editingTags: { $set: false },
         showTrash: { $set: true },
         tag: { $set: null },
         previousIndex: { $set: -1 },
@@ -121,7 +117,6 @@ export const actionMap = new ActionMap({
     selectTag(state: AppState, { tag }: { tag: T.TagEntity }) {
       return update(state, {
         showNavigation: { $set: false },
-        editingTags: { $set: false },
         showTrash: { $set: false },
         tag: { $set: tag },
         previousIndex: { $set: -1 },
@@ -168,12 +163,6 @@ export const actionMap = new ActionMap({
           });
         }
       }
-    },
-
-    editTags(state: AppState) {
-      return update(state, {
-        editingTags: { $set: !state.editingTags },
-      });
     },
 
     newNote: {
@@ -341,7 +330,6 @@ export const actionMap = new ActionMap({
 
     selectNote(state: AppState) {
       return update(state, {
-        editingTags: { $set: false },
         revision: { $set: null },
         revisions: { $set: null },
       });

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -67,6 +67,7 @@ export type ToggleSimperiumConnectionStatus = Action<
 >;
 export type ToggleEditMode = Action<'TOGGLE_EDIT_MODE'>;
 export type ToggleTagDrawer = Action<'TAG_DRAWER_TOGGLE', { show: boolean }>;
+export type ToggleTagEditing = Action<'TAG_EDITING_TOGGLE'>;
 export type SelectNote = Action<'SELECT_NOTE', { note: T.NoteEntity }>;
 
 export type ActionType =
@@ -94,7 +95,8 @@ export type ActionType =
   | ToggleEditMode
   | ToggleNoteInfo
   | ToggleSimperiumConnectionStatus
-  | ToggleTagDrawer;
+  | ToggleTagDrawer
+  | ToggleTagEditing;
 
 export type ActionCreator<A extends ActionType> = (...args: any[]) => A;
 export type Reducer<S> = (state: S | undefined, action: ActionType) => S;
@@ -175,7 +177,6 @@ type LegacyAction =
     >
   | Action<'App.authChanged'>
   | Action<'App.closeDialog', { key: unknown }>
-  | Action<'App.editTags'>
   | Action<'App.emptyTrash', { noteBucket: T.Bucket<T.Note> }>
   | Action<'App.loadNotes', { noteBucket: T.Bucket<T.Note> }>
   | Action<'App.newNote', { noteBucket: T.Bucket<T.Note>; content: string }>

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -30,7 +30,6 @@ import * as T from '../types';
 
 export type AppState = {
   dialogs: unknown[];
-  editingTags: boolean;
   isViewingRevisions: boolean;
   nextDialogKey: number;
   notes: T.NoteEntity[] | null;

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -53,3 +53,7 @@ export const toggleTagDrawer: A.ActionCreator<A.ToggleTagDrawer> = (
   type: 'TAG_DRAWER_TOGGLE',
   show,
 });
+
+export const toggleTagEditing: A.ActionCreator<A.ToggleTagEditing> = () => ({
+  type: 'TAG_EDITING_TOGGLE',
+});

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -93,7 +93,6 @@ const showNoteInfo: A.Reducer<boolean> = (state = false, action) => {
 };
 
 const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
-  console.log(action.type);
   switch (action.type) {
     case 'App.selectNote':
       return { ...action.note, hasRemoteUpdate: action.hasRemoteUpdate };

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -16,6 +16,22 @@ const editMode: A.Reducer<boolean> = (state = true, action) => {
   }
 };
 
+const editingTags: A.Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'TAG_EDITING_TOGGLE':
+      return !state;
+    case 'App.selectNote':
+    case 'App.selectTag':
+    case 'App.selectTrash':
+    case 'App.showAllNotes':
+    case 'App.toggleNavigation':
+    case 'App.toggleNoteInfo':
+      return false;
+    default:
+      return state;
+  }
+};
+
 const filteredNotes: A.Reducer<T.NoteEntity[]> = (
   state = emptyList as T.NoteEntity[],
   action
@@ -77,6 +93,7 @@ const showNoteInfo: A.Reducer<boolean> = (state = false, action) => {
 };
 
 const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
+  console.log(action.type);
   switch (action.type) {
     case 'App.selectNote':
       return { ...action.note, hasRemoteUpdate: action.hasRemoteUpdate };
@@ -101,6 +118,7 @@ const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
 
 export default combineReducers({
   editMode,
+  editingTags,
   filteredNotes,
   listTitle,
   note,

--- a/lib/tag-list/index.tsx
+++ b/lib/tag-list/index.tsx
@@ -8,16 +8,16 @@ import { get } from 'lodash';
 import TagListInput from './input';
 import appState from '../flux/app-state';
 import { renameTag, reorderTags, trashTag } from '../state/domain/tags';
+import { toggleTagEditing } from '../state/ui/actions';
 import { tracks } from '../analytics';
 
-const { editTags, selectTagAndSelectFirstNote } = appState.actionCreators;
+const { selectTagAndSelectFirstNote } = appState.actionCreators;
 const { recordEvent } = tracks;
 
 export class TagList extends Component {
   static displayName = 'TagList';
 
   static propTypes = {
-    editingTags: PropTypes.bool.isRequired,
     onSelectTag: PropTypes.func.isRequired,
     onEditTags: PropTypes.func.isRequired,
     renameTag: PropTypes.func.isRequired,
@@ -92,14 +92,14 @@ export class TagList extends Component {
   }
 }
 
-const mapStateToProps = ({ appState: state }) => ({
-  editingTags: state.editingTags,
+const mapStateToProps = ({ appState: state, ui: { editingTags } }) => ({
+  editingTags,
   tags: state.tags,
   selectedTag: state.tag,
 });
 
 const mapDispatchToProps = dispatch => ({
-  onEditTags: () => dispatch(editTags()),
+  onEditTags: () => dispatch(toggleTagEditing()),
   onSelectTag: tag => {
     dispatch(selectTagAndSelectFirstNote({ tag }));
     recordEvent('list_tag_viewed');


### PR DESCRIPTION
### Fix
Moves Tag Editing state from flux to redux. This is a pretty straight forward one.

### Test
1. Open menu (hamburger)
2. Click 'Edit' above tags
3. Edit some tags
4. Click 'Close'
5. Click 'Edit' again
6. Click somewhere else
7. Does it move out of edit mode?
8. Repeat
