### PR TITLE
Refactor: Remove previousIndex

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -463,15 +463,6 @@ export const App = connect(
       this.props.noteBucket.touch(noteId);
     };
 
-    // gets the index of the note located before the currently selected one
-    getPreviousNoteIndex = note => {
-      const previousIndex = this.props.ui.filteredNotes.findIndex(
-        ({ id }) => note.id === id
-      );
-
-      return Math.max(previousIndex - 1, 0);
-    };
-
     syncActivityHooks = data => {
       activityHooks(data, {
         onIdle: () => {

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -265,7 +265,6 @@ export const App = connect(
       }
 
       if (cmdOrCtrl && shiftKey && 'KeyN' === code) {
-        this.props.createNote();
         this.props.actions.newNote({
           noteBucket: this.props.noteBucket,
         });
@@ -333,7 +332,6 @@ export const App = connect(
       if (canRun(command)) {
         // newNote expects a bucket to be passed in, but the action method itself wouldn't do that
         if (command.action === 'newNote') {
-          this.props.createNote();
           this.props.actions.newNote({
             noteBucket: this.props.noteBucket,
           });

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -64,6 +64,9 @@ export class AboutDialog extends Component<Props> {
                     Focus search field
                   </Keys>
                 </li>
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'G']}>Search within note</Keys>
+                </li>
                 {isElectron && (
                   <li>
                     <Keys keys={[CmdOrCtrl, '+']}>Increase font size</Keys>

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -70,12 +70,8 @@ export const actionMap = new ActionMap({
               if (e) {
                 return debug(`newNote: could not create note - ${e.message}`);
               }
-              dispatch(
-                this.action('loadAndSelectNote', {
-                  noteBucket,
-                  noteId: note.id,
-                })
-              );
+              dispatch(actions.ui.createNote());
+              setTimeout(() => dispatch(actions.ui.selectNote(note)), 500);
             }
           );
         };

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -2,7 +2,6 @@ import { get, partition } from 'lodash';
 import update from 'react-addons-update';
 import Debug from 'debug';
 import ActionMap from './action-map';
-import analytics from '../analytics';
 import actions from '../state/actions';
 
 import { AppState, State } from '../state';
@@ -176,7 +175,6 @@ export const actionMap = new ActionMap({
       creator({
         noteBucket,
         note,
-        previousIndex,
       }: {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
@@ -185,7 +183,7 @@ export const actionMap = new ActionMap({
           if (note) {
             note.data.deleted = true;
             noteBucket.update(note.id, note.data);
-            dispatch(actions.ui.trashNote(previousIndex));
+            dispatch(actions.ui.trashNote());
           }
         };
       },
@@ -195,7 +193,6 @@ export const actionMap = new ActionMap({
       creator({
         noteBucket,
         note,
-        previousIndex,
       }: {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
@@ -204,7 +201,7 @@ export const actionMap = new ActionMap({
           if (note) {
             note.data.deleted = false;
             noteBucket.update(note.id, note.data);
-            dispatch(actions.ui.restoreNote(previousIndex));
+            dispatch(actions.ui.restoreNote());
           }
         };
       },
@@ -214,7 +211,6 @@ export const actionMap = new ActionMap({
       creator({
         noteBucket,
         note,
-        previousIndex,
       }: {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
@@ -222,7 +218,7 @@ export const actionMap = new ActionMap({
         return dispatch => {
           noteBucket.remove(note.id);
           dispatch(this.action('loadNotes', { noteBucket }));
-          dispatch(actions.ui.deleteNoteForever(previousIndex));
+          dispatch(actions.ui.deleteNoteForever());
         };
       },
     },

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -209,9 +209,7 @@ const createCompositeNoteList = (
 export class NoteList extends Component<Props> {
   static displayName = 'NoteList';
 
-  state = {
-    selected: { noteId: null, index: null },
-  };
+  state = { selectedIndex: null };
 
   list = createRef<List>();
 
@@ -238,9 +236,7 @@ export class NoteList extends Component<Props> {
       showTrash,
       tagResultsFound,
     } = nextProps;
-    const {
-      selected: { noteId, index },
-    } = this.state;
+    const { selectedIndex } = this.state;
 
     if (
       noteDisplay !== this.props.noteDisplay ||
@@ -252,9 +248,9 @@ export class NoteList extends Component<Props> {
     }
 
     if (
-      index &&
+      selectedIndex &&
       selectedNote &&
-      notes[index]?.id === selectedNote.id &&
+      notes[selectedIndex]?.id === selectedNote.id &&
       showTrash === this.props.showTrash &&
       openedTag === this.props.openedTag
     ) {
@@ -264,19 +260,20 @@ export class NoteList extends Component<Props> {
     const nextIndex = this.getHighlightedIndex(nextProps);
 
     if (null === nextIndex) {
-      return this.setState({
-        selected: { noteId: null, index: null },
-      });
+      return this.setState({ selectedIndex: null });
     }
 
-    if (!selectedNote || selectedNote.id !== notes[nextIndex].id) {
+    if (
+      notes.length &&
+      (!selectedNote || selectedNote.id !== notes[nextIndex]?.id)
+    ) {
       // select the note that should be selected, if it isn't already
-      this.props.onSelectNote(notes[nextIndex].id);
+      this.props.onSelectNote(
+        notes[Math.max(0, Math.min(notes.length - 1, nextIndex))].id
+      );
     }
 
-    this.setState({
-      selected: { noteId: notes[nextIndex].id, index: nextIndex },
-    });
+    this.setState({ selectedIndex: nextIndex });
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -297,9 +294,7 @@ export class NoteList extends Component<Props> {
   handleShortcut = (event: KeyboardEvent) => {
     const { ctrlKey, code, metaKey, shiftKey } = event;
     const { notes } = this.props;
-    const {
-      selected: { index },
-    } = this.state;
+    const { selectedIndex: index } = this.state;
 
     const highlightedIndex = this.getHighlightedIndex(this.props);
 
@@ -343,9 +338,7 @@ export class NoteList extends Component<Props> {
 
   getHighlightedIndex = (props: Props) => {
     const { notes, selectedNote } = props;
-    const {
-      selected: { noteId, index },
-    } = this.state;
+    const { selectedIndex: index } = this.state;
 
     // Cases:
     //   - the notes list is empty
@@ -396,9 +389,7 @@ export class NoteList extends Component<Props> {
       showTrash,
       tagResultsFound,
     } = this.props;
-    const {
-      selected: { index: highlightedIndex },
-    } = this.state;
+    const { selectedIndex: highlightedIndex } = this.state;
 
     const compositeNoteList = createCompositeNoteList(
       notes,

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -36,10 +36,11 @@ type StateProps = {
   hasLoaded: boolean;
   noteDisplay: T.ListDisplayMode;
   notes: T.NoteEntity[];
+  openedTag: T.TagEntity | null;
   searchQuery: string;
+  selectedNote: T.NoteEntity | null;
   selectedNoteContent: string;
   selectedNotePreview: { title: string; preview: string };
-  selectedNoteId?: T.EntityId;
   showTrash: boolean;
   tagResultsFound: number;
 };
@@ -51,7 +52,7 @@ type DispatchProps = {
   onPinNote: (note: T.NoteEntity, shouldPin: boolean) => any;
 };
 
-type Props = OwnProps & StateProps & DispatchProps;
+type Props = Readonly<OwnProps & StateProps & DispatchProps>;
 
 type NoteListItem =
   | T.NoteEntity
@@ -85,14 +86,14 @@ const renderNote = (
   {
     searchQuery,
     noteDisplay,
-    selectedNoteId,
+    highlightedIndex,
     onSelectNote,
     onPinNote,
     isSmallScreen,
   }: {
     searchQuery: string;
     noteDisplay: T.ListDisplayMode;
-    selectedNoteId?: T.EntityId;
+    highlightedIndex: number;
     onSelectNote: DispatchProps['onSelectNote'];
     onPinNote: DispatchProps['onPinNote'];
     isSmallScreen: boolean;
@@ -130,7 +131,7 @@ const renderNote = (
   const isPinned = note.data.systemTags.includes('pinned');
   const isPublished = !!note.data.publishURL;
   const classes = classNames('note-list-item', {
-    'note-list-item-selected': !isSmallScreen && selectedNoteId === note.id,
+    'note-list-item-selected': !isSmallScreen && highlightedIndex === index,
     'note-list-item-pinned': isPinned,
     'published-note': isPublished,
   });
@@ -208,15 +209,18 @@ const createCompositeNoteList = (
 export class NoteList extends Component<Props> {
   static displayName = 'NoteList';
 
+  state = {
+    selected: { noteId: null, index: null },
+  };
+
   list = createRef<List>();
 
   static propTypes = {
     isSmallScreen: PropTypes.bool.isRequired,
     noteDisplay: PropTypes.string.isRequired,
-    notes: PropTypes.array.isRequired,
     onEmptyTrash: PropTypes.any.isRequired,
-    onSelectNote: PropTypes.func.isRequired,
     onPinNote: PropTypes.func.isRequired,
+    onSelectNote: PropTypes.func.isRequired,
     showTrash: PropTypes.bool,
   };
 
@@ -224,18 +228,58 @@ export class NoteList extends Component<Props> {
     this.toggleShortcuts(true);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: Readonly<Props>): void {
+  UNSAFE_componentWillReceiveProps(nextProps: Props): void {
+    const {
+      notes,
+      noteDisplay,
+      openedTag,
+      selectedNote,
+      selectedNoteContent,
+      showTrash,
+      tagResultsFound,
+    } = nextProps;
+    const {
+      selected: { noteId, index },
+    } = this.state;
+
     if (
-      nextProps.noteDisplay !== this.props.noteDisplay ||
-      nextProps.notes !== this.props.notes ||
-      nextProps.tagResultsFound !== this.props.tagResultsFound ||
-      nextProps.selectedNoteContent !== this.props.selectedNoteContent
+      noteDisplay !== this.props.noteDisplay ||
+      notes !== this.props.notes ||
+      tagResultsFound !== this.props.tagResultsFound ||
+      selectedNoteContent !== this.props.selectedNoteContent
     ) {
       heightCache.clearAll();
     }
+
+    if (
+      index &&
+      selectedNote &&
+      notes[index]?.id === selectedNote.id &&
+      showTrash === this.props.showTrash &&
+      openedTag === this.props.openedTag
+    ) {
+      return;
+    }
+
+    const nextIndex = this.getHighlightedIndex(nextProps);
+
+    if (null === nextIndex) {
+      return this.setState({
+        selected: { noteId: null, index: null },
+      });
+    }
+
+    if (!selectedNote || selectedNote.id !== notes[nextIndex].id) {
+      // select the note that should be selected, if it isn't already
+      this.props.onSelectNote(notes[nextIndex].id);
+    }
+
+    this.setState({
+      selected: { noteId: notes[nextIndex].id, index: nextIndex },
+    });
   }
 
-  componentDidUpdate(prevProps: Readonly<Props>) {
+  componentDidUpdate(prevProps: Props) {
     if (
       prevProps.noteDisplay !== this.props.noteDisplay ||
       prevProps.notes !== this.props.notes ||
@@ -252,29 +296,35 @@ export class NoteList extends Component<Props> {
 
   handleShortcut = (event: KeyboardEvent) => {
     const { ctrlKey, code, metaKey, shiftKey } = event;
-    const { notes, selectedNoteId } = this.props;
+    const { notes } = this.props;
+    const {
+      selected: { index },
+    } = this.state;
 
-    const selectedIndex =
-      selectedNoteId && notes
-        ? notes.findIndex(({ id }) => id === selectedNoteId)
-        : -1;
+    const highlightedIndex = this.getHighlightedIndex(this.props);
 
     const cmdOrCtrl = ctrlKey || metaKey;
     if (cmdOrCtrl && shiftKey && code === 'KeyK') {
-      if (selectedIndex > 0) {
-        this.props.onSelectNote(notes[selectedIndex - 1].id);
+      if (-1 === highlightedIndex || index < 0 || !notes[index - 1]?.id) {
+        return true;
       }
 
+      this.props.onSelectNote(notes[index - 1].id);
       event.stopPropagation();
       event.preventDefault();
       return false;
     }
 
     if (cmdOrCtrl && shiftKey && code === 'KeyJ') {
-      if (selectedIndex < notes.length - 1) {
-        this.props.onSelectNote(notes[selectedIndex + 1].id);
+      if (
+        -1 === highlightedIndex ||
+        index >= notes.length ||
+        !notes[index + 1]?.id
+      ) {
+        return true;
       }
 
+      this.props.onSelectNote(notes[index + 1].id);
       event.stopPropagation();
       event.preventDefault();
       return false;
@@ -291,6 +341,48 @@ export class NoteList extends Component<Props> {
     }
   };
 
+  getHighlightedIndex = (props: Props) => {
+    const { notes, selectedNote } = props;
+    const {
+      selected: { noteId, index },
+    } = this.state;
+
+    // Cases:
+    //   - the notes list is empty
+    //   - nothing has been selected -> select the first item if it exists
+    //   - the selected note matches the index -> use the index
+    //   - selected note is in the list -> use the index where it's found
+    //   - selected note isn't in the list -> previous index?
+
+    if (notes.length === 0) {
+      return null;
+    }
+
+    if (!selectedNote && !index) {
+      const firstNote = notes.findIndex(item => item?.id);
+
+      return firstNote > -1 ? firstNote : null;
+    }
+
+    if (selectedNote && selectedNote.id === notes[index]?.id) {
+      return index;
+    }
+
+    const noteAt = notes.findIndex(item => item?.id === selectedNote?.id);
+
+    if (selectedNote && noteAt > -1) {
+      return noteAt;
+    }
+
+    if (selectedNote) {
+      return Math.min(index, notes.length - 1); // different note, same index
+      // throw new Error('selected note not in list');
+    }
+
+    // we have no selected note here, but we do have a previous index
+    return index;
+  };
+
   render() {
     const {
       hasLoaded,
@@ -301,10 +393,12 @@ export class NoteList extends Component<Props> {
       onEmptyTrash,
       onPinNote,
       searchQuery,
-      selectedNoteId,
       showTrash,
       tagResultsFound,
     } = this.props;
+    const {
+      selected: { index: highlightedIndex },
+    } = this.state;
 
     const compositeNoteList = createCompositeNoteList(
       notes,
@@ -312,12 +406,15 @@ export class NoteList extends Component<Props> {
       tagResultsFound
     );
 
+    const specialRows = compositeNoteList.length - notes.length;
+
     const renderNoteRow = renderNote(compositeNoteList, {
       searchQuery,
+      highlightedIndex:
+        highlightedIndex !== null ? highlightedIndex + specialRows : null,
       noteDisplay,
       onSelectNote,
       onPinNote,
-      selectedNoteId,
       isSmallScreen,
     });
 
@@ -372,7 +469,14 @@ const { emptyTrash, loadAndSelectNote } = appState.actionCreators;
 
 const mapStateToProps: S.MapState<StateProps> = ({
   appState: state,
-  ui: { filteredNotes, note, searchQuery, showTrash, tagSuggestions },
+  ui: {
+    filteredNotes,
+    note,
+    openedTag,
+    searchQuery,
+    showTrash,
+    tagSuggestions,
+  },
   settings: { noteDisplay },
 }) => {
   /**
@@ -401,10 +505,11 @@ const mapStateToProps: S.MapState<StateProps> = ({
     hasLoaded: state.notes !== null,
     noteDisplay,
     notes: filteredNotes,
+    openedTag,
     searchQuery,
+    selectedNote: note,
     selectedNotePreview,
     selectedNoteContent: get(note, 'data.content'),
-    selectedNoteId: note?.id,
     showTrash,
     tagResultsFound: tagSuggestions.length,
   };

--- a/lib/note-toolbar-container.ts
+++ b/lib/note-toolbar-container.ts
@@ -24,46 +24,32 @@ type NoteChanger = {
   note: T.NoteEntity;
 };
 
-type ListChanger = NoteChanger & { previousIndex: number };
-
 type DispatchProps = {
-  deleteNoteForever: (args: ListChanger) => any;
-  restoreNote: (args: ListChanger) => any;
+  deleteNoteForever: (args: NoteChanger) => any;
+  restoreNote: (args: NoteChanger) => any;
   shareNote: () => any;
   showDialog: () => any;
   toggleFocusMode: () => any;
-  trashNote: (args: ListChanger) => any;
+  trashNote: (args: NoteChanger) => any;
 };
 
 type Props = OwnProps & StateProps & DispatchProps;
 
 export class NoteToolbarContainer extends Component<Props> {
-  // Gets the index of the note located before the currently selected one
-  getPreviousNoteIndex = (note: T.NoteEntity) => {
-    const previousIndex = this.props.notes.findIndex(
-      ({ id }) => note.id === id
-    );
-
-    return Math.max(previousIndex - 1, 0);
-  };
-
   onTrashNote = (note: T.NoteEntity) => {
     const { noteBucket } = this.props;
-    const previousIndex = this.getPreviousNoteIndex(note);
-    this.props.trashNote({ noteBucket, note, previousIndex });
+    this.props.trashNote({ noteBucket, note });
     analytics.tracks.recordEvent('editor_note_deleted');
   };
 
   onDeleteNoteForever = (note: T.NoteEntity) => {
     const { noteBucket } = this.props;
-    const previousIndex = this.getPreviousNoteIndex(note);
-    this.props.deleteNoteForever({ noteBucket, note, previousIndex });
+    this.props.deleteNoteForever({ noteBucket, note });
   };
 
   onRestoreNote = (note: T.NoteEntity) => {
     const { noteBucket } = this.props;
-    const previousIndex = this.getPreviousNoteIndex(note);
-    this.props.restoreNote({ noteBucket, note, previousIndex });
+    this.props.restoreNote({ noteBucket, note });
     analytics.tracks.recordEvent('editor_note_restored');
   };
 

--- a/lib/search-bar/index.tsx
+++ b/lib/search-bar/index.tsx
@@ -72,8 +72,6 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (
   { noteBucket }
 ) => ({
   onNewNote: (content: string) => {
-    dispatch(createNote());
-    dispatch(search(''));
     dispatch(newNote({ noteBucket, content }));
     analytics.tracks.recordEvent('list_note_created');
   },

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -64,10 +64,16 @@ export const middleware: S.Middleware = store => {
         break;
 
       case 'REMOTE_NOTE_UPDATE':
+        updateNote(action.noteId, action.data);
         searchProcessor.postMessage({
-          action: 'updateNote',
-          noteId: action.noteId,
-          data: action.data,
+          action: 'filterNotes',
+        });
+        break;
+
+      case 'CREATE_NOTE':
+        searchProcessor.postMessage({
+          action: 'filterNotes',
+          searchQuery: '',
         });
         break;
 

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -75,6 +75,7 @@ export const middleware: S.Middleware = store => {
         searchProcessor.postMessage({
           action: 'filterNotes',
           openedTag: action.tag.data.name,
+          showTrash: false,
         });
         break;
 

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -1,5 +1,5 @@
 import actions from '../state/actions';
-import { init, updateFilter } from './worker';
+import { init, updateFilter, updateNote } from './worker';
 import { filterTags } from '../tag-suggestions';
 
 import * as A from '../state/action-types';
@@ -14,10 +14,7 @@ export const middleware: S.Middleware = store => {
     port2: _searchProcessor,
   } = new MessageChannel();
 
-  const setFilteredNotes = (
-    noteIds: Set<T.EntityId>,
-    previousIndex?: number
-  ) => {
+  const setFilteredNotes = (noteIds: Set<T.EntityId>) => {
     const {
       appState,
       tags,
@@ -29,8 +26,7 @@ export const middleware: S.Middleware = store => {
     store.dispatch(
       actions.ui.filterNotes(
         appState.notes?.filter(({ id }) => noteIds.has(id)) || emptyList,
-        tagSuggestions.length > 0 ? tagSuggestions : emptyList,
-        previousIndex
+        tagSuggestions.length > 0 ? tagSuggestions : emptyList
       )
     );
   };
@@ -48,6 +44,7 @@ export const middleware: S.Middleware = store => {
   let hasInitialized = false;
 
   return next => (action: A.ActionType) => {
+    const prevState = store.getState();
     const result = next(action);
 
     switch (action.type) {
@@ -106,9 +103,20 @@ export const middleware: S.Middleware = store => {
 
       case 'DELETE_NOTE_FOREVER':
       case 'RESTORE_NOTE':
+        updateNote(prevState.ui.note.id, {
+          ...prevState.ui.note.data,
+          deleted: false,
+        });
+        setFilteredNotes(updateFilter('fullSearch'));
+        break;
+
       case 'TRASH_NOTE':
       case 'App.trashNote':
-        setFilteredNotes(updateFilter('fullSearch'), action.previousIndex);
+        updateNote(prevState.ui.note.id, {
+          ...prevState.ui.note.data,
+          deleted: true,
+        });
+        setFilteredNotes(updateFilter('fullSearch'));
         break;
 
       case 'App.authChanged':

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -50,20 +50,17 @@ export type SetWPToken = Action<'setWPToken', { token: string }>;
 export type CloseDialog = Action<'CLOSE_DIALOG'>;
 export type CloseNote = Action<'CLOSE_NOTE'>;
 export type CreateNote = Action<'CREATE_NOTE'>;
-export type DeleteNoteForever = Action<
-  'DELETE_NOTE_FOREVER',
-  { previousIndex: number }
->;
+export type DeleteNoteForever = Action<'DELETE_NOTE_FOREVER'>;
 export type FilterNotes = Action<
   'FILTER_NOTES',
-  { notes: T.NoteEntity[]; previousIndex: number; tags: T.TagEntity[] }
+  { notes: T.NoteEntity[]; tags: T.TagEntity[] }
 >;
 export type FocusSearchField = Action<'FOCUS_SEARCH_FIELD'>;
 export type RemoteNoteUpdate = Action<
   'REMOTE_NOTE_UPDATE',
   { noteId: T.EntityId; data: T.Note }
 >;
-export type RestoreNote = Action<'RESTORE_NOTE', { previousIndex: number }>;
+export type RestoreNote = Action<'RESTORE_NOTE'>;
 export type ShowDialog = Action<'SHOW_DIALOG', { dialog: T.DialogType }>;
 export type Search = Action<'SEARCH', { searchQuery: string }>;
 export type SelectRevision = Action<
@@ -99,7 +96,7 @@ export type ToggleEditMode = Action<'TOGGLE_EDIT_MODE'>;
 export type ToggleRevisions = Action<'REVISIONS_TOGGLE'>;
 export type ToggleTagDrawer = Action<'TAG_DRAWER_TOGGLE', { show: boolean }>;
 export type ToggleTagEditing = Action<'TAG_EDITING_TOGGLE'>;
-export type TrashNote = Action<'TRASH_NOTE', { previousIndex: number }>;
+export type TrashNote = Action<'TRASH_NOTE'>;
 export type SelectNote = Action<
   'SELECT_NOTE',
   { note: T.NoteEntity; options?: { hasRemoteUpdate: boolean } }
@@ -158,7 +155,6 @@ type LegacyAction =
       {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
-        previousIndex: number;
       }
     >
   | Action<
@@ -187,7 +183,6 @@ type LegacyAction =
       {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
-        previousIndex: number;
       }
     >
   | Action<
@@ -207,7 +202,6 @@ type LegacyAction =
       {
         noteBucket: T.Bucket<T.Note>;
         note: T.NoteEntity;
-        previousIndex: number;
       }
     >
   | Action<'App.authChanged'>

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -13,22 +13,17 @@ export const createNote: A.ActionCreator<A.CreateNote> = () => ({
   type: 'CREATE_NOTE',
 });
 
-export const deleteNoteForever: A.ActionCreator<A.DeleteNoteForever> = (
-  previousIndex: number
-) => ({
+export const deleteNoteForever: A.ActionCreator<A.DeleteNoteForever> = () => ({
   type: 'DELETE_NOTE_FOREVER',
-  previousIndex,
 });
 
 export const filterNotes: A.ActionCreator<A.FilterNotes> = (
   notes: T.NoteEntity[],
-  tags: T.TagEntity[],
-  previousIndex: number
+  tags: T.TagEntity[]
 ) => ({
   type: 'FILTER_NOTES',
   notes,
   tags,
-  previousIndex,
 });
 
 export const focusSearchField: A.ActionCreator<A.FocusSearchField> = () => ({
@@ -70,11 +65,8 @@ export const openTag: A.ActionCreator<A.OpenTag> = (tag: T.TagEntity) => ({
   tag,
 });
 
-export const restoreNote: A.ActionCreator<A.RestoreNote> = (
-  previousIndex: number
-) => ({
+export const restoreNote: A.ActionCreator<A.RestoreNote> = () => ({
   type: 'RESTORE_NOTE',
-  previousIndex,
 });
 
 export const selectRevision: A.ActionCreator<A.SelectRevision> = (
@@ -158,9 +150,6 @@ export const toggleTagEditing: A.ActionCreator<A.ToggleTagEditing> = () => ({
   type: 'TAG_EDITING_TOGGLE',
 });
 
-export const trashNote: A.ActionCreator<A.TrashNote> = (
-  previousIndex: number
-) => ({
+export const trashNote: A.ActionCreator<A.TrashNote> = () => ({
   type: 'TRASH_NOTE',
-  previousIndex,
 });

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -115,22 +115,6 @@ const selectedRevision: A.Reducer<T.NoteEntity | null> = (
   }
 };
 
-const previousIndex: A.Reducer<number> = (state = -1, action) => {
-  switch (action.type) {
-    case 'DELETE_NOTE_FOREVER':
-    case 'RESTORE_NOTE':
-    case 'TRASH_NOTE':
-      return action.previousIndex || state;
-    case 'OPEN_TAG':
-    case 'SELECT_TRASH':
-    case 'SHOW_ALL_NOTES':
-    case 'FILTER_NOTES':
-      return -1;
-    default:
-      return state;
-  }
-};
-
 const showNoteList: A.Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'CLOSE_NOTE':
@@ -235,11 +219,6 @@ const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
         : action.note;
     case 'SET_SYSTEM_TAG':
       return toggleSystemTag(action.note, action.tagName, action.shouldHaveTag);
-    case 'FILTER_NOTES':
-      // keep note if still in new filtered list otherwise try to choose first note in list
-      return state && action.notes.some(({ id }) => id === state.id)
-        ? state
-        : action.notes[Math.max(action.previousIndex, 0)] || null;
     default:
       return state;
   }
@@ -259,7 +238,6 @@ export default combineReducers({
   note,
   noteRevisions,
   openedTag,
-  previousIndex,
   searchQuery,
   selectedRevision,
   showNavigation,

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -133,8 +133,16 @@ const unsyncedNoteIds: A.Reducer<T.EntityId[]> = (
   action
 ) => ('SET_UNSYNCED_NOTE_IDS' === action.type ? action.noteIds : state);
 
-const searchQuery: A.Reducer<string> = (state = '', action) =>
-  'SEARCH' === action.type ? action.searchQuery : state;
+const searchQuery: A.Reducer<string> = (state = '', action) => {
+  switch (action.type) {
+    case 'CREATE_NOTE':
+      return '';
+    case 'SEARCH':
+      return action.searchQuery;
+    default:
+      return state;
+  }
+};
 
 const simperiumConnected: A.Reducer<boolean> = (state = false, action) =>
   'SIMPERIUM_CONNECTION_STATUS_TOGGLE' === action.type


### PR DESCRIPTION
We have been tracking `previousIndex` when trashing, restoring, and deleting notes forever in order to properly find the next note to select after these operations. This process required tracking the `previuosIndex` through multiple contexts, some of which only sometimes tracked it. The result was a confusing system we couldn't touch without breaking.

In this patch we're eliminating the `previousIndex` altogether and moving the logic for selecting a note into the `note-list` where it holds the notion of a previous or a next note, a note above or a note below the current selection.

While this may ultimately be a pit-stop on the road to refactoring how `selectedNote` or `note` is stored in state it removes the state tracking that was so cumbersome and fragile.