### PR TITLE
Add types to BootWarning component

### DIFF
--- a/lib/components/boot-warning/index.tsx
+++ b/lib/components/boot-warning/index.tsx
@@ -1,14 +1,8 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-
+import React, { FunctionComponent } from 'react';
 import './style';
 
-const BootWarning = ({ children }) => (
+const BootWarning: FunctionComponent = ({ children }) => (
   <h3 className="boot-warning__message">{children}</h3>
 );
-
-BootWarning.propTypes = {
-  children: PropTypes.node.isRequired,
-};
 
 export default BootWarning;


### PR DESCRIPTION
### Fix
This PR adds TS types and removes prop types.

### Test
Just types, no testing needed. If you want to test turn off history in Firefox and ensure you get a warning about not being able to retrieve your notes.
