### PR TITLE
Refactor: Move system-tag updating into Redux and into middleware

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -91,7 +91,6 @@ const mapDispatchToProps: S.MapDispatch<
         'resetFontSize',
         'setLineLength',
         'setNoteDisplay',
-        'setMarkdown',
         'setAccountName',
         'toggleAutoHideMenuBar',
         'toggleFocusMode',

--- a/lib/dialogs/share/index.tsx
+++ b/lib/dialogs/share/index.tsx
@@ -12,6 +12,7 @@ import Dialog from '../../dialog';
 import TabPanels from '../../components/tab-panels';
 import PanelTitle from '../../components/panel-title';
 import ToggleControl from '../../controls/toggle';
+import actions from '../../state/actions';
 
 import * as S from '../../state';
 import * as T from '../../types';
@@ -20,10 +21,15 @@ const shareTabs = ['collaborate', 'publish'];
 
 type StateProps = {
   settings: S.State['settings'];
-  note: T.NoteEntity | null;
+  note: T.NoteEntity;
 };
 
-type Props = StateProps;
+type DispatchProps = {
+  publishNote: (note: T.NoteEntity, shouldPublish: boolean) => any;
+  updateNoteTags: (args: { note: T.NoteEntity; tags: T.TagName[] }) => any;
+};
+
+type Props = StateProps & DispatchProps;
 
 export class ShareDialog extends Component<Props> {
   static propTypes = {
@@ -33,15 +39,10 @@ export class ShareDialog extends Component<Props> {
     appState: PropTypes.object.isRequired,
     requestClose: PropTypes.func.isRequired,
     tagBucket: PropTypes.object.isRequired,
-    updateNoteTags: PropTypes.func.isRequired,
   };
 
-  onTogglePublished = event => {
-    this.props.actions.publishNote({
-      noteBucket: this.props.noteBucket,
-      note: this.props.note,
-      publish: event.currentTarget.checked,
-    });
+  onTogglePublished = (event: React.MouseEvent<HTMLInputElement>) => {
+    this.props.publishNote(this.props.note, event.currentTarget.checked);
   };
 
   getPublishURL = url => (isEmpty(url) ? undefined : `http://simp.ly/p/${url}`);
@@ -222,4 +223,10 @@ const mapStateToProps: S.MapState<StateProps> = ({
   note,
 });
 
-export default connect(mapStateToProps, { updateNoteTags })(ShareDialog);
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
+  publishNote: (note, shouldPublish) =>
+    dispatch(actions.ui.publishNote(note, shouldPublish)),
+  updateNoteTags: ({ note, tags }) => dispatch(updateNoteTags({ note, tags })),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ShareDialog);

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -10,29 +10,6 @@ import * as T from '../types';
 
 const debug = Debug('appState');
 
-const toggleSystemTag = (
-  note: T.NoteEntity,
-  systemTag: T.SystemTag,
-  shouldHaveTag: boolean
-) => {
-  const {
-    data: { systemTags = [] },
-  } = note;
-  const hasTagAlready = systemTags.includes(systemTag);
-
-  return hasTagAlready !== shouldHaveTag
-    ? {
-        ...note,
-        data: {
-          ...note.data,
-          systemTags: shouldHaveTag
-            ? [...systemTags, systemTag]
-            : systemTags.filter(tag => tag !== systemTag),
-        },
-      }
-    : note;
-};
-
 const initialState: AppState = {
   notes: null,
   tags: [],
@@ -209,48 +186,6 @@ export const actionMap = new ActionMap({
             dispatch(actions.ui.selectNote(note, { hasRemoteUpdate }));
           });
         };
-      },
-    },
-
-    pinNote: {
-      creator({ noteBucket, note, pin: shouldPin }) {
-        const updated = toggleSystemTag(note, 'pinned', shouldPin);
-
-        if (note !== updated) {
-          noteBucket.update(note.id, updated.data);
-        }
-
-        return actions.ui.selectNote(updated);
-      },
-    },
-
-    markdownNote: {
-      creator({ noteBucket, note, markdown: shouldEnableMarkdown }) {
-        const updated = toggleSystemTag(note, 'markdown', shouldEnableMarkdown);
-
-        if (updated !== note) {
-          noteBucket.update(note.id, updated.data);
-        }
-
-        return actions.ui.selectNote(updated);
-      },
-    },
-
-    publishNote: {
-      creator({ noteBucket, note, publish: shouldPublish }) {
-        const updated = toggleSystemTag(note, 'published', shouldPublish);
-
-        if (updated !== note) {
-          noteBucket.update(note.id, updated.data);
-
-          if (shouldPublish) {
-            analytics.tracks.recordEvent('editor_note_published');
-          } else {
-            analytics.tracks.recordEvent('editor_note_unpublished');
-          }
-        }
-
-        return actions.ui.selectNote(updated);
       },
     },
 

--- a/lib/note-info/index.tsx
+++ b/lib/note-info/index.tsx
@@ -1,11 +1,9 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 import onClickOutside from 'react-onclickoutside';
 import { includes, isEmpty } from 'lodash';
 import format from 'date-fns/format';
 
-import appState from '../flux/app-state';
 import PanelTitle from '../components/panel-title';
 import ToggleControl from '../controls/toggle';
 import CrossIcon from '../icons/cross';
@@ -16,6 +14,7 @@ import * as S from '../state';
 import * as T from '../types';
 
 type OwnProps = {
+  markdownEnabled: boolean;
   noteBucket: T.Bucket<T.Note>;
 };
 
@@ -27,21 +26,14 @@ type StateProps = {
 
 type DispatchProps = {
   onMarkdownNote: (note: T.NoteEntity, isMarkdown: boolean) => any;
-  onPinNote: (note: T.NoteEntity, shouldPinNote: boolean) => any;
   onOutsideClick: () => any;
+  onPinNote: (note: T.NoteEntity, shouldPin: boolean) => any;
 };
 
 type Props = OwnProps & StateProps & DispatchProps;
 
 export class NoteInfo extends Component<Props> {
   static displayName = 'NoteInfo';
-
-  static propTypes = {
-    markdownEnabled: PropTypes.bool,
-    onPinNote: PropTypes.func.isRequired,
-    onMarkdownNote: PropTypes.func.isRequired,
-    onOutsideClick: PropTypes.func.isRequired,
-  };
 
   handleClickOutside = () => this.props.onOutsideClick();
 
@@ -208,25 +200,17 @@ function characterCount(content: string) {
   );
 }
 
-const { markdownNote, pinNote } = appState.actionCreators;
-
 const mapStateToProps: S.MapState<StateProps> = ({ ui: { note } }) => ({
   note,
   isMarkdown: !!note && note.data.systemTags.includes('markdown'),
   isPinned: !!note && note.data.systemTags.includes('pinned'),
 });
 
-const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (
-  dispatch,
-  { noteBucket }
-) => ({
-  onMarkdownNote: (note, markdown = true) => {
-    dispatch(markdownNote({ markdown, note, noteBucket }));
-    // Update global setting to set markdown flag for new notes
-    dispatch(actions.settings.setMarkdown(markdown));
-  },
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
+  onMarkdownNote: (note, markdown = true) =>
+    dispatch(actions.ui.markdownNote(note, markdown)),
   onOutsideClick: () => dispatch(actions.ui.toggleNoteInfo()),
-  onPinNote: (note, pin) => dispatch(pinNote({ noteBucket, note, pin })),
+  onPinNote: (note, pin) => dispatch(actions.ui.pinNote(note, pin)),
 });
 
 export default connect(

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -29,16 +29,37 @@ import {
 } from './decorators';
 import TagSuggestions, { getMatchingTags } from '../tag-suggestions';
 
-import { closeNote } from '../state/ui/actions';
+import actions from '../state/actions';
 
 import * as S from '../state';
 import * as T from '../types';
 
-type StateProps = {
-  selectedNoteId?: T.EntityId;
+type OwnProps = {
+  noteBucket: T.Bucket<T.Note>;
 };
 
-type Props = StateProps;
+type StateProps = {
+  hasLoaded: boolean;
+  nextNote: T.NoteEntity;
+  noteDisplay: T.ListDisplayMode;
+  notes: T.NoteEntity[];
+  prevNote: T.NoteEntity;
+  searchQuery: string;
+  selectedNoteContent: string;
+  selectedNotePreview: { title: string; preview: string };
+  selectedNoteId?: T.EntityId;
+  showTrash: boolean;
+  tagResultsFound: number;
+};
+
+type DispatchProps = {
+  closeNote: () => any;
+  onEmptyTrash: () => any;
+  onSelectNote: (noteId: T.EntityId | null) => any;
+  onPinNote: (note: T.NoteEntity, shouldPin: boolean) => any;
+};
+
+type Props = OwnProps & StateProps & DispatchProps;
 
 AutoSizer.displayName = 'AutoSizer';
 List.displayName = 'List';
@@ -471,11 +492,11 @@ export class NoteList extends Component<Props> {
     );
   }
 
-  onPinNote = note =>
+  onPinNote = (note: T.NoteEntity) =>
     this.props.onPinNote(note, !note.data.systemTags.includes('pinned'));
 }
 
-const { emptyTrash, loadAndSelectNote, pinNote } = appState.actionCreators;
+const { emptyTrash, loadAndSelectNote } = appState.actionCreators;
 
 const mapStateToProps: S.MapState<StateProps> = ({
   appState: state,
@@ -539,8 +560,11 @@ const mapStateToProps: S.MapState<StateProps> = ({
   };
 };
 
-const mapDispatchToProps = (dispatch, { noteBucket }) => ({
-  closeNote: () => dispatch(closeNote()),
+const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (
+  dispatch,
+  { noteBucket }
+) => ({
+  closeNote: () => dispatch(actions.ui.closeNote()),
   onEmptyTrash: () => dispatch(emptyTrash({ noteBucket })),
   onSelectNote: noteId => {
     if (noteId) {
@@ -548,14 +572,7 @@ const mapDispatchToProps = (dispatch, { noteBucket }) => ({
       analytics.tracks.recordEvent('list_note_opened');
     }
   },
-  onPinNote: (note, pin) => dispatch(pinNote({ noteBucket, note, pin })),
+  onPinNote: (note, shouldPin) => dispatch(actions.ui.pinNote(note, shouldPin)),
 });
-
-NoteList.propTypes = {
-  hasLoaded: PropTypes.bool.isRequired,
-  nextNote: PropTypes.object,
-  prevNote: PropTypes.object,
-  selectedNoteContent: PropTypes.string,
-};
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteList);

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -24,10 +24,6 @@ export type SetLineLength = Action<
   'setLineLength',
   { lineLength: T.LineLength }
 >;
-export type SetMarkdownEnabled = Action<
-  'setMarkdownEnabled',
-  { markdownEnabled: boolean }
->;
 export type SetNoteDisplay = Action<
   'setNoteDisplay',
   { noteDisplay: T.ListDisplayMode }
@@ -73,6 +69,10 @@ export type SelectRevision = Action<
   { revision: T.NoteEntity }
 >;
 export type SetAuth = Action<'AUTH_SET', { status: AuthState }>;
+export type SetSystemTag = Action<
+  'SET_SYSTEM_TAG',
+  { note: T.NoteEntity; tagName: T.SystemTag; shouldHaveTag: boolean }
+>;
 export type SetUnsyncedNoteIds = Action<
   'SET_UNSYNCED_NOTE_IDS',
   { noteIds: T.EntityId[] }
@@ -117,12 +117,12 @@ export type ActionType =
   | SetFocusMode
   | SetFontSize
   | SetLineLength
-  | SetMarkdownEnabled
   | SetNoteDisplay
   | SetSortReversed
   | SetSortTagsAlpha
   | SetSortType
   | SetSpellCheck
+  | SetSystemTag
   | SetTheme
   | SetUnsyncedNoteIds
   | SetWPToken
@@ -161,10 +161,6 @@ type LegacyAction =
       { callback?: Function; preferencesBucket: T.Bucket<T.Preferences> }
     >
   | Action<
-      'App.markdownNote',
-      { noteBucket: T.Bucket<T.Note>; note: T.NoteEntity; markdown: boolean }
-    >
-  | Action<
       'App.noteUpdatedRemotely',
       {
         noteBucket: T.Bucket<T.Note>;
@@ -172,14 +168,6 @@ type LegacyAction =
         data: object;
         remoteUpdateInfo: object;
       }
-    >
-  | Action<
-      'App.pinNote',
-      { noteBucket: T.Bucket<T.Note>; note: T.NoteEntity; pin: boolean }
-    >
-  | Action<
-      'App.publishNote',
-      { noteBucket: T.Bucket<T.Note>; note: T.NoteEntity; publish: boolean }
     >
   | Action<
       'App.restoreNote',

--- a/lib/state/domain/notes.ts
+++ b/lib/state/domain/notes.ts
@@ -1,6 +1,30 @@
 import { noteBucket } from './buckets';
 import isEmailTag from '../../utils/is-email-tag';
 import { createTag } from './tags';
+import * as T from '../../types';
+
+export const toggleSystemTag = (
+  note: T.NoteEntity,
+  systemTag: T.SystemTag,
+  shouldHaveTag: boolean
+) => {
+  const {
+    data: { systemTags = [] },
+  } = note;
+  const hasTagAlready = systemTags.includes(systemTag);
+
+  return hasTagAlready !== shouldHaveTag
+    ? {
+        ...note,
+        data: {
+          ...note.data,
+          systemTags: shouldHaveTag
+            ? [...systemTags, systemTag]
+            : systemTags.filter(tag => tag !== systemTag),
+        },
+      }
+    : note;
+};
 
 export const updateNoteTags = ({ note, tags }) => {
   return (dispatch, getState) => {

--- a/lib/state/settings/actions.ts
+++ b/lib/state/settings/actions.ts
@@ -64,11 +64,6 @@ export const toggleSortTagsAlpha = () => (dispatch, getState) => {
   });
 };
 
-export const setMarkdown: A.ActionCreator<A.SetMarkdownEnabled> = markdownEnabled => ({
-  type: 'setMarkdownEnabled',
-  markdownEnabled,
-});
-
 export const setAccountName: A.ActionCreator<A.SetAccountName> = accountName => ({
   type: 'setAccountName',
   accountName,

--- a/lib/state/settings/reducer.ts
+++ b/lib/state/settings/reducer.ts
@@ -37,8 +37,10 @@ const reducer: A.Reducer<typeof initialState> = (
       };
     case 'setLineLength':
       return { ...state, lineLength: action.lineLength };
-    case 'setMarkdownEnabled':
-      return { ...state, markdownEnabled: action.markdownEnabled };
+    case 'SET_SYSTEM_TAG':
+      return 'markdown' === action.tagName
+        ? { ...state, markdownEnabled: action.shouldHaveTag }
+        : state;
     case 'setNoteDisplay':
       return { ...state, noteDisplay: action.noteDisplay };
     case 'setSortReversed':

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -1,6 +1,8 @@
 import debugFactory from 'debug';
 import actions from '../actions';
 
+import { toggleSystemTag } from '../domain/notes';
+
 import * as A from '../action-types';
 import * as S from '../';
 import * as T from '../../types';
@@ -47,6 +49,14 @@ export const middleware: S.Middleware = store => {
     const nextState = store.getState();
 
     switch (action.type) {
+      case 'SET_SYSTEM_TAG':
+        buckets.note.update(
+          action.note.id,
+          toggleSystemTag(action.note, action.tagName, action.shouldHaveTag)
+            .data
+        );
+        break;
+
       case 'REVISIONS_TOGGLE':
         fetchRevisions(store, nextState);
         break;

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -29,6 +29,36 @@ export const focusSearchField: A.ActionCreator<A.FocusSearchField> = () => ({
   type: 'FOCUS_SEARCH_FIELD',
 });
 
+export const markdownNote: A.ActionCreator<A.SetSystemTag> = (
+  note: T.NoteEntity,
+  isMarkdown: boolean
+) => ({
+  type: 'SET_SYSTEM_TAG',
+  note,
+  tagName: 'markdown',
+  shouldHaveTag: isMarkdown,
+});
+
+export const pinNote: A.ActionCreator<A.SetSystemTag> = (
+  note: T.NoteEntity,
+  shouldPin: boolean
+) => ({
+  type: 'SET_SYSTEM_TAG',
+  note,
+  tagName: 'pinned',
+  shouldHaveTag: shouldPin,
+});
+
+export const publishNote: A.ActionCreator<A.SetSystemTag> = (
+  note: T.NoteEntity,
+  shoudlPublish: boolean
+) => ({
+  type: 'SET_SYSTEM_TAG',
+  note,
+  tagName: 'published',
+  shouldHaveTag: shoudlPublish,
+});
+
 export const openTag: A.ActionCreator<A.OpenTag> = (tag: T.TagEntity) => ({
   type: 'OPEN_TAG',
   tag,

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -1,4 +1,7 @@
 import { combineReducers } from 'redux';
+
+import { toggleSystemTag } from '../domain/notes';
+
 import * as A from '../action-types';
 import * as T from '../../types';
 
@@ -213,6 +216,8 @@ const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
             hasRemoteUpdate: action.options.hasRemoteUpdate,
           }
         : action.note;
+    case 'SET_SYSTEM_TAG':
+      return toggleSystemTag(action.note, action.tagName, action.shouldHaveTag);
     case 'FILTER_NOTES':
       // keep note if still in new filtered list otherwise try to choose first note in list
       return state && action.notes.some(({ id }) => id === state.id)


### PR DESCRIPTION
Previously we have been using a Simperium roundtrip in order to
update the pinned/markdown/publish status for a note. This involved
dispatching an action to set those system tags, waiting for a response,
and a second dispatch to update the app state by re-selecting the
changed note.

This involved a number of data races including some important ones
involved in updating the currently-selected note.

In this patch we've moved that update logic into Redux middleware
and adjusted the app reducers so that changes are reflected immediately
in the app and Simperium gets updated in the background.

If and when note updates fail or reflect different changes from the
remote side then we will update through the usual data flow for
receiving remote changes.

Because pinning, setting Markdown status, and publishing are all three
facets of the same interaction I have merged them into this one patch
and created action-creators that all collapse into the same action,
which is setting the status of a system tag.

## Testing

Run through the checklist and pay extra attention to pinning, setting
Markdown, and publishing.