### PR TITLE
Refactor: Move compositeNoteList into render

### DIFF
--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -375,6 +375,12 @@ export class NoteList extends Component<Props> {
 
   handleShortcut = event => {
     const { ctrlKey, key, metaKey, shiftKey } = event;
+    const { notes, selectedNoteId } = this.props;
+
+    const selectedIndex =
+      selectedNoteId && notes
+        ? notes.findIndex(({ id }) => id === selectedNoteId)
+        : -1;
 
     const cmdOrCtrl = ctrlKey || metaKey;
     if (
@@ -382,7 +388,9 @@ export class NoteList extends Component<Props> {
       shiftKey &&
       (key === 'ArrowUp' || key.toLowerCase() === 'k')
     ) {
-      this.props.onSelectNote(this.props.nextNote.id);
+      if (selectedIndex > 0) {
+        this.props.onSelectNote(notes[selectedIndex - 1].id);
+      }
 
       event.stopPropagation();
       event.preventDefault();
@@ -394,7 +402,9 @@ export class NoteList extends Component<Props> {
       shiftKey &&
       (key === 'ArrowDown' || key.toLowerCase() === 'j')
     ) {
-      this.props.onSelectNote(this.props.prevNote.id);
+      if (selectedIndex < notes.length - 1) {
+        this.props.onSelectNote(notes[selectedIndex + 1].id);
+      }
 
       event.stopPropagation();
       event.preventDefault();
@@ -510,18 +520,6 @@ const mapStateToProps: S.MapState<StateProps> = ({
   ui: { filteredNotes, note, searchQuery, showTrash },
   settings: { noteDisplay },
 }) => {
-  const selectedNote = note;
-  const selectedNoteId = selectedNote?.id;
-  const selectedNoteIndex = filteredNotes.findIndex(
-    ({ id }) => id === selectedNoteId
-  );
-
-  const nextNoteId = Math.max(0, selectedNoteIndex - 1);
-  const prevNoteId = Math.min(filteredNotes.length - 1, selectedNoteIndex + 1);
-
-  const nextNote = filteredNotes[nextNoteId];
-  const prevNote = filteredNotes[prevNoteId];
-
   /**
    * Although not used directly in the React component this value
    * is used to bust the cache when editing a note and the number
@@ -542,19 +540,16 @@ const mapStateToProps: S.MapState<StateProps> = ({
    *
    * @type {String} preview excerpt for the current note
    */
-  const selectedNotePreview =
-    selectedNote && getNoteTitleAndPreview(selectedNote).preview;
+  const selectedNotePreview = note && getNoteTitleAndPreview(note).preview;
 
   return {
     hasLoaded: state.notes !== null,
-    nextNote,
     noteDisplay,
     notes: filteredNotes,
-    prevNote,
     searchQuery,
     selectedNotePreview,
-    selectedNoteContent: get(selectedNote, 'data.content'),
-    selectedNoteId,
+    selectedNoteContent: get(note, 'data.content'),
+    selectedNoteId: note?.id,
     showTrash,
     tags: state.tags,
   };

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -423,9 +423,16 @@ export class NoteList extends Component<Props> {
       noteDisplay,
       showTrash,
       tagResultsFound,
+      tags,
       notes,
       isSmallScreen,
     } = this.props;
+
+    const compositeNoteList = createCompositeNoteList(
+      notes,
+      searchQuery,
+      getMatchingTags(tags, searchQuery).length
+    );
 
     const listItemsClasses = classNames('note-list-items', noteDisplay);
 

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -40,10 +40,8 @@ type OwnProps = {
 
 type StateProps = {
   hasLoaded: boolean;
-  nextNote: T.NoteEntity;
   noteDisplay: T.ListDisplayMode;
   notes: T.NoteEntity[];
-  prevNote: T.NoteEntity;
   searchQuery: string;
   selectedNoteContent: string;
   selectedNotePreview: { title: string; preview: string };


### PR DESCRIPTION
### Fix
A refactor that clarifies what part of the code is dealing with the compositeNoteList (just the `render` function) and allows the rest of the component to still operate on the plain notes list.

See #1989 (this splits out some of the changes there into their own PR)

I also alphabetized some props in here because it was bugging me.

This also might make #1829 easier to revisit

### Test
Make sure the note list still works as expected, especially with searching and tag suggestions.

### Release
TBD
