### PR TITLE
Refactor: Visible Panes as Set

### DIFF
--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -1,9 +1,10 @@
-import { difference, union } from 'lodash';
-import { AnyAction, combineReducers } from 'redux';
+import { combineReducers } from 'redux';
+
+import * as set from '../../utils/set-utils';
+
 import * as A from '../action-types';
 import * as T from '../../types';
 
-const defaultVisiblePanes = ['editor', 'noteList'];
 const emptyList: unknown[] = [];
 
 const filteredNotes: A.Reducer<T.NoteEntity[]> = (
@@ -21,14 +22,14 @@ const simperiumConnected: A.Reducer<boolean> = (state = false, action) =>
     ? action.simperiumConnected
     : state;
 
-const visiblePanes: A.Reducer<string[]> = (
-  state = defaultVisiblePanes,
+const visiblePanes: A.Reducer<Set<string>> = (
+  state = new Set(['editor', 'noteList']),
   action
 ) => {
   if ('TAG_DRAWER_TOGGLE' === action.type) {
     return action.show
-      ? union(state, ['tagDrawer'])
-      : difference(state, ['tagDrawer']);
+      ? set.include(state, 'tagDrawer')
+      : set.exclude(state, 'tagDrawer');
   }
 
   return state;

--- a/lib/utils/set-utils.ts
+++ b/lib/utils/set-utils.ts
@@ -1,0 +1,20 @@
+export const include = <T>(set: Set<T>, value: T): Set<T> => {
+  if (set.has(value)) {
+    return set;
+  }
+
+  return new Set(set).add(value);
+};
+
+export const exclude = <T>(set: Set<T>, value: T): Set<T> => {
+  if (!set.has(value)) {
+    return set;
+  }
+
+  const without = new Set(set);
+  without.delete(value);
+  return without;
+};
+
+export const toggle = <T>(set: Set<T>, value: T): Set<T> =>
+  set.has(value) ? exclude(set, value) : include(set, value);

--- a/lib/utils/test/set-utils.ts
+++ b/lib/utils/test/set-utils.ts
@@ -1,0 +1,63 @@
+import * as set from '../set-utils';
+
+it('should return same reference if included value already in set', () => {
+  const s = new Set([1, 2, 3]);
+  expect(set.include(s, 2)).toBe(s);
+});
+
+it('should add item to set', () => {
+  expect(set.include(new Set([1, 2, 3]), 4)).toEqual(new Set([1, 2, 3, 4]));
+});
+
+it('should return same reference if excluded value already missing from set', () => {
+  const s = new Set([1, 2, 3]);
+  expect(set.exclude(s, 5)).toBe(s);
+});
+
+it('should remove item from set', () => {
+  expect(set.exclude(new Set([1, 2, 3]), 2)).toEqual(new Set([1, 3]));
+});
+
+it('should remove item when toggling existing value', () => {
+  expect(set.toggle(new Set(['a', 'b', 'c']), 'b')).toEqual(
+    new Set(['a', 'c'])
+  );
+});
+
+it('should add item when toggling missing value', () => {
+  expect(set.toggle(new Set(['a', 'b', 'c']), 'd')).toEqual(
+    new Set(['a', 'b', 'c', 'd'])
+  );
+});
+
+it('does not perform value equality when including', () => {
+  expect(set.include(new Set([{}]), {})).toEqual(new Set([{}, {}]));
+  expect(set.include(new Set([[1, 2]]), [1, 2])).toEqual(
+    new Set([
+      [1, 2],
+      [1, 2],
+    ])
+  );
+
+  const o = {};
+  const so = new Set([o]);
+  expect(set.include(so, o)).toBe(so);
+
+  const l = [true, false];
+  const sl = new Set([l]);
+  expect(set.include(sl, l)).toBe(sl);
+});
+
+it('does not perform value equality when excluding', () => {
+  const s1 = new Set([{}]);
+  expect(set.exclude(s1, {})).toBe(s1);
+
+  const s2 = new Set([[1, 2]]);
+  expect(set.exclude(s2, [1, 2])).toBe(s2);
+
+  const o = {};
+  expect(set.exclude(new Set([o]), o)).toEqual(new Set());
+
+  const l = [true, false];
+  expect(set.exclude(new Set([l]), l)).toEqual(new Set());
+});


### PR DESCRIPTION
This patch introduces a new set utility library for adding, removing,
and toggling values in a set to make a working "option bag."

It also changes the `visiblePane` state from a list of strings into this
new option bag, removing the reliance on the `lodash` equivalent
functions for using the array.

This is meant to be precursor work for #1901 and #1903 should it be useful.