### PR TITLE
Add keyboard shortcuts explainer

### DIFF
--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -33,17 +33,17 @@ const buildEditMenu = settings => {
         label: '&Select All',
         role: 'selectall',
       },
+      { type: 'separator' },
       {
-        type: 'separator',
+        label: '&Trash Note',
+        click: appCommandSender({ action: 'trashNote' }),
       },
+      { type: 'separator' },
       {
         label: 'Search &Notes…',
-        accelerator: 'CommandOrControl+Shift+F',
         click: appCommandSender({ action: 'focusSearchField' }),
       },
-      {
-        type: 'separator',
-      },
+      { type: 'separator' },
       {
         label: 'C&heck Spelling',
         type: 'checkbox',

--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -38,7 +38,7 @@ const buildEditMenu = settings => {
       },
       {
         label: 'Search &Notes…',
-        accelerator: 'CommandOrControl+F',
+        accelerator: 'CommandOrControl+Shift+F',
         click: appCommandSender({ action: 'focusSearchField' }),
       },
       {

--- a/desktop/menus/file-menu.js
+++ b/desktop/menus/file-menu.js
@@ -5,7 +5,6 @@ const { appCommandSender } = require('./utils');
 const submenu = [
   {
     label: '&New Note',
-    accelerator: 'CommandOrControl+N',
     click: appCommandSender({ action: 'newNote' }),
   },
   { type: 'separator' },

--- a/desktop/menus/format-menu.js
+++ b/desktop/menus/format-menu.js
@@ -3,7 +3,6 @@ const { appCommandSender } = require('./utils');
 const submenu = [
   {
     label: 'Insert &Checklist',
-    accelerator: 'CommandOrControl+Shift+C',
     click: appCommandSender({ action: 'insertChecklist' }),
   },
 ];

--- a/desktop/menus/help-menu.js
+++ b/desktop/menus/help-menu.js
@@ -4,11 +4,17 @@ const menuItems = require('./menu-items');
 const platform = require('../detect/platform');
 const build = require('../detect/build');
 
+const { appCommandSender } = require('./utils');
+
 const submenu = [
   {
     label: 'Help && &Support',
     accelerator: platform.isLinux() ? 'F1' : null,
     click: () => shell.openExternal('https://simplenote.com/help'),
+  },
+  {
+    label: '&Keyboard Shortcuts',
+    click: appCommandSender({ action: 'showDialog', dialog: 'KEYBINDINGS' }),
   },
   { type: 'separator' },
   {

--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, Suspense } from 'react';
+import React, { Component, Suspense } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 
@@ -8,6 +8,7 @@ import RevisionSelector from '../revision-selector';
 import SearchBar from '../search-bar';
 import SimplenoteCompactLogo from '../icons/simplenote-compact';
 import TransitionDelayEnter from '../components/transition-delay-enter';
+import actions from '../state/actions';
 
 import * as S from '../state';
 import * as T from '../types';
@@ -33,62 +34,105 @@ type OwnProps = {
 
 type StateProps = {
   isNoteOpen: boolean;
+  keyboardShortcutsAreOpen: boolean;
 };
 
-type Props = OwnProps & StateProps;
+type DispatchProps = {
+  hideKeyboardShortcuts: () => any;
+  showKeyboardShortcuts: () => any;
+};
 
-export const AppLayout: FunctionComponent<Props> = ({
-  isFocusMode = false,
-  isNavigationOpen,
-  isNoteInfoOpen,
-  isNoteOpen,
-  isSmallScreen,
-  noteBucket,
-  onUpdateContent,
-  syncNote,
-}) => {
-  const mainClasses = classNames('app-layout', {
-    'is-focus-mode': isFocusMode,
-    'is-navigation-open': isNavigationOpen,
-    'is-note-open': isNoteOpen,
-    'is-showing-note-info': isNoteInfoOpen,
-  });
+type Props = OwnProps & StateProps & DispatchProps;
 
-  const placeholder = (
-    <TransitionDelayEnter delay={1000}>
-      <div className="app-layout__placeholder">
-        <SimplenoteCompactLogo />
+export class AppLayout extends Component<Props> {
+  componentDidMount() {
+    window.addEventListener('keydown', this.openKeybindingsHelp, false);
+  }
+
+  componentWillUnmount(): void {
+    window.removeEventListener('keydown', this.openKeybindingsHelp, false);
+  }
+
+  openKeybindingsHelp = (event: KeyboardEvent) => {
+    const {
+      hideKeyboardShortcuts,
+      keyboardShortcutsAreOpen,
+      showKeyboardShortcuts,
+    } = this.props;
+    const { ctrlKey, code, metaKey } = event;
+
+    const cmdOrCtrl = ctrlKey || metaKey;
+
+    if (cmdOrCtrl && code === 'Slash') {
+      keyboardShortcutsAreOpen
+        ? hideKeyboardShortcuts()
+        : showKeyboardShortcuts();
+    }
+  };
+
+  render = () => {
+    const {
+      isFocusMode = false,
+      isNavigationOpen,
+      isNoteInfoOpen,
+      isNoteOpen,
+      isSmallScreen,
+      noteBucket,
+      onUpdateContent,
+      syncNote,
+    } = this.props;
+
+    const mainClasses = classNames('app-layout', {
+      'is-focus-mode': isFocusMode,
+      'is-navigation-open': isNavigationOpen,
+      'is-note-open': isNoteOpen,
+      'is-showing-note-info': isNoteInfoOpen,
+    });
+
+    const placeholder = (
+      <TransitionDelayEnter delay={1000}>
+        <div className="app-layout__placeholder">
+          <SimplenoteCompactLogo />
+        </div>
+      </TransitionDelayEnter>
+    );
+
+    return (
+      <div className={mainClasses}>
+        <Suspense fallback={placeholder}>
+          <div className="app-layout__source-column theme-color-bg theme-color-fg">
+            <SearchBar noteBucket={noteBucket} />
+            <NoteList noteBucket={noteBucket} isSmallScreen={isSmallScreen} />
+          </div>
+          <div className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border">
+            <RevisionSelector onUpdateContent={onUpdateContent} />
+            <NoteToolbarContainer
+              noteBucket={noteBucket}
+              toolbar={<NoteToolbar />}
+            />
+            <NoteEditor
+              isSmallScreen={isSmallScreen}
+              noteBucket={noteBucket}
+              onUpdateContent={onUpdateContent}
+              syncNote={syncNote}
+            />
+          </div>
+        </Suspense>
       </div>
-    </TransitionDelayEnter>
-  );
+    );
+  };
+}
 
-  return (
-    <div className={mainClasses}>
-      <Suspense fallback={placeholder}>
-        <div className="app-layout__source-column theme-color-bg theme-color-fg">
-          <SearchBar noteBucket={noteBucket} />
-          <NoteList noteBucket={noteBucket} isSmallScreen={isSmallScreen} />
-        </div>
-        <div className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border">
-          <RevisionSelector onUpdateContent={onUpdateContent} />
-          <NoteToolbarContainer
-            noteBucket={noteBucket}
-            toolbar={<NoteToolbar />}
-          />
-          <NoteEditor
-            isSmallScreen={isSmallScreen}
-            noteBucket={noteBucket}
-            onUpdateContent={onUpdateContent}
-            syncNote={syncNote}
-          />
-        </div>
-      </Suspense>
-    </div>
-  );
-};
-
-const mapStateToProps: S.MapState<StateProps> = ({ ui: { showNoteList } }) => ({
+const mapStateToProps: S.MapState<StateProps> = ({
+  ui: { dialogs, showNoteList },
+}) => ({
+  keyboardShortcutsAreOpen: dialogs.includes('KEYBINDINGS'),
   isNoteOpen: !showNoteList,
 });
 
-export default connect(mapStateToProps)(AppLayout);
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
+  hideKeyboardShortcuts: () => actions.ui.closeDialog('KEYBINDINGS'),
+  showKeyboardShortcuts: () => actions.ui.showDialog('KEYBINDINGS'),
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(AppLayout);

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -55,7 +55,7 @@ export type DispatchProps = {
   closeNote: () => any;
   focusSearchField: () => any;
   selectNote: (note: T.NoteEntity) => any;
-  showDialog: () => any;
+  showDialog: (type: T.DialogType) => any;
 };
 
 export type Props = DispatchProps;
@@ -229,8 +229,8 @@ export const App = connect(
       }
     }
 
-    handleShortcut = event => {
-      const { ctrlKey, key, metaKey } = event;
+    handleShortcut = (event: KeyboardEvent) => {
+      const { code, ctrlKey, key, metaKey, shiftKey } = event;
 
       // Is either cmd or ctrl pressed? (But not both)
       const cmdOrCtrl = (ctrlKey || metaKey) && ctrlKey !== metaKey;
@@ -238,7 +238,8 @@ export const App = connect(
       // open tag list
       if (
         cmdOrCtrl &&
-        't' === key.toLowerCase() &&
+        shiftKey &&
+        'KeyT' === code &&
         !this.props.showNavigation
       ) {
         this.props.openTagList();

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -50,17 +50,23 @@ export type OwnProps = {
   noteBucket: object;
 };
 
+export type StateProps = S.State & {
+  authIsPending: boolean;
+  isAuthorized: boolean;
+};
+
 export type DispatchProps = {
   createNote: () => any;
   closeNote: () => any;
   focusSearchField: () => any;
   selectNote: (note: T.NoteEntity) => any;
   showDialog: (type: T.DialogType) => any;
+  trashNote: (previousIndex: number) => any;
 };
 
-export type Props = DispatchProps;
+export type Props = OwnProps & StateProps & DispatchProps;
 
-const mapStateToProps = state => ({
+const mapStateToProps: S.MapState<StateProps> = state => ({
   ...state,
   authIsPending: selectors.auth.authIsPending(state),
   isAuthorized: selectors.auth.isAuthorized(state),
@@ -117,6 +123,7 @@ const mapDispatchToProps: S.MapDispatch<
     selectNote: note => dispatch(actions.ui.selectNote(note)),
     setUnsyncedNoteIds: noteIds => dispatch(setUnsyncedNoteIds(noteIds)),
     showDialog: dialog => dispatch(actions.ui.showDialog(dialog)),
+    trashNote: previousIndex => dispatch(actions.ui.trashNote(previousIndex)),
   };
 };
 
@@ -230,7 +237,7 @@ export const App = connect(
     }
 
     handleShortcut = (event: KeyboardEvent) => {
-      const { code, ctrlKey, key, metaKey, shiftKey } = event;
+      const { code, ctrlKey, metaKey, shiftKey } = event;
 
       // Is either cmd or ctrl pressed? (But not both)
       const cmdOrCtrl = (ctrlKey || metaKey) && ctrlKey !== metaKey;
@@ -243,6 +250,40 @@ export const App = connect(
         !this.props.showNavigation
       ) {
         this.props.openTagList();
+
+        event.stopPropagation();
+        event.preventDefault();
+        return false;
+      }
+
+      if (cmdOrCtrl && shiftKey && 'KeyF' === code) {
+        this.props.focusSearchField();
+
+        event.stopPropagation();
+        event.preventDefault();
+        return false;
+      }
+
+      if (cmdOrCtrl && shiftKey && 'KeyN' === code) {
+        this.props.createNote();
+        this.props.actions.newNote({
+          noteBucket: this.props.noteBucket,
+        });
+        analytics.tracks.recordEvent('list_note_created');
+
+        event.stopPropagation();
+        event.preventDefault();
+        return false;
+      }
+
+      if (this.props.ui.note && cmdOrCtrl && 'Delete' === code) {
+        this.props.actions.trashNote({
+          noteBucket: this.props.noteBucket,
+          note: this.props.ui.note,
+          previousIndex: this.props.appState.notes.findIndex(
+            ({ id }) => this.props.ui.note.id === id
+          ),
+        });
 
         event.stopPropagation();
         event.preventDefault();
@@ -267,6 +308,16 @@ export const App = connect(
 
       if ('showDialog' === command.action) {
         return this.props.showDialog(command.dialog);
+      }
+
+      if ('trashNote' === command.action && this.props.ui.note) {
+        return this.props.actions.trashNote({
+          noteBucket: this.props.noteBucket,
+          note: this.props.ui.note,
+          previousIndex: this.props.appState.notes.findIndex(
+            ({ id }) => this.props.ui.note.id === id
+          ),
+        });
       }
 
       const canRun = overEvery(

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -276,7 +276,11 @@ export const App = connect(
         return false;
       }
 
-      if (this.props.ui.note && cmdOrCtrl && 'Delete' === code) {
+      if (
+        this.props.ui.note &&
+        cmdOrCtrl &&
+        ('Delete' === code || 'Backspace' === code)
+      ) {
         this.props.actions.trashNote({
           noteBucket: this.props.noteBucket,
           note: this.props.ui.note,

--- a/lib/dialog-renderer/index.tsx
+++ b/lib/dialog-renderer/index.tsx
@@ -1,11 +1,11 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import Modal from 'react-modal';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import AboutDialog from '../dialogs/about';
 import ImportDialog from '../dialogs/import';
+import KeybindingsDialog from '../dialogs/keybindings';
 import SettingsDialog from '../dialogs/settings';
 import ShareDialog from '../dialogs/share';
 import { closeDialog } from '../state/ui/actions';
@@ -63,6 +63,12 @@ export class DialogRenderer extends Component<Props> {
                 key="import"
                 buckets={buckets}
                 isElectron={isElectron}
+              />
+            ) : 'KEYBINDINGS' === dialog ? (
+              <KeybindingsDialog
+                key="keybindings"
+                isElectron={isElectron}
+                isMacApp={isMacApp}
               />
             ) : 'SETTINGS' === dialog ? (
               <SettingsDialog

--- a/lib/dialogs/about/index.tsx
+++ b/lib/dialogs/about/index.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 import SimplenoteLogo from '../../icons/simplenote';
 import CrossIcon from '../../icons/cross';
 import TopRightArrowIcon from '../../icons/arrow-top-right';

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -16,20 +16,30 @@ type DispatchProps = {
 
 type Props = OwnProps & DispatchProps;
 
-const Keys = ({ keys }: { keys: (string | [string, string])[] }) => (
-  <div className="keybindings__key-list">
-    {keys.map((key, i) => (
-      <Fragment key={i}>
-        {i > 0 && ' + '}
-        {'string' === typeof key ? (
-          <kbd key={key}>{key}</kbd>
-        ) : (
-          <>
-            <kbd>{key[0]}</kbd> / <kbd>{key[1]}</kbd>
-          </>
-        )}
-      </Fragment>
-    ))}
+const Keys = ({
+  keys,
+  children,
+}: {
+  keys: (string | [string, string])[];
+  children: React.ReactNode;
+}) => (
+  <div className="keybindings__key-item">
+    <div className="keybindings__key-list">
+      {keys.map((key, i) => (
+        <Fragment key={i}>
+          {i > 0 && ' + '}
+          {'string' === typeof key ? (
+            <kbd key={key}>{key}</kbd>
+          ) : (
+            <>
+              <kbd>{key[0]}</kbd> / <kbd>{key[1]}</kbd>
+            </>
+          )}
+        </Fragment>
+      ))}
+    </div>
+    {'\u2000-\u2000'}
+    <div className="keybindings__key-description">{children}</div>
   </div>
 );
 
@@ -47,17 +57,28 @@ export class AboutDialog extends Component<Props> {
               <h1>View</h1>
               <ul>
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'Shift', 'F']} /> - Focus search field
+                  <Keys keys={[CmdOrCtrl, '?']}>Show keyboard shortcuts</Keys>
                 </li>
                 <li>
-                  <Keys keys={[CmdOrCtrl, '+']} /> - Increase font size
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'F']}>
+                    Focus search field
+                  </Keys>
                 </li>
-                <li>
-                  <Keys keys={[CmdOrCtrl, '-']} /> - Decrease font size
-                </li>
-                <li>
-                  <Keys keys={[CmdOrCtrl, '0']} /> - Reset font size
-                </li>
+                {isElectron && (
+                  <li>
+                    <Keys keys={[CmdOrCtrl, '+']}>Increase font size</Keys>
+                  </li>
+                )}
+                {isElectron && (
+                  <li>
+                    <Keys keys={[CmdOrCtrl, '-']}>Decrease font size</Keys>
+                  </li>
+                )}
+                {isElectron && (
+                  <li>
+                    <Keys keys={[CmdOrCtrl, '0']}>Reset font size</Keys>
+                  </li>
+                )}
               </ul>
             </section>
 
@@ -66,26 +87,38 @@ export class AboutDialog extends Component<Props> {
               <ul>
                 {isElectron && (
                   <li>
-                    <Keys keys={[CmdOrCtrl, ',']} /> - Open app preferences
+                    <Keys keys={[CmdOrCtrl, ',']}>Open app preferences</Keys>
                   </li>
                 )}
                 {isElectron && (
                   <li>
-                    <Keys keys={[CmdOrCtrl, 'Shift', 'E']} /> - Export all notes
+                    <Keys keys={[CmdOrCtrl, 'Shift', 'E']}>
+                      Export all notes
+                    </Keys>
                   </li>
                 )}
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'Shift', 'T']} /> - Toggle tag list
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'T']}>Toggle tag list</Keys>
                 </li>
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'Shift', 'K']} /> - Select previous
-                  note
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'K']}>
+                    Select previous note
+                  </Keys>
                 </li>
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'Shift', 'J']} /> - Select next note
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'J']}>Select next note</Keys>
                 </li>
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'Shift', 'N']} /> - Show note list
+                  <Keys keys={[CmdOrCtrl, 'T']}>
+                    Toggle editing content/tags
+                  </Keys>
+                </li>
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'L']}>
+                    Show note list
+                    <br />
+                    (on narrow screens)
+                  </Keys>
                 </li>
               </ul>
             </section>
@@ -94,21 +127,25 @@ export class AboutDialog extends Component<Props> {
               <h1>Note Editing</h1>
               <ul>
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'N']} /> - Create new note
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'N']}>Create new note</Keys>
                 </li>
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'P']} /> - Print note
+                  <Keys keys={[CmdOrCtrl, 'Delete']}>Trash note</Keys>
+                </li>
+                {isElectron && (
+                  <li>
+                    <Keys keys={[CmdOrCtrl, 'P']}>Print note</Keys>
+                  </li>
+                )}
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'P']}>
+                    Toggle Markdown preview
+                  </Keys>
                 </li>
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'T']} /> - Toggle editing content/tags
-                </li>
-                <li>
-                  <Keys keys={[CmdOrCtrl, 'Shift', 'P']} /> - Toggle Markdown
-                  preview
-                </li>
-                <li>
-                  <Keys keys={[CmdOrCtrl, 'Shift', 'C']} /> - Insert checklist
-                  item
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'C']}>
+                    Insert checklist item
+                  </Keys>
                 </li>
               </ul>
             </section>

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -1,0 +1,126 @@
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import Dialog from '../../dialog';
+import { closeDialog } from '../../state/ui/actions';
+
+import * as S from '../../state';
+
+type OwnProps = {
+  isElectron: boolean;
+  isMacApp: boolean;
+};
+
+type DispatchProps = {
+  closeDialog: () => any;
+};
+
+type Props = OwnProps & DispatchProps;
+
+const Keys = ({ keys }: { keys: (string | [string, string])[] }) => (
+  <div className="keybindings__key-list">
+    {keys.map((key, i) => (
+      <Fragment key={i}>
+        {i > 0 && ' + '}
+        {'string' === typeof key ? (
+          <kbd key={key}>{key}</kbd>
+        ) : (
+          <>
+            <kbd>{key[0]}</kbd> / <kbd>{key[1]}</kbd>
+          </>
+        )}
+      </Fragment>
+    ))}
+  </div>
+);
+
+export class AboutDialog extends Component<Props> {
+  render() {
+    const { closeDialog, isElectron, isMacApp } = this.props;
+
+    const CmdOrCtrl = isMacApp ? 'Cmd' : 'Ctrl';
+
+    return (
+      <div className="keybindings">
+        <Dialog onDone={closeDialog} title="Keyboard Shortcuts">
+          <div className="keybindings__sections">
+            <section>
+              <h1>View</h1>
+              <ul>
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'F']} /> - Focus search field
+                </li>
+                <li>
+                  <Keys keys={[CmdOrCtrl, '+']} /> - Increase font size
+                </li>
+                <li>
+                  <Keys keys={[CmdOrCtrl, '-']} /> - Decrease font size
+                </li>
+                <li>
+                  <Keys keys={[CmdOrCtrl, '0']} /> - Reset font size
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h1>Navigation</h1>
+              <ul>
+                {isElectron && (
+                  <li>
+                    <Keys keys={[CmdOrCtrl, ',']} /> - Open app preferences
+                  </li>
+                )}
+                {isElectron && (
+                  <li>
+                    <Keys keys={[CmdOrCtrl, 'Shift', 'E']} /> - Export all notes
+                  </li>
+                )}
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'T']} /> - Toggle tag list
+                </li>
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'K']} /> - Select previous
+                  note
+                </li>
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'J']} /> - Select next note
+                </li>
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'N']} /> - Show note list
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h1>Note Editing</h1>
+              <ul>
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'N']} /> - Create new note
+                </li>
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'P']} /> - Print note
+                </li>
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'T']} /> - Toggle editing content/tags
+                </li>
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'P']} /> - Toggle Markdown
+                  preview
+                </li>
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'C']} /> - Insert checklist
+                  item
+                </li>
+              </ul>
+            </section>
+          </div>
+        </Dialog>
+      </div>
+    );
+  }
+}
+
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
+  closeDialog,
+};
+
+export default connect(null, mapDispatchToProps)(AboutDialog);

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -57,7 +57,7 @@ export class AboutDialog extends Component<Props> {
               <h1>View</h1>
               <ul>
                 <li>
-                  <Keys keys={[CmdOrCtrl, '?']}>Show keyboard shortcuts</Keys>
+                  <Keys keys={[CmdOrCtrl, '/']}>Show keyboard shortcuts</Keys>
                 </li>
                 <li>
                   <Keys keys={[CmdOrCtrl, 'Shift', 'F']}>

--- a/lib/dialogs/keybindings/style.scss
+++ b/lib/dialogs/keybindings/style.scss
@@ -1,0 +1,69 @@
+.keybindings {
+  .dialog {
+    position: relative;
+    max-height: 480px;
+    max-width: 1020px;
+    overflow-y: scroll;
+    margin: auto;
+
+    @media only screen and (max-width: 1050px) {
+      max-width: 720px;
+    }
+
+    @media only screen and (max-width: 780px) {
+      max-width: 480px;
+    }
+  }
+
+  .dialog-content {
+    padding: 10px 20px 20px 20px;
+  }
+
+  ul {
+    padding-left: 0;
+  }
+
+  li {
+    margin-bottom: 6px;
+    list-style: none;
+  }
+
+  kbd {
+    border-radius: 5px;
+    margin: 4px;
+    padding: 0 5px;
+    font-size: 12px;
+    min-width: 8px;
+    text-align: center;
+    display: inline-block;
+    box-shadow: 0 1px 1px gray;
+
+    .theme-dark & {
+      border: 1px solid white;
+    }
+
+    .theme-light & {
+      border: 1px solid black;
+    }
+  }
+}
+
+.keybindings__key-list {
+  min-width: 80px;
+  display: inline-block;
+}
+
+.keybindings__sections {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+
+  section {
+    margin-right: 2em;
+
+    h1 {
+      font-size: 18px;
+    }
+  }
+}

--- a/lib/dialogs/keybindings/style.scss
+++ b/lib/dialogs/keybindings/style.scss
@@ -1,13 +1,10 @@
 .keybindings {
   .dialog {
-    position: relative;
-    max-height: 480px;
-    max-width: 1020px;
-    overflow-y: scroll;
+    max-width: 1120px;
     margin: auto;
 
-    @media only screen and (max-width: 1050px) {
-      max-width: 720px;
+    @media only screen and (max-width: 1150px) {
+      max-width: 760px;
     }
 
     @media only screen and (max-width: 780px) {
@@ -48,12 +45,26 @@
   }
 }
 
+.keybindings__key-item {
+  display: flex;
+  align-items: baseline;
+}
+
 .keybindings__key-list {
   min-width: 80px;
   display: inline-block;
 }
 
+.keybindings__key-description {
+  display: inline-block;
+  margin-left: 4px;
+}
+
 .keybindings__sections {
+  position: relative;
+  max-height: 480px;
+  overflow-y: scroll;
+
   width: 100%;
   display: flex;
   flex-direction: row;

--- a/lib/icon-button/style.scss
+++ b/lib/icon-button/style.scss
@@ -8,11 +8,12 @@
   }
 
   &:disabled {
-    opacity: .4;
+    opacity: 0.4;
   }
 }
 
 .icon-button__tooltip {
   position: relative;
   top: -8px;
+  font-size: 14px !important;
 }

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -11,9 +11,8 @@ import SettingsIcon from '../icons/settings';
 import SyncStatus from '../components/sync-status';
 import { viewExternalUrl } from '../utils/url-utils';
 import appState from '../flux/app-state';
-import { showDialog } from '../state/ui/actions';
 
-import { toggleNavigation, selectTrash } from '../state/ui/actions';
+import { showDialog, toggleNavigation, selectTrash } from '../state/ui/actions';
 
 import * as S from '../state';
 import * as T from '../types';
@@ -36,6 +35,7 @@ type DispatchProps = {
   onSettings: () => any;
   onShowAllNotes: () => any;
   selectTrash: () => any;
+  showKeyboardShortcuts: () => any;
 };
 
 type Props = OwnProps & StateProps & DispatchProps;
@@ -112,6 +112,15 @@ export class NavigationBar extends Component<Props> {
               <button
                 type="button"
                 className="navigation-bar__footer-item theme-color-fg-dim"
+                onClick={this.props.showKeyboardShortcuts}
+              >
+                Keyboard Shortcuts
+              </button>
+            </div>
+            <div className="navigation-bar__footer">
+              <button
+                type="button"
+                className="navigation-bar__footer-item theme-color-fg-dim"
                 onClick={this.onHelpClicked}
               >
                 Help &amp; Support
@@ -136,7 +145,6 @@ export class NavigationBar extends Component<Props> {
 }
 
 const mapStateToProps: S.MapState<StateProps> = ({
-  appState: state,
   settings,
   ui: { dialogs, openedTag, showNavigation, showTrash },
 }) => ({
@@ -155,6 +163,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   onShowAllNotes: showAllNotesAndSelectFirst,
   onSettings: () => showDialog('SETTINGS'),
   selectTrash,
+  showKeyboardShortcuts: () => showDialog('KEYBINDINGS'),
 };
 
 export default connect(

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -116,9 +116,9 @@ class NoteContentEditor extends Component<Props> {
 
     if (isElectron()) {
       this.ipc.on('appCommand', this.onAppCommand);
-    } else {
-      window.addEventListener('keydown', this.handleKeydown, false);
     }
+
+    window.addEventListener('keydown', this.handleKeydown, false);
   }
 
   handleEditorStateChange = editorState => {
@@ -227,9 +227,9 @@ class NoteContentEditor extends Component<Props> {
   componentWillUnmount() {
     if (isElectron()) {
       this.ipc.removeListener('appCommand', this.onAppCommand);
-    } else {
-      window.removeEventListener('keydown', this.handleKeydown, false);
     }
+
+    window.removeEventListener('keydown', this.handleKeydown, false);
   }
 
   focus = () => {

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -84,8 +84,8 @@ export class NoteEditor extends Component<Props> {
       return false;
     }
 
-    // open note list - shift + n
-    if (this.props.isSmallScreen && cmdOrCtrl && shiftKey && 'KeyN' === code) {
+    // open note list
+    if (this.props.isSmallScreen && cmdOrCtrl && shiftKey && 'KeyL' === code) {
       this.props.closeNote();
       event.stopPropagation();
       event.preventDefault();
@@ -93,7 +93,12 @@ export class NoteEditor extends Component<Props> {
     }
 
     // toggle between tag editor and note editor
-    if (cmdOrCtrl && 'KeyT' === code && this.props.isEditorActive) {
+    if (
+      !shiftKey &&
+      cmdOrCtrl &&
+      'KeyT' === code &&
+      this.props.isEditorActive
+    ) {
       // prefer focusing the edit field first
       if (!this.editFieldHasFocus()) {
         this.focusNoteEditor && this.focusNoteEditor();

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -118,7 +118,7 @@ export class NoteToolbar extends Component<Props> {
             <IconButton
               icon={<TrashIcon />}
               onClick={this.props.onTrashNote.bind(null, note)}
-              title="Trash"
+              title="Trash • Ctrl+Delete"
             />
           </div>
           <div className="note-toolbar__button">

--- a/lib/search-bar/index.tsx
+++ b/lib/search-bar/index.tsx
@@ -45,13 +45,17 @@ export const SearchBar: Component<Props> = ({
   toggleNavigation,
 }) => (
   <div className="search-bar theme-color-border">
-    <IconButton icon={<MenuIcon />} onClick={toggleNavigation} title="Menu" />
+    <IconButton
+      icon={<MenuIcon />}
+      onClick={toggleNavigation}
+      title="Menu • Ctrl+Shift+T"
+    />
     <SearchField />
     <IconButton
       disabled={showTrash}
       icon={<NewNoteIcon />}
       onClick={() => onNewNote(withoutTags(searchQuery))}
-      title="New Note"
+      title="New Note • Ctrl+Shift+N"
     />
   </div>
 );

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -13,7 +13,7 @@ const dialogs: A.Reducer<T.DialogType[]> = (state = [], action) => {
       return state.slice(0, -1);
 
     case 'SHOW_DIALOG':
-      return [...state, action.dialog];
+      return state.includes(action.dialog) ? state : [...state, action.dialog];
 
     case 'App.authChanged':
       return [];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -61,7 +61,12 @@ export type Bucket<T = unknown> = {
 ///////////////////////////////////////
 // Application Types
 ///////////////////////////////////////
-export type DialogType = 'ABOUT' | 'IMPORT' | 'SETTINGS' | 'SHARE';
+export type DialogType =
+  | 'ABOUT'
+  | 'KEYBINDINGS'
+  | 'IMPORT'
+  | 'SETTINGS'
+  | 'SHARE';
 export type LineLength = 'full' | 'narrow';
 export type ListDisplayMode = 'expanded' | 'comfy' | 'condensed';
 export type SortType = 'alphabetical' | 'creationDate' | 'modificationDate';

--- a/scss/_components.scss
+++ b/scss/_components.scss
@@ -20,6 +20,7 @@
 @import 'dialogs/import/dropzone/style';
 @import 'dialogs/import/source-importer/style';
 @import 'dialogs/import/source-importer/executor/style';
+@import 'dialogs/keybindings/style';
 @import 'dialogs/settings/style';
 @import 'dialogs/share/style';
 @import 'dialogs/button-group/style';


### PR DESCRIPTION
Follows #603
Resolves #700
Resolves #798
Resolves #985
Resolves #1167
Resolves #1222

This application has had keyboard shortcuts since #603 but they have
been undocumented making them hard to discover and remember.

In this patch we're picking up the work started in #700 and adding
a keyboard shortcut overylay, opened through the Help menu or by
pressing `CmdOrCtrl` + `?`. This dialog shows a list of the
app-specific keyboard shortcuts and what they do.

Oh yeah, and we're changing the "Find" shortcut to <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd>
in accordance with earlier design decisions to differentiate "search within
this note" vs. "search all notes" and also removes the <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Up</kbd>/<kbd>Down</kbd>
from note navigation so that it stops interfering with text selection.

<img width="648" alt="Screen Shot 2020-04-01 at 10 30 54 PM" src="https://user-images.githubusercontent.com/5431237/78214086-2f2ba900-7469-11ea-9035-6aa11a3c90f0.png">

![keyboardExplainer mov](https://user-images.githubusercontent.com/5431237/78214582-74040f80-746a-11ea-9ab1-48ddc062a11a.gif)

![Screen Shot 2020-04-16 at 7 42 38 PM](https://user-images.githubusercontent.com/5431237/79526592-7776c980-801a-11ea-918c-637a0db6aa4f.png)

## Testing

Run through the testing checklist.
Pay particular attention to keyboard shortcuts.
Try to break them and use them in unintended circumstances.