### PR TITLE
Fix: Highlight all search matches in Markdown previews and in note list

### DIFF
--- a/lib/note-detail/render-to-node.ts
+++ b/lib/note-detail/render-to-node.ts
@@ -23,12 +23,14 @@ const markMatches = (sourceNode: Text, terms: string[]): void => {
       // we have to remember the MATCH because we'll replace it
       const match = (node as Text).splitText(start);
 
-      match.splitText(term.length);
+      const after = match.splitText(term.length);
 
       const marked = document.createElement('span');
       marked.setAttribute('class', 'search-match');
       match.parentNode?.replaceChild(marked, match);
       marked.appendChild(match);
+
+      markMatches(after, terms);
     });
   });
 };

--- a/lib/note-detail/render-to-node.ts
+++ b/lib/note-detail/render-to-node.ts
@@ -1,9 +1,83 @@
+import { getTerms } from '../utils/filter-notes';
 import { renderNoteToHtml } from '../utils/render-note-to-html';
 
-export const renderToNode = (node, content) => {
+const markMatches = (sourceNode: Text, terms: string[]): void => {
+  const parent = sourceNode.parentNode as Node;
+
+  terms.forEach(term => {
+    // we only want to mark TEXT_NODE matches
+    // it wouldn't work well to match "pan" inside of "<span>"
+    parent.childNodes.forEach(node => {
+      if (
+        node.nodeType !== Node.TEXT_NODE ||
+        !node.textContent?.toLocaleLowerCase().includes(term)
+      ) {
+        return;
+      }
+
+      // split text node into | BEFORE | MATCH | AFTER
+      const start = node.textContent
+        ?.toLocaleLowerCase()
+        .indexOf(term) as number;
+
+      // we have to remember the MATCH because we'll replace it
+      const match = (node as Text).splitText(start);
+
+      match.splitText(term.length);
+
+      const marked = document.createElement('span');
+      marked.setAttribute('class', 'search-match');
+      match.parentNode?.replaceChild(marked, match);
+      marked.appendChild(match);
+    });
+  });
+};
+
+export const renderToNode = (
+  node: Element,
+  content: string,
+  searchQuery: string
+) => {
   renderNoteToHtml(content)
     .then(html => {
       node.innerHTML = html;
+      return node;
+    })
+    .then(node => {
+      if (!searchQuery) {
+        return node.querySelectorAll('pre code');
+      }
+
+      const terms = getTerms(searchQuery).map(s => s.toLocaleLowerCase());
+      if (!terms.length) {
+        return node.querySelectorAll('pre code');
+      }
+
+      const treeWalker = document.createTreeWalker(
+        node,
+        NodeFilter.SHOW_TEXT,
+        {
+          acceptNode: function(textNode: Text) {
+            return terms.some(term =>
+              textNode.textContent?.toLocaleLowerCase().includes(term)
+            )
+              ? NodeFilter.FILTER_ACCEPT
+              : NodeFilter.FILTER_REJECT;
+          },
+        },
+        false
+      );
+
+      const nodes: Text[] = [];
+      let currentNode: Node | null = treeWalker.currentNode;
+
+      while (currentNode) {
+        nodes.push(currentNode as Text);
+        currentNode = treeWalker.nextNode();
+      }
+
+      nodes.forEach(textNode => markMatches(textNode, terms));
+
       return node.querySelectorAll('pre code');
     })
     .then(codeElements => {

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -33,6 +33,7 @@ import actions from '../state/actions';
 
 import * as S from '../state';
 import * as T from '../types';
+import { getTerms } from '../utils/filter-notes';
 
 type OwnProps = {
   noteBucket: T.Bucket<T.Note>;
@@ -266,7 +267,8 @@ const renderNote = (
     'published-note': isPublished,
   });
 
-  const decorators = [checkboxDecorator, makeFilterDecorator(searchQuery)];
+  const terms = getTerms(searchQuery).map(makeFilterDecorator);
+  const decorators = [checkboxDecorator, ...terms];
 
   const selectNote = () => {
     onSelectNote(note.id);

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -118,4 +118,8 @@ optgroup {
   padding-left: 2px;
   padding-right: 2px;
   color: $studio-white;
+
+  &[data-current-match='true'] {
+    background-color: $studio-yellow-60;
+  }
 }


### PR DESCRIPTION

Previously we have only been highlighting search matches in
the plaintext view. If you're viewing the preview of a note
you won't see any indication of where the matches were.

In this patch we're adding a new stage in the HTML rendering
pipeline for the preview that replaces search matches in the
note with the wrapping `<span>` that highlights it as a match.

Further, I've added the ability to select the next and previous
search matches with <kbd>Ctrl</kbd>+<kbd>G</kbd> and with <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>G</kbd>.
This should alleviate a number of issues around finding search
matches inside long notes.

### Other problems
 - ~the note list only appears to highlight one term~ (resolved by splitting search into terms in 7d43f80)
 - ~the preview might only be highlighting the first or first N term matches for each term~ (resolved through recursion in 11de4fb)

### Before
![noPreviewHighlights mov](https://user-images.githubusercontent.com/5431237/78465317-f7ab3f80-76a8-11ea-95b6-bffdc27b67a7.gif)

### After
![highlightsEverywhere mov](https://user-images.githubusercontent.com/5431237/78465554-ef083880-76ab-11ea-9bdc-c979fa87b32d.gif)

### Searching matches within a note
![selectingNextMatches mov](https://user-images.githubusercontent.com/5431237/78466266-0e0ac880-76b4-11ea-9fb2-a6cbc27f0a30.gif)

