### PR TITLE
e2e tests: improve reliability of login test

### DIFF
--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -3,6 +3,9 @@ import path from 'path';
 import rimraf from 'rimraf';
 import { Application } from 'spectron';
 
+const TEST_USERNAME = process.env.TEST_USERNAME as string;
+const TEST_PASSWORD = process.env.TEST_PASSWORD as string;
+
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 const app: Application = new Application({
@@ -26,21 +29,62 @@ describe('E2E', () => {
     expect(app.isRunning()).toEqual(true);
   });
 
-  test('logs in', async () => {
+  const usernameField = () => app.client.$('#login__field-username');
+  const passwordField = () => app.client.$('#login__field-password');
+  const loginButton = () => app.client.$('#login__login-button');
+
+  const enterLoginInfo = async (
+    username: string,
+    password: string,
+    maxWait = 500
+  ) => {
     await app.client.waitUntilWindowLoaded();
 
-    app.client
-      .$('#login__field-username')
-      .setValue(process.env.TEST_USERNAME as string);
-    app.client
-      .$('#login__field-password')
-      .setValue(process.env.TEST_PASSWORD as string);
+    expect(usernameField().waitForExist(maxWait)).toBeTruthy();
+    usernameField().setValue(username);
+    expect(passwordField().waitForExist(maxWait)).toBeTruthy();
+    passwordField().setValue(password);
+  };
 
+  test('login with wrong password fails', async () => {
+    await app.client.waitUntilWindowLoaded();
+    await enterLoginInfo(TEST_USERNAME, `${TEST_PASSWORD}_wrong`);
     await wait(500);
+    expect(loginButton().waitForExist(500)).toBeTruthy();
+    loginButton().click();
 
-    app.client.$('#login__login-button').click();
+    expect(
+      app.client.$('[data-error-name="invalid-credentials"]').waitForExist(5000)
+    ).toBeTruthy();
+  }, 6000);
+
+  test('login with correct password logs in', async () => {
+    await app.client.waitUntilWindowLoaded();
+    await enterLoginInfo(TEST_USERNAME, TEST_PASSWORD);
+    await wait(2000); // DDoS guard
+    expect(loginButton().waitForExist(500)).toBeTruthy();
+    loginButton().click();
 
     await app.client.waitUntilWindowLoaded();
-    await app.client.waitForExist('.note-list', 10000);
+    expect(app.client.$('.note-list').waitForExist(10000)).toBeTruthy();
+  }, 20000);
+
+  test('can create new note by clicking on new note button', async () => {
+    await app.client.waitUntilWindowLoaded();
+    await enterLoginInfo(TEST_USERNAME, TEST_PASSWORD);
+    await wait(2000); // DDoS guard
+    expect(loginButton().waitForExist(500)).toBeTruthy();
+    loginButton().click();
+
+    await app.client.waitUntilWindowLoaded();
+    const newNoteButton = app.client.$('button[data-title="New Note"]');
+    expect(newNoteButton.waitForExist(10000)).toBeTruthy();
+    newNoteButton.click();
+
+    expect(
+      app.client
+        .$('.public-DraftEditor-content.focus-visible')
+        .waitForExist(2000)
+    ).toBeTruthy();
   }, 20000);
 });

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -54,7 +54,7 @@ const waitForEvent = async (
       }
     };
 
-    await f();
+    f();
   });
 };
 

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -21,7 +21,7 @@ const waitForEvent = async (
 ): Promise<any[]> => {
   const tic = Date.now();
 
-  return new Promise(async (resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const f = async () => {
       const result = await app.client.execute(function() {
         var events = window.testEvents;

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -208,6 +208,10 @@ export const App = connect(
       );
 
       this.toggleShortcuts(true);
+
+      if ('test' === process.env.NODE_ENV) {
+        window.testEvents.push('booted');
+      }
     }
 
     componentWillUnmount() {
@@ -316,7 +320,7 @@ export const App = connect(
       setUnsyncedNoteIds(getUnsyncedNoteIds(noteBucket));
 
       if ('test' === process.env.NODE_ENV) {
-        window.testHasLoadedNotes = true;
+        window.testEvents.push('notesLoaded');
       }
     };
 

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -209,9 +209,7 @@ export const App = connect(
 
       this.toggleShortcuts(true);
 
-      if ('test' === process.env.NODE_ENV) {
-        window.testEvents.push('booted');
-      }
+      __TEST__ && window.testEvents.push('booted');
     }
 
     componentWillUnmount() {
@@ -319,9 +317,7 @@ export const App = connect(
       loadNotes({ noteBucket });
       setUnsyncedNoteIds(getUnsyncedNoteIds(noteBucket));
 
-      if ('test' === process.env.NODE_ENV) {
-        window.testEvents.push('notesLoaded');
-      }
+      __TEST__ && window.testEvents.push('notesLoaded');
     };
 
     onNoteRemoved = () => this.onNotesIndex();

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -314,6 +314,10 @@ export const App = connect(
 
       loadNotes({ noteBucket });
       setUnsyncedNoteIds(getUnsyncedNoteIds(noteBucket));
+
+      if ('test' === process.env.NODE_ENV) {
+        window.testHasLoadedNotes = true;
+      }
     };
 
     onNoteRemoved = () => this.onNotesIndex();

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -73,13 +73,18 @@ export class Auth extends Component {
           {this.props.hasInvalidCredentials && (
             <p
               className="login__auth-message is-error"
-              data-error-name="invalid-credentials"
+              data-error-name="invalid-login"
             >
               Could not log in with the provided email address and password.
             </p>
           )}
           {this.props.hasLoginError && (
-            <p className="login__auth-message is-error">{errorMessage}</p>
+            <p
+              className="login__auth-message is-error"
+              data-error-name="invalid-login"
+            >
+              {errorMessage}
+            </p>
           )}
           {passwordErrorMessage && (
             <p className="login__auth-message is-error">

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -71,7 +71,10 @@ export class Auth extends Component {
           <h1>{buttonLabel}</h1>
 
           {this.props.hasInvalidCredentials && (
-            <p className="login__auth-message is-error">
+            <p
+              className="login__auth-message is-error"
+              data-error-name="invalid-credentials"
+            >
               Could not log in with the provided email address and password.
             </p>
           )}

--- a/lib/boot.ts
+++ b/lib/boot.ts
@@ -1,3 +1,7 @@
+if ('test' === process.env.NODE_ENV) {
+  window.testEvents = [];
+}
+
 import './utils/ensure-platform-support';
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';

--- a/lib/boot.ts
+++ b/lib/boot.ts
@@ -1,4 +1,4 @@
-if ('test' === process.env.NODE_ENV) {
+if (__TEST__) {
   window.testEvents = [];
 }
 

--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -1,0 +1,9 @@
+declare var __TEST__: boolean;
+
+interface Window {
+  _tkq: Array;
+  testEvents: (string | [string, ...any[]])[];
+  wpcom: {
+    tracks: object;
+  };
+}

--- a/lib/icon-button/index.tsx
+++ b/lib/icon-button/index.tsx
@@ -8,7 +8,7 @@ export const IconButton = ({ icon, title, ...props }) => (
     enterDelay={200}
     title={title}
   >
-    <button className="icon-button" type="button" {...props}>
+    <button className="icon-button" type="button" data-title={title} {...props}>
       {icon}
     </button>
   </Tooltip>

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -179,9 +179,19 @@ class NoteContentEditor extends Component<Props> {
       noteId !== prevProps.noteId ||
       content.version !== prevProps.content.version
     ) {
-      this.setState({
-        editorState: this.createNewEditorState(content.text, searchQuery),
-      });
+      this.setState(
+        {
+          editorState: this.createNewEditorState(content.text, searchQuery),
+        },
+        () => {
+          if ('test' === process.env.NODE_ENV) {
+            window.testEvents.push([
+              'editorNewNote',
+              plainTextContent(this.state.editorState),
+            ]);
+          }
+        }
+      );
       return;
     }
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -183,14 +183,12 @@ class NoteContentEditor extends Component<Props> {
         {
           editorState: this.createNewEditorState(content.text, searchQuery),
         },
-        () => {
-          if ('test' === process.env.NODE_ENV) {
-            window.testEvents.push([
-              'editorNewNote',
-              plainTextContent(this.state.editorState),
-            ]);
-          }
-        }
+        () =>
+          __TEST__ &&
+          window.testEvents.push([
+            'editorNewNote',
+            plainTextContent(this.state.editorState),
+          ])
       );
       return;
     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "make dev",
     "start": "make start NODE_ENV=development",
-    "test-e2e": "npx jest --config=./jest.config.e2e.js",
+    "test-e2e": "npx jest --config=./jest.config.e2e.js --runInBand",
     "test": "make test",
     "lint": "make lint",
     "format": "make format",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,7 +85,7 @@ module.exports = () => {
         chunkFilename: isDevMode ? '[id].css' : '[id].[hash].css',
       }),
       new webpack.DefinePlugin({
-        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+        __TEST__: JSON.stringify(process.env.NODE_ENV === 'test'),
         config: JSON.stringify(config),
       }),
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,6 +85,7 @@ module.exports = () => {
         chunkFilename: isDevMode ? '[id].css' : '[id].[hash].css',
       }),
       new webpack.DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         config: JSON.stringify(config),
       }),
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),


### PR DESCRIPTION
Previously the tests were a bit flakey, working some times and not others.  In
this patch we've added the `--runInBand` option to `jest` so that the tests run
sequentially in the same process as the test runny. It may have been that
`jest` was attempting to run the tests in parallel even though the nature of
testing Electron/Spectron doesn't support this and so we would sometimes fail
based on concurrency conflicts.

A few new tests have been added in order to verify that the new updates are
working and to demonstrate how we can start adding testable behaviors into the
app. We still need to improve how the tests are organized and setup to minimize
the noise in the code and isolate the tests.

## Review: Signaling from the app to the tests

We would ideally like to avoid timeouts as a way of progressing through our
tests. Timeouts are inherently flakey because they represent race conditions
on uncontrollable factors. That means we prefer to wait for specific events
and send those events from the running app to the test runner.

In this PR I've created a system that pushes new entries to a global array in
order to signal an event.

```ts
// when we only need to indicate that an event occurred
window.testEvents.push('notesLoaded');

// when we want to send data out as well
window.testEvents.push(['noteSelected', noteId, note.content]);
```

This looks similar to our Redux actions though may occur at different times
and circumstances. These are to be used when we can't wait for the presence
of specific DOM nodes via the builtin `webdriverio` function `waitForExist()`.

Through the use of a webpack `DefinePlugin` entry we can do this with a simple
conditional which will be stripped entirely from `development` and `production`
builds, purely because it's discernible at compile-time if the condition is true.

```ts
__TEST__ && window.testEvents.push('someEvent');
```

## Testing

Since this _only_ affects the in-progress e2e tests it should have zero impact on
the resultant app code. Test by running the e2e test suite.

**It is necessary to build the app with `NODE_ENV=test` before running these tests.**
I hope to cure this at some point but it's just an inconvenience at the moment.

```bash
NODE_ENV=test npm run build
npm run test-e2e
```