### PR TITLE
State Refactor: move setSearchFocus to two actions, focusSearch and blurSearch

### DIFF
--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -39,7 +39,7 @@ const buildEditMenu = settings => {
       {
         label: 'Search &Notes…',
         accelerator: 'CommandOrControl+F',
-        click: appCommandSender({ action: 'setSearchFocus' }),
+        click: appCommandSender({ action: 'focusSearch' }),
       },
       {
         type: 'separator',

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -33,6 +33,7 @@ import {
 import {
   createNote,
   closeNote,
+  setSearchFocus,
   setUnsyncedNoteIds,
   toggleSimperiumConnectionStatus,
 } from './state/ui/actions';
@@ -53,6 +54,7 @@ export type DispatchProps = {
   createNote: () => any;
   closeNote: () => any;
   selectNote: (note: T.NoteEntity) => any;
+  setSearchFocus: () => any;
 };
 
 export type Props = DispatchProps;
@@ -107,8 +109,7 @@ const mapDispatchToProps: S.MapDispatch<
     resetAuth: () => dispatch(reduxActions.auth.reset()),
     selectNote: (note: T.NoteEntity) => dispatch(actions.ui.selectNote(note)),
     setAuthorized: () => dispatch(reduxActions.auth.setAuthorized()),
-    setSearchFocus: () =>
-      dispatch(actionCreators.setSearchFocus({ searchFocus: true })),
+    setSearchFocus: () => dispatch(setSearchFocus()),
     setSimperiumConnectionStatus: connected =>
       dispatch(toggleSimperiumConnectionStatus(connected)),
     selectNote: note => dispatch(actions.ui.selectNote(note)),

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -33,7 +33,7 @@ import {
 import {
   createNote,
   closeNote,
-  setSearchFocus,
+  focusSearch,
   setUnsyncedNoteIds,
   toggleSimperiumConnectionStatus,
 } from './state/ui/actions';
@@ -54,7 +54,7 @@ export type DispatchProps = {
   createNote: () => any;
   closeNote: () => any;
   selectNote: (note: T.NoteEntity) => any;
-  setSearchFocus: () => any;
+  focusSearch: () => any;
 };
 
 export type Props = DispatchProps;
@@ -109,7 +109,7 @@ const mapDispatchToProps: S.MapDispatch<
     resetAuth: () => dispatch(reduxActions.auth.reset()),
     selectNote: (note: T.NoteEntity) => dispatch(actions.ui.selectNote(note)),
     setAuthorized: () => dispatch(reduxActions.auth.setAuthorized()),
-    setSearchFocus: () => dispatch(setSearchFocus()),
+    focusSearch: () => dispatch(focusSearch()),
     setSimperiumConnectionStatus: connected =>
       dispatch(toggleSimperiumConnectionStatus(connected)),
     selectNote: note => dispatch(actions.ui.selectNote(note)),

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -41,7 +41,6 @@ const initialState: AppState = {
   showNavigation: false,
   dialogs: [],
   nextDialogKey: 0,
-  searchFocus: false,
   unsyncedNoteIds: [], // note bucket only
 };
 
@@ -282,12 +281,6 @@ export const actionMap = new ActionMap({
     setRevision(state: AppState, { revision }) {
       return update(state, {
         revision: { $set: revision },
-      });
-    },
-
-    setSearchFocus(state: AppState, { searchFocus = true }) {
-      return update(state, {
-        searchFocus: { $set: searchFocus },
       });
     },
 

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -4,9 +4,8 @@ import SmallCrossIcon from '../icons/cross-small';
 import appState from '../flux/app-state';
 import { tracks } from '../analytics';
 import { State } from '../state';
-import { search } from '../state/ui/actions';
+import { search, unsetSearchFocus } from '../state/ui/actions';
 
-const { setSearchFocus } = appState.actionCreators;
 const { recordEvent } = tracks;
 const KEY_ESC = 27;
 
@@ -19,9 +18,9 @@ export class SearchField extends Component<ConnectedProps> {
   inputField = createRef<HTMLInputElement>();
 
   componentDidUpdate() {
-    const { searchFocus, onSearchFocused } = this.props;
+    const { searchFocused, onSearchFocused } = this.props;
 
-    if (searchFocus && this.inputField.current) {
+    if (searchFocused && this.inputField.current) {
       this.inputField.current.select();
       this.inputField.current.focus();
       onSearchFocused();
@@ -78,11 +77,11 @@ export class SearchField extends Component<ConnectedProps> {
 
 const mapStateToProps = ({
   appState: state,
-  ui: { listTitle, searchQuery },
+  ui: { listTitle, searchFocused, searchQuery },
 }: State) => ({
   isTagSelected: !!state.tag,
   placeholder: listTitle,
-  searchFocus: state.searchFocus,
+  searchFocused,
   searchQuery,
 });
 
@@ -91,7 +90,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(search(query));
     recordEvent('list_notes_searched');
   },
-  onSearchFocused: () => dispatch(setSearchFocus({ searchFocus: false })),
+  onSearchFocused: () => dispatch(unsetSearchFocus()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(SearchField);

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -4,7 +4,7 @@ import SmallCrossIcon from '../icons/cross-small';
 import appState from '../flux/app-state';
 import { tracks } from '../analytics';
 import { State } from '../state';
-import { search, unsetSearchFocus } from '../state/ui/actions';
+import { search, blurSearch } from '../state/ui/actions';
 
 const { recordEvent } = tracks;
 const KEY_ESC = 27;
@@ -90,7 +90,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(search(query));
     recordEvent('list_notes_searched');
   },
-  onSearchFocused: () => dispatch(unsetSearchFocus()),
+  onSearchFocused: () => dispatch(blurSearch()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(SearchField);

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -51,15 +51,13 @@ export type SetWPToken = Action<'setWPToken', { token: string }>;
 /*
  * Normal action types
  */
+export type BlurSearch = Action<'BLUR_SEARCH'>;
 export type CreateNote = Action<'CREATE_NOTE'>;
 export type CloseNote = Action<'CLOSE_NOTE'>;
 export type FilterNotes = Action<'FILTER_NOTES', { notes: T.NoteEntity[] }>;
+export type FocusSearch = Action<'FOCUS_SEARCH'>;
 export type Search = Action<'SEARCH', { searchQuery: string }>;
 export type SetAuth = Action<'AUTH_SET', { status: AuthState }>;
-
-export type SetSearchFocus = Action<'SET_SEARCH_FOCUS'>;
-export type UnsetSearchFocus = Action<'UNSET_SEARCH_FOCUS'>;
-
 export type SetUnsyncedNoteIds = Action<
   'SET_UNSYNCED_NOTE_IDS',
   { noteIds: T.EntityId[] }
@@ -76,10 +74,12 @@ export type ToggleTagEditing = Action<'TAG_EDITING_TOGGLE'>;
 export type SelectNote = Action<'SELECT_NOTE', { note: T.NoteEntity }>;
 
 export type ActionType =
+  | BlurSearch
   | CreateNote
   | CloseNote
   | LegacyAction
   | FilterNotes
+  | FocusSearch
   | Search
   | SelectNote
   | SetAccountName
@@ -90,7 +90,6 @@ export type ActionType =
   | SetLineLength
   | SetMarkdownEnabled
   | SetNoteDisplay
-  | SetSearchFocus
   | SetSortReversed
   | SetSortTagsAlpha
   | SetSortType
@@ -103,8 +102,7 @@ export type ActionType =
   | ToggleRevisions
   | ToggleSimperiumConnectionStatus
   | ToggleTagDrawer
-  | ToggleTagEditing
-  | UnsetSearchFocus;
+  | ToggleTagEditing;
 
 export type ActionCreator<A extends ActionType> = (...args: any[]) => A;
 export type Reducer<S> = (state: S | undefined, action: ActionType) => S;

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -56,6 +56,10 @@ export type CloseNote = Action<'CLOSE_NOTE'>;
 export type FilterNotes = Action<'FILTER_NOTES', { notes: T.NoteEntity[] }>;
 export type Search = Action<'SEARCH', { searchQuery: string }>;
 export type SetAuth = Action<'AUTH_SET', { status: AuthState }>;
+
+export type SetSearchFocus = Action<'SET_SEARCH_FOCUS'>;
+export type UnsetSearchFocus = Action<'UNSET_SEARCH_FOCUS'>;
+
 export type SetUnsyncedNoteIds = Action<
   'SET_UNSYNCED_NOTE_IDS',
   { noteIds: T.EntityId[] }
@@ -86,6 +90,7 @@ export type ActionType =
   | SetLineLength
   | SetMarkdownEnabled
   | SetNoteDisplay
+  | SetSearchFocus
   | SetSortReversed
   | SetSortTagsAlpha
   | SetSortType
@@ -98,7 +103,8 @@ export type ActionType =
   | ToggleRevisions
   | ToggleSimperiumConnectionStatus
   | ToggleTagDrawer
-  | ToggleTagEditing;
+  | ToggleTagEditing
+  | UnsetSearchFocus;
 
 export type ActionCreator<A extends ActionType> = (...args: any[]) => A;
 export type Reducer<S> = (state: S | undefined, action: ActionType) => S;
@@ -191,7 +197,6 @@ type LegacyAction =
   | Action<'App.selectTagAndSElectFirstNote'>
   | Action<'App.selectTrash'>
   | Action<'App.setRevision', { revision: T.NoteEntity }>
-  | Action<'App.setSearchFocus', { searchFocus: boolean }>
   | Action<'App.setShouldPrintNote', { shouldPrint: boolean }>
   | Action<'App.setUnsyncedNoteIds', { noteIds: T.EntityId[] }>
   | Action<'App.showAllNotes'>

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -35,7 +35,6 @@ export type AppState = {
   preferences?: T.Preferences;
   previousIndex: number;
   revision: T.NoteEntity | null;
-  searchFocused: boolean;
   showNavigation: boolean;
   showTrash: boolean;
   tags: T.TagEntity[];

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -35,7 +35,7 @@ export type AppState = {
   preferences?: T.Preferences;
   previousIndex: number;
   revision: T.NoteEntity | null;
-  searchFocus: boolean;
+  searchFocused: boolean;
   showNavigation: boolean;
   showTrash: boolean;
   tags: T.TagEntity[];

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -1,6 +1,10 @@
 import * as A from '../action-types';
 import * as T from '../../types';
 
+export const blurSearch: A.ActionCreator<A.BlurSearch> = () => ({
+  type: 'BLUR_SEARCH',
+});
+
 export const createNote: A.ActionCreator<A.CreateNote> = () => ({
   type: 'CREATE_NOTE',
 });
@@ -14,6 +18,10 @@ export const filterNotes: A.ActionCreator<A.FilterNotes> = (
 ) => ({
   type: 'FILTER_NOTES',
   notes,
+});
+
+export const focusSearch: A.ActionCreator<A.FocusSearch> = () => ({
+  type: 'FOCUS_SEARCH',
 });
 
 export const setUnsyncedNoteIds: A.ActionCreator<A.SetUnsyncedNoteIds> = (
@@ -37,14 +45,6 @@ export const toggleSimperiumConnectionStatus: A.ActionCreator<A.ToggleSimperiumC
 export const search: A.ActionCreator<A.Search> = (searchQuery: string) => ({
   type: 'SEARCH',
   searchQuery,
-});
-
-export const setSearchFocus: A.ActionCreator<A.SetSearchFocus> = () => ({
-  type: 'SET_SEARCH_FOCUS',
-});
-
-export const unsetSearchFocus: A.ActionCreator<A.UnsetSearchFocus> = () => ({
-  type: 'UNSET_SEARCH_FOCUS',
 });
 
 export const selectNote: A.ActionCreator<A.SelectNote> = (

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -39,6 +39,14 @@ export const search: A.ActionCreator<A.Search> = (searchQuery: string) => ({
   searchQuery,
 });
 
+export const setSearchFocus: A.ActionCreator<A.SetSearchFocus> = () => ({
+  type: 'SET_SEARCH_FOCUS',
+});
+
+export const unsetSearchFocus: A.ActionCreator<A.UnsetSearchFocus> = () => ({
+  type: 'UNSET_SEARCH_FOCUS',
+});
+
 export const selectNote: A.ActionCreator<A.SelectNote> = (
   note: T.NoteEntity
 ) => ({ type: 'SELECT_NOTE', note });

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -76,9 +76,9 @@ const searchQuery: A.Reducer<string> = (state = '', action) =>
 
 const searchFocused: A.Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
-    case 'SET_SEARCH_FOCUS':
+    case 'FOCUS_SEARCH':
       return true;
-    case 'UNSET_SEARCH_FOCUS':
+    case 'BLUR_SEARCH':
       return false;
     default:
       return state;

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -74,6 +74,17 @@ const unsyncedNoteIds: A.Reducer<T.EntityId[]> = (
 const searchQuery: A.Reducer<string> = (state = '', action) =>
   'SEARCH' === action.type ? action.searchQuery : state;
 
+const searchFocused: A.Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'SET_SEARCH_FOCUS':
+      return true;
+    case 'UNSET_SEARCH_FOCUS':
+      return false;
+    default:
+      return state;
+  }
+};
+
 const simperiumConnected: A.Reducer<boolean> = (state = false, action) =>
   'SIMPERIUM_CONNECTION_STATUS_TOGGLE' === action.type
     ? action.simperiumConnected
@@ -129,6 +140,7 @@ export default combineReducers({
   filteredNotes,
   listTitle,
   note,
+  searchFocused,
   searchQuery,
   showNoteInfo,
   showNoteList,

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import appState from '../flux/app-state';
 import { tracks } from '../analytics';
-import { search, setSearchFocus } from '../state/ui/actions';
+import { search, focusSearch } from '../state/ui/actions';
 import filterAtMost from '../utils/filter-at-most';
 
 import * as S from '../state';
@@ -120,7 +120,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
   onSearch: query => {
     dispatch(search(query));
     recordEvent('list_notes_searched');
-    dispatch(setSearchFocus());
+    dispatch(focusSearch());
   },
 });
 

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -2,13 +2,12 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import appState from '../flux/app-state';
 import { tracks } from '../analytics';
-import { search } from '../state/ui/actions';
+import { search, setSearchFocus } from '../state/ui/actions';
 import filterAtMost from '../utils/filter-at-most';
 
 import * as S from '../state';
 import * as T from '../types';
 
-const { setSearchFocus } = appState.actionCreators;
 const { recordEvent } = tracks;
 
 type StateProps = {
@@ -121,7 +120,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
   onSearch: query => {
     dispatch(search(query));
     recordEvent('list_notes_searched');
-    dispatch(setSearchFocus({ searchFocus: true }));
+    dispatch(setSearchFocus());
   },
 });
 


### PR DESCRIPTION
### Fix
This moves `setSearchFocus` to Redux state

### Test
1. Make sure search/filter behaves as expected
2. Searching for a tag also should focus search when a tag suggestion is clicked
2. Also test the keybinding (cmd+F) in Electron to focus the search field

### Review
The state boolean was originally called `searchFocus`, I renamed it to `searchFocused`.

The corresponding action was originally `set` with `true` and `false` arguments. I experimented with breaking it out instead into a `focusSearch` and `blurSearch` action. I still think it's somewhat confusing that the search field calls `onSearchFocus` to unfocus search... but we can refactor it into oblivion once we move everything into Redux. 

### Release
`RELEASE-NOTES.txt` was updated in TBD with:
> TBD