### PR TITLE
Fix: Render unicode bullet as list in Markdown preview

### DIFF
--- a/lib/utils/render-note-to-html.ts
+++ b/lib/utils/render-note-to-html.ts
@@ -6,7 +6,7 @@ const enableCheckboxes = {
   replace: '<input type="checkbox" ',
 };
 
-export const renderNoteToHtml = content => {
+export const renderNoteToHtml = (content: string) => {
   return import(/* webpackChunkName: 'showdown' */ 'showdown').then(
     ({ default: showdown }) => {
       showdown.extension('enableCheckboxes', enableCheckboxes);
@@ -18,7 +18,12 @@ export const renderNoteToHtml = content => {
       markdownConverter.setOption('ghMentions', false);
       markdownConverter.setOption('smoothLivePreview', true);
 
-      return sanitizeHtml(markdownConverter.makeHtml(content));
+      const withNormalizedBullets = content.replace(
+        /([ \t\u2000-\u200a]*)\u2022(\s)/gm,
+        '$1-$2'
+      );
+
+      return sanitizeHtml(markdownConverter.makeHtml(withNormalizedBullets));
     }
   );
 };


### PR DESCRIPTION
Previously we have been failing to render bulleted-lists which use the
Unicode `\u2022` "Bullet". The preview would fail to show the line as
a new list item and therefore inline it and any successive list items
into a single paragraph/item.

Now we are replacing those bullets before rendering the Markdown so
that it will render properly as any other bullet would.

## Testing

Create a note with a Unicode bullet for the list items

```
 - one
 + two
 * three
 • this is the Unicode bullet
```

In `develop` it will render inline with the previous item inside the Preview.
![Screen Shot 2020-02-20 at 1 57 10 PM](https://user-images.githubusercontent.com/5431237/74977941-e9e77680-53e8-11ea-814b-62268194551f.png)

In this branch it should appear as a proper rendered bullet.
![Screen Shot 2020-02-20 at 1 56 41 PM](https://user-images.githubusercontent.com/5431237/74977902-da682d80-53e8-11ea-811d-7798c294760c.png)
