### PR TITLE
Update Testing Checklist: Search results should appear instantly now

### DIFF
--- a/TESTING-CHECKLIST.md
+++ b/TESTING-CHECKLIST.md
@@ -41,7 +41,7 @@
 - [ ] Searching in the search field highlights matches in the note editor during preview
 - [ ] Clearing the search field immediately updates filtered notes
 - [ ] Clicking on different tags or `All Notes` or `Trash` immediately updates filtered notes
-- [ ] Can search by keyword, filtering debounced
+- [ ] Can search by keyword, filtered instantly
 - [ ] Tag auto-completes appear when typing in search field
 - [ ] Typing `tag:` does not result a list of all tags in the autocompleter
 - [ ] Typing `tag:` and something else, like `tag:te` results in autocomplete results starting with that something else, e.g. `test`


### PR DESCRIPTION
This updates the testing checklist in response to the merge of #1941 where we eliminated our search debounce in favor of a faster search.

## Testing

No testing is necessary since this only affects the checklist.
Please review the wording.