### PR TITLE
Fix revisions loading on revisions panel toggle

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -42,7 +42,7 @@ class NoteContentEditor extends Component<Props> {
     content: PropTypes.shape({
       text: PropTypes.string.isRequired,
       hasRemoteUpdate: PropTypes.bool.isRequired,
-      version: PropTypes.string,
+      version: PropTypes.number,
     }),
     noteId: PropTypes.string,
     onChangeContent: PropTypes.func.isRequired,

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { connect, DispatchProp } from 'react-redux';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 
@@ -30,12 +30,16 @@ type DispatchProps = {
   toggleRevisions: () => any;
 };
 
+type OwnProps = {
+  onShowRevisions: (note: T.NoteEntity | null) => any;
+};
+
 type StateProps = {
   editMode: boolean;
   note: T.NoteEntity | null;
 };
 
-type Props = DispatchProps & StateProps;
+type Props = DispatchProps & OwnProps & StateProps;
 
 export class NoteToolbar extends Component<Props> {
   static displayName = 'NoteToolbar';
@@ -55,6 +59,11 @@ export class NoteToolbar extends Component<Props> {
     onShareNote: noop,
     onTrashNote: noop,
     toggleFocusMode: noop,
+  };
+
+  showRevisions = () => {
+    this.props.toggleRevisions();
+    this.props.onShowRevisions(this.props.note);
   };
 
   render() {
@@ -103,7 +112,7 @@ export class NoteToolbar extends Component<Props> {
           <div className="note-toolbar__button">
             <IconButton
               icon={<RevisionsIcon />}
-              onClick={this.props.toggleRevisions}
+              onClick={this.showRevisions}
               title="History"
             />
           </div>

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -49,8 +49,6 @@ export class RevisionSelector extends Component<Props, ComponentState> {
   componentWillReceiveProps({ revisions: nextRevisions }: Props) {
     const { revisions: prevRevisions } = this.props;
 
-    console.log(nextRevisions);
-
     if (nextRevisions === prevRevisions) {
       return;
     }

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -49,6 +49,8 @@ export class RevisionSelector extends Component<Props, ComponentState> {
   componentWillReceiveProps({ revisions: nextRevisions }: Props) {
     const { revisions: prevRevisions } = this.props;
 
+    console.log(nextRevisions);
+
     if (nextRevisions === prevRevisions) {
       return;
     }
@@ -175,7 +177,6 @@ export class RevisionSelector extends Component<Props, ComponentState> {
 }
 
 const mapStateToProps: S.MapState<StateProps> = ({
-  appState: state,
   ui: { note, showRevisions },
 }) => ({
   isViewingRevisions: showRevisions,


### PR DESCRIPTION
### Fix
I broke the loading of revisions with this removal: https://github.com/Automattic/simplenote-electron/pull/1903/files#diff-e98743febf9f62311da7008a480dad44L60

This adds it back.  This is a terrible way of loading revisions but it gets us back to a good state.

### Test
1. Load app
2. Open revisions panel
3. Revert note