### PR TITLE
Fix: Console error on loading Settings->Display dialog

### DIFF
--- a/lib/controls/checkbox/index.tsx
+++ b/lib/controls/checkbox/index.tsx
@@ -14,7 +14,7 @@ function CheckboxControl({ className, ...props }) {
 }
 
 CheckboxControl.propTypes = {
-  className: PropTypes.string.isRequired,
+  className: PropTypes.string,
 };
 
 export default CheckboxControl;


### PR DESCRIPTION
### Fix
This fixes the following console error which is thrown when opening Settings and the Display tab:

```Warning: Failed prop type: The prop `className` is marked as required in `CheckboxControl`, but its value is `undefined`.
    in CheckboxControl (created by SettingsGroup)
    in SettingsGroup (created by DisplayPanel)```

Fixed by making `className` an optional prop of the child component.

### Test
1. Open Settings
2. Click Display tab
3. Note lack of console errors

### Release
These changes do not require release notes.
