### PR TITLE
Fix application signing to generate appx for windows store

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,11 +204,10 @@ jobs:
           command: |
             # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
             # Ref: https://travis-ci.community/t/codesigning-on-windows/
-            # 
-            # Fix: Import .p12 into the local certificate store. Sign Tool will use 
+            #
+            # Fix: Import .p12 into the local certificate store. Sign Tool will use
             # package.json's `certificateSubjectName` to find the imported cert.
             Import-PfxCertificate -FilePath C:\Users\circleci\simplenote-electron\resources\certificates\win.p12 -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
-            make package-win32 IS_WINDOWS=true
             npx electron-builder --win -p onTag
       - persist_to_workspace:
           root: C:\Users\circleci\simplenote-electron
@@ -216,6 +215,38 @@ jobs:
             - release\*.exe
             - release\*.appx
             - release\*.yml
+  windowsstore:
+    executor:
+      name: win/default
+    working_directory: C:\Users\circleci\simplenote-electron
+    environment:
+      CSC_LINK: ''
+      WIN_CSC_LINK: ''
+    steps:
+      - checkout
+      - attach_workspace:
+          at: C:\Users\circleci\simplenote-electron
+      - run:
+          name: Install make
+          command: cinst make
+      - run:
+          name: Install node version
+          command: |
+            $NODE_VERSION = Get-Content .\.nvmrc
+            nvm install $NODE_VERSION
+            nvm use $NODE_VERSION
+      - run:
+          name: Npm install
+          command: |
+            npm ci
+      - run:
+          name: Build windows
+          command: |
+            npx electron-builder --win --config=./electron-builder-appx.json -p onTag
+      - persist_to_workspace:
+          root: C:\Users\circleci\simplenote-electron
+          paths:
+            - release\*.appx
   artifacts:
     docker:
       - image: buildpack-deps:trusty
@@ -246,9 +277,19 @@ workflows:
           requires:
             - build
           filters: *job_filters
+      - windowsstore:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - none
+            tags:
+              only: /.*/
       - artifacts:
           requires:
             - linux
             - mac
             - windows
+            - windowsstore
           filters: *job_filters

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.15.1]
+
+### Other Changes
+
+- Fix application signing to generate proper appx for Windows Store [#1960](https://github.com/Automattic/simplenote-electron/pull/1960)
+
 ## [v1.15.0]
 
 ### Enhancements

--- a/electron-builder-appx.json
+++ b/electron-builder-appx.json
@@ -1,5 +1,13 @@
 {
+  "productName": "Simplenote",
+  "appId": "com.automattic.simplenote",
+  "directories": {
+    "output": "release",
+    "buildResources": "resources"
+  },
+  "files": ["desktop", "dist", "shared"],
   "win": {
+    "icon": "resources/images/simplenote.ico",
     "target": [
       {
         "target": "appx"
@@ -12,7 +20,8 @@
     "publisher": "CN=E2E5A157-746D-4B04-9116-ABE5CB928306",
     "publisherDisplayName": "Automattic",
     "backgroundColor": "transparent",
-    "artifactName": "Simplenote-win-${version}-${arch}.${ext}"
+    "artifactName": "Simplenote-win-store-${version}-${arch}.${ext}"
   },
-  "extends": "./electron-builder.json"
+  "afterSign": "./after_sign_hook.js",
+  "afterAllArtifactBuild": "./after_sign_hook.js"
 }

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -42,6 +42,10 @@
       {
         "target": "nsis",
         "arch": ["ia32", "x64"]
+      },
+      {
+        "target": "appx",
+        "arch": ["ia32", "x64"]
       }
     ]
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplenote",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "support@simplenote.com"
   },
   "productName": "Simplenote",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "main": "desktop/index.js",
   "license": "GPL-2.0",
   "homepage": "https://simplenote.com",


### PR DESCRIPTION
**DO NOT MERGE** until #1959 has been merged

Replaces #1955 
Replaces #1958

### Fix
Windows App store requires that the appx be unsigned. This PR adds an additional job to build the appx for release to the store.

### Test
1. Run the build on a tag and upload the built asset to the Windows store.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.txt` was updated with:


Props to @belcherj for actually doing the work to fix this issue. This PR is a clone of his.