### PR TITLE
Fixes background on tag edit button

### DIFF
--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -18,7 +18,6 @@
 
     .tag-list-edit-toggle {
       opacity: 0;
-      padding-right: 0;
 
       .touch-enabled & {
         opacity: 1;


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/6817400/74369325-2ee52a80-4da3-11ea-9bba-30ccf500f8c8.gif)

After:
![after](https://user-images.githubusercontent.com/6817400/74369331-31e01b00-4da3-11ea-8166-be1e3916faa2.gif)

