### PR TITLE
Fix: Remember opened tag in search and send previous index

### DIFF
--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -17,16 +17,17 @@ export const middleware: S.Middleware = store => {
 
   searchProcessor.onmessage = event => {
     switch (event.data.action) {
-      case 'filterNotes':
+      case 'filterNotes': {
+        const { appState, ui } = store.getState();
         store.dispatch(
           actions.ui.filterNotes(
-            store
-              .getState()
-              .appState.notes?.filter(({ id }) => event.data.noteIds.has(id)) ||
-              emptyList
+            appState.notes?.filter(({ id }) => event.data.noteIds.has(id)) ||
+              emptyList,
+            ui.previousIndex
           )
         );
         break;
+      }
     }
   };
 

--- a/lib/search/worker/index.ts
+++ b/lib/search/worker/index.ts
@@ -18,6 +18,7 @@ self.onmessage = bootEvent => {
   let searchQuery = '';
   let searchTerms: string[] = [];
   let filterTags = new Set<T.TagName>();
+  let openedTag: string | null = null;
   let showTrash = false;
 
   const tagsFromSearch = (query: string) => {
@@ -111,14 +112,18 @@ self.onmessage = bootEvent => {
       }
 
       if ('string' === typeof event.data.openedTag) {
-        filterTags = tagsFromSearch(searchQuery);
-        filterTags.add(event.data.openedTag.toLocaleLowerCase());
+        openedTag = event.data.openedTag.toLocaleLowerCase();
       } else if (null === event.data.openedTag) {
         filterTags = tagsFromSearch(searchQuery);
+        openedTag = null;
       }
 
       if ('boolean' === typeof event.data.showTrash) {
         showTrash = event.data.showTrash;
+      }
+
+      if (openedTag) {
+        filterTags.add(openedTag);
       }
 
       queueUpdateFilter();


### PR DESCRIPTION
In #1941 we introduced two regressions and this patch fixes them.

 - search needs to remember the opened tag and limit results to those
   matching within that tag. this was overlooked when updating the
   search query and updating the `filterTags` _from_ that search query

 - when passing the `filterNotes` action back to the application we
   have to make sure to pass the previous index. this was lost during
   the merge of the PR because because the additions from #1919, which
   fixed the previous regression for it, were deleted as part of
   moving `ui/middleware` into `search/index`

With these changes in place the two regressions should be fixed again.

## Testing

Apart from the normal checklist note that #1941 introduced regressions
to the following items. Verify that they are fixed in this branch.

 - [ ] Selects note above recently-trashed note
 - [ ] Selects note above recently-restored note in trash view
 - [ ] Selects note above recently-deleted-forever note in trash view
 - [ ] Can search by keyword with tag selected