### PR TITLE
[WIP] Refactor: Move trashNote into Redux state

### DIFF
--- a/lib/note-toolbar-container.ts
+++ b/lib/note-toolbar-container.ts
@@ -55,7 +55,6 @@ export class NoteToolbarContainer extends Component<Props> {
     const { isViewingRevisions, toolbar } = this.props;
 
     const handlers = {
-      noteBucket: this.props.noteBucket,
       onDeleteNoteForever: this.onDeleteNoteForever,
       onRestoreNote: this.onRestoreNote,
       onShareNote: this.onShareNote,

--- a/lib/note-toolbar-container.ts
+++ b/lib/note-toolbar-container.ts
@@ -30,18 +30,11 @@ type DispatchProps = {
   shareNote: () => any;
   showDialog: () => any;
   toggleFocusMode: () => any;
-  trashNote: (args: NoteChanger) => any;
 };
 
 type Props = OwnProps & StateProps & DispatchProps;
 
 export class NoteToolbarContainer extends Component<Props> {
-  onTrashNote = (note: T.NoteEntity) => {
-    const { noteBucket } = this.props;
-    this.props.trashNote({ noteBucket, note });
-    analytics.tracks.recordEvent('editor_note_deleted');
-  };
-
   onDeleteNoteForever = (note: T.NoteEntity) => {
     const { noteBucket } = this.props;
     this.props.deleteNoteForever({ noteBucket, note });
@@ -62,10 +55,10 @@ export class NoteToolbarContainer extends Component<Props> {
     const { isViewingRevisions, toolbar } = this.props;
 
     const handlers = {
+      noteBucket: this.props.noteBucket,
       onDeleteNoteForever: this.onDeleteNoteForever,
       onRestoreNote: this.onRestoreNote,
       onShareNote: this.onShareNote,
-      onTrashNote: this.onTrashNote,
       toggleFocusMode: this.props.toggleFocusMode,
     };
 
@@ -84,14 +77,13 @@ const mapStateToProps: S.MapState<StateProps> = ({
   notes: filteredNotes,
 });
 
-const { deleteNoteForever, restoreNote, trashNote } = appState.actionCreators;
+const { deleteNoteForever, restoreNote } = appState.actionCreators;
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
   deleteNoteForever: args => dispatch(deleteNoteForever(args)),
   restoreNote: args => dispatch(restoreNote(args)),
   shareNote: () => dispatch(showDialog('SHARE')),
   toggleFocusMode: () => dispatch(toggleFocusMode()),
-  trashNote: args => dispatch(trashNote(args)),
 });
 
 export default connect(

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -26,20 +26,12 @@ import {
 import * as S from '../state';
 import * as T from '../types';
 
-type OwnProps = {
-  noteBucket: T.Bucket<T.Note>;
-};
-
 type DispatchProps = {
   closeNote: () => any;
   toggleEditMode: () => any;
   toggleNoteInfo: () => any;
   toggleRevisions: () => any;
-  trashNote: (
-    noteBucket: T.Bucket<T.Note>,
-    note: T.NoteEntity,
-    previousIndex: number
-  ) => any;
+  trashNote: (note: T.NoteEntity) => any;
 };
 
 type StateProps = {
@@ -49,7 +41,7 @@ type StateProps = {
   note: T.NoteEntity | null;
 };
 
-type Props = OwnProps & DispatchProps & StateProps;
+type Props = DispatchProps & StateProps;
 
 export class NoteToolbar extends Component<Props> {
   static displayName = 'NoteToolbar';
@@ -69,8 +61,7 @@ export class NoteToolbar extends Component<Props> {
   };
 
   onTrashNote = (note: T.NoteEntity) => {
-    const { noteBucket } = this.props;
-    this.props.trashNote(noteBucket, note);
+    this.props.trashNote(note);
     analytics.tracks.recordEvent('editor_note_deleted');
   };
 

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -36,7 +36,6 @@ type DispatchProps = {
 
 type StateProps = {
   editMode: boolean;
-  notes: T.NoteEntity[];
   markdownEnabled: boolean;
   note: T.NoteEntity | null;
 };
@@ -178,13 +177,12 @@ export class NoteToolbar extends Component<Props> {
   };
 }
 const mapStateToProps: S.MapState<StateProps> = ({
-  ui: { editMode, filteredNotes, note, selectedRevision },
+  ui: { editMode, note, selectedRevision },
 }) => {
   const revisionOrNote = selectedRevision || note;
 
   return {
     editMode,
-    notes: filteredNotes,
     markdownEnabled: revisionOrNote
       ? revisionOrNote.data.systemTags.includes('markdown')
       : false,

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -68,19 +68,9 @@ export class NoteToolbar extends Component<Props> {
     toggleFocusMode: noop,
   };
 
-  // Gets the index of the note located before the currently selected one
-  getPreviousNoteIndex = (note: T.NoteEntity) => {
-    const previousIndex = this.props.notes.findIndex(
-      ({ id }) => note.id === id
-    );
-
-    return Math.max(previousIndex - 1, 0);
-  };
-
   onTrashNote = (note: T.NoteEntity) => {
     const { noteBucket } = this.props;
-    const previousIndex = this.getPreviousNoteIndex(note);
-    this.props.trashNote(noteBucket, note, previousIndex);
+    this.props.trashNote(noteBucket, note);
     analytics.tracks.recordEvent('editor_note_deleted');
   };
 
@@ -144,7 +134,6 @@ export class NoteToolbar extends Component<Props> {
           <div className="note-toolbar__button">
             <IconButton
               icon={<TrashIcon />}
-              title="Trash • Ctrl+Delete"
               onClick={this.onTrashNote.bind(null, note)}
               title="Trash • Ctrl+Delete"
             />

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -118,11 +118,6 @@ export const middleware: S.Middleware = store => {
         break;
 
       case 'TRASH_NOTE':
-      case 'App.trashNote':
-        updateNote(prevState.ui.note.id, {
-          ...prevState.ui.note.data,
-          deleted: true,
-        });
         setFilteredNotes(updateFilter('fullSearch'));
         break;
 

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -101,10 +101,7 @@ export type ToggleEditMode = Action<'TOGGLE_EDIT_MODE'>;
 export type ToggleRevisions = Action<'REVISIONS_TOGGLE'>;
 export type ToggleTagDrawer = Action<'TAG_DRAWER_TOGGLE', { show: boolean }>;
 export type ToggleTagEditing = Action<'TAG_EDITING_TOGGLE'>;
-export type TrashNote = Action<
-  'TRASH_NOTE',
-  { noteBucket: T.Bucket<T.Note>; note: T.NoteEntity }
->;
+export type TrashNote = Action<'TRASH_NOTE', { note: T.NoteEntity }>;
 
 export type ActionType =
   | CloseNote
@@ -152,7 +149,7 @@ export type ActionType =
 export type ActionCreator<A extends ActionType> = (...args: any[]) => A;
 export type Reducer<S> = (state: S | undefined, action: ActionType) => S;
 
-type LegacyAction = 
+type LegacyAction =
   | Action<
       'App.deleteNoteForever',
       {

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -56,7 +56,6 @@ export type FilterNotes = Action<
   { notes: T.NoteEntity[]; tags: T.TagEntity[] }
 >;
 export type FocusSearchField = Action<'FOCUS_SEARCH_FIELD'>;
-export type OpenTag = Action<'OPEN_TAG', { tag: T.TagEntity }>;
 export type RemoteNoteUpdate = Action<
   'REMOTE_NOTE_UPDATE',
   { noteId: T.EntityId; data: T.Note }
@@ -64,10 +63,6 @@ export type RemoteNoteUpdate = Action<
 export type RestoreNote = Action<'RESTORE_NOTE'>;
 export type ShowDialog = Action<'SHOW_DIALOG', { dialog: T.DialogType }>;
 export type Search = Action<'SEARCH', { searchQuery: string }>;
-export type SelectNote = Action<
-  'SELECT_NOTE',
-  { note: T.NoteEntity; options?: { hasRemoteUpdate: boolean } }
->;
 export type SelectRevision = Action<
   'SELECT_REVISION',
   { revision: T.NoteEntity }
@@ -102,6 +97,11 @@ export type ToggleRevisions = Action<'REVISIONS_TOGGLE'>;
 export type ToggleTagDrawer = Action<'TAG_DRAWER_TOGGLE', { show: boolean }>;
 export type ToggleTagEditing = Action<'TAG_EDITING_TOGGLE'>;
 export type TrashNote = Action<'TRASH_NOTE', { note: T.NoteEntity }>;
+export type SelectNote = Action<
+  'SELECT_NOTE',
+  { note: T.NoteEntity; options?: { hasRemoteUpdate: boolean } }
+>;
+export type OpenTag = Action<'OPEN_TAG', { tag: T.TagEntity }>;
 
 export type ActionType =
   | CloseNote

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -56,6 +56,7 @@ export type FilterNotes = Action<
   { notes: T.NoteEntity[]; tags: T.TagEntity[] }
 >;
 export type FocusSearchField = Action<'FOCUS_SEARCH_FIELD'>;
+export type OpenTag = Action<'OPEN_TAG', { tag: T.TagEntity }>;
 export type RemoteNoteUpdate = Action<
   'REMOTE_NOTE_UPDATE',
   { noteId: T.EntityId; data: T.Note }
@@ -63,6 +64,10 @@ export type RemoteNoteUpdate = Action<
 export type RestoreNote = Action<'RESTORE_NOTE'>;
 export type ShowDialog = Action<'SHOW_DIALOG', { dialog: T.DialogType }>;
 export type Search = Action<'SEARCH', { searchQuery: string }>;
+export type SelectNote = Action<
+  'SELECT_NOTE',
+  { note: T.NoteEntity; options?: { hasRemoteUpdate: boolean } }
+>;
 export type SelectRevision = Action<
   'SELECT_REVISION',
   { revision: T.NoteEntity }
@@ -96,12 +101,10 @@ export type ToggleEditMode = Action<'TOGGLE_EDIT_MODE'>;
 export type ToggleRevisions = Action<'REVISIONS_TOGGLE'>;
 export type ToggleTagDrawer = Action<'TAG_DRAWER_TOGGLE', { show: boolean }>;
 export type ToggleTagEditing = Action<'TAG_EDITING_TOGGLE'>;
-export type TrashNote = Action<'TRASH_NOTE'>;
-export type SelectNote = Action<
-  'SELECT_NOTE',
-  { note: T.NoteEntity; options?: { hasRemoteUpdate: boolean } }
+export type TrashNote = Action<
+  'TRASH_NOTE',
+  { noteBucket: T.Bucket<T.Note>; note: T.NoteEntity }
 >;
-export type OpenTag = Action<'OPEN_TAG', { tag: T.TagEntity }>;
 
 export type ActionType =
   | CloseNote
@@ -149,7 +152,7 @@ export type ActionType =
 export type ActionCreator<A extends ActionType> = (...args: any[]) => A;
 export type Reducer<S> = (state: S | undefined, action: ActionType) => S;
 
-type LegacyAction =
+type LegacyAction = 
   | Action<
       'App.deleteNoteForever',
       {
@@ -196,13 +199,6 @@ type LegacyAction =
   | Action<
       'App.toggleShareAnalyticsPreference',
       { preferencesBucket: T.Bucket<T.Preferences> }
-    >
-  | Action<
-      'App.trashNote',
-      {
-        noteBucket: T.Bucket<T.Note>;
-        note: T.NoteEntity;
-      }
     >
   | Action<'App.authChanged'>
   | Action<'App.emptyTrash', { noteBucket: T.Bucket<T.Note> }>

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -60,6 +60,10 @@ export const middleware: S.Middleware = store => {
       case 'REVISIONS_TOGGLE':
         fetchRevisions(store, nextState);
         break;
+
+      case 'TRASH_NOTE':
+        buckets.note.update(action.note.id, action.note.data);
+        break;
     }
 
     return result;

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -150,6 +150,11 @@ export const toggleTagEditing: A.ActionCreator<A.ToggleTagEditing> = () => ({
   type: 'TAG_EDITING_TOGGLE',
 });
 
-export const trashNote: A.ActionCreator<A.TrashNote> = () => ({
+export const trashNote: A.ActionCreator<A.TrashNote> = (
+  noteBucket: T.Bucket<T.Note>,
+  note: T.NoteEntity
+) => ({
   type: 'TRASH_NOTE',
+  noteBucket,
+  note,
 });

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -151,10 +151,8 @@ export const toggleTagEditing: A.ActionCreator<A.ToggleTagEditing> = () => ({
 });
 
 export const trashNote: A.ActionCreator<A.TrashNote> = (
-  noteBucket: T.Bucket<T.Note>,
   note: T.NoteEntity
 ) => ({
   type: 'TRASH_NOTE',
-  noteBucket,
   note,
 });

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -208,7 +208,6 @@ const showTrash: A.Reducer<boolean> = (state = false, action) => {
 };
 
 const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
-  console.log(action);
   switch (action.type) {
     case 'App.emptyTrash':
     case 'SELECT_TRASH':

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -208,6 +208,7 @@ const showTrash: A.Reducer<boolean> = (state = false, action) => {
 };
 
 const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
+  console.log(action);
   switch (action.type) {
     case 'App.emptyTrash':
     case 'SELECT_TRASH':
@@ -215,9 +216,13 @@ const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
     case 'CLOSE_NOTE':
     case 'DELETE_NOTE_FOREVER':
     case 'RESTORE_NOTE':
-    case 'TRASH_NOTE':
     case 'OPEN_TAG':
       return null;
+    case 'TRASH_NOTE':
+      if (state) {
+        state.data.deleted = true;
+      }
+      return state;
     case 'SELECT_NOTE':
       return action.options
         ? {


### PR DESCRIPTION
### TODO
* ~Eliminate function passing to child by moving `onTrashNote` into `note-toolbar`~
* Move analytics into middleware (probably in a different experimental PR) see #2001 

### Fix
TBD

### Test
1. Trash a note

### Release
`RELEASE-NOTES.txt` was updated with:
TBD