### PR TITLE
Adjust webpack settings to inline webworker and avoid security issues

### DIFF
--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -1,4 +1,4 @@
-import SearchWorker from 'worker-loader!./worker';
+import SearchWorker from './worker';
 
 import actions from '../state/actions';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,14 @@ module.exports = () => {
     module: {
       rules: [
         {
+          test: /lib\/search\/worker\/index\.ts$/,
+          exclude: /node_modules/,
+          use: {
+            loader: 'worker-loader',
+            options: { inline: true, fallback: false },
+          },
+        },
+        {
           test: /\.[jt]sx?$/,
           exclude: /node_modules\/core-js/,
           use: [


### PR DESCRIPTION
When I deployed #1941 to staging.simplenote.com I discovered that the WebWorker wasn't loading. The reason was because it was being served from another domain than the website itself. This triggered content security policies in the browser.

With this change we're no longer loading an external script. Instead, webpack builds a `BLOB` containing the source of the worker and ships it inline with the rest of the application code, eliminating the external script load.

After re-deploying to staging I confirmed that this fixes the loading problem.