### PR TITLE
Move list title to redux

### DIFF
--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -40,7 +40,6 @@ const initialState: AppState = {
   tags: [],
   revision: null,
   showTrash: false,
-  listTitle: 'All Notes',
   showNavigation: false,
   showNoteInfo: false,
   isViewingRevisions: false,
@@ -96,7 +95,6 @@ export const actionMap = new ActionMap({
         showNavigation: { $set: false },
         editingTags: { $set: false },
         showTrash: { $set: false },
-        listTitle: { $set: 'All Notes' },
         tag: { $set: null },
         previousIndex: { $set: -1 },
       });
@@ -107,7 +105,6 @@ export const actionMap = new ActionMap({
         showNavigation: { $set: false },
         editingTags: { $set: false },
         showTrash: { $set: true },
-        listTitle: { $set: 'Trash' },
         tag: { $set: null },
         previousIndex: { $set: -1 },
       });
@@ -131,7 +128,6 @@ export const actionMap = new ActionMap({
         showNavigation: { $set: false },
         editingTags: { $set: false },
         showTrash: { $set: false },
-        listTitle: { $set: tag.data.name },
         tag: { $set: tag },
         previousIndex: { $set: -1 },
       });

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -75,10 +75,10 @@ export class SearchField extends Component<ConnectedProps> {
   }
 }
 
-const mapStateToProps = ({ appState: state }: State) => ({
+const mapStateToProps = ({ appState: state, ui: { listTitle } }: State) => ({
   filter: state.filter,
   isTagSelected: !!state.tag,
-  placeholder: state.listTitle,
+  placeholder: listTitle,
   searchFocus: state.searchFocus,
 });
 

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -32,7 +32,6 @@ export type AppState = {
   editingTags: boolean;
   filter: string;
   isViewingRevisions: boolean;
-  listTitle: T.TranslatableString;
   nextDialogKey: number;
   notes: T.NoteEntity[] | null;
   preferences?: T.Preferences;

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -11,14 +11,17 @@ const filteredNotes: A.Reducer<T.NoteEntity[]> = (
   action
 ) => ('FILTER_NOTES' === action.type ? action.notes : state);
 
-const listTitle: A.Reducer<string> = (state = 'All Notes', action) => {
+const listTitle: A.Reducer<T.TranslatableString> = (
+  state = 'All Notes',
+  action
+) => {
   switch (action.type) {
     case 'App.showAllNotes':
       return 'All Notes';
     case 'App.selectTrash':
       return 'Trash';
     case 'App.selectTag':
-      return action?.tag?.data?.name;
+      return action.tag.data.name;
     default:
       return state;
   }

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -11,6 +11,19 @@ const filteredNotes: A.Reducer<T.NoteEntity[]> = (
   action
 ) => ('FILTER_NOTES' === action.type ? action.notes : state);
 
+const listTitle: A.Reducer<string> = (state = 'All Notes', action) => {
+  switch (action.type) {
+    case 'App.showAllNotes':
+      return 'All Notes';
+    case 'App.selectTrash':
+      return 'Trash';
+    case 'App.selectTag':
+      return action?.tag?.data?.name;
+    default:
+      return state;
+  }
+};
+
 const unsyncedNoteIds: A.Reducer<T.EntityId[]> = (
   state = emptyList as T.EntityId[],
   action
@@ -57,6 +70,7 @@ const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
 
 export default combineReducers({
   filteredNotes,
+  listTitle,
   note,
   simperiumConnected,
   unsyncedNoteIds,


### PR DESCRIPTION
### Fix
Move list title to redux. The list title is used as the placeholder for the search field.

### Test
1. Should be 'All Notes' when page loads
2. Open trash, should be 'Trash'
3. Select tag, should be the tags name.