### PR TITLE
Use actions import over direct import of actions

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import 'focus-visible/dist/focus-visible.js';
 import appState from './flux/app-state';
 import { loadTags } from './state/domain/tags';
-import reduxActions from './state/actions';
 import selectors from './state/selectors';
 import browserShell from './browser-shell';
 import NoteInfo from './note-info';
@@ -22,16 +21,6 @@ import { setLastSyncedTime } from './utils/sync/last-synced-time';
 import analytics from './analytics';
 import classNames from 'classnames';
 import { debounce, get, has, isObject, overEvery, pick, values } from 'lodash';
-import {
-  createNote,
-  closeNote,
-  setUnsyncedNoteIds,
-  toggleNavigation,
-  toggleSimperiumConnectionStatus,
-} from './state/ui/actions';
-
-import * as settingsActions from './state/settings/actions';
-
 import actions from './state/actions';
 import * as S from './state';
 import * as T from './types';
@@ -83,7 +72,7 @@ const mapDispatchToProps: S.MapDispatch<
   return {
     actions: bindActionCreators(actionCreators, dispatch),
     ...bindActionCreators(
-      pick(settingsActions, [
+      pick(actions.settings, [
         'activateTheme',
         'decreaseFontSize',
         'increaseFontSize',
@@ -97,23 +86,23 @@ const mapDispatchToProps: S.MapDispatch<
       ]),
       dispatch
     ),
-    closeNote: () => dispatch(closeNote()),
+    closeNote: () => dispatch(actions.ui.closeNote()),
     remoteNoteUpdate: (noteId, data) =>
       dispatch(actions.simperium.remoteNoteUpdate(noteId, data)),
     loadTags: () => dispatch(loadTags()),
-    setSortType: thenReloadNotes(settingsActions.setSortType),
-    toggleSortOrder: thenReloadNotes(settingsActions.toggleSortOrder),
-    toggleSortTagsAlpha: thenReloadTags(settingsActions.toggleSortTagsAlpha),
-    createNote: () => dispatch(createNote()),
-    openTagList: () => dispatch(toggleNavigation()),
-    resetAuth: () => dispatch(reduxActions.auth.reset()),
+    setSortType: thenReloadNotes(actions.settings.setSortType),
+    toggleSortOrder: thenReloadNotes(actions.settings.toggleSortOrder),
+    toggleSortTagsAlpha: thenReloadTags(actions.settings.toggleSortTagsAlpha),
+    createNote: () => dispatch(actions.ui.createNote()),
+    openTagList: () => dispatch(actions.ui.toggleNavigation()),
+    resetAuth: () => dispatch(actions.auth.reset()),
     selectNote: (note: T.NoteEntity) => dispatch(actions.ui.selectNote(note)),
-    setAuthorized: () => dispatch(reduxActions.auth.setAuthorized()),
+    setAuthorized: () => dispatch(actions.auth.setAuthorized()),
     focusSearchField: () => dispatch(actions.ui.focusSearchField()),
     setSimperiumConnectionStatus: (connected) =>
-      dispatch(toggleSimperiumConnectionStatus(connected)),
-    selectNote: (note) => dispatch(actions.ui.selectNote(note)),
-    setUnsyncedNoteIds: (noteIds) => dispatch(setUnsyncedNoteIds(noteIds)),
+      dispatch(actions.ui.toggleSimperiumConnectionStatus(connected)),
+    setUnsyncedNoteIds: (noteIds) =>
+      dispatch(actions.ui.setUnsyncedNoteIds(noteIds)),
     showDialog: (dialog) => dispatch(actions.ui.showDialog(dialog)),
     trashNote: (previousIndex) => dispatch(actions.ui.trashNote(previousIndex)),
   };

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -10,8 +10,8 @@ import Spinner from '../components/spinner';
 
 import { hasInvalidCredentials, hasLoginError } from '../state/auth/selectors';
 import { isElectron, isMac } from '../utils/platform';
-import { reset } from '../state/auth/actions';
-import { setWPToken } from '../state/settings/actions';
+import actions from '../state/actions';
+
 import { viewExternalUrl } from '../utils/url-utils';
 
 export class Auth extends Component {
@@ -346,8 +346,8 @@ export class Auth extends Component {
 }
 
 const mapDispatchToProps = (dispatch) => ({
-  resetErrors: () => dispatch(reset()),
-  saveWPToken: (token) => dispatch(setWPToken(token)),
+  resetErrors: () => dispatch(actions.auth.reset()),
+  saveWPToken: (token) => dispatch(actions.settings.setWPToken(token)),
 });
 
 const mapStateToProps = (state) => ({

--- a/lib/dialog-renderer/index.tsx
+++ b/lib/dialog-renderer/index.tsx
@@ -8,8 +8,7 @@ import ImportDialog from '../dialogs/import';
 import KeybindingsDialog from '../dialogs/keybindings';
 import SettingsDialog from '../dialogs/settings';
 import ShareDialog from '../dialogs/share';
-import { closeDialog } from '../state/ui/actions';
-
+import actions from '../state/actions';
 import * as S from '../state';
 import * as T from '../types';
 
@@ -70,7 +69,7 @@ const mapStateToProps: S.MapState<StateProps> = ({ ui: { dialogs } }) => ({
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
-  closeDialog,
+  closeDialog: actions.ui.closeDialog,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(DialogRenderer);

--- a/lib/dialogs/about/index.tsx
+++ b/lib/dialogs/about/index.tsx
@@ -4,7 +4,7 @@ import SimplenoteLogo from '../../icons/simplenote';
 import CrossIcon from '../../icons/cross';
 import TopRightArrowIcon from '../../icons/arrow-top-right';
 import Dialog from '../../dialog';
-import { closeDialog } from '../../state/ui/actions';
+import actions from '../../state/actions';
 
 import * as S from '../../state';
 
@@ -126,7 +126,7 @@ export class AboutDialog extends Component<Props> {
 }
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
-  closeDialog,
+  closeDialog: actions.ui.closeDialog,
 };
 
 export default connect(null, mapDispatchToProps)(AboutDialog);

--- a/lib/dialogs/import/index.tsx
+++ b/lib/dialogs/import/index.tsx
@@ -7,7 +7,7 @@ import ImportSourceSelector from './source-selector';
 import TransitionFadeInOut from '../../components/transition-fade-in-out';
 import TransitionDelayEnter from '../../components/transition-delay-enter';
 import Spinner from '../../components/spinner';
-import { closeDialog } from '../../state/ui/actions';
+import actions from '../../state/actions';
 
 import * as S from '../../state';
 
@@ -81,7 +81,7 @@ class ImportDialog extends Component<Props> {
 }
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
-  closeDialog,
+  closeDialog: actions.ui.closeDialog,
 };
 
 export default connect(null, mapDispatchToProps)(ImportDialog);

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -1,8 +1,8 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import Dialog from '../../dialog';
-import { closeDialog } from '../../state/ui/actions';
 import { isElectron, isMac } from '../../utils/platform';
+import actions from '../../state/actions';
 
 import * as S from '../../state';
 
@@ -154,7 +154,7 @@ export class AboutDialog extends Component<DispatchProps> {
 }
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
-  closeDialog,
+  closeDialog: actions.ui.closeDialog,
 };
 
 export default connect(null, mapDispatchToProps)(AboutDialog);

--- a/lib/dialogs/settings/index.tsx
+++ b/lib/dialogs/settings/index.tsx
@@ -12,9 +12,7 @@ import DisplayPanel from './panels/display';
 import ToolsPanel from './panels/tools';
 
 import appState from '../../flux/app-state';
-import { setWPToken } from '../../state/settings/actions';
-
-import { closeDialog } from '../../state/ui/actions';
+import actions from '../../state/actions';
 
 import * as S from '../../state';
 
@@ -147,8 +145,8 @@ export class SettingsDialog extends Component<Props> {
 const { toggleShareAnalyticsPreference } = appState.actionCreators;
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({
-  closeDialog: () => dispatch(closeDialog()),
-  setWPToken: (token) => dispatch(setWPToken(token)),
+  closeDialog: () => dispatch(actions.ui.closeDialog()),
+  setWPToken: (token) => dispatch(actions.settings.setWPToken(token)),
   toggleShareAnalyticsPreference: (args) => {
     dispatch(toggleShareAnalyticsPreference(args));
   },

--- a/lib/dialogs/settings/panels/display.tsx
+++ b/lib/dialogs/settings/panels/display.tsx
@@ -9,7 +9,7 @@ import SettingsGroup, { Item } from '../../settings-group';
 import ToggleGroup from '../../toggle-settings-group';
 
 import appState from '../../../flux/app-state';
-import * as settingsActions from '../../../state/settings/actions';
+import actions from '../../../state/actions';
 import { loadTags } from '../../../state/domain/tags';
 
 const DisplayPanel = (props) => {
@@ -158,8 +158,9 @@ const mapStateToProps = ({ settings }) => {
 const mapDispatchToProps = (dispatch) => {
   const { loadNotes } = appState.actionCreators;
   return {
-    actions: bindActionCreators(settingsActions, dispatch),
+    actions: bindActionCreators(actions.settings, dispatch),
     loadNotes: (noteBucket) => dispatch(loadNotes({ noteBucket })),
+    actions: bindActionCreators(actions.settings, dispatch),
     loadTags: () => dispatch(loadTags()),
   };
 };

--- a/lib/dialogs/settings/panels/tools.tsx
+++ b/lib/dialogs/settings/panels/tools.tsx
@@ -6,7 +6,7 @@ import exportZipArchive from '../../../utils/export';
 import PanelTitle from '../../../components/panel-title';
 import ButtonGroup from '../../button-group';
 
-import { showDialog } from '../../../state/ui/actions';
+import actions from '../../../state/actions';
 
 import * as S from '../../../state';
 
@@ -46,7 +46,7 @@ const ToolsPanel: FunctionComponent<Props> = ({ showDialog }) => {
 };
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({
-  showDialog: () => dispatch(showDialog('IMPORT')),
+  showDialog: () => dispatch(actions.ui.showDialog('IMPORT')),
 });
 
 export default connect(null, mapDispatchToProps)(ToolsPanel);

--- a/lib/dialogs/share/index.tsx
+++ b/lib/dialogs/share/index.tsx
@@ -12,7 +12,7 @@ import Dialog from '../../dialog';
 import TabPanels from '../../components/tab-panels';
 import PanelTitle from '../../components/panel-title';
 import ToggleControl from '../../controls/toggle';
-import { closeDialog, publishNote } from '../../state/ui/actions';
+import actions from '../../state/actions';
 
 import * as S from '../../state';
 import * as T from '../../types';
@@ -217,9 +217,9 @@ const mapStateToProps: S.MapState<StateProps> = ({
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({
-  closeDialog: () => dispatch(closeDialog()),
+  closeDialog: () => dispatch(actions.ui.closeDialog()),
   publishNote: (note, shouldPublish) =>
-    dispatch(publishNote(note, shouldPublish)),
+    dispatch(actions.ui.publishNote(note, shouldPublish)),
   updateNoteTags: ({ note, tags }) => dispatch(updateNoteTags({ note, tags })),
 });
 

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -13,7 +13,7 @@ import SyncStatus from '../components/sync-status';
 import { viewExternalUrl } from '../utils/url-utils';
 import appState from '../flux/app-state';
 
-import { showDialog, toggleNavigation, selectTrash } from '../state/ui/actions';
+import actions from '../state/actions';
 
 import * as S from '../state';
 import * as T from '../types';
@@ -149,12 +149,12 @@ const mapStateToProps: S.MapState<StateProps> = ({
 const { showAllNotesAndSelectFirst } = appState.actionCreators;
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
-  onAbout: () => showDialog('ABOUT'),
-  onOutsideClick: toggleNavigation,
+  onAbout: () => actions.ui.showDialog('ABOUT'),
+  onOutsideClick: actions.ui.toggleNavigation,
   onShowAllNotes: showAllNotesAndSelectFirst,
-  onSettings: () => showDialog('SETTINGS'),
-  selectTrash,
-  showKeyboardShortcuts: () => showDialog('KEYBINDINGS'),
+  onSettings: () => actions.ui.showDialog('SETTINGS'),
+  selectTrash: actions.ui.selectTrash,
+  showKeyboardShortcuts: () => actions.ui.showDialog('KEYBINDINGS'),
 };
 
 export default connect(

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -4,9 +4,7 @@ import { connect } from 'react-redux';
 import TagField from '../tag-field';
 import { property } from 'lodash';
 import NoteDetail from '../note-detail';
-import { toggleEditMode } from '../state/ui/actions';
-
-import { closeNote, markdownNote } from '../state/ui/actions';
+import actions from '../state/actions';
 
 import * as S from '../state';
 import * as T from '../types';
@@ -184,10 +182,10 @@ const mapStateToProps: S.MapState<StateProps> = ({
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({
-  closeNote: () => dispatch(closeNote()),
+  closeNote: () => dispatch(actions.ui.closeNote()),
   toggleMarkdown: (note, enableMarkdown) =>
-    dispatch(markdownNote(note, enableMarkdown)),
-  toggleEditMode: () => dispatch(toggleEditMode()),
+    dispatch(actions.ui.markdownNote(note, enableMarkdown)),
+  toggleEditMode: () => dispatch(actions.ui.toggleEditMode()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteEditor);

--- a/lib/note-toolbar-container.ts
+++ b/lib/note-toolbar-container.ts
@@ -3,8 +3,7 @@ import { connect } from 'react-redux';
 
 import analytics from './analytics';
 import appState from './flux/app-state';
-import { toggleFocusMode } from './state/settings/actions';
-import { showDialog } from './state/ui/actions';
+import actions from './state/actions';
 
 import * as S from './state';
 import * as T from './types';
@@ -89,8 +88,8 @@ const { deleteNoteForever, restoreNote, trashNote } = appState.actionCreators;
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({
   deleteNoteForever: (args) => dispatch(deleteNoteForever(args)),
   restoreNote: (args) => dispatch(restoreNote(args)),
-  shareNote: () => dispatch(showDialog('SHARE')),
-  toggleFocusMode: () => dispatch(toggleFocusMode()),
+  shareNote: () => dispatch(actions.ui.showDialog('SHARE')),
+  toggleFocusMode: () => dispatch(actions.settings.toggleFocusMode()),
   trashNote: (args) => dispatch(trashNote(args)),
 });
 

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -12,13 +12,7 @@ import RevisionsIcon from '../icons/revisions';
 import TrashIcon from '../icons/trash';
 import ShareIcon from '../icons/share';
 import SidebarIcon from '../icons/sidebar';
-
-import {
-  closeNote,
-  toggleEditMode,
-  toggleNoteInfo,
-  toggleRevisions,
-} from '../state/ui/actions';
+import actions from '../state/actions';
 
 import * as S from '../state';
 import * as T from '../types';
@@ -185,10 +179,10 @@ const mapStateToProps: S.MapState<StateProps> = ({
 };
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
-  closeNote,
-  toggleEditMode,
-  toggleNoteInfo,
-  toggleRevisions,
+  closeNote: actions.ui.closeNote,
+  toggleEditMode: actions.ui.toggleEditMode,
+  toggleNoteInfo: actions.ui.toggleNoteInfo,
+  toggleRevisions: actions.ui.toggleRevisions,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteToolbar);

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -6,7 +6,7 @@ import { orderBy } from 'lodash';
 import classNames from 'classnames';
 import Slider from '../components/slider';
 import { updateNoteTags } from '../state/domain/notes';
-import { selectRevision, toggleRevisions } from '../state/ui/actions';
+import actions from '../state/actions';
 
 import * as S from '../state';
 import * as T from '../types';
@@ -191,9 +191,10 @@ const mapStateToProps: S.MapState<StateProps> = ({
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({
-  setRevision: (revision: T.NoteEntity) => dispatch(selectRevision(revision)),
-  resetIsViewingRevisions: () => dispatch(toggleRevisions()),
-  cancelRevision: () => dispatch(toggleRevisions()),
+  setRevision: (revision: T.NoteEntity) =>
+    dispatch(actions.ui.selectRevision(revision)),
+  resetIsViewingRevisions: () => dispatch(actions.ui.toggleRevisions()),
+  cancelRevision: () => dispatch(actions.ui.toggleRevisions()),
   updateNoteTags: (arg) => dispatch(updateNoteTags(arg)),
 });
 

--- a/lib/search-bar/index.tsx
+++ b/lib/search-bar/index.tsx
@@ -14,7 +14,7 @@ import NewNoteIcon from '../icons/new-note';
 import SearchField from '../search-field';
 import MenuIcon from '../icons/menu';
 import { withoutTags } from '../utils/filter-notes';
-import { createNote, search, toggleNavigation } from '../state/ui/actions';
+import actions from '../state/actions';
 
 import * as S from '../state';
 import * as T from '../types';
@@ -76,7 +76,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (
     analytics.tracks.recordEvent('list_note_created');
   },
   toggleNavigation: () => {
-    dispatch(toggleNavigation());
+    dispatch(actions.ui.toggleNavigation());
   },
 });
 

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import SmallCrossIcon from '../icons/cross-small';
 import analytics from '../analytics';
 import { State } from '../state';
-import { search } from '../state/ui/actions';
+import actions from '../state/actions';
 
 import { registerSearchField } from '../state/ui/search-field-middleware';
 
@@ -109,7 +109,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({
   onSearch: (query: string) => {
-    dispatch(search(query));
+    dispatch(actions.ui.search(query));
     analytics.tracks.recordEvent('list_notes_searched');
   },
 });

--- a/lib/tag-email-tooltip/index.tsx
+++ b/lib/tag-email-tooltip/index.tsx
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import appState from '../flux/app-state';
-
-import { showDialog } from '../state/ui/actions';
+import actions from '../state/actions';
 
 export const EmailToolTip = ({ openShareDialog }) => (
   <div className="tag-email-tooltip">
@@ -21,7 +20,7 @@ export const EmailToolTip = ({ openShareDialog }) => (
 );
 
 const mapDispatchToProps = (dispatch) => ({
-  openShareDialog: () => dispatch(showDialog('SHARE')),
+  openShareDialog: () => dispatch(actions.ui.showDialog('SHARE')),
 });
 
 EmailToolTip.propTypes = {

--- a/lib/tag-list/index.tsx
+++ b/lib/tag-list/index.tsx
@@ -6,7 +6,7 @@ import EditableList from '../editable-list';
 import { get } from 'lodash';
 import TagListInput from './input';
 import { renameTag, reorderTags, trashTag } from '../state/domain/tags';
-import { openTag, toggleTagEditing } from '../state/ui/actions';
+import actions from '../state/actions';
 import analytics from '../analytics';
 
 import * as S from '../state';
@@ -108,9 +108,9 @@ const mapStateToProps: S.MapState<StateProps> = ({
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({
-  onEditTags: () => dispatch(toggleTagEditing()),
+  onEditTags: () => dispatch(actions.ui.toggleTagEditing()),
   openTag: (tag) => {
-    dispatch(openTag(tag));
+    dispatch(actions.ui.openTag(tag));
     analytics.tracks.recordEvent('list_tag_viewed');
   },
   renameTag: (arg) => dispatch(renameTag(arg)),

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import analytics from '../analytics';
-import { search } from '../state/ui/actions';
+import actions from '../state/actions';
 import filterAtMost from '../utils/filter-at-most';
 
 import * as S from '../state';
@@ -96,7 +96,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({
   onSearch: (query) => {
-    dispatch(search(query));
+    dispatch(actions.ui.search(query));
     analytics.tracks.recordEvent('list_notes_searched');
   },
 });


### PR DESCRIPTION
### Fix
Import actions using `import actions from '../state/actions';` rather than directly importing actions.

### Test
This affects the whole app. I think the checklist might be necessary.

### Release
Use actions import over direct import of actions