### PR TITLE
Fix: Use proper import path for state types in app layout

### DIFF
--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -9,7 +9,7 @@ import SearchBar from '../search-bar';
 import SimplenoteCompactLogo from '../icons/simplenote-compact';
 import TransitionDelayEnter from '../components/transition-delay-enter';
 
-import * as S from './state';
+import * as S from '../state';
 import * as T from '../types';
 
 const NoteList = React.lazy(() =>


### PR DESCRIPTION
In #1895 we added an import to `./state` that should have been
`../state`. This didn't break the app because the import only
affected the types.

In this patch we're fixing the import path.

## Testing

This should have no impact on the final built code and therefore
no changes on the output.