### PR TITLE
Fixes tag list editing mode

### DIFF
--- a/lib/editable-list/index.tsx
+++ b/lib/editable-list/index.tsx
@@ -343,8 +343,9 @@ export class EditableList extends Component<Props> {
 }
 
 const mapStateToProps: S.MapState<StateProps> = ({
-  appState: { editingTags, tags },
+  appState: { tags },
   settings: { sortTagsAlpha },
+  ui: { editingTags },
 }) => ({
   editing: editingTags,
   items: tags,


### PR DESCRIPTION
### Fix
Fixes note list editing. editingTags is now on the ui state branch not appState.

### Test
1. Can you enter edit mode for the tag list?

