### PR TITLE
Move tagsLoaded to redux

### DIFF
--- a/lib/dialogs/settings/panels/tools.tsx
+++ b/lib/dialogs/settings/panels/tools.tsx
@@ -1,8 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 
-import appState from '../../../flux/app-state';
 import exportZipArchive from '../../../utils/export';
 
 import PanelTitle from '../../../components/panel-title';

--- a/lib/editable-list/index.tsx
+++ b/lib/editable-list/index.tsx
@@ -343,8 +343,8 @@ export class EditableList extends Component<Props> {
 }
 
 const mapStateToProps: S.MapState<StateProps> = ({
-  appState: { tags },
   settings: { sortTagsAlpha },
+  tags,
   ui: { editingTags },
 }) => ({
   editing: editingTags,

--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -241,28 +241,6 @@ export const actionMap = new ActionMap({
       },
     },
 
-    tagsLoaded(
-      state: AppState,
-      { tags, sortTagsAlpha }: { tags: T.TagEntity[]; sortTagsAlpha: boolean }
-    ) {
-      tags = tags.slice();
-      if (sortTagsAlpha) {
-        // Sort tags alphabetically by 'name' value
-        tags.sort((a, b) => {
-          return get(a, 'data.name', '')
-            .toLowerCase()
-            .localeCompare(get(b, 'data.name', '').toLowerCase());
-        });
-      } else {
-        // Sort the tags by their 'index' value
-        tags.sort((a, b) => (a.data.index | 0) - (b.data.index | 0));
-      }
-
-      return update(state, {
-        tags: { $set: tags },
-      });
-    },
-
     loadPreferences: {
       creator({
         callback,

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -19,6 +19,7 @@ export const middleware: S.Middleware = store => {
     previousIndex?: number
   ) => {
     const {
+      appState,
       tags,
       ui: { searchQuery },
     } = store.getState();

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -19,11 +19,11 @@ export const middleware: S.Middleware = store => {
     previousIndex?: number
   ) => {
     const {
-      appState,
+      tags,
       ui: { searchQuery },
     } = store.getState();
 
-    const tagSuggestions = filterTags(appState.tags, searchQuery);
+    const tagSuggestions = filterTags(tags, searchQuery);
 
     store.dispatch(
       actions.ui.filterNotes(

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -85,6 +85,10 @@ export type StoreRevisions = Action<
   'STORE_REVISIONS',
   { noteId: T.EntityId; revisions: T.NoteEntity[] }
 >;
+export type TagsLoaded = Action<
+  'TAGS_LOADED',
+  { tags: T.TagEntity[]; sortTagsAlpha: boolean }
+>;
 export type ToggleNavigation = Action<'NAVIGATION_TOGGLE'>;
 export type ToggleNoteInfo = Action<'NOTE_INFO_TOGGLE'>;
 export type ToggleSimperiumConnectionStatus = Action<
@@ -135,6 +139,7 @@ export type ActionType =
   | ShowAllNotes
   | ShowDialog
   | StoreRevisions
+  | TagsLoaded
   | ToggleEditMode
   | ToggleNavigation
   | ToggleNoteInfo

--- a/lib/state/actions.ts
+++ b/lib/state/actions.ts
@@ -1,11 +1,13 @@
 import * as auth from './auth/actions';
 import * as settings from './settings/actions';
 import * as simperium from './simperium/actions';
+import * as tags from './tags/actions';
 import * as ui from './ui/actions';
 
 export default {
   auth,
   simperium,
   settings,
+  tags,
   ui,
 };

--- a/lib/state/domain/notes.ts
+++ b/lib/state/domain/notes.ts
@@ -38,9 +38,7 @@ export const updateNoteTags = ({ note, tags }) => {
       modificationDate: Math.floor(Date.now() / 1000),
     });
 
-    const existingTagNames = new Set(
-      getState().appState.tags.map(tag => tag.data.name)
-    );
+    const existingTagNames = new Set(getState().tags.map(tag => tag.data.name));
 
     tags
       .filter(name => !existingTagNames.has(name))

--- a/lib/state/domain/tags.ts
+++ b/lib/state/domain/tags.ts
@@ -1,7 +1,5 @@
 import { noteBucket, tagBucket } from './buckets';
-import appState from '../../flux/app-state';
-
-const { tagsLoaded } = appState.actionCreators;
+import actions from '../actions';
 
 export const loadTags = () => (dispatch, getState) => {
   const sortTagsAlpha = getState().settings.sortTagsAlpha;
@@ -16,7 +14,7 @@ export const loadTags = () => (dispatch, getState) => {
         tags.push(cursor.value);
         cursor.continue();
       } else {
-        dispatch(tagsLoaded({ tags, sortTagsAlpha }));
+        dispatch(actions.tags.tagsLoaded(tags, sortTagsAlpha));
       }
     };
   });

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -26,6 +26,7 @@ import simperiumMiddleware from './simperium/middleware';
 
 import auth from './auth/reducer';
 import settings from './settings/reducer';
+import tags from './tags/reducer';
 import ui from './ui/reducer';
 
 import * as A from './action-types';
@@ -36,7 +37,6 @@ export type AppState = {
   preferences?: T.Preferences;
   revision: T.NoteEntity | null;
   showNavigation: boolean;
-  tags: T.TagEntity[];
   tag?: T.TagEntity;
   unsyncedNoteIds: T.EntityId[];
 };
@@ -45,6 +45,7 @@ export const reducers = combineReducers<State, A.ActionType>({
   appState: appState.reducer.bind(appState),
   auth,
   settings,
+  tags,
   ui,
 });
 
@@ -52,6 +53,7 @@ export type State = {
   appState: AppState;
   auth: ReturnType<typeof auth>;
   settings: ReturnType<typeof settings>;
+  tags: ReturnType<typeof tags>;
   ui: ReturnType<typeof ui>;
 };
 

--- a/lib/state/tags/actions.ts
+++ b/lib/state/tags/actions.ts
@@ -1,0 +1,11 @@
+import * as A from '../action-types';
+import * as T from '../../types';
+
+export const tagsLoaded: A.ActionCreator<A.TagsLoaded> = (
+  tags: T.TagEntity[],
+  sortTagsAlpha: boolean
+) => ({
+  type: 'TAGS_LOADED',
+  tags,
+  sortTagsAlpha,
+});

--- a/lib/state/tags/reducer.ts
+++ b/lib/state/tags/reducer.ts
@@ -9,8 +9,8 @@ const tags: A.Reducer<T.TagEntity[]> = (state = [], action) => {
         // Sort tags alphabetically by 'name' value
         sortedTags.sort((a: T.TagEntity, b: T.TagEntity) => {
           return a?.data?.name
-            .toLowerCase()
-            .localeCompare(b.data?.name.toLowerCase());
+            .toLocaleLowerCase()
+            .localeCompare(b.data?.name.toLocaleLowerCase());
         });
       } else {
         // Sort the tags by their 'index' value

--- a/lib/state/tags/reducer.ts
+++ b/lib/state/tags/reducer.ts
@@ -1,0 +1,29 @@
+import * as A from '../action-types';
+import * as T from '../../types';
+
+const tags: A.Reducer<T.TagEntity[]> = (state = [], action) => {
+  switch (action.type) {
+    case 'TAGS_LOADED': {
+      const sortedTags = action.tags.slice();
+      if (action.sortTagsAlpha) {
+        // Sort tags alphabetically by 'name' value
+        sortedTags.sort((a: T.TagEntity, b: T.TagEntity) => {
+          return a?.data?.name
+            .toLowerCase()
+            .localeCompare(b.data?.name.toLowerCase());
+        });
+      } else {
+        // Sort the tags by their 'index' value
+        sortedTags.sort(
+          (a: T.TagEntity, b: T.TagEntity) =>
+            (a.data.index | 0) - (b.data.index | 0)
+        );
+      }
+      return sortedTags;
+    }
+    default:
+      return state;
+  }
+};
+
+export default tags;

--- a/lib/tag-list/index.tsx
+++ b/lib/tag-list/index.tsx
@@ -99,11 +99,11 @@ export class TagList extends Component<Props> {
 }
 
 const mapStateToProps: S.MapState<StateProps> = ({
-  appState: state,
+  tags,
   ui: { editingTags, openedTag },
 }) => ({
   editingTags,
-  tags: state.tags,
+  tags,
   openedTag,
 });
 

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -91,13 +91,11 @@ export const filterTags = (tags: T.TagEntity[], query: string) => {
   return filterAtMost(tags, matcher, 5);
 };
 
-const mapStateToProps: S.MapState<StateProps> = ({
+const mapStateToProps: S.MapState<StateProps> = {
   appState: state,
   ui: { searchQuery, tagSuggestions },
-}) => ({
-  filteredTags: tagSuggestions,
   searchQuery,
-});
+};
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
   onSearch: query => {

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -91,11 +91,12 @@ export const filterTags = (tags: T.TagEntity[], query: string) => {
   return filterAtMost(tags, matcher, 5);
 };
 
-const mapStateToProps: S.MapState<StateProps> = {
-  appState: state,
+const mapStateToProps: S.MapState<StateProps> = ({
   ui: { searchQuery, tagSuggestions },
+}) => ({
+  filteredTags: tagSuggestions,
   searchQuery,
-};
+});
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
   onSearch: query => {


### PR DESCRIPTION
### Fix
Moves tagsLoaded to redux from appState. This is the most minor change that I could make getting it ported over. The tags functionality in state/domain will need to be refactored to use the middleware architecture but this PR gets tags out of appState.

### Test
1. We should run the full checklist on this one.
2. Open the sidebar, do tags load?
3. Delete a tag, reload page, do tags load as expected
4. Manually sort tags, reload, do they stay sorted
5. Change the settings for sort tags alpha
6. Open side bar, are they alpha sorted
7. Reload page, are they alpha sorted?

### Release
Not updated: Moved tagsLoaded to redux
