### PR TITLE
State refactor: Move toggle navigation to Redux

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -34,6 +34,7 @@ import {
   createNote,
   closeNote,
   setUnsyncedNoteIds,
+  toggleNavigation,
   toggleSimperiumConnectionStatus,
 } from './state/ui/actions';
 
@@ -103,7 +104,7 @@ const mapDispatchToProps: S.MapDispatch<
     toggleSortOrder: thenReloadNotes(settingsActions.toggleSortOrder),
     toggleSortTagsAlpha: thenReloadTags(settingsActions.toggleSortTagsAlpha),
     createNote: () => dispatch(createNote()),
-    openTagList: () => dispatch(actionCreators.toggleNavigation()),
+    openTagList: () => dispatch(toggleNavigation()),
     resetAuth: () => dispatch(reduxActions.auth.reset()),
     selectNote: (note: T.NoteEntity) => dispatch(actions.ui.selectNote(note)),
     setAuthorized: () => dispatch(reduxActions.auth.setAuthorized()),
@@ -233,7 +234,7 @@ export const App = connect(
       if (
         cmdOrCtrl &&
         't' === key.toLowerCase() &&
-        !this.state.showNavigation
+        !this.props.showNavigation
       ) {
         this.props.openTagList();
 
@@ -438,7 +439,7 @@ export const App = connect(
         settings,
         tagBucket,
         isSmallScreen,
-        ui: { showNoteInfo },
+        ui: { showNavigation, showNoteInfo },
       } = this.props;
       const isMacApp = isElectronMac();
 
@@ -451,7 +452,7 @@ export const App = connect(
 
       const mainClasses = classNames('simplenote-app', {
         'note-info-open': showNoteInfo,
-        'navigation-open': state.showNavigation,
+        'navigation-open': showNavigation,
         'is-electron': isElectron(),
         'is-macos': isMacApp,
       });
@@ -461,12 +462,10 @@ export const App = connect(
           {isDevConfig && <DevBadge />}
           {isAuthorized ? (
             <div className={mainClasses}>
-              {state.showNavigation && (
-                <NavigationBar isElectron={isElectron()} />
-              )}
+              {showNavigation && <NavigationBar isElectron={isElectron()} />}
               <AppLayout
                 isFocusMode={settings.focusModeEnabled}
-                isNavigationOpen={state.showNavigation}
+                isNavigationOpen={showNavigation}
                 isNoteInfoOpen={showNoteInfo}
                 isSmallScreen={isSmallScreen}
                 noteBucket={noteBucket}

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -37,7 +37,6 @@ const initialState: AppState = {
   notes: null,
   tags: [],
   revision: null,
-  showNavigation: false,
   dialogs: [],
   nextDialogKey: 0,
   searchFocus: false,
@@ -56,18 +55,6 @@ export const actionMap = new ActionMap({
       });
     },
 
-    toggleNavigation(state: AppState) {
-      if (state.showNavigation) {
-        return update(state, {
-          showNavigation: { $set: false },
-        });
-      }
-
-      return update(state, {
-        showNavigation: { $set: true },
-      });
-    },
-
     showAllNotesAndSelectFirst: {
       creator() {
         return (dispatch, getState) => {
@@ -83,7 +70,6 @@ export const actionMap = new ActionMap({
 
     showAllNotes(state: AppState) {
       return update(state, {
-        showNavigation: { $set: false },
         tag: { $set: null },
         previousIndex: { $set: -1 },
       });
@@ -91,7 +77,6 @@ export const actionMap = new ActionMap({
 
     selectTrash(state: AppState) {
       return update(state, {
-        showNavigation: { $set: false },
         tag: { $set: null },
         previousIndex: { $set: -1 },
       });
@@ -112,7 +97,6 @@ export const actionMap = new ActionMap({
 
     selectTag(state: AppState, { tag }: { tag: T.TagEntity }) {
       return update(state, {
-        showNavigation: { $set: false },
         tag: { $set: tag },
         previousIndex: { $set: -1 },
       });
@@ -142,7 +126,7 @@ export const actionMap = new ActionMap({
       };
 
       if (type === 'Settings') {
-        updateCommands.showNavigation = { $set: false };
+        // updateCommands.showNavigation = { $set: false }; //@todo
       }
 
       return update(state, updateCommands);

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -125,10 +125,6 @@ export const actionMap = new ActionMap({
         nextDialogKey: { $set: state.nextDialogKey + 1 },
       };
 
-      if (type === 'Settings') {
-        // updateCommands.showNavigation = { $set: false }; //@todo
-      }
-
       return update(state, updateCommands);
     },
 

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -14,7 +14,23 @@ import { viewExternalUrl } from '../utils/url-utils';
 import appState from '../flux/app-state';
 import DialogTypes from '../../shared/dialog-types';
 
-export class NavigationBar extends Component {
+import { toggleNavigation } from '../state/ui/actions';
+
+import * as S from '../state';
+import * as T from '../types';
+
+type StateProps = {
+  showNavigation: boolean;
+};
+
+type DispatchProps = {
+  onOutsideClick: () => any;
+  toggleNavigation: Function;
+};
+
+type Props = StateProps & DispatchProps;
+
+export class NavigationBar extends Component<Props> {
   static displayName = 'NavigationBar';
 
   static propTypes = {
@@ -22,12 +38,10 @@ export class NavigationBar extends Component {
     dialogs: PropTypes.array.isRequired,
     isElectron: PropTypes.bool.isRequired,
     onAbout: PropTypes.func.isRequired,
-    onOutsideClick: PropTypes.func.isRequired,
     onSettings: PropTypes.func.isRequired,
     onShowAllNotes: PropTypes.func.isRequired,
     selectTrash: PropTypes.func.isRequired,
     selectedTag: PropTypes.object,
-    showNavigation: PropTypes.bool.isRequired,
     showTrash: PropTypes.bool.isRequired,
   };
 
@@ -127,11 +141,15 @@ export class NavigationBar extends Component {
   }
 }
 
-const mapStateToProps = ({ appState: state, settings, ui: { showTrash } }) => ({
+const mapStateToProps = ({
+  appState: state,
+  settings,
+  ui: { showNavigation, showTrash },
+}) => ({
   autoHideMenuBar: settings.autoHideMenuBar,
   dialogs: state.dialogs,
   selectedTag: state.tag,
-  showNavigation: state.showNavigation,
+  showNavigation,
   showTrash,
 });
 
@@ -139,10 +157,9 @@ const {
   showAllNotesAndSelectFirst,
   selectTrash,
   showDialog,
-  toggleNavigation,
 } = appState.actionCreators;
 
-const mapDispatchToProps = {
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   onAbout: () => showDialog({ dialog: DialogTypes.ABOUT }),
   onOutsideClick: toggleNavigation,
   onShowAllNotes: showAllNotesAndSelectFirst,

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -25,7 +25,7 @@ type StateProps = {
 
 type DispatchProps = {
   onOutsideClick: () => any;
-  toggleNavigation: Function;
+  toggleNavigation: () => any;
 };
 
 type Props = StateProps & DispatchProps;

--- a/lib/search-bar/index.tsx
+++ b/lib/search-bar/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -14,16 +14,18 @@ import NewNoteIcon from '../icons/new-note';
 import SearchField from '../search-field';
 import MenuIcon from '../icons/menu';
 import { withoutTags } from '../utils/filter-notes';
-import { createNote, search } from '../state/ui/actions';
+import { createNote, search, toggleNavigation } from '../state/ui/actions';
 
 import * as S from '../state';
+import * as T from '../types';
 
-const { newNote, toggleNavigation } = appState.actionCreators;
+const { newNote } = appState.actionCreators;
 const { recordEvent } = tracks;
 
 type OwnProps = {
   onNewNote: Function;
-  onToggleNavigation: Function;
+  noteBucket: object;
+  onNoteOpened: Function;
 };
 
 type StateProps = {
@@ -31,16 +33,20 @@ type StateProps = {
   showTrash: boolean;
 };
 
-type Props = OwnProps & StateProps;
+type DispatchProps = {
+  toggleNavigation: () => any;
+};
 
-export const SearchBar: FunctionComponent<Props> = ({
+type Props = OwnProps & StateProps & DispatchProps;
+
+export const SearchBar: Component<Props> = ({
   onNewNote,
-  onToggleNavigation,
   searchQuery,
   showTrash,
+  toggleNavigation,
 }) => (
   <div className="search-bar theme-color-border">
-    <IconButton icon={<MenuIcon />} onClick={onToggleNavigation} title="Menu" />
+    <IconButton icon={<MenuIcon />} onClick={toggleNavigation} title="Menu" />
     <SearchField />
     <IconButton
       disabled={showTrash}
@@ -58,14 +64,19 @@ const mapStateToProps: S.MapState<StateProps> = ({
   showTrash,
 });
 
-const mapDispatchToProps = (dispatch, { noteBucket }) => ({
+const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (
+  dispatch,
+  { noteBucket }
+) => ({
   onNewNote: (content: string) => {
     dispatch(createNote());
     dispatch(search(''));
     dispatch(newNote({ noteBucket, content }));
     recordEvent('list_note_created');
   },
-  onToggleNavigation: () => dispatch(toggleNavigation()),
+  toggleNavigation: () => {
+    dispatch(toggleNavigation());
+  },
 });
 
 SearchBar.displayName = 'SearchBar';

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -60,6 +60,8 @@ export type SetUnsyncedNoteIds = Action<
   'SET_UNSYNCED_NOTE_IDS',
   { noteIds: T.EntityId[] }
 >;
+
+export type ToggleNavigation = Action<'NAVIGATION_TOGGLE'>;
 export type ToggleNoteInfo = Action<'NOTE_INFO_TOGGLE'>;
 export type ToggleSimperiumConnectionStatus = Action<
   'SIMPERIUM_CONNECTION_STATUS_TOGGLE',
@@ -94,6 +96,7 @@ export type ActionType =
   | SetUnsyncedNoteIds
   | SetWPToken
   | ToggleEditMode
+  | ToggleNavigation
   | ToggleNoteInfo
   | ToggleRevisions
   | ToggleSimperiumConnectionStatus
@@ -197,5 +200,4 @@ type LegacyAction =
   | Action<'App.showAllNotes'>
   | Action<'App.showAllNotesAndSelectFirst'>
   | Action<'App.showDialog', { dialog: object }>
-  | Action<'App.tagsLoaded', { tags: T.TagEntity[]; sortTagsAlpha: boolean }>
-  | Action<'App.toggleNavigation'>;
+  | Action<'App.tagsLoaded', { tags: T.TagEntity[]; sortTagsAlpha: boolean }>;

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -47,6 +47,10 @@ export const toggleEditMode: A.ActionCreator<A.ToggleEditMode> = () => ({
   type: 'TOGGLE_EDIT_MODE',
 });
 
+export const toggleNavigation: A.ActionCreator<A.ToggleNavigation> = () => ({
+  type: 'NAVIGATION_TOGGLE',
+});
+
 export const toggleNoteInfo: A.ActionCreator<A.ToggleNoteInfo> = () => ({
   type: 'NOTE_INFO_TOGGLE',
 });

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -24,7 +24,7 @@ const editingTags: A.Reducer<boolean> = (state = false, action) => {
     case 'App.selectTag':
     case 'App.selectTrash':
     case 'App.showAllNotes':
-    case 'App.toggleNavigation':
+    case 'NAVIGATION_TOGGLE':
     case 'App.toggleNoteInfo':
       return false;
     default:
@@ -84,7 +84,22 @@ const showNoteInfo: A.Reducer<boolean> = (state = false, action) => {
     case 'NOTE_INFO_TOGGLE':
       return !state;
 
-    case 'App.toggleNavigation':
+    case 'NAVIGATION_TOGGLE':
+      return false;
+
+    default:
+      return state;
+  }
+};
+
+const showNavigation: A.Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'NAVIGATION_TOGGLE':
+      return !state;
+
+    case 'App.selectTag':
+    case 'App.selectTrash':
+    case 'App.showAllNotes':
       return false;
     default:
       return state;
@@ -144,6 +159,7 @@ export default combineReducers({
   listTitle,
   note,
   searchQuery,
+  showNavigation,
   showNoteInfo,
   showNoteList,
   showRevisions,

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -101,6 +101,11 @@ const showNavigation: A.Reducer<boolean> = (state = false, action) => {
     case 'App.selectTrash':
     case 'App.showAllNotes':
       return false;
+    case 'App.showDialog':
+      if (action.dialog && action.dialog.type === 'Settings') {
+        return false;
+      }
+      return state;
     default:
       return state;
   }


### PR DESCRIPTION
### Fix
Move `showNavigation` and `toggleNavigation` to Redux state. Adds action `NAVIGATION_TOGGLE`.

### Test
1. Clickie the hamburger
2. Notification panel should appear
3. It should go away with ESC or clicking anywhere
4. Key combo cmd+T should also toggle it in and out
5. Try to break other things too

### Review
See comment about `editingTags` state

### Release
`RELEASE-NOTES.txt` was updated in TBD with:

> TBD