### PR TITLE
Refactor: Move isElectron and isMacApp checks to a util

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -16,20 +16,12 @@ import DevBadge from './components/dev-badge';
 import DialogRenderer from './dialog-renderer';
 import { getIpcRenderer } from './utils/electron';
 import exportZipArchive from './utils/export';
+import { isElectron, isMac } from './utils/platform';
 import { activityHooks, getUnsyncedNoteIds, nudgeUnsynced } from './utils/sync';
 import { setLastSyncedTime } from './utils/sync/last-synced-time';
 import analytics from './analytics';
 import classNames from 'classnames';
-import {
-  debounce,
-  get,
-  has,
-  isObject,
-  matchesProperty,
-  overEvery,
-  pick,
-  values,
-} from 'lodash';
+import { debounce, get, has, isObject, overEvery, pick, values } from 'lodash';
 import {
   createNote,
   closeNote,
@@ -127,16 +119,6 @@ const mapDispatchToProps: S.MapDispatch<
   };
 };
 
-const isElectron = (() => {
-  // https://github.com/atom/electron/issues/2288
-  const foundElectron = has(window, 'process.type');
-
-  return () => foundElectron;
-})();
-
-const isElectronMac = () =>
-  matchesProperty('process.platform', 'darwin')(window);
-
 export const App = connect(
   mapStateToProps,
   mapDispatchToProps
@@ -173,7 +155,7 @@ export const App = connect(
     };
 
     UNSAFE_componentWillMount() {
-      if (isElectron()) {
+      if (isElectron) {
         this.initializeElectron();
       }
 
@@ -515,7 +497,6 @@ export const App = connect(
         isSmallScreen,
         ui: { showNavigation, showNoteInfo },
       } = this.props;
-      const isMacApp = isElectronMac();
 
       const themeClass = `theme-${this.getTheme()}`;
 
@@ -527,8 +508,8 @@ export const App = connect(
       const mainClasses = classNames('simplenote-app', {
         'note-info-open': showNoteInfo,
         'navigation-open': showNavigation,
-        'is-electron': isElectron(),
-        'is-macos': isMacApp,
+        'is-electron': isElectron,
+        'is-macos': isMac,
       });
 
       return (
@@ -536,7 +517,7 @@ export const App = connect(
           {isDevConfig && <DevBadge />}
           {isAuthorized ? (
             <div className={mainClasses}>
-              {showNavigation && <NavigationBar isElectron={isElectron()} />}
+              {showNavigation && <NavigationBar />}
               <AppLayout
                 isFocusMode={settings.focusModeEnabled}
                 isNavigationOpen={showNavigation}
@@ -555,16 +536,12 @@ export const App = connect(
               onAuthenticate={this.props.onAuthenticate}
               onCreateUser={this.props.onCreateUser}
               authorizeUserWithToken={this.props.authorizeUserWithToken}
-              isMacApp={isMacApp}
-              isElectron={isElectron()}
             />
           )}
           <DialogRenderer
             appProps={this.props}
             buckets={{ noteBucket, preferencesBucket, tagBucket }}
             themeClass={themeClass}
-            isElectron={isElectron()}
-            isMacApp={isMacApp}
           />
         </div>
       );

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -9,6 +9,7 @@ import SimplenoteLogo from '../icons/simplenote';
 import Spinner from '../components/spinner';
 
 import { hasInvalidCredentials, hasLoginError } from '../state/auth/selectors';
+import { isElectron, isMac } from '../utils/platform';
 import { reset } from '../state/auth/actions';
 import { setWPToken } from '../state/settings/actions';
 import { viewExternalUrl } from '../utils/url-utils';
@@ -20,8 +21,6 @@ export class Auth extends Component {
     hasInvalidCredentials: PropTypes.bool,
     hasLoginError: PropTypes.bool,
     isAuthenticated: PropTypes.bool,
-    isElectron: PropTypes.bool,
-    isMacApp: PropTypes.bool,
     onAuthenticate: PropTypes.func.isRequired,
     onCreateUser: PropTypes.func.isRequired,
     resetErrors: PropTypes.func.isRequired,
@@ -46,7 +45,6 @@ export class Auth extends Component {
       return null;
     }
 
-    const { isMacApp, isElectron } = this.props;
     const { isCreatingAccount, passwordErrorMessage } = this.state;
     const submitClasses = classNames('button', 'button-primary', {
       pending: this.props.authPending,
@@ -65,7 +63,7 @@ export class Auth extends Component {
 
     return (
       <div className="login">
-        {isMacApp && <div className="login__draggable-area" />}
+        {isMac && <div className="login__draggable-area" />}
         <SimplenoteLogo />
         <form className="login__form" onSubmit={this.onLogin}>
           <h1>{buttonLabel}</h1>

--- a/lib/dialog-renderer/index.tsx
+++ b/lib/dialog-renderer/index.tsx
@@ -17,8 +17,6 @@ type OwnProps = {
   appProps: object;
   buckets: Record<'noteBucket' | 'tagBucket' | 'preferencesBucket', T.Bucket>;
   themeClass: string;
-  isElectron: boolean;
-  isMacApp: boolean;
 };
 
 type StateProps = {
@@ -35,14 +33,7 @@ export class DialogRenderer extends Component<Props> {
   static displayName = 'DialogRenderer';
 
   render() {
-    const {
-      appProps,
-      buckets,
-      themeClass,
-      isElectron,
-      isMacApp,
-      closeDialog,
-    } = this.props;
+    const { appProps, buckets, themeClass, closeDialog } = this.props;
 
     return (
       <Fragment>
@@ -59,25 +50,11 @@ export class DialogRenderer extends Component<Props> {
             {'ABOUT' === dialog ? (
               <AboutDialog key="about" />
             ) : 'IMPORT' === dialog ? (
-              <ImportDialog
-                key="import"
-                buckets={buckets}
-                isElectron={isElectron}
-              />
+              <ImportDialog key="import" buckets={buckets} />
             ) : 'KEYBINDINGS' === dialog ? (
-              <KeybindingsDialog
-                key="keybindings"
-                isElectron={isElectron}
-                isMacApp={isMacApp}
-              />
+              <KeybindingsDialog key="keybindings" />
             ) : 'SETTINGS' === dialog ? (
-              <SettingsDialog
-                key="settings"
-                buckets={buckets}
-                isElectron={isElectron}
-                isMacApp={isMacApp}
-                {...appProps}
-              />
+              <SettingsDialog key="settings" buckets={buckets} {...appProps} />
             ) : 'SHARE' === dialog ? (
               <ShareDialog key="share" />
             ) : null}

--- a/lib/dialogs/import/index.tsx
+++ b/lib/dialogs/import/index.tsx
@@ -24,7 +24,6 @@ type Props = DispatchProps;
 class ImportDialog extends Component<Props> {
   static propTypes = {
     buckets: PropTypes.object,
-    isElectron: PropTypes.bool.isRequired,
   };
 
   state = {
@@ -33,7 +32,7 @@ class ImportDialog extends Component<Props> {
   };
 
   render() {
-    const { buckets, closeDialog, isElectron } = this.props;
+    const { buckets, closeDialog } = this.props;
     const { importStarted, selectedSource } = this.state;
 
     const selectSource = source => this.setState({ selectedSource: source });
@@ -57,7 +56,6 @@ class ImportDialog extends Component<Props> {
         <div className="import__inner">
           {!sourceIsSelected && (
             <ImportSourceSelector
-              isElectron={isElectron}
               locked={importStarted}
               selectSource={selectSource}
             />

--- a/lib/dialogs/import/source-selector.tsx
+++ b/lib/dialogs/import/source-selector.tsx
@@ -2,12 +2,13 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { reject } from 'lodash';
 
+import { isElectron } from '../../utils/platform';
 import PanelTitle from '../../components/panel-title';
 import ButtonGroup from '../button-group';
 
 import sources from './sources';
 
-const ImportSourceSelector = ({ isElectron, selectSource }) => {
+const ImportSourceSelector = ({ selectSource }) => {
   return (
     <Fragment>
       <PanelTitle headingLevel="3">Import from</PanelTitle>
@@ -22,7 +23,6 @@ const ImportSourceSelector = ({ isElectron, selectSource }) => {
 };
 
 ImportSourceSelector.propTypes = {
-  isElectron: PropTypes.bool.isRequired,
   selectSource: PropTypes.func.isRequired,
 };
 

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -2,19 +2,13 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import Dialog from '../../dialog';
 import { closeDialog } from '../../state/ui/actions';
+import { isElectron, isMac } from '../../utils/platform';
 
 import * as S from '../../state';
-
-type OwnProps = {
-  isElectron: boolean;
-  isMacApp: boolean;
-};
 
 type DispatchProps = {
   closeDialog: () => any;
 };
-
-type Props = OwnProps & DispatchProps;
 
 const Keys = ({
   keys,
@@ -43,11 +37,11 @@ const Keys = ({
   </div>
 );
 
-export class AboutDialog extends Component<Props> {
+export class AboutDialog extends Component<DispatchProps> {
   render() {
-    const { closeDialog, isElectron, isMacApp } = this.props;
+    const { closeDialog } = this.props;
 
-    const CmdOrCtrl = isMacApp ? 'Cmd' : 'Ctrl';
+    const CmdOrCtrl = isMac ? 'Cmd' : 'Ctrl';
 
     return (
       <div className="keybindings">

--- a/lib/dialogs/settings/index.tsx
+++ b/lib/dialogs/settings/index.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import Dialog from '../../dialog';
+import { isElectron } from '../../utils/platform';
 import TabPanels from '../../components/tab-panels';
 import { viewExternalUrl } from '../../utils/url-utils';
 
@@ -23,8 +24,6 @@ type OwnProps = {
   actions: object;
   appState: object;
   buckets: Record<'noteBucket' | 'tagBucket' | 'preferencesBucket', T.Bucket>;
-  isElectron: boolean;
-  isMacApp: boolean;
   onSignOut: () => any;
   settings: S.State['settings'];
   toggleShareAnalyticsPreference: (preferencesBucket: object) => any;
@@ -71,7 +70,7 @@ export class SettingsDialog extends Component<Props> {
   };
 
   signOut = () => {
-    const { onSignOut, setWPToken, isElectron } = this.props;
+    const { onSignOut, setWPToken } = this.props;
 
     // Reset the WordPress Token
     setWPToken(null);
@@ -85,7 +84,6 @@ export class SettingsDialog extends Component<Props> {
   };
 
   showUnsyncedWarning = () => {
-    const { isElectron } = this.props;
     isElectron ? this.showElectronWarningDialog() : this.showWebWarningDialog();
   };
 
@@ -124,7 +122,7 @@ export class SettingsDialog extends Component<Props> {
   };
 
   render() {
-    const { buckets, closeDialog, isElectron, isMacApp, settings } = this.props;
+    const { buckets, closeDialog, settings } = this.props;
     const { analyticsEnabled } = this.props.appState.preferences;
 
     return (
@@ -138,11 +136,7 @@ export class SettingsDialog extends Component<Props> {
               this.onToggleShareAnalyticsPreference
             }
           />
-          <DisplayPanel
-            buckets={buckets}
-            isElectron={isElectron}
-            isMacApp={isMacApp}
-          />
+          <DisplayPanel buckets={buckets} />
           <ToolsPanel />
         </TabPanels>
       </Dialog>

--- a/lib/dialogs/settings/panels/display.tsx
+++ b/lib/dialogs/settings/panels/display.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 
+import { isElectron, isMac } from '../../../utils/platform';
 import RadioGroup from '../../radio-settings-group';
 import SettingsGroup, { Item } from '../../settings-group';
 import ToggleGroup from '../../toggle-settings-group';
@@ -17,8 +18,6 @@ const DisplayPanel = props => {
     activeTheme,
     autoHideMenuBar,
     buckets: { noteBucket },
-    isElectron,
-    isMacApp,
     lineLength,
     loadNotes,
     noteDisplay,
@@ -112,7 +111,7 @@ const DisplayPanel = props => {
         <Item title="Dark" slug="dark" />
       </SettingsGroup>
 
-      {isElectron && !isMacApp && (
+      {isElectron && !isMac && (
         <SettingsGroup
           title="Menu Bar"
           slug="autoHideMenuBar"
@@ -135,8 +134,6 @@ DisplayPanel.propTypes = {
   buckets: PropTypes.shape({
     noteBucket: PropTypes.object.isRequired,
   }),
-  isElectron: PropTypes.bool.isRequired,
-  isMacApp: PropTypes.bool.isRequired,
   lineLength: PropTypes.string.isRequired,
   loadNotes: PropTypes.func.isRequired,
   loadTags: PropTypes.func.isRequired,

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import onClickOutside from 'react-onclickoutside';
 
 import analytics from '../analytics';
+import { isElectron } from '../utils/platform';
 import NavigationBarItem from './item';
 import TagList from '../tag-list';
 import NotesIcon from '../icons/notes';
@@ -16,10 +17,6 @@ import { showDialog, toggleNavigation, selectTrash } from '../state/ui/actions';
 
 import * as S from '../state';
 import * as T from '../types';
-
-type OwnProps = {
-  isElectron: boolean;
-};
 
 type StateProps = {
   autoHideMenuBar: boolean;
@@ -38,7 +35,7 @@ type DispatchProps = {
   showKeyboardShortcuts: () => any;
 };
 
-type Props = OwnProps & StateProps & DispatchProps;
+type Props = StateProps & DispatchProps;
 
 export class NavigationBar extends Component<Props> {
   static displayName = 'NavigationBar';
@@ -72,13 +69,7 @@ export class NavigationBar extends Component<Props> {
   };
 
   render() {
-    const {
-      autoHideMenuBar,
-      isElectron,
-      onAbout,
-      onSettings,
-      onShowAllNotes,
-    } = this.props;
+    const { autoHideMenuBar, onAbout, onSettings, onShowAllNotes } = this.props;
     return (
       <div className="navigation-bar theme-color-bg theme-color-fg theme-color-border">
         <div className="navigation-bar__folders">

--- a/lib/utils/import/evernote/index.ts
+++ b/lib/utils/import/evernote/index.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import { createStream } from 'sax';
+import { isElectron } from '../../platform';
 import parseISO from 'date-fns/parseISO';
 import { endsWith, get, has } from 'lodash';
 
@@ -7,7 +8,7 @@ import CoreImporter from '../';
 import enmlToMarkdown from './enml-to-markdown';
 
 let fs = null;
-const isElectron = has(window, 'process.type');
+
 if (isElectron) {
   fs = __non_webpack_require__('fs'); // eslint-disable-line no-undef
 }

--- a/lib/utils/platform.ts
+++ b/lib/utils/platform.ts
@@ -1,0 +1,4 @@
+// https://github.com/atom/electron/issues/22
+export const isElectron = !!window?.process?.type;
+
+export const isMac = window?.process?.platofrm === 'darwin';

--- a/lib/utils/platform.ts
+++ b/lib/utils/platform.ts
@@ -1,4 +1,4 @@
 // https://github.com/atom/electron/issues/22
 export const isElectron = !!window?.process?.type;
 
-export const isMac = window?.process?.platofrm === 'darwin';
+export const isMac = window?.process?.platform === 'darwin';


### PR DESCRIPTION
### Fix
Moves isElectron and isMacApp checks to a util which allows us to remove a bunch of prop drilling.

### Test
1. Do you see settings in tag panel at the bottom on web?
1. Do you not see settings in tag panel at the bottom on electron?
1. In the import dialog do not you see Evernote on web?
1. In the import dialog do you see Evernote on electron?

### Release
Moved isElectron and isMacApp checks to a util