### PR TITLE
CircleCi: Ignore webapp-staging and webapp-develop in addition to webapp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,15 +208,22 @@ workflows:
       - build:
           filters:
             branches:
-              ignore: webapp
+              ignore:
+                - webapp
+                - webapp-develop
+                - webapp-staging
             tags:
               only: /.*/
+
       - linux:
           requires:
             - build
           filters:
             branches:
-              ignore: webapp
+              ignore:
+                - webapp
+                - webapp-develop
+                - webapp-staging
             tags:
               only: /.*/
       - mac:
@@ -224,7 +231,10 @@ workflows:
             - build
           filters:
             branches:
-              ignore: webapp
+              ignore:
+                - webapp
+                - webapp-develop
+                - webapp-staging
             tags:
               only: /.*/
       - windows:
@@ -232,7 +242,10 @@ workflows:
             - build
           filters:
             branches:
-              ignore: webapp
+              ignore:
+                - webapp
+                - webapp-develop
+                - webapp-staging
             tags:
               only: /.*/
       - artifacts:
@@ -242,6 +255,9 @@ workflows:
             - windows
           filters:
             branches:
-              ignore: webapp
+              ignore:
+                - webapp
+                - webapp-develop
+                - webapp-staging
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,14 @@ orbs:
   win: circleci/windows@2.2.0
 
 references:
+  job_filters: &job_filters
+    branches:
+      ignore:
+        - webapp
+        - webapp-develop
+        - webapp-staging
+    tags:
+      only: /.*/
   restore_nvm: &restore_nvm
     restore_cache:
       name: Restoring NVM cache
@@ -206,58 +214,22 @@ workflows:
   simplenote:
     jobs:
       - build:
-          filters:
-            branches:
-              ignore:
-                - webapp
-                - webapp-develop
-                - webapp-staging
-            tags:
-              only: /.*/
-
+          filters: *job_filters
       - linux:
           requires:
             - build
-          filters:
-            branches:
-              ignore:
-                - webapp
-                - webapp-develop
-                - webapp-staging
-            tags:
-              only: /.*/
+          filters: *job_filters
       - mac:
           requires:
             - build
-          filters:
-            branches:
-              ignore:
-                - webapp
-                - webapp-develop
-                - webapp-staging
-            tags:
-              only: /.*/
+          filters: *job_filters
       - windows:
           requires:
             - build
-          filters:
-            branches:
-              ignore:
-                - webapp
-                - webapp-develop
-                - webapp-staging
-            tags:
-              only: /.*/
+          filters: *job_filters
       - artifacts:
           requires:
             - linux
             - mac
             - windows
-          filters:
-            branches:
-              ignore:
-                - webapp
-                - webapp-develop
-                - webapp-staging
-            tags:
-              only: /.*/
+          filters: *job_filters


### PR DESCRIPTION
### Fix
Currently, we tell CircleCi to ignore the branch `webapp`. This PR adds ignores for webapp-staging and webapp-develop.

Since adding these additional ignore branches created a lot of repeated code this PR drys up the job configuration.

### Test
1. Do all the CircleCi jobs pass?
