### PR TITLE
Add testing job to CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/node:12.14.0
+      - image: circleci/node:12.14.0-browsers
     shell: /bin/bash --login
     working_directory: ~/simplenote
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/node:12.14.0-browsers
+      - image: circleci/node:12.14.0
     shell: /bin/bash --login
     working_directory: ~/simplenote
     steps:
@@ -106,7 +106,6 @@ jobs:
       - *npm_restore_cache
       - *npm_install
       - run: NODE_ENV=test npm run build
-      - run: npm run test-e2e
       - run: npm test
       - run: npm run lint
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,11 +85,33 @@ jobs:
       - *npm_restore_cache
       - *npm_install
       - run: make build
-      - run: make lint
-      - run: make test
       - persist_to_workspace:
           root: ~/simplenote
           paths: *app_cache_paths
+
+  test:
+    docker:
+      - image: circleci/node:12.14.0
+    shell: /bin/bash --login
+    working_directory: ~/simplenote
+    steps:
+      - *install_linux_deps
+      - checkout
+      - run:
+          name: Decrypt assets
+          command: |
+            openssl aes-256-cbc -md md5 -d -in ./resources/certificates/win.p12.enc -out ./resources/certificates/win.p12 -k ${SECRETS_ENCRYPTION_KEY}
+            openssl aes-256-cbc -md md5 -d -in ./resources/certificates/mac.p12.enc -out ./resources/certificates/mac.p12 -k ${SECRETS_ENCRYPTION_KEY}
+            openssl aes-256-cbc -md md5 -d -in ./resources/secrets/config.json.enc -out ./config.json -k ${SECRETS_ENCRYPTION_KEY}
+      - *restore_nvm
+      - *setup_nvm
+      - *save_nvm
+      - *npm_restore_cache
+      - *npm_install
+      - run: NODE_ENV=test npm run build
+      - run: npm run test-e2e
+      - run: npm test
+      - run: npm run lint
 
   linux:
     docker:
@@ -209,6 +231,15 @@ workflows:
           filters:
             branches:
               ignore: webapp
+            tags:
+              only: /.*/
+      - test:
+          filters:
+            branches:
+              ignore:
+                - webapp
+                - webapp-develop
+                - webapp-staging
             tags:
               only: /.*/
       - linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,13 @@ orbs:
   win: circleci/windows@2.2.0
 
 references:
+  decrypt: &decrypt
+    run:
+      name: Decrypt assets
+      command: |
+        openssl aes-256-cbc -md md5 -d -in ./resources/certificates/win.p12.enc -out ./resources/certificates/win.p12 -k ${SECRETS_ENCRYPTION_KEY}
+        openssl aes-256-cbc -md md5 -d -in ./resources/certificates/mac.p12.enc -out ./resources/certificates/mac.p12 -k ${SECRETS_ENCRYPTION_KEY}
+        openssl aes-256-cbc -md md5 -d -in ./resources/secrets/config.json.enc -out ./config.json -k ${SECRETS_ENCRYPTION_KEY}
   restore_nvm: &restore_nvm
     restore_cache:
       name: Restoring NVM cache
@@ -73,12 +80,7 @@ jobs:
     steps:
       - *install_linux_deps
       - checkout
-      - run:
-          name: Decrypt assets
-          command: |
-            openssl aes-256-cbc -md md5 -d -in ./resources/certificates/win.p12.enc -out ./resources/certificates/win.p12 -k ${SECRETS_ENCRYPTION_KEY}
-            openssl aes-256-cbc -md md5 -d -in ./resources/certificates/mac.p12.enc -out ./resources/certificates/mac.p12 -k ${SECRETS_ENCRYPTION_KEY}
-            openssl aes-256-cbc -md md5 -d -in ./resources/secrets/config.json.enc -out ./config.json -k ${SECRETS_ENCRYPTION_KEY}
+      - *decrypt
       - *restore_nvm
       - *setup_nvm
       - *save_nvm
@@ -97,12 +99,7 @@ jobs:
     steps:
       - *install_linux_deps
       - checkout
-      - run:
-          name: Decrypt assets
-          command: |
-            openssl aes-256-cbc -md md5 -d -in ./resources/certificates/win.p12.enc -out ./resources/certificates/win.p12 -k ${SECRETS_ENCRYPTION_KEY}
-            openssl aes-256-cbc -md md5 -d -in ./resources/certificates/mac.p12.enc -out ./resources/certificates/mac.p12 -k ${SECRETS_ENCRYPTION_KEY}
-            openssl aes-256-cbc -md md5 -d -in ./resources/secrets/config.json.enc -out ./config.json -k ${SECRETS_ENCRYPTION_KEY}
+      - *decrypt
       - *restore_nvm
       - *setup_nvm
       - *save_nvm


### PR DESCRIPTION
### Fix
Adds a test job to CircleCi. This job includes the unit tests and linting.

### Test
- Does the CircleCi `test` job pass?
- Do the logs of the CircleCi `test` job look correct?

### Release Note:

- Added a testing job to ci config to run separately from builds