### PR TITLE
Move previous index store to Redux

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -395,11 +395,11 @@ export const App = connect(
 
     // gets the index of the note located before the currently selected one
     getPreviousNoteIndex = note => {
-      const noteIndex = this.props.ui.filteredNotes.findIndex(
+      const previousIndex = this.props.ui.filteredNotes.findIndex(
         ({ id }) => note.id === id
       );
 
-      return Math.max(noteIndex - 1, 0);
+      return Math.max(previousIndex - 1, 0);
     };
 
     syncActivityHooks = data => {

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -34,7 +34,6 @@ const toggleSystemTag = (
 };
 
 const initialState: AppState = {
-  previousIndex: -1,
   notes: null,
   tags: [],
   dialogs: [],
@@ -70,14 +69,12 @@ export const actionMap = new ActionMap({
     showAllNotes(state: AppState) {
       return update(state, {
         tag: { $set: null },
-        previousIndex: { $set: -1 },
       });
     },
 
     selectTrash(state: AppState) {
       return update(state, {
         tag: { $set: null },
-        previousIndex: { $set: -1 },
       });
     },
 
@@ -97,7 +94,6 @@ export const actionMap = new ActionMap({
     selectTag(state: AppState, { tag }: { tag: T.TagEntity }) {
       return update(state, {
         tag: { $set: tag },
-        previousIndex: { $set: -1 },
       });
     },
 
@@ -316,11 +312,9 @@ export const actionMap = new ActionMap({
       creator({
         noteBucket,
         note,
-        previousIndex,
       }: {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
-        previousIndex: number;
       }) {
         return () => {
           if (note) {
@@ -335,11 +329,9 @@ export const actionMap = new ActionMap({
       creator({
         noteBucket,
         note,
-        previousIndex,
       }: {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
-        previousIndex: number;
       }) {
         return dispatch => {
           if (note) {
@@ -354,11 +346,9 @@ export const actionMap = new ActionMap({
       creator({
         noteBucket,
         note,
-        previousIndex,
       }: {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
-        previousIndex: number;
       }) {
         return dispatch => {
           noteBucket.remove(note.id);

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -312,14 +312,16 @@ export const actionMap = new ActionMap({
       creator({
         noteBucket,
         note,
+        previousIndex,
       }: {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
       }) {
-        return () => {
+        return dispatch => {
           if (note) {
             note.data.deleted = true;
             noteBucket.update(note.id, note.data);
+            dispatch(actions.ui.trashNote(previousIndex));
           }
         };
       },
@@ -329,6 +331,7 @@ export const actionMap = new ActionMap({
       creator({
         noteBucket,
         note,
+        previousIndex,
       }: {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
@@ -337,6 +340,7 @@ export const actionMap = new ActionMap({
           if (note) {
             note.data.deleted = false;
             noteBucket.update(note.id, note.data);
+            dispatch(actions.ui.restoreNote(previousIndex));
           }
         };
       },
@@ -346,6 +350,7 @@ export const actionMap = new ActionMap({
       creator({
         noteBucket,
         note,
+        previousIndex,
       }: {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
@@ -353,6 +358,7 @@ export const actionMap = new ActionMap({
         return dispatch => {
           noteBucket.remove(note.id);
           dispatch(this.action('loadNotes', { noteBucket }));
+          dispatch(actions.ui.deleteNoteForever(previousIndex));
         };
       },
     },

--- a/lib/note-toolbar-container.ts
+++ b/lib/note-toolbar-container.ts
@@ -25,16 +25,13 @@ type NoteChanger = {
   note: T.NoteEntity;
 };
 
-type ListChanger = NoteChanger & { previousIndex: number };
-
 type DispatchProps = {
-  closeNote: () => any;
-  deleteNoteForever: (args: ListChanger) => any;
-  restoreNote: (args: ListChanger) => any;
-  toggleRevisions: () => any;
+  closeNote: (noteIndex: number) => any;
+  deleteNoteForever: (args: NoteChanger) => any;
+  restoreNote: (args: NoteChanger) => any;
   shareNote: () => any;
   toggleFocusMode: () => any;
-  trashNote: (args: ListChanger) => any;
+  trashNote: (args: NoteChanger) => any;
 };
 
 type Props = OwnProps & StateProps & DispatchProps;
@@ -50,21 +47,23 @@ export class NoteToolbarContainer extends Component<Props> {
   onTrashNote = (note: T.NoteEntity) => {
     const { noteBucket } = this.props;
     const previousIndex = this.getPreviousNoteIndex(note);
-    this.props.closeNote();
-    this.props.trashNote({ noteBucket, note, previousIndex });
+    this.props.closeNote(previousIndex);
+    this.props.trashNote({ noteBucket, note });
     analytics.tracks.recordEvent('editor_note_deleted');
   };
 
   onDeleteNoteForever = (note: T.NoteEntity) => {
     const { noteBucket } = this.props;
     const previousIndex = this.getPreviousNoteIndex(note);
-    this.props.deleteNoteForever({ noteBucket, note, previousIndex });
+    this.props.closeNote(previousIndex);
+    this.props.deleteNoteForever({ noteBucket, note });
   };
 
   onRestoreNote = (note: T.NoteEntity) => {
     const { noteBucket } = this.props;
     const previousIndex = this.getPreviousNoteIndex(note);
-    this.props.restoreNote({ noteBucket, note, previousIndex });
+    this.props.closeNote(previousIndex);
+    this.props.restoreNote({ noteBucket, note });
     analytics.tracks.recordEvent('editor_note_restored');
   };
 
@@ -107,7 +106,7 @@ const {
 } = appState.actionCreators;
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
-  closeNote: () => dispatch(closeNote()),
+  closeNote: (noteIndex: number) => dispatch(closeNote(noteIndex)),
   deleteNoteForever: args => dispatch(deleteNoteForever(args)),
   restoreNote: args => dispatch(restoreNote(args)),
   shareNote: () => dispatch(showDialog({ dialog: DialogTypes.SHARE })),

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -52,7 +52,7 @@ export type SetWPToken = Action<'setWPToken', { token: string }>;
  * Normal action types
  */
 export type CreateNote = Action<'CREATE_NOTE'>;
-export type CloseNote = Action<'CLOSE_NOTE', { noteIndex: number }>;
+export type CloseNote = Action<'CLOSE_NOTE', { noteIndex: number | null }>;
 export type FilterNotes = Action<
   'FILTER_NOTES',
   { notes: T.NoteEntity[]; noteIndex: number }

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -52,8 +52,11 @@ export type SetWPToken = Action<'setWPToken', { token: string }>;
  * Normal action types
  */
 export type CreateNote = Action<'CREATE_NOTE'>;
-export type CloseNote = Action<'CLOSE_NOTE'>;
-export type FilterNotes = Action<'FILTER_NOTES', { notes: T.NoteEntity[] }>;
+export type CloseNote = Action<'CLOSE_NOTE', { noteIndex: number }>;
+export type FilterNotes = Action<
+  'FILTER_NOTES',
+  { notes: T.NoteEntity[]; noteIndex: number }
+>;
 export type FocusSearchField = Action<'FOCUS_SEARCH_FIELD'>;
 export type Search = Action<'SEARCH', { searchQuery: string }>;
 export type SelectRevision = Action<
@@ -126,7 +129,6 @@ type LegacyAction =
       {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
-        previousIndex: number;
       }
     >
   | Action<
@@ -167,7 +169,6 @@ type LegacyAction =
       {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
-        previousIndex: number;
       }
     >
   | Action<
@@ -187,7 +188,6 @@ type LegacyAction =
       {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
-        previousIndex: number;
       }
     >
   | Action<'App.authChanged'>

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -52,10 +52,14 @@ export type SetWPToken = Action<'setWPToken', { token: string }>;
  * Normal action types
  */
 export type CreateNote = Action<'CREATE_NOTE'>;
-export type CloseNote = Action<'CLOSE_NOTE', { noteIndex: number | null }>;
+export type CloseNote = Action<'CLOSE_NOTE'>;
+export type DeleteNoteForever = Action<
+  'DELETE_NOTE_FOREVER',
+  { previousIndex: number }
+>;
 export type FilterNotes = Action<
   'FILTER_NOTES',
-  { notes: T.NoteEntity[]; noteIndex: number }
+  { notes: T.NoteEntity[]; previousIndex: number }
 >;
 export type FocusSearchField = Action<'FOCUS_SEARCH_FIELD'>;
 export type Search = Action<'SEARCH', { searchQuery: string }>;
@@ -63,6 +67,7 @@ export type SelectRevision = Action<
   'SELECT_REVISION',
   { revision: T.NoteEntity }
 >;
+export type RestoreNote = Action<'RESTORE_NOTE', { previousIndex: number }>;
 export type SetAuth = Action<'AUTH_SET', { status: AuthState }>;
 export type SetUnsyncedNoteIds = Action<
   'SET_UNSYNCED_NOTE_IDS',
@@ -82,6 +87,7 @@ export type ToggleEditMode = Action<'TOGGLE_EDIT_MODE'>;
 export type ToggleRevisions = Action<'REVISIONS_TOGGLE'>;
 export type ToggleTagDrawer = Action<'TAG_DRAWER_TOGGLE', { show: boolean }>;
 export type ToggleTagEditing = Action<'TAG_EDITING_TOGGLE'>;
+export type TrashNote = Action<'TRASH_NOTE', { previousIndex: number }>;
 export type SelectNote = Action<
   'SELECT_NOTE',
   { note: T.NoteEntity; options?: { hasRemoteUpdate: boolean } }
@@ -90,9 +96,11 @@ export type SelectNote = Action<
 export type ActionType =
   | CreateNote
   | CloseNote
+  | DeleteNoteForever
   | LegacyAction
   | FilterNotes
   | FocusSearchField
+  | RestoreNote
   | Search
   | SelectNote
   | SelectRevision
@@ -118,7 +126,8 @@ export type ActionType =
   | ToggleRevisions
   | ToggleSimperiumConnectionStatus
   | ToggleTagDrawer
-  | ToggleTagEditing;
+  | ToggleTagEditing
+  | TrashNote;
 
 export type ActionCreator<A extends ActionType> = (...args: any[]) => A;
 export type Reducer<S> = (state: S | undefined, action: ActionType) => S;
@@ -129,6 +138,7 @@ type LegacyAction =
       {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
+        previousIndex: number;
       }
     >
   | Action<
@@ -169,6 +179,7 @@ type LegacyAction =
       {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
+        previousIndex: number;
       }
     >
   | Action<
@@ -188,6 +199,7 @@ type LegacyAction =
       {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
+        previousIndex: number;
       }
     >
   | Action<'App.authChanged'>

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -36,7 +36,6 @@ export type AppState = {
   nextDialogKey: number;
   notes: T.NoteEntity[] | null;
   preferences?: T.Preferences;
-  previousIndex: number;
   revision: T.NoteEntity | null;
   showNavigation: boolean;
   tags: T.TagEntity[];

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -5,7 +5,9 @@ export const createNote: A.ActionCreator<A.CreateNote> = () => ({
   type: 'CREATE_NOTE',
 });
 
-export const closeNote: A.ActionCreator<A.CloseNote> = (noteIndex: number) => ({
+export const closeNote: A.ActionCreator<A.CloseNote> = (
+  noteIndex: number | null
+) => ({
   type: 'CLOSE_NOTE',
   noteIndex,
 });

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -5,15 +5,18 @@ export const createNote: A.ActionCreator<A.CreateNote> = () => ({
   type: 'CREATE_NOTE',
 });
 
-export const closeNote: A.ActionCreator<A.CloseNote> = () => ({
+export const closeNote: A.ActionCreator<A.CloseNote> = (noteIndex: number) => ({
   type: 'CLOSE_NOTE',
+  noteIndex,
 });
 
 export const filterNotes: A.ActionCreator<A.FilterNotes> = (
-  notes: T.NoteEntity[]
+  notes: T.NoteEntity[],
+  noteIndex: number
 ) => ({
   type: 'FILTER_NOTES',
   notes,
+  noteIndex,
 });
 
 export const focusSearchField: A.ActionCreator<A.FocusSearchField> = () => ({

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -5,24 +5,35 @@ export const createNote: A.ActionCreator<A.CreateNote> = () => ({
   type: 'CREATE_NOTE',
 });
 
-export const closeNote: A.ActionCreator<A.CloseNote> = (
-  noteIndex: number | null
-) => ({
+export const closeNote: A.ActionCreator<A.CloseNote> = () => ({
   type: 'CLOSE_NOTE',
-  noteIndex,
+});
+
+export const deleteNoteForever: A.ActionCreator<A.DeleteNoteForever> = (
+  previousIndex: number
+) => ({
+  type: 'DELETE_NOTE_FOREVER',
+  previousIndex,
 });
 
 export const filterNotes: A.ActionCreator<A.FilterNotes> = (
   notes: T.NoteEntity[],
-  noteIndex: number
+  previousIndex: number
 ) => ({
   type: 'FILTER_NOTES',
   notes,
-  noteIndex,
+  previousIndex,
 });
 
 export const focusSearchField: A.ActionCreator<A.FocusSearchField> = () => ({
   type: 'FOCUS_SEARCH_FIELD',
+});
+
+export const restoreNote: A.ActionCreator<A.RestoreNote> = (
+  previousIndex: number
+) => ({
+  type: 'RESTORE_NOTE',
+  previousIndex,
 });
 
 export const selectRevision: A.ActionCreator<A.SelectRevision> = (
@@ -89,4 +100,11 @@ export const toggleTagDrawer: A.ActionCreator<A.ToggleTagDrawer> = (
 
 export const toggleTagEditing: A.ActionCreator<A.ToggleTagEditing> = () => ({
   type: 'TAG_EDITING_TOGGLE',
+});
+
+export const trashNote: A.ActionCreator<A.TrashNote> = (
+  previousIndex: number
+) => ({
+  type: 'TRASH_NOTE',
+  previousIndex,
 });

--- a/lib/state/ui/middleware.ts
+++ b/lib/state/ui/middleware.ts
@@ -8,7 +8,9 @@ let searchTimeout: NodeJS.Timeout;
 
 export const middleware: S.Middleware = store => {
   const updateNotes = () =>
-    store.dispatch(filterAction(filterNotes(store.getState())));
+    store.dispatch(
+      filterAction(filterNotes(store.getState()), store.getState().ui.noteIndex)
+    );
 
   return next => (action: A.ActionType) => {
     const result = next(action);

--- a/lib/state/ui/middleware.ts
+++ b/lib/state/ui/middleware.ts
@@ -19,9 +19,16 @@ export const middleware: S.Middleware = store => {
     const result = next(action);
 
     switch (action.type) {
-      // on clicks re-filter "immediately"
-      case 'App.authChanged':
+      // on clicks re-filter immediately
       case 'App.deleteNoteForever':
+      case 'RESTORE_NOTE':
+      case 'TRASH_NOTE':
+        clearTimeout(searchTimeout);
+        updateNotes();
+        break;
+
+      // on events re-filter "immediately"
+      case 'App.authChanged':
       case 'App.notesLoaded':
       case 'App.restoreNote':
       case 'App.selectTag':

--- a/lib/state/ui/middleware.ts
+++ b/lib/state/ui/middleware.ts
@@ -9,7 +9,10 @@ let searchTimeout: NodeJS.Timeout;
 export const middleware: S.Middleware = store => {
   const updateNotes = () =>
     store.dispatch(
-      filterAction(filterNotes(store.getState()), store.getState().ui.noteIndex)
+      filterAction(
+        filterNotes(store.getState()),
+        store.getState().ui.previousIndex
+      )
     );
 
   return next => (action: A.ActionType) => {

--- a/lib/state/ui/middleware.ts
+++ b/lib/state/ui/middleware.ts
@@ -20,7 +20,7 @@ export const middleware: S.Middleware = store => {
 
     switch (action.type) {
       // on clicks re-filter immediately
-      case 'App.deleteNoteForever':
+      case 'DELETE_NOTE_FOREVER':
       case 'RESTORE_NOTE':
       case 'TRASH_NOTE':
         clearTimeout(searchTimeout);
@@ -30,7 +30,6 @@ export const middleware: S.Middleware = store => {
       // on events re-filter "immediately"
       case 'App.authChanged':
       case 'App.notesLoaded':
-      case 'App.restoreNote':
       case 'App.selectTag':
       case 'App.selectTrash':
       case 'App.showAllNotes':

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -84,6 +84,21 @@ const selectedRevision: A.Reducer<T.NoteEntity | null> = (
   }
 };
 
+const noteIndex: A.Reducer<number> = (state = -1, action) => {
+  console.log(action.type);
+  console.log(action);
+  switch (action.type) {
+    case 'CLOSE_NOTE':
+      return action.noteIndex;
+    case 'App.selectTag':
+    case 'App.selectTrash':
+    case 'App.showAllNotes':
+      return -1;
+    default:
+      return state;
+  }
+};
+
 const showNoteList: A.Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'CLOSE_NOTE':
@@ -188,7 +203,7 @@ const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
       // keep note if still in new filtered list otherwise try to choose first note in list
       return state && action.notes.some(({ id }) => id === state.id)
         ? state
-        : action.notes[0] || null;
+        : action.notes[Math.max(action.noteIndex, 0)] || null;
     default:
       return state;
   }
@@ -201,6 +216,7 @@ export default combineReducers({
   listTitle,
   note,
   noteRevisions,
+  noteIndex,
   searchQuery,
   selectedRevision,
   showNavigation,

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -85,8 +85,6 @@ const selectedRevision: A.Reducer<T.NoteEntity | null> = (
 };
 
 const noteIndex: A.Reducer<number> = (state = -1, action) => {
-  console.log(action.type);
-  console.log(action);
   switch (action.type) {
     case 'CLOSE_NOTE':
       return action.noteIndex || state;

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -186,7 +186,7 @@ const showTrash: A.Reducer<boolean> = (state = false, action) => {
 const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
   switch (action.type) {
     case 'CLOSE_NOTE':
-    case 'App.trashNote':
+    case 'TRASH_NOTE':
     case 'App.emptyTrash':
     case 'App.showAllNotes':
     case 'App.selectTrash':

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -84,10 +84,12 @@ const selectedRevision: A.Reducer<T.NoteEntity | null> = (
   }
 };
 
-const noteIndex: A.Reducer<number> = (state = -1, action) => {
+const previousIndex: A.Reducer<number> = (state = -1, action) => {
   switch (action.type) {
-    case 'CLOSE_NOTE':
-      return action.noteIndex || state;
+    case 'DELETE_NOTE_FOREVER':
+    case 'RESTORE_NOTE':
+    case 'TRASH_NOTE':
+      return action.previousIndex || state;
     case 'App.selectTag':
     case 'App.selectTrash':
     case 'App.showAllNotes':
@@ -201,7 +203,7 @@ const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
       // keep note if still in new filtered list otherwise try to choose first note in list
       return state && action.notes.some(({ id }) => id === state.id)
         ? state
-        : action.notes[Math.max(action.noteIndex, 0)] || null;
+        : action.notes[Math.max(action.previousIndex, 0)] || null;
     default:
       return state;
   }
@@ -214,7 +216,7 @@ export default combineReducers({
   listTitle,
   note,
   noteRevisions,
-  noteIndex,
+  previousIndex,
   searchQuery,
   selectedRevision,
   showNavigation,

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -89,7 +89,7 @@ const noteIndex: A.Reducer<number> = (state = -1, action) => {
   console.log(action);
   switch (action.type) {
     case 'CLOSE_NOTE':
-      return action.noteIndex;
+      return action.noteIndex || state;
     case 'App.selectTag':
     case 'App.selectTrash':
     case 'App.showAllNotes':

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -185,12 +185,14 @@ const showTrash: A.Reducer<boolean> = (state = false, action) => {
 
 const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
   switch (action.type) {
-    case 'CLOSE_NOTE':
-    case 'TRASH_NOTE':
+    case 'App.deleteNoteForever':
     case 'App.emptyTrash':
-    case 'App.showAllNotes':
-    case 'App.selectTrash':
     case 'App.selectTag':
+    case 'App.selectTrash':
+    case 'App.showAllNotes':
+    case 'CLOSE_NOTE':
+    case 'RESTORE_NOTE':
+    case 'TRASH_NOTE':
       return null;
     case 'SELECT_NOTE':
       return action.options

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -185,12 +185,12 @@ const showTrash: A.Reducer<boolean> = (state = false, action) => {
 
 const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
   switch (action.type) {
-    case 'App.deleteNoteForever':
     case 'App.emptyTrash':
     case 'App.selectTag':
     case 'App.selectTrash':
     case 'App.showAllNotes':
     case 'CLOSE_NOTE':
+    case 'DELETE_NOTE_FOREVER':
     case 'RESTORE_NOTE':
     case 'TRASH_NOTE':
       return null;


### PR DESCRIPTION
### Fix

Moves the previousIndex state from app state to redux. This implementation is mimicking what we were doing in app state and should not be considered a final implementation of how this should be done.  One app state is migrated we can take a better look at how to implement this properly.

Also a fix for:

Selects note above recently-trashed note ⭕️ selects top note in list 5
Selects note above recently-restored note in trash view ⭕️ selects top note in list 5
Selects note above recently-deleted-forever note in trash view ⭕️ selects top note in list 5

In #1851 we inadvertently broke this behavior and then in #1895 removed the mechanism that had previously enabled it.

Taken from: https://github.com/Automattic/simplenote-electron/issues/1911 Thanks @dmsnell 

### Test
1. Test that selects note above recently-trashed note
2. Test that selects note above recently-restored note in trash view
3. Tets that selects note above recently-deleted-forever note in trash view