### PR TITLE
Move select trash and show all notes to redux

### DIFF
--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -33,7 +33,7 @@ export const actionMap = new ActionMap({
     showAllNotesAndSelectFirst: {
       creator() {
         return (dispatch, getState) => {
-          dispatch(this.action('showAllNotes'));
+          dispatch(actions.ui.showAllNotes());
           dispatch(
             this.action('notesLoaded', {
               notes: getState().appState.notes,
@@ -41,14 +41,6 @@ export const actionMap = new ActionMap({
           );
         };
       },
-    },
-
-    showAllNotes(state: AppState) {
-      return update(state, {});
-    },
-
-    selectTrash(state: AppState) {
-      return update(state, {});
     },
 
     showDialog(state: AppState, { dialog }) {

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -43,10 +43,6 @@ type Props = OwnProps & StateProps & DispatchProps;
 export class NavigationBar extends Component<Props> {
   static displayName = 'NavigationBar';
 
-  static defaultProps = {
-    onShowAllNotes: function() {},
-  };
-
   // Used by onClickOutside wrapper
   handleClickOutside = () => {
     const { dialogs, onOutsideClick, showNavigation } = this.props;
@@ -158,7 +154,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   onOutsideClick: toggleNavigation,
   onShowAllNotes: showAllNotesAndSelectFirst,
   onSettings: () => showDialog({ dialog: DialogTypes.SETTINGS }),
-  selectTrash: () => selectTrash(),
+  selectTrash,
 };
 
 export default connect(

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -13,7 +13,7 @@ import { viewExternalUrl } from '../utils/url-utils';
 import appState from '../flux/app-state';
 import DialogTypes from '../../shared/dialog-types';
 
-import { toggleNavigation } from '../state/ui/actions';
+import { toggleNavigation, selectTrash } from '../state/ui/actions';
 
 import * as S from '../state';
 import * as T from '../types';
@@ -151,18 +151,14 @@ const mapStateToProps: S.MapState<StateProps> = ({
   showTrash,
 });
 
-const {
-  showAllNotesAndSelectFirst,
-  selectTrash,
-  showDialog,
-} = appState.actionCreators;
+const { showAllNotesAndSelectFirst, showDialog } = appState.actionCreators;
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   onAbout: () => showDialog({ dialog: DialogTypes.ABOUT }),
   onOutsideClick: toggleNavigation,
   onShowAllNotes: showAllNotesAndSelectFirst,
   onSettings: () => showDialog({ dialog: DialogTypes.SETTINGS }),
-  selectTrash,
+  selectTrash: () => selectTrash(),
 };
 
 export default connect(

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -73,7 +73,7 @@ export const middleware: S.Middleware = store => {
         });
         break;
 
-      case 'App.selectTrash':
+      case 'SELECT_TRASH':
         searchProcessor.postMessage({
           action: 'filterNotes',
           openedTag: null,
@@ -81,7 +81,7 @@ export const middleware: S.Middleware = store => {
         });
         break;
 
-      case 'App.showAllNotes':
+      case 'SHOW_ALL_NOTES':
         searchProcessor.postMessage({
           action: 'filterNotes',
           openedTag: null,

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -68,6 +68,7 @@ export type SelectRevision = Action<
   'SELECT_REVISION',
   { revision: T.NoteEntity }
 >;
+export type SelectTrash = Action<'SELECT_TRASH'>;
 export type SetAuth = Action<'AUTH_SET', { status: AuthState }>;
 export type SetSystemTag = Action<
   'SET_SYSTEM_TAG',
@@ -77,6 +78,7 @@ export type SetUnsyncedNoteIds = Action<
   'SET_UNSYNCED_NOTE_IDS',
   { noteIds: T.EntityId[] }
 >;
+export type ShowAllNotes = Action<'SHOW_ALL_NOTES'>;
 export type StoreRevisions = Action<
   'STORE_REVISIONS',
   { noteId: T.EntityId; revisions: T.NoteEntity[] }
@@ -111,6 +113,7 @@ export type ActionType =
   | Search
   | SelectNote
   | SelectRevision
+  | SelectTrash
   | SetAccountName
   | SetAuth
   | SetAutoHideMenuBar
@@ -126,6 +129,7 @@ export type ActionType =
   | SetTheme
   | SetUnsyncedNoteIds
   | SetWPToken
+  | ShowAllNotes
   | StoreRevisions
   | ToggleEditMode
   | ToggleNavigation
@@ -205,10 +209,8 @@ type LegacyAction =
   | Action<'App.notesLoaded', { notes: T.NoteEntity[] }>
   | Action<'App.onNoteBeforeRemoteUpdate', { noteId: T.EntityId }>
   | Action<'App.preferencesLoaded', { analyticsEnabled: boolean }>
-  | Action<'App.selectTrash'>
   | Action<'App.setShouldPrintNote', { shouldPrint: boolean }>
   | Action<'App.setUnsyncedNoteIds', { noteIds: T.EntityId[] }>
-  | Action<'App.showAllNotes'>
   | Action<'App.showAllNotesAndSelectFirst'>
   | Action<'App.showDialog', { dialog: object }>
   | Action<'App.tagsLoaded', { tags: T.TagEntity[]; sortTagsAlpha: boolean }>;

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -78,11 +78,19 @@ export const selectRevision: A.ActionCreator<A.SelectRevision> = (
   revision,
 });
 
+export const selectTrash: A.ActionCreator<A.SelectTrash> = () => ({
+  type: 'SELECT_TRASH',
+});
+
 export const setUnsyncedNoteIds: A.ActionCreator<A.SetUnsyncedNoteIds> = (
   noteIds: T.EntityId[]
 ) => ({
   type: 'SET_UNSYNCED_NOTE_IDS',
   noteIds,
+});
+
+export const showAllNotes: A.ActionCreator<A.ShowAllNotes> = () => ({
+  type: 'SHOW_ALL_NOTES',
 });
 
 export const storeRevisions: A.ActionCreator<A.StoreRevisions> = (

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -25,8 +25,8 @@ const editingTags: A.Reducer<boolean> = (state = false, action) => {
       return !state;
     case 'SELECT_NOTE':
     case 'OPEN_TAG':
-    case 'App.selectTrash':
-    case 'App.showAllNotes':
+    case 'SELECT_TRASH':
+    case 'SHOW_ALL_NOTES':
     case 'NAVIGATION_TOGGLE':
     case 'App.toggleNoteInfo':
       return false;
@@ -45,9 +45,9 @@ const listTitle: A.Reducer<T.TranslatableString> = (
   action
 ) => {
   switch (action.type) {
-    case 'App.showAllNotes':
+    case 'SHOW_ALL_NOTES':
       return 'All Notes';
-    case 'App.selectTrash':
+    case 'SELECT_TRASH':
       return 'Trash';
     case 'OPEN_TAG':
       return action.tag.data.name;
@@ -73,8 +73,8 @@ const noteRevisions: A.Reducer<T.NoteEntity[]> = (
 
 const openedTag: A.Reducer<T.TagEntity | null> = (state = null, action) => {
   switch (action.type) {
-    case 'App.selectTrash':
-    case 'App.showAllNotes':
+    case 'SELECT_TRASH':
+    case 'SHOW_ALL_NOTES':
       return null;
     case 'OPEN_TAG':
       return action.tag;
@@ -106,8 +106,8 @@ const previousIndex: A.Reducer<number> = (state = -1, action) => {
     case 'TRASH_NOTE':
       return action.previousIndex || state;
     case 'OPEN_TAG':
-    case 'App.selectTrash':
-    case 'App.showAllNotes':
+    case 'SELECT_TRASH':
+    case 'SHOW_ALL_NOTES':
       return -1;
     default:
       return state;
@@ -159,8 +159,8 @@ const showNavigation: A.Reducer<boolean> = (state = false, action) => {
       return !state;
 
     case 'OPEN_TAG':
-    case 'App.selectTrash':
-    case 'App.showAllNotes':
+    case 'SELECT_TRASH':
+    case 'SHOW_ALL_NOTES':
       return false;
     case 'App.showDialog':
       if (action.dialog && action.dialog.type === 'Settings') {
@@ -186,11 +186,11 @@ const showRevisions: A.Reducer<boolean> = (state = false, action) => {
 
 const showTrash: A.Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
-    case 'App.selectTrash':
+    case 'SELECT_TRASH':
       return true;
     case 'CREATE_NOTE':
     case 'OPEN_TAG':
-    case 'App.showAllNotes': {
+    case 'SHOW_ALL_NOTES': {
       return false;
     }
     default:
@@ -201,8 +201,8 @@ const showTrash: A.Reducer<boolean> = (state = false, action) => {
 const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
   switch (action.type) {
     case 'App.emptyTrash':
-    case 'App.selectTrash':
-    case 'App.showAllNotes':
+    case 'SELECT_TRASH':
+    case 'SHOW_ALL_NOTES':
     case 'CLOSE_NOTE':
     case 'DELETE_NOTE_FOREVER':
     case 'RESTORE_NOTE':


### PR DESCRIPTION
### Fix
This creates actions for select trash and show all notes in redux and calls
them instead of the app-state functions.

### Test
1. View trash, did it show?
2. Open Tag, does it show?
3. Show All, does it show all?

### Release
`RELEASE-NOTES.txt` should be updated with:

- Refactored internal state and data flow
[#1971](https://github.com/Automattic/simplenote-electron/pull/1971) (selectTrash and showAllNotes),

