### PR TITLE
Fix: print stylesheets for Firefox

### DIFF
--- a/scss/print.scss
+++ b/scss/print.scss
@@ -7,9 +7,25 @@
     border: 0;
   }
 
+  .dev-badge {
+    display: none;
+  }
+
   .tag-field,
   .note-toolbar-wrapper {
     display: none;
+  }
+
+  /* Firefox only prints the first page if any divs are display: flex */
+  .app,
+  .simplenote-app,
+  .app-layout,
+  .app-layout__note-column,
+  .note-editor,
+  .note-detail-wrapper,
+  .note-detail {
+    display: block;
+    overflow: visible;
   }
 
   .note-detail-wrapper {
@@ -20,7 +36,7 @@
     overflow: visible;
   }
 
-  [class^="note-detail-"] {
+  [class^='note-detail-'] {
     max-width: 100%;
     width: 100%;
     color: $studio-black;


### PR DESCRIPTION
### Fix
I happened to notice that Firefox only prints the first page of longer notes. Turns out this is a Firefox bug with `display:flex;`. In order to fix it, we need to set every `div` up the tree that is `display:flex` to `display:block`.

See https://bugzilla.mozilla.org/show_bug.cgi?id=939897

### Todo
There's still something wrong with printing in Markdown preview mode

### Test
1. Open a long note in Firefox
2. Print the note
3. Verify that all pages print and no extraneous elements show up
4. Verify that printing long notes still looks good in other browsers

### Release
Not updated: Fix a bug that caused long notes to be truncated to the first page when printing in Firefox.
