### PR TITLE
Add testing job to CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,13 @@ orbs:
   win: circleci/windows@2.2.0
 
 references:
+  decrypt: &decrypt
+    run:
+      name: Decrypt assets
+      command: |
+        openssl aes-256-cbc -md md5 -d -in ./resources/certificates/win.p12.enc -out ./resources/certificates/win.p12 -k ${SECRETS_ENCRYPTION_KEY}
+        openssl aes-256-cbc -md md5 -d -in ./resources/certificates/mac.p12.enc -out ./resources/certificates/mac.p12 -k ${SECRETS_ENCRYPTION_KEY}
+        openssl aes-256-cbc -md md5 -d -in ./resources/secrets/config.json.enc -out ./config.json -k ${SECRETS_ENCRYPTION_KEY}
   job_filters: &job_filters
     branches:
       ignore:
@@ -81,23 +88,33 @@ jobs:
     steps:
       - *install_linux_deps
       - checkout
-      - run:
-          name: Decrypt assets
-          command: |
-            openssl aes-256-cbc -md md5 -d -in ./resources/certificates/win.p12.enc -out ./resources/certificates/win.p12 -k ${SECRETS_ENCRYPTION_KEY}
-            openssl aes-256-cbc -md md5 -d -in ./resources/certificates/mac.p12.enc -out ./resources/certificates/mac.p12 -k ${SECRETS_ENCRYPTION_KEY}
-            openssl aes-256-cbc -md md5 -d -in ./resources/secrets/config.json.enc -out ./config.json -k ${SECRETS_ENCRYPTION_KEY}
+      - *decrypt
       - *restore_nvm
       - *setup_nvm
       - *save_nvm
       - *npm_restore_cache
       - *npm_install
       - run: make build
-      - run: make lint
-      - run: make test
       - persist_to_workspace:
           root: ~/simplenote
           paths: *app_cache_paths
+  test:
+    docker:
+      - image: circleci/node:12.14.0
+    shell: /bin/bash --login
+    working_directory: ~/simplenote
+    steps:
+      - *install_linux_deps
+      - checkout
+      - *decrypt
+      - *restore_nvm
+      - *setup_nvm
+      - *save_nvm
+      - *npm_restore_cache
+      - *npm_install
+      - run: NODE_ENV=test npm run build
+      - run: npm test
+      - run: npm run lint
 
   linux:
     docker:
@@ -214,6 +231,8 @@ workflows:
   simplenote:
     jobs:
       - build:
+          filters: *job_filters
+      - test:
           filters: *job_filters
       - linux:
           requires:


### PR DESCRIPTION
Remake of https://github.com/Automattic/simplenote-electron/pull/1930 which was merged down into another branch. Cleaner to just remake PR.

### Fix
Adds a test job to CircleCi. This job includes the unit tests and linting.

### Test
- Does the CircleCi `test` job pass?
- Do the logs of the CircleCi `test` job look correct?

### Release Note:

- Added a testing job to ci config to run separately from builds