### PR TITLE
Include diff-match-patch surrogate fix v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16660,9 +16660,9 @@
       "dev": true
     },
     "simperium": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/simperium/-/simperium-1.0.3.tgz",
-      "integrity": "sha512-EA4PTNJxinmLJmjABYZNnLEmVFCLVNhqoEjbIV7nKURYQFi5wiZFBr9OHIy3un/RC4R5MhrTCxRM0OH6uf2omA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/simperium/-/simperium-1.0.4.tgz",
+      "integrity": "sha512-kMnq/f+8D3+1WJD1smXdN79LCpFs9IYpL37/xHsBGtQcd8zJeoDI3MD4CCNiy9vQxZiOVMC9LICtvgiZ7vCZXw==",
       "requires": {
         "@babel/polyfill": "7.7.0",
         "uuid": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "sax": "1.2.4",
     "semver": "7.1.1",
     "showdown": "1.9.1",
-    "simperium": "1.0.3",
+    "simperium": "1.0.4",
     "string-replace-to-array": "1.0.3",
     "turndown": "5.0.3",
     "unorm": "1.6.0",


### PR DESCRIPTION
Updates `node-simperium` in order to incorportate the second fix in
`diff-match-patch` for the successive surrogate issue. Specifically
this fix includes a custom URI decoder to accept changes from the
server which would otherwise crash the decoding thread (invalid Unicode
characters URI-encoded as if they were - Python 2 encoding surrogate
halves separately).

This change should not have a noticable impact on the app and should
only fix a few remaining cases where successive surrogate pairs could
previously interrupt the syncing process.