### PR TITLE
Move viewing revisions logic to redux

### DIFF
--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -39,7 +39,6 @@ const initialState: AppState = {
   revision: null,
   showTrash: false,
   showNavigation: false,
-  isViewingRevisions: false,
   dialogs: [],
   nextDialogKey: 0,
   searchFocus: false,
@@ -283,12 +282,6 @@ export const actionMap = new ActionMap({
     setRevision(state: AppState, { revision }) {
       return update(state, {
         revision: { $set: revision },
-      });
-    },
-
-    setIsViewingRevisions(state: AppState, { isViewingRevisions }) {
-      return update(state, {
-        isViewingRevisions: { $set: isViewingRevisions },
       });
     },
 

--- a/lib/note-toolbar-container.ts
+++ b/lib/note-toolbar-container.ts
@@ -107,9 +107,9 @@ export class NoteToolbarContainer extends Component<Props> {
 
 const mapStateToProps: S.MapState<StateProps> = ({
   appState,
-  ui: { filteredNotes, note, visiblePanes },
+  ui: { filteredNotes, note, showRevisions },
 }) => ({
-  isViewingRevisions: visiblePanes.has('revisions'),
+  isViewingRevisions: showRevisions,
   notes: filteredNotes,
   revisionOrNote: appState.revision || note,
 });

--- a/lib/note-toolbar-container.ts
+++ b/lib/note-toolbar-container.ts
@@ -33,7 +33,7 @@ type DispatchProps = {
   deleteNoteForever: (args: ListChanger) => any;
   noteRevisions: (args: NoteChanger) => any;
   restoreNote: (args: ListChanger) => any;
-  setIsViewingRevisions: (isViewingRevisions: boolean) => any;
+  toggleRevisions: () => any;
   shareNote: () => any;
   toggleFocusMode: () => any;
   trashNote: (args: ListChanger) => any;
@@ -90,7 +90,6 @@ export class NoteToolbarContainer extends Component<Props> {
       onShowRevisions: this.onShowRevisions,
       onShareNote: this.onShareNote,
       onTrashNote: this.onTrashNote,
-      setIsViewingRevisions: this.props.setIsViewingRevisions,
       toggleFocusMode: this.props.toggleFocusMode,
     };
 
@@ -108,9 +107,9 @@ export class NoteToolbarContainer extends Component<Props> {
 
 const mapStateToProps: S.MapState<StateProps> = ({
   appState,
-  ui: { filteredNotes, note },
+  ui: { filteredNotes, note, visiblePanes },
 }) => ({
-  isViewingRevisions: appState.isViewingRevisions,
+  isViewingRevisions: visiblePanes.has('revisions'),
   notes: filteredNotes,
   revisionOrNote: appState.revision || note,
 });
@@ -119,7 +118,6 @@ const {
   deleteNoteForever,
   noteRevisions,
   restoreNote,
-  setIsViewingRevisions,
   showDialog,
   trashNote,
 } = appState.actionCreators;
@@ -129,9 +127,6 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
   deleteNoteForever: args => dispatch(deleteNoteForever(args)),
   noteRevisions: args => dispatch(noteRevisions(args)),
   restoreNote: args => dispatch(restoreNote(args)),
-  setIsViewingRevisions: (isViewingRevisions: boolean) => {
-    dispatch(setIsViewingRevisions({ isViewingRevisions }));
-  },
   shareNote: () => dispatch(showDialog({ dialog: DialogTypes.SHARE })),
   toggleFocusMode: () => dispatch(toggleFocusMode()),
   trashNote: args => dispatch(trashNote(args)),

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import { connect, DispatchProp } from 'react-redux';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 
@@ -12,6 +12,7 @@ import RevisionsIcon from '../icons/revisions';
 import TrashIcon from '../icons/trash';
 import ShareIcon from '../icons/share';
 import SidebarIcon from '../icons/sidebar';
+import { toggleRevisions } from '../state/ui/actions';
 
 import { closeNote, toggleEditMode, toggleNoteInfo } from '../state/ui/actions';
 
@@ -22,6 +23,7 @@ type DispatchProps = {
   closeNote: () => any;
   toggleEditMode: () => any;
   toggleNoteInfo: () => any;
+  toggleRevisions: () => any;
 };
 
 type StateProps = {
@@ -38,9 +40,7 @@ export class NoteToolbar extends Component<Props> {
     onRestoreNote: PropTypes.func,
     onTrashNote: PropTypes.func,
     onDeleteNoteForever: PropTypes.func,
-    onShowRevisions: PropTypes.func,
     onShareNote: PropTypes.func,
-    setIsViewingRevisions: PropTypes.func,
     toggleFocusMode: PropTypes.func.isRequired,
     markdownEnabled: PropTypes.bool,
   };
@@ -48,16 +48,9 @@ export class NoteToolbar extends Component<Props> {
   static defaultProps = {
     onDeleteNoteForever: noop,
     onRestoreNote: noop,
-    onShowRevisions: noop,
     onShareNote: noop,
     onTrashNote: noop,
-    setIsViewingRevisions: noop,
     toggleFocusMode: noop,
-  };
-
-  showRevisions = () => {
-    this.props.setIsViewingRevisions(true);
-    this.props.onShowRevisions(this.props.note);
   };
 
   render() {
@@ -106,7 +99,7 @@ export class NoteToolbar extends Component<Props> {
           <div className="note-toolbar__button">
             <IconButton
               icon={<RevisionsIcon />}
-              onClick={this.showRevisions}
+              onClick={this.props.toggleRevisions}
               title="History"
             />
           </div>
@@ -184,6 +177,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   closeNote,
   toggleEditMode,
   toggleNoteInfo,
+  toggleRevisions,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteToolbar);

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -12,9 +12,13 @@ import RevisionsIcon from '../icons/revisions';
 import TrashIcon from '../icons/trash';
 import ShareIcon from '../icons/share';
 import SidebarIcon from '../icons/sidebar';
-import { toggleRevisions } from '../state/ui/actions';
 
-import { closeNote, toggleEditMode, toggleNoteInfo } from '../state/ui/actions';
+import {
+  closeNote,
+  toggleEditMode,
+  toggleNoteInfo,
+  toggleRevisions,
+} from '../state/ui/actions';
 
 import * as S from '../state';
 import * as T from '../types';

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import Slider from '../components/slider';
 import appState from '../flux/app-state';
 import { updateNoteTags } from '../state/domain/notes';
+import { toggleRevisions } from '../state/ui/actions';
 
 import * as S from '../state';
 import * as T from '../types';
@@ -175,22 +176,22 @@ export class RevisionSelector extends Component<Props, ComponentState> {
 
 const mapStateToProps: S.MapState<StateProps> = ({
   appState: state,
-  ui: { note },
+  ui: { note, visiblePanes },
 }) => ({
-  isViewingRevisions: state.isViewingRevisions,
+  isViewingRevisions: visiblePanes.has('revisions'),
   note: note,
 });
 
-const { setRevision, setIsViewingRevisions } = appState.actionCreators;
+const { setRevision } = appState.actionCreators;
 
 const mapDispatchToProps = dispatch => ({
   setRevision: revision => dispatch(setRevision({ revision })),
   resetIsViewingRevisions: () => {
-    dispatch(setIsViewingRevisions({ isViewingRevisions: false }));
+    dispatch(toggleRevisions());
   },
   cancelRevision: () => {
     dispatch(setRevision({ revision: null }));
-    dispatch(setIsViewingRevisions({ isViewingRevisions: false }));
+    dispatch(toggleRevisions());
   },
   updateNoteTags: arg => dispatch(updateNoteTags(arg)),
 });

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -176,9 +176,9 @@ export class RevisionSelector extends Component<Props, ComponentState> {
 
 const mapStateToProps: S.MapState<StateProps> = ({
   appState: state,
-  ui: { note, visiblePanes },
+  ui: { note, showRevisions },
 }) => ({
-  isViewingRevisions: visiblePanes.has('revisions'),
+  isViewingRevisions: showRevisions,
   note: note,
 });
 

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -66,6 +66,7 @@ export type ToggleSimperiumConnectionStatus = Action<
   { simperiumConnected: boolean }
 >;
 export type ToggleEditMode = Action<'TOGGLE_EDIT_MODE'>;
+export type ToggleRevisions = Action<'REVISIONS_TOGGLE'>;
 export type ToggleTagDrawer = Action<'TAG_DRAWER_TOGGLE', { show: boolean }>;
 export type ToggleTagEditing = Action<'TAG_EDITING_TOGGLE'>;
 export type SelectNote = Action<'SELECT_NOTE', { note: T.NoteEntity }>;
@@ -94,6 +95,7 @@ export type ActionType =
   | SetWPToken
   | ToggleEditMode
   | ToggleNoteInfo
+  | ToggleRevisions
   | ToggleSimperiumConnectionStatus
   | ToggleTagDrawer
   | ToggleTagEditing;
@@ -188,7 +190,6 @@ type LegacyAction =
   | Action<'App.selectTag', { tag: T.TagEntity }>
   | Action<'App.selectTagAndSElectFirstNote'>
   | Action<'App.selectTrash'>
-  | Action<'App.setIsViewingRevisions', { isReviewingRevisions: boolean }>
   | Action<'App.setRevision', { revision: T.NoteEntity }>
   | Action<'App.setSearchFocus', { searchFocus: boolean }>
   | Action<'App.setShouldPrintNote', { shouldPrint: boolean }>

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -30,7 +30,6 @@ import * as T from '../types';
 
 export type AppState = {
   dialogs: unknown[];
-  isViewingRevisions: boolean;
   nextDialogKey: number;
   notes: T.NoteEntity[] | null;
   preferences?: T.Preferences;

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -23,6 +23,10 @@ export const setUnsyncedNoteIds: A.ActionCreator<A.SetUnsyncedNoteIds> = (
   noteIds,
 });
 
+export const toggleRevisions: A.ActionCreator<A.ToggleRevisions> = () => ({
+  type: 'REVISIONS_TOGGLE',
+});
+
 export const toggleSimperiumConnectionStatus: A.ActionCreator<A.ToggleSimperiumConnectionStatus> = (
   simperiumConnected: boolean
 ) => ({

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -86,7 +86,6 @@ const showNoteInfo: A.Reducer<boolean> = (state = false, action) => {
 
     case 'App.toggleNavigation':
       return false;
-
     default:
       return state;
   }

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -91,6 +91,15 @@ const showNoteInfo: A.Reducer<boolean> = (state = false, action) => {
   }
 };
 
+const showRevisions: A.Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'REVISIONS_TOGGLE':
+      return !state;
+    default:
+      return state;
+  }
+};
+
 const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
   switch (action.type) {
     case 'App.selectNote':
@@ -123,6 +132,7 @@ export default combineReducers({
   searchQuery,
   showNoteInfo,
   showNoteList,
+  showRevisions,
   simperiumConnected,
   unsyncedNoteIds,
 });


### PR DESCRIPTION
### Fix
Move viewing revisions logic to redux.

### Test
1. open revisions
2. cancel revisions
3. restore revisions
4. when revisions panel is open click outside of the revisions panel
