### PR TITLE
Search: Stop auto-selecting previous index (performance)

### DIFF
--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -108,6 +108,7 @@ const previousIndex: A.Reducer<number> = (state = -1, action) => {
     case 'OPEN_TAG':
     case 'SELECT_TRASH':
     case 'SHOW_ALL_NOTES':
+    case 'FILTER_NOTES':
       return -1;
     default:
       return state;


### PR DESCRIPTION
In #1941 we introduced instant search results.
In #1919 and in #1966 we refactored the `previousIndex` into Redux

The result was that we weren't resetting the `previousIndex` properly
and so on every search we would select _some_ note, often the first
one in the list. If this note were large or slow to render then the
performance gains we achieved with search were destroyed by the cost
of rendering the notes.

In this patch we're properly resetting the `previousNote` whenever
we actually filter the notes. This means that searches will clear
the selected note if it's not in the search results. This also brings
back the performance gains we got by refactoring search itself.

## Testing

Open an account with large or slow-to-render notes.
Search for almost anything.

In `develop` you might notice that the app becomes unresponsive.
In this branch you should see full responsiveness.

Verify that when trashing, restoring, and permanently deleting a
note that the one above it in the note list gets selected.