### PR TITLE
Fix: Remove tags from state on logout

### DIFF
--- a/lib/state/tags/reducer.ts
+++ b/lib/state/tags/reducer.ts
@@ -21,6 +21,11 @@ const tags: A.Reducer<T.TagEntity[]> = (state = [], action) => {
       }
       return sortedTags;
     }
+    case 'AUTH_SET':
+      if (action.status === 'not-authorized') {
+        return [];
+      }
+      return state;
     default:
       return state;
   }


### PR DESCRIPTION
### Fix
After moving the tags state to redux we were not clearing out tags on log out. This PR sets tags to an empty array

### Test
1. Be logged in
2. Have tags
3. Log out
4. Look at redux chrome dev tools plugin
5. Observe no tags in state

### Release
Fix: Remove tags from state on logout
