### PR TITLE
Fix: load tags from redux not appState

### DIFF
--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -168,9 +168,10 @@ export class NoteEditor extends Component<Props> {
 const mapStateToProps: S.MapState<StateProps> = ({
   appState: state,
   settings,
+  tags,
   ui: { note, editMode, selectedRevision },
 }) => ({
-  allTags: state.tags,
+  allTags: tags,
   fontSize: settings.fontSize,
   editMode,
   isEditorActive: !state.showNavigation,


### PR DESCRIPTION
### Fix
In: https://github.com/Automattic/simplenote-electron/pull/1991 I missed one of the places where tags get loaded from appState.

