### PR TITLE
Refactor: Replace search field focus state with middleware

### DIFF
--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -39,7 +39,7 @@ const buildEditMenu = settings => {
       {
         label: 'Search &Notes…',
         accelerator: 'CommandOrControl+F',
-        click: appCommandSender({ action: 'setSearchFocus' }),
+        click: appCommandSender({ action: 'focusSearchField' }),
       },
       {
         type: 'separator',

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -52,6 +52,7 @@ export type OwnProps = {
 export type DispatchProps = {
   createNote: () => any;
   closeNote: () => any;
+  focusSearchField: () => any;
   selectNote: (note: T.NoteEntity) => any;
 };
 
@@ -107,8 +108,7 @@ const mapDispatchToProps: S.MapDispatch<
     resetAuth: () => dispatch(reduxActions.auth.reset()),
     selectNote: (note: T.NoteEntity) => dispatch(actions.ui.selectNote(note)),
     setAuthorized: () => dispatch(reduxActions.auth.setAuthorized()),
-    setSearchFocus: () =>
-      dispatch(actionCreators.setSearchFocus({ searchFocus: true })),
+    focusSearchField: () => dispatch(actions.ui.focusSearchField()),
     setSimperiumConnectionStatus: connected =>
       dispatch(toggleSimperiumConnectionStatus(connected)),
     selectNote: note => dispatch(actions.ui.selectNote(note)),
@@ -252,6 +252,10 @@ export const App = connect(
 
       if ('printNote' === command.action) {
         return window.print();
+      }
+
+      if ('focusSearchField' === command.action) {
+        return this.props.focusSearchField();
       }
 
       const canRun = overEvery(

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -40,7 +40,6 @@ const initialState: AppState = {
   showNavigation: false,
   dialogs: [],
   nextDialogKey: 0,
-  searchFocus: false,
   unsyncedNoteIds: [], // note bucket only
 };
 
@@ -274,12 +273,6 @@ export const actionMap = new ActionMap({
     setRevision(state: AppState, { revision }) {
       return update(state, {
         revision: { $set: revision },
-      });
-    },
-
-    setSearchFocus(state: AppState, { searchFocus = true }) {
-      return update(state, {
-        searchFocus: { $set: searchFocus },
       });
     },
 

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -30,12 +30,14 @@ export class SearchField extends Component<ConnectedProps> {
     this.inputField.current.blur();
   };
 
-  focus = () => {
+  focus = (operation = 'focus-only') => {
     if (!this.inputField.current) {
       return;
     }
 
-    this.inputField.current.select();
+    if ('select' === operation) {
+      this.inputField.current.select();
+    }
     this.inputField.current.focus();
   };
 

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -1,12 +1,12 @@
 import React, { Component, createRef, FormEvent, KeyboardEvent } from 'react';
 import { connect } from 'react-redux';
 import SmallCrossIcon from '../icons/cross-small';
-import appState from '../flux/app-state';
 import { tracks } from '../analytics';
 import { State } from '../state';
 import { search } from '../state/ui/actions';
 
-const { setSearchFocus } = appState.actionCreators;
+import { registerSearchField } from '../state/ui/search-field-middleware';
+
 const { recordEvent } = tracks;
 const KEY_ESC = 27;
 
@@ -18,20 +18,31 @@ export class SearchField extends Component<ConnectedProps> {
 
   inputField = createRef<HTMLInputElement>();
 
-  componentDidUpdate() {
-    const { searchFocus, onSearchFocused } = this.props;
-
-    if (searchFocus && this.inputField.current) {
-      this.inputField.current.select();
-      this.inputField.current.focus();
-      onSearchFocused();
-    }
+  componentDidMount() {
+    registerSearchField(this.focus);
   }
+
+  blur = () => {
+    if (!this.inputField.current) {
+      return;
+    }
+
+    this.inputField.current.blur();
+  };
+
+  focus = () => {
+    if (!this.inputField.current) {
+      return;
+    }
+
+    this.inputField.current.select();
+    this.inputField.current.focus();
+  };
 
   interceptEsc = (event: KeyboardEvent) => {
     if (KEY_ESC === event.keyCode) {
-      if (this.props.searchQuery === '' && this.inputField.current) {
-        this.inputField.current.blur();
+      if (this.props.searchQuery === '') {
+        this.blur();
       }
       this.clearQuery();
     }
@@ -82,7 +93,6 @@ const mapStateToProps = ({
 }: State) => ({
   isTagSelected: !!state.tag,
   placeholder: listTitle,
-  searchFocus: state.searchFocus,
   searchQuery,
 });
 
@@ -91,7 +101,6 @@ const mapDispatchToProps = dispatch => ({
     dispatch(search(query));
     recordEvent('list_notes_searched');
   },
-  onSearchFocused: () => dispatch(setSearchFocus({ searchFocus: false })),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(SearchField);

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -54,6 +54,7 @@ export type SetWPToken = Action<'setWPToken', { token: string }>;
 export type CreateNote = Action<'CREATE_NOTE'>;
 export type CloseNote = Action<'CLOSE_NOTE'>;
 export type FilterNotes = Action<'FILTER_NOTES', { notes: T.NoteEntity[] }>;
+export type FocusSearchField = Action<'FOCUS_SEARCH_FIELD'>;
 export type Search = Action<'SEARCH', { searchQuery: string }>;
 export type SetAuth = Action<'AUTH_SET', { status: AuthState }>;
 export type SetUnsyncedNoteIds = Action<
@@ -76,6 +77,7 @@ export type ActionType =
   | CloseNote
   | LegacyAction
   | FilterNotes
+  | FocusSearchField
   | Search
   | SelectNote
   | SetAccountName
@@ -191,7 +193,6 @@ type LegacyAction =
   | Action<'App.selectTagAndSElectFirstNote'>
   | Action<'App.selectTrash'>
   | Action<'App.setRevision', { revision: T.NoteEntity }>
-  | Action<'App.setSearchFocus', { searchFocus: boolean }>
   | Action<'App.setShouldPrintNote', { shouldPrint: boolean }>
   | Action<'App.setUnsyncedNoteIds', { noteIds: T.EntityId[] }>
   | Action<'App.showAllNotes'>

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -20,6 +20,7 @@ import { omit } from 'lodash';
 import appState from '../flux/app-state';
 
 import uiMiddleware from './ui/middleware';
+import searchFieldMiddleware from './ui/search-field-middleware';
 
 import auth from './auth/reducer';
 import settings from './settings/reducer';
@@ -35,7 +36,6 @@ export type AppState = {
   preferences?: T.Preferences;
   previousIndex: number;
   revision: T.NoteEntity | null;
-  searchFocus: boolean;
   showNavigation: boolean;
   tags: T.TagEntity[];
   tag?: T.TagEntity;
@@ -66,7 +66,7 @@ export const store = createStore<State, A.ActionType, {}, {}>(
         [path]: omit(state[path], 'focusModeEnabled'),
       }),
     }),
-    applyMiddleware(thunk, uiMiddleware)
+    applyMiddleware(thunk, uiMiddleware, searchFieldMiddleware)
   )
 );
 

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -16,6 +16,10 @@ export const filterNotes: A.ActionCreator<A.FilterNotes> = (
   notes,
 });
 
+export const focusSearchField: A.ActionCreator<A.FocusSearchField> = () => ({
+  type: 'FOCUS_SEARCH_FIELD',
+});
+
 export const setUnsyncedNoteIds: A.ActionCreator<A.SetUnsyncedNoteIds> = (
   noteIds: T.EntityId[]
 ) => ({

--- a/lib/state/ui/search-field-middleware.ts
+++ b/lib/state/ui/search-field-middleware.ts
@@ -10,8 +10,12 @@ export const middleware: S.Middleware = () => {
     const result = next(action);
 
     switch (action.type) {
-      case 'FOCUS_SEARCH_FIELD':
+      case 'SEARCH':
         searchFields.forEach(focus => focus());
+        break;
+
+      case 'FOCUS_SEARCH_FIELD':
+        searchFields.forEach(focus => focus('select'));
         break;
     }
 

--- a/lib/state/ui/search-field-middleware.ts
+++ b/lib/state/ui/search-field-middleware.ts
@@ -1,0 +1,22 @@
+import * as A from '../action-types';
+import * as S from '../';
+
+const searchFields = new Set<Function>();
+
+export const registerSearchField = (focus: Function) => searchFields.add(focus);
+
+export const middleware: S.Middleware = () => {
+  return next => (action: A.ActionType) => {
+    const result = next(action);
+
+    switch (action.type) {
+      case 'FOCUS_SEARCH_FIELD':
+        searchFields.forEach(focus => focus());
+        break;
+    }
+
+    return result;
+  };
+};
+
+export default middleware;

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { tracks } from '../analytics';
-import { focusSearchField, search } from '../state/ui/actions';
+import { search } from '../state/ui/actions';
 import filterAtMost from '../utils/filter-at-most';
 
 import * as S from '../state';
@@ -119,7 +119,6 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
   onSearch: query => {
     dispatch(search(query));
     recordEvent('list_notes_searched');
-    dispatch(focusSearchField());
   },
 });
 

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -1,14 +1,12 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import appState from '../flux/app-state';
 import { tracks } from '../analytics';
-import { search } from '../state/ui/actions';
+import { focusSearchField, search } from '../state/ui/actions';
 import filterAtMost from '../utils/filter-at-most';
 
 import * as S from '../state';
 import * as T from '../types';
 
-const { setSearchFocus } = appState.actionCreators;
 const { recordEvent } = tracks;
 
 type StateProps = {
@@ -121,7 +119,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
   onSearch: query => {
     dispatch(search(query));
     recordEvent('list_notes_searched');
-    dispatch(setSearchFocus({ searchFocus: true }));
+    dispatch(focusSearchField());
   },
 });
 


### PR DESCRIPTION
Alternative idea to #1908

`searchFocus` isn't quite app state. We have been using it as a
workaround in order to trigger side-effects from Redux in order
to focus the search field.

In this patch we're removing that state altogether and replacing
it with a custom middleware specific to the search field. This too
is somewhat ugly because of the coupling between the middleware
and the search field component; it needs more thought on how best
to register the DOM node containing focus.

Nevertheless by removing the `state` property we are able to remove
more code and the update loop that was necessary to set focus,
update, an then record that the focus was already set or unset.

Storing a state value for focus doesn't match the reality that the
focus is a property of the DOM node and changes independently from
the Redux actions being dispatched in the app.
