### PR TITLE
Refactor: Move revision-fetching into new Simperium middleware

### DIFF
--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -9,7 +9,7 @@ import SearchBar from '../search-bar';
 import SimplenoteCompactLogo from '../icons/simplenote-compact';
 import TransitionDelayEnter from '../components/transition-delay-enter';
 
-import * as S from './state';
+import * as S from '../state';
 import * as T from '../types';
 
 const NoteList = React.lazy(() =>
@@ -27,7 +27,6 @@ type OwnProps = {
   isSmallScreen: boolean;
   note: T.NoteEntity;
   noteBucket: T.Bucket<T.Note>;
-  revisions: T.NoteEntity[];
   onUpdateContent: Function;
   syncNote: Function;
 };
@@ -45,7 +44,6 @@ export const AppLayout: FunctionComponent<Props> = ({
   isNoteOpen,
   isSmallScreen,
   noteBucket,
-  revisions,
   onUpdateContent,
   syncNote,
 }) => {
@@ -72,10 +70,7 @@ export const AppLayout: FunctionComponent<Props> = ({
           <NoteList noteBucket={noteBucket} isSmallScreen={isSmallScreen} />
         </div>
         <div className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border">
-          <RevisionSelector
-            revisions={revisions || []}
-            onUpdateContent={onUpdateContent}
-          />
+          <RevisionSelector onUpdateContent={onUpdateContent} />
           <NoteToolbarContainer
             noteBucket={noteBucket}
             toolbar={<NoteToolbar />}

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -473,7 +473,6 @@ export const App = connect(
                 isNoteInfoOpen={showNoteInfo}
                 isSmallScreen={isSmallScreen}
                 noteBucket={noteBucket}
-                revisions={state.revisions}
                 onUpdateContent={this.onUpdateContent}
                 syncNote={this.syncNote}
               />

--- a/lib/boot.ts
+++ b/lib/boot.ts
@@ -10,6 +10,7 @@ import Debug from 'debug';
 import { initClient } from './client';
 import getConfig from '../get-config';
 import store from './state';
+import * as simperiumMiddleware from './state/simperium/middleware';
 import {
   reset as resetAuth,
   setAuthorized,
@@ -231,6 +232,9 @@ if (cookie.email && config.is_app_engine) {
 }
 
 Modal.setAppElement('#root');
+simperiumMiddleware.storeBuckets({
+  note: client.bucket('note'),
+});
 
 render(
   React.createElement(Provider, { store }, React.createElement(App, props)),

--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -239,7 +239,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
   settings,
 }) => ({
   dialogs: state.dialogs,
-  note: state.revision || ui.note,
+  note: ui.selectedRevision || ui.note,
   showNoteInfo: ui.showNoteInfo,
   spellCheckEnabled: settings.spellCheckEnabled,
 });

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -168,14 +168,14 @@ export class NoteEditor extends Component<Props> {
 const mapStateToProps: S.MapState<StateProps> = ({
   appState: state,
   settings,
-  ui: { note, editMode },
+  ui: { note, editMode, selectedRevision },
 }) => ({
   allTags: state.tags,
   fontSize: settings.fontSize,
   editMode,
   isEditorActive: !state.showNavigation,
   note,
-  revision: state.revision,
+  revision: selectedRevision,
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({

--- a/lib/note-toolbar-container.ts
+++ b/lib/note-toolbar-container.ts
@@ -18,7 +18,6 @@ type OwnProps = {
 type StateProps = {
   isViewingRevisions: boolean;
   notes: T.NoteEntity[];
-  revisionOrNote: T.NoteEntity | null;
 };
 
 type NoteChanger = {
@@ -31,7 +30,6 @@ type ListChanger = NoteChanger & { previousIndex: number };
 type DispatchProps = {
   closeNote: () => any;
   deleteNoteForever: (args: ListChanger) => any;
-  noteRevisions: (args: NoteChanger) => any;
   restoreNote: (args: ListChanger) => any;
   toggleRevisions: () => any;
   shareNote: () => any;
@@ -70,24 +68,17 @@ export class NoteToolbarContainer extends Component<Props> {
     analytics.tracks.recordEvent('editor_note_restored');
   };
 
-  onShowRevisions = (note: T.NoteEntity) => {
-    const { noteBucket } = this.props;
-    this.props.noteRevisions({ noteBucket, note });
-    analytics.tracks.recordEvent('editor_versions_accessed');
-  };
-
   onShareNote = () => {
     this.props.shareNote();
     analytics.tracks.recordEvent('editor_share_dialog_viewed');
   };
 
   render() {
-    const { isViewingRevisions, toolbar, revisionOrNote } = this.props;
+    const { isViewingRevisions, toolbar } = this.props;
 
     const handlers = {
       onDeleteNoteForever: this.onDeleteNoteForever,
       onRestoreNote: this.onRestoreNote,
-      onShowRevisions: this.onShowRevisions,
       onShareNote: this.onShareNote,
       onTrashNote: this.onTrashNote,
       toggleFocusMode: this.props.toggleFocusMode,
@@ -97,26 +88,19 @@ export class NoteToolbarContainer extends Component<Props> {
       return null;
     }
 
-    const markdownEnabled = revisionOrNote
-      ? revisionOrNote.data.systemTags.includes('markdown')
-      : false;
-
-    return cloneElement(toolbar, { ...handlers, markdownEnabled });
+    return cloneElement(toolbar, { ...handlers });
   }
 }
 
 const mapStateToProps: S.MapState<StateProps> = ({
-  appState,
-  ui: { filteredNotes, note, showRevisions },
+  ui: { filteredNotes, showRevisions },
 }) => ({
   isViewingRevisions: showRevisions,
   notes: filteredNotes,
-  revisionOrNote: appState.revision || note,
 });
 
 const {
   deleteNoteForever,
-  noteRevisions,
   restoreNote,
   showDialog,
   trashNote,
@@ -125,7 +109,6 @@ const {
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
   closeNote: () => dispatch(closeNote()),
   deleteNoteForever: args => dispatch(deleteNoteForever(args)),
-  noteRevisions: args => dispatch(noteRevisions(args)),
   restoreNote: args => dispatch(restoreNote(args)),
   shareNote: () => dispatch(showDialog({ dialog: DialogTypes.SHARE })),
   toggleFocusMode: () => dispatch(toggleFocusMode()),

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -30,16 +30,13 @@ type DispatchProps = {
   toggleRevisions: () => any;
 };
 
-type OwnProps = {
-  onShowRevisions: (note: T.NoteEntity | null) => any;
-};
-
 type StateProps = {
   editMode: boolean;
+  markdownEnabled: boolean;
   note: T.NoteEntity | null;
 };
 
-type Props = DispatchProps & OwnProps & StateProps;
+type Props = DispatchProps & StateProps;
 
 export class NoteToolbar extends Component<Props> {
   static displayName = 'NoteToolbar';
@@ -50,7 +47,6 @@ export class NoteToolbar extends Component<Props> {
     onDeleteNoteForever: PropTypes.func,
     onShareNote: PropTypes.func,
     toggleFocusMode: PropTypes.func.isRequired,
-    markdownEnabled: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -59,11 +55,6 @@ export class NoteToolbar extends Component<Props> {
     onShareNote: noop,
     onTrashNote: noop,
     toggleFocusMode: noop,
-  };
-
-  showRevisions = () => {
-    this.props.toggleRevisions();
-    this.props.onShowRevisions(this.props.note);
   };
 
   render() {
@@ -112,7 +103,7 @@ export class NoteToolbar extends Component<Props> {
           <div className="note-toolbar__button">
             <IconButton
               icon={<RevisionsIcon />}
-              onClick={this.showRevisions}
+              onClick={this.props.toggleRevisions}
               title="History"
             />
           </div>
@@ -180,11 +171,18 @@ export class NoteToolbar extends Component<Props> {
 }
 
 const mapStateToProps: S.MapState<StateProps> = ({
-  ui: { note, editMode },
-}) => ({
-  editMode,
-  note,
-});
+  ui: { note, editMode, selectedRevision },
+}) => {
+  const revisionOrNote = selectedRevision || note;
+
+  return {
+    editMode,
+    markdownEnabled: revisionOrNote
+      ? revisionOrNote.data.systemTags.includes('markdown')
+      : false,
+    note,
+  };
+};
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   closeNote,

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -5,9 +5,8 @@ import format from 'date-fns/format';
 import { orderBy } from 'lodash';
 import classNames from 'classnames';
 import Slider from '../components/slider';
-import appState from '../flux/app-state';
 import { updateNoteTags } from '../state/domain/notes';
-import { toggleRevisions } from '../state/ui/actions';
+import { selectRevision, toggleRevisions } from '../state/ui/actions';
 
 import * as S from '../state';
 import * as T from '../types';
@@ -16,9 +15,7 @@ const sortedRevisions = (revisions: T.NoteEntity[]) =>
   orderBy(revisions, 'version', 'asc');
 
 type OwnProps = {
-  revisions: T.NoteEntity[];
   onUpdateContent: Function;
-  setRevision: Function;
   resetIsViewingRevisions: Function;
   cancelRevision: Function;
   updateNoteTags: Function;
@@ -27,6 +24,17 @@ type OwnProps = {
 type StateProps = {
   isViewingRevisions: boolean;
   note: T.NoteEntity | null;
+  revisions: T.NoteEntity[];
+};
+
+type DispatchProps = {
+  setRevision: (revision: T.NoteEntity | null) => any;
+  resetIsViewingRevisions: () => any;
+  cancelRevision: () => any;
+  updateNoteTags: (arg: {
+    note: T.NoteEntity | null;
+    tags: T.TagName[];
+  }) => any;
 };
 
 type ComponentState = {
@@ -34,7 +42,7 @@ type ComponentState = {
   selection: number;
 };
 
-type Props = OwnProps & StateProps;
+type Props = OwnProps & StateProps & DispatchProps;
 
 export class RevisionSelector extends Component<Props, ComponentState> {
   constructor(props: Props, ...args: unknown[]) {
@@ -108,7 +116,7 @@ export class RevisionSelector extends Component<Props, ComponentState> {
     const revision = revisions[selection];
 
     this.setState({ selection });
-    this.props.setRevision(revision);
+    this.props.setRevision(revision || null);
   };
 
   onCancelRevision = () => {
@@ -175,23 +183,17 @@ export class RevisionSelector extends Component<Props, ComponentState> {
 }
 
 const mapStateToProps: S.MapState<StateProps> = ({
-  ui: { note, showRevisions },
+  ui: { note, noteRevisions, showRevisions },
 }) => ({
   isViewingRevisions: showRevisions,
   note: note,
+  revisions: noteRevisions,
 });
 
-const { setRevision } = appState.actionCreators;
-
-const mapDispatchToProps = dispatch => ({
-  setRevision: revision => dispatch(setRevision({ revision })),
-  resetIsViewingRevisions: () => {
-    dispatch(toggleRevisions());
-  },
-  cancelRevision: () => {
-    dispatch(setRevision({ revision: null }));
-    dispatch(toggleRevisions());
-  },
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
+  setRevision: (revision: T.NoteEntity) => dispatch(selectRevision(revision)),
+  resetIsViewingRevisions: () => dispatch(toggleRevisions()),
+  cancelRevision: () => dispatch(toggleRevisions()),
   updateNoteTags: arg => dispatch(updateNoteTags(arg)),
 });
 

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -56,12 +56,19 @@ export type CloseNote = Action<'CLOSE_NOTE'>;
 export type FilterNotes = Action<'FILTER_NOTES', { notes: T.NoteEntity[] }>;
 export type FocusSearchField = Action<'FOCUS_SEARCH_FIELD'>;
 export type Search = Action<'SEARCH', { searchQuery: string }>;
+export type SelectRevision = Action<
+  'SELECT_REVISION',
+  { revision: T.NoteEntity }
+>;
 export type SetAuth = Action<'AUTH_SET', { status: AuthState }>;
 export type SetUnsyncedNoteIds = Action<
   'SET_UNSYNCED_NOTE_IDS',
   { noteIds: T.EntityId[] }
 >;
-
+export type StoreRevisions = Action<
+  'STORE_REVISIONS',
+  { noteId: T.EntityId; revisions: T.NoteEntity[] }
+>;
 export type ToggleNavigation = Action<'NAVIGATION_TOGGLE'>;
 export type ToggleNoteInfo = Action<'NOTE_INFO_TOGGLE'>;
 export type ToggleSimperiumConnectionStatus = Action<
@@ -72,7 +79,10 @@ export type ToggleEditMode = Action<'TOGGLE_EDIT_MODE'>;
 export type ToggleRevisions = Action<'REVISIONS_TOGGLE'>;
 export type ToggleTagDrawer = Action<'TAG_DRAWER_TOGGLE', { show: boolean }>;
 export type ToggleTagEditing = Action<'TAG_EDITING_TOGGLE'>;
-export type SelectNote = Action<'SELECT_NOTE', { note: T.NoteEntity }>;
+export type SelectNote = Action<
+  'SELECT_NOTE',
+  { note: T.NoteEntity; options?: { hasRemoteUpdate: boolean } }
+>;
 
 export type ActionType =
   | CreateNote
@@ -82,6 +92,7 @@ export type ActionType =
   | FocusSearchField
   | Search
   | SelectNote
+  | SelectRevision
   | SetAccountName
   | SetAuth
   | SetAutoHideMenuBar
@@ -97,6 +108,7 @@ export type ActionType =
   | SetTheme
   | SetUnsyncedNoteIds
   | SetWPToken
+  | StoreRevisions
   | ToggleEditMode
   | ToggleNavigation
   | ToggleNoteInfo
@@ -132,10 +144,6 @@ type LegacyAction =
   | Action<
       'App.markdownNote',
       { noteBucket: T.Bucket<T.Note>; note: T.NoteEntity; markdown: boolean }
-    >
-  | Action<
-      'App.noteRevisions',
-      { noteBucket: T.Bucket<T.Note>; note: T.NoteEntity }
     >
   | Action<
       'App.noteUpdatedRemotely',
@@ -187,15 +195,12 @@ type LegacyAction =
   | Action<'App.emptyTrash', { noteBucket: T.Bucket<T.Note> }>
   | Action<'App.loadNotes', { noteBucket: T.Bucket<T.Note> }>
   | Action<'App.newNote', { noteBucket: T.Bucket<T.Note>; content: string }>
-  | Action<'App.noteRevisionsLoaded', { reivisions: T.NoteEntity[] }>
   | Action<'App.notesLoaded', { notes: T.NoteEntity[] }>
   | Action<'App.onNoteBeforeRemoteUpdate', { noteId: T.EntityId }>
   | Action<'App.preferencesLoaded', { analyticsEnabled: boolean }>
-  | Action<'App.selectNote', { note: T.NoteEntity; hasRemoteUpdate: boolean }>
   | Action<'App.selectTag', { tag: T.TagEntity }>
   | Action<'App.selectTagAndSElectFirstNote'>
   | Action<'App.selectTrash'>
-  | Action<'App.setRevision', { revision: T.NoteEntity }>
   | Action<'App.setShouldPrintNote', { shouldPrint: boolean }>
   | Action<'App.setUnsyncedNoteIds', { noteIds: T.EntityId[] }>
   | Action<'App.showAllNotes'>

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -7,6 +7,7 @@
 import {
   Dispatch as ReduxDispatch,
   Middleware as ReduxMiddleware,
+  MiddlewareAPI,
   Store as ReduxStore,
   compose,
   createStore,
@@ -21,6 +22,7 @@ import appState from '../flux/app-state';
 
 import uiMiddleware from './ui/middleware';
 import searchFieldMiddleware from './ui/search-field-middleware';
+import simperiumMiddleware from './simperium/middleware';
 
 import auth from './auth/reducer';
 import settings from './settings/reducer';
@@ -66,9 +68,19 @@ export const store = createStore<State, A.ActionType, {}, {}>(
         [path]: omit(state[path], 'focusModeEnabled'),
       }),
     }),
-    applyMiddleware(thunk, uiMiddleware, searchFieldMiddleware)
+    applyMiddleware(
+      thunk,
+      uiMiddleware,
+      searchFieldMiddleware,
+      simperiumMiddleware
+    )
   )
 );
+
+export type Store = {
+  dispatch: Dispatch;
+  getState(): State;
+};
 
 export type MapState<StateProps, OwnProps = {}> = (
   state: State,

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -1,0 +1,59 @@
+import debugFactory from 'debug';
+import actions from '../actions';
+
+import * as A from '../action-types';
+import * as S from '../';
+import * as T from '../../types';
+
+const debug = debugFactory('simperium-middleware');
+
+type Buckets = {
+  note: T.Bucket<T.Note>;
+};
+
+const buckets: Buckets = {} as Buckets;
+
+export const storeBuckets = (newBuckets: Buckets) => {
+  buckets.note = newBuckets.note;
+};
+
+const fetchRevisions = (store: S.Store, state: S.State) => {
+  if (!state.ui.showRevisions || !state.ui.note) {
+    return;
+  }
+
+  const note = state.ui.note;
+
+  buckets.note.getRevisions(
+    note.id,
+    (error: unknown, revisions: T.NoteEntity[]) => {
+      if (error) {
+        return debug(`Failed to load revisions for note ${note.id}: ${error}`);
+      }
+
+      const thisState = store.getState();
+      if (!(thisState.ui.note && note.id === thisState.ui.note.id)) {
+        return;
+      }
+
+      store.dispatch(actions.ui.storeRevisions(note.id, revisions));
+    }
+  );
+};
+
+export const middleware: S.Middleware = store => {
+  return next => (action: A.ActionType) => {
+    const result = next(action);
+    const nextState = store.getState();
+
+    switch (action.type) {
+      case 'REVISIONS_TOGGLE':
+        fetchRevisions(store, nextState);
+        break;
+    }
+
+    return result;
+  };
+};
+
+export default middleware;

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -20,11 +20,27 @@ export const focusSearchField: A.ActionCreator<A.FocusSearchField> = () => ({
   type: 'FOCUS_SEARCH_FIELD',
 });
 
+export const selectRevision: A.ActionCreator<A.SelectRevision> = (
+  revision: T.NoteEntity
+) => ({
+  type: 'SELECT_REVISION',
+  revision,
+});
+
 export const setUnsyncedNoteIds: A.ActionCreator<A.SetUnsyncedNoteIds> = (
   noteIds: T.EntityId[]
 ) => ({
   type: 'SET_UNSYNCED_NOTE_IDS',
   noteIds,
+});
+
+export const storeRevisions: A.ActionCreator<A.StoreRevisions> = (
+  noteId: T.EntityId,
+  revisions: T.NoteEntity[]
+) => ({
+  type: 'STORE_REVISIONS',
+  noteId,
+  revisions,
 });
 
 export const toggleRevisions: A.ActionCreator<A.ToggleRevisions> = () => ({

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -20,7 +20,7 @@ const editingTags: A.Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'TAG_EDITING_TOGGLE':
       return !state;
-    case 'App.selectNote':
+    case 'SELECT_NOTE':
     case 'App.selectTag':
     case 'App.selectTrash':
     case 'App.showAllNotes':
@@ -53,12 +53,43 @@ const listTitle: A.Reducer<T.TranslatableString> = (
   }
 };
 
+const noteRevisions: A.Reducer<T.NoteEntity[]> = (
+  state = emptyList as T.NoteEntity[],
+  action
+) => {
+  switch (action.type) {
+    case 'STORE_REVISIONS':
+      return action.revisions;
+    case 'CREATE_NOTE':
+    case 'SELECT_NOTE':
+      return emptyList as T.NoteEntity[];
+    default:
+      return state;
+  }
+};
+
+const selectedRevision: A.Reducer<T.NoteEntity | null> = (
+  state = null,
+  action
+) => {
+  switch (action.type) {
+    case 'SELECT_REVISION':
+      return action.revision;
+    case 'CREATE_NOTE':
+    case 'REVISIONS_TOGGLE':
+    case 'SELECT_NOTE':
+      return null;
+    default:
+      return state;
+  }
+};
+
 const showNoteList: A.Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
-    case 'CLOSE_NOTE': {
+    case 'CLOSE_NOTE':
       return true;
-    }
-    case 'App.selectNote':
+
+    case 'SELECT_NOTE':
       return false;
 
     default:
@@ -115,6 +146,9 @@ const showRevisions: A.Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'REVISIONS_TOGGLE':
       return !state;
+    case 'SELECT_NOTE':
+    case 'CREATE_NOTE':
+      return false;
     default:
       return state;
   }
@@ -136,8 +170,6 @@ const showTrash: A.Reducer<boolean> = (state = false, action) => {
 
 const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
   switch (action.type) {
-    case 'App.selectNote':
-      return { ...action.note, hasRemoteUpdate: action.hasRemoteUpdate };
     case 'CLOSE_NOTE':
     case 'App.trashNote':
     case 'App.emptyTrash':
@@ -146,7 +178,12 @@ const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
     case 'App.selectTag':
       return null;
     case 'SELECT_NOTE':
-      return action.note;
+      return action.options
+        ? {
+            ...action.note,
+            hasRemoteUpdate: action.options.hasRemoteUpdate,
+          }
+        : action.note;
     case 'FILTER_NOTES':
       // keep note if still in new filtered list otherwise try to choose first note in list
       return state && action.notes.some(({ id }) => id === state.id)
@@ -163,7 +200,9 @@ export default combineReducers({
   filteredNotes,
   listTitle,
   note,
+  noteRevisions,
   searchQuery,
+  selectedRevision,
   showNavigation,
   showNoteInfo,
   showNoteList,


### PR DESCRIPTION
As part of our efforts to replace the "wonky app state" we have come across
a few different elements of state that are closer matches to middleware behaviors
than reducer behaviors. Fetching the revisions for a note is one such activity.

Revisions should be gathered whenever we open the revision slider. Previously
when opening the slider we were making two dispatches: one to set the slider
visibility and another to fetch the revisions. Two dispatches are not necessary
and the fetching is purely as side-effect of opening the panel.

In this patch we're creating a new middleware file where we plan to move all
Simperium side-effects eventually. Right now it only watches for appropriate
changes to the revision slider visibility.

Note that the use of middleware has removed the need to chain dispatch calls
as was previously done between `noteRevisions` and `noteRevisionsLoaded`. We
now have a reactive response to `REVISIONS_TOGGLE` and a more declarative
`STORE_REVISIONS` action.

Because revision state is so closely related to this work we are also moving
the revision state into Redux proper and fixing a bug or two in the process.

 - Previously the revision slider would stay open when selecting another
   note or when creating a new note through the keyboard shortcuts. It did
   this because the React component was imperatively calling to close the
   panel on `outsideClick`. Now it properly closes when using the keyboard
   shortcuts because the `showRevisions` reducer is now listening for those
   actions. We could have left it open but I made the decision that it was
   best to prevent confusion to close it. In `develop`, even though the
   slider stays open it fails to fetch the revisions when changing notes.
   This too is due to the existing imperative and confusing data flows.

 - Previously it was possible to select another note in the time it took
   to download the note revisions. In this race you could potentially see
   the revisions for another note. Now this has been resolved by only
   storing the note revisions if we are still on the same note as when
   they were requested.

## Testing

Use the checklist but add extra tests for revisions.

To see the existing bug in production open the revision slide for a note and
then navigate the note list with <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>j</kbd> or the equivalent in non-macOS
systems. Similarly you can navigate in the opposite direction with <kbd>k</kbd> instead
of <kbd>j</kbd>. Note that the revision slider stays open and also that it doesn't
fetch the revisions of the newly-selected note. Repeat the experiment by creating
a new note with <kbd>⌘</kbd>+<kbd>n</kbd>.