### PR TITLE
Refactor: Move tag suggestions into Redux 

### DIFF
--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -27,7 +27,7 @@ import {
   checkboxDecorator,
   makeFilterDecorator,
 } from './decorators';
-import TagSuggestions, { getMatchingTags } from '../tag-suggestions';
+import TagSuggestions from '../tag-suggestions';
 
 import actions from '../state/actions';
 
@@ -47,7 +47,7 @@ type StateProps = {
   selectedNotePreview: { title: string; preview: string };
   selectedNoteId?: T.EntityId;
   showTrash: boolean;
-  tags: T.TagEntity[];
+  tagResultsFound: number;
 };
 
 type DispatchProps = {
@@ -431,10 +431,8 @@ export class NoteList extends Component<Props> {
       searchQuery,
       selectedNoteId,
       showTrash,
-      tags,
+      tagResultsFound,
     } = this.props;
-
-    const tagResultsFound = getMatchingTags(tags, searchQuery).length;
 
     const compositeNoteList = createCompositeNoteList(
       notes,
@@ -515,7 +513,7 @@ const { emptyTrash, loadAndSelectNote } = appState.actionCreators;
 
 const mapStateToProps: S.MapState<StateProps> = ({
   appState: state,
-  ui: { filteredNotes, note, searchQuery, showTrash },
+  ui: { filteredNotes, note, searchQuery, showTrash, tagSuggestions },
   settings: { noteDisplay },
 }) => {
   /**
@@ -549,7 +547,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
     selectedNoteContent: get(note, 'data.content'),
     selectedNoteId: note?.id,
     showTrash,
-    tags: state.tags,
+    tagResultsFound: tagSuggestions.length,
   };
 };
 

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -1,5 +1,6 @@
 import actions from '../state/actions';
 import { init, updateFilter } from './worker';
+import { filterTags } from '../tag-suggestions';
 
 import * as A from '../state/action-types';
 import * as S from '../state';
@@ -17,10 +18,17 @@ export const middleware: S.Middleware = store => {
     noteIds: Set<T.EntityId>,
     previousIndex?: number
   ) => {
-    const { appState } = store.getState();
+    const {
+      appState,
+      ui: { searchQuery },
+    } = store.getState();
+
+    const tagSuggestions = filterTags(appState.tags, searchQuery);
+
     store.dispatch(
       actions.ui.filterNotes(
         appState.notes?.filter(({ id }) => noteIds.has(id)) || emptyList,
+        tagSuggestions.length > 0 ? tagSuggestions : emptyList,
         previousIndex
       )
     );

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -56,7 +56,7 @@ export type DeleteNoteForever = Action<
 >;
 export type FilterNotes = Action<
   'FILTER_NOTES',
-  { notes: T.NoteEntity[]; previousIndex: number }
+  { notes: T.NoteEntity[]; previousIndex: number; tags: T.TagEntity[] }
 >;
 export type FocusSearchField = Action<'FOCUS_SEARCH_FIELD'>;
 export type RemoteNoteUpdate = Action<

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -22,10 +22,12 @@ export const deleteNoteForever: A.ActionCreator<A.DeleteNoteForever> = (
 
 export const filterNotes: A.ActionCreator<A.FilterNotes> = (
   notes: T.NoteEntity[],
+  tags: T.TagEntity[],
   previousIndex: number
 ) => ({
   type: 'FILTER_NOTES',
   notes,
+  tags,
   previousIndex,
 });
 

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -245,6 +245,11 @@ const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
   }
 };
 
+const tagSuggestions: A.Reducer<T.TagEntity[]> = (
+  state = emptyList as T.TagEntity[],
+  action
+) => ('FILTER_NOTES' === action.type ? action.tags : state);
+
 export default combineReducers({
   dialogs,
   editMode,
@@ -263,5 +268,6 @@ export default combineReducers({
   showRevisions,
   showTrash,
   simperiumConnected,
+  tagSuggestions,
   unsyncedNoteIds,
 });

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -91,25 +91,11 @@ export const filterTags = (tags: T.TagEntity[], query: string) => {
   return filterAtMost(tags, matcher, 5);
 };
 
-let lastTags = null;
-let lastQuery = null;
-let lastMatches = [];
-export const getMatchingTags = (tags, query) => {
-  if (lastTags === tags && lastQuery === query) {
-    return lastMatches;
-  }
-
-  lastTags = tags;
-  lastQuery = query;
-  lastMatches = filterTags(tags, query);
-  return lastMatches;
-};
-
 const mapStateToProps: S.MapState<StateProps> = ({
   appState: state,
-  ui: { searchQuery },
+  ui: { searchQuery, tagSuggestions },
 }) => ({
-  filteredTags: getMatchingTags(state.tags, searchQuery),
+  filteredTags: tagSuggestions,
   searchQuery,
 });
 


### PR DESCRIPTION
Since we introduced tag suggestions in #1648 we have been recalculating
the list of tag suggestions on every render, at least twice (once to get
the count of tag suggestions in `note-list` and once in `tag-suggestions`).

In order to prevent needless re-rendering we implemented custom memoization
in the `tag-suggestions` component.

In this patch we're moving the tag suggestions logic into our search module
where the tag suggestions can update with the rest of the search results.
By doing this we'll leave one place to update them, couple them with the
filtered notes, and be able to remove our custom memoizatoin without losing
the benefits it brought us.