### PR TITLE
Tag suggestions: Matches should be case insensitive

### DIFF
--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -98,6 +98,7 @@ export const filterTags = (tags: T.TagEntity[], query: string) => {
   // but without knowing where the cursor is it's maybe the best we can do
   const tagTerm = query
     .trim()
+    .toLowerCase()
     .split(' ')
     .pop();
 
@@ -112,8 +113,9 @@ export const filterTags = (tags: T.TagEntity[], query: string) => {
   const term = isPrefixMatch ? tagTerm.slice(4) : tagTerm;
 
   const matcher: (tag: T.TagEntity) => boolean = isPrefixMatch
-    ? ({ data: { name } }) => name !== term && name.startsWith(term)
-    : ({ data: { name } }) => name.includes(term);
+    ? ({ data: { name } }) =>
+        name.toLowerCase() !== term && name.toLowerCase().startsWith(term)
+    : ({ data: { name } }) => name.toLowerCase().includes(term);
 
   return filterAtMost(tags, matcher, 5);
 };

--- a/lib/tag-suggestions/test.tsx
+++ b/lib/tag-suggestions/test.tsx
@@ -36,6 +36,11 @@ it('finds mid-tag matches', () => {
   expect(filterTags(infixen, 'code')).toEqual(infixen);
 });
 
+it('finds case insensitive matches', () => {
+  expect(filterTags(animals, 'Cat')).toEqual(['cat'].map(t));
+  expect(filterTags(animals, 'OWL')).toEqual(['owl'].map(t));
+});
+
 it('uses the last space-separated segment in the query for search', () => {
   expect(filterTags(infixen, 'code bug')).toEqual([]);
   expect(filterTags(infixen, 'bug code')).toEqual(infixen);


### PR DESCRIPTION
### Fix
Tag suggestions should be case insensitive. Quick fix by lowercasing all the comparison strings before comparing (since `startsWith` doesn't have a flag for case sensitivity and moving to regex seemed overly complex). Added a test for this too.

### Test
1. Search for the name of a tag but with different case.
2. Verify tag suggestions suggest the tag.
3. Smoke test for other regressions involving search and tag suggestions.

### Release
`RELEASE-NOTES.txt` was updated in TBD with:

> Fixed tag suggestions to be case insensitive