### PR TITLE
Feature: Import from Google Keep

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- Added possibility to import notes from Google Keep [#2015](https://github.com/Automattic/simplenote-electron/pull/2015)???
+- Added possibility to import notes from Google Keep [#2015](https://github.com/Automattic/simplenote-electron/pull/2015)
 
 ### Other Changes
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,10 @@
 
 ## [v1.15.1]
 
+### Enhancements
+
+- Added possibility to import notes from Google Keep [#2015](https://github.com/Automattic/simplenote-electron/pull/2015)???
+
 ### Other Changes
 
 - Fix application signing to generate proper appx for Windows Store [#1960](https://github.com/Automattic/simplenote-electron/pull/1960)

--- a/lib/dialogs/import/source-importer/executor/index.tsx
+++ b/lib/dialogs/import/source-importer/executor/index.tsx
@@ -9,11 +9,13 @@ import TransitionFadeInOut from '../../../../components/transition-fade-in-out';
 import ImportProgress from '../progress';
 
 import EvernoteImporter from '../../../../utils/import/evernote';
+import GoogleKeepImporter from '../../../../utils/import/googlekeep';
 import SimplenoteImporter from '../../../../utils/import/simplenote';
 import TextFileImporter from '../../../../utils/import/text-files';
 
 const importers = {
   evernote: EvernoteImporter,
+  googlekeep: GoogleKeepImporter,
   plaintext: TextFileImporter,
   simplenote: SimplenoteImporter,
 };

--- a/lib/dialogs/import/sources.ts
+++ b/lib/dialogs/import/sources.ts
@@ -11,6 +11,13 @@ const sources = [
     optionsHint: 'Images and other media will not be imported.',
   },
   {
+    name: 'Google Keep',
+    slug: 'googlekeep',
+    acceptedTypes: '.zip',
+    electronOnly: true,
+    instructions: 'Choose an archive file exported from Google Takeout (.zip)',
+  },
+  {
     name: 'Simplenote',
     slug: 'simplenote',
     acceptedTypes: '.json',

--- a/lib/dialogs/import/sources.ts
+++ b/lib/dialogs/import/sources.ts
@@ -13,9 +13,11 @@ const sources = [
   {
     name: 'Google Keep',
     slug: 'googlekeep',
-    acceptedTypes: '.zip',
+    acceptedTypes: '.zip,.json',
     electronOnly: true,
-    instructions: 'Choose an archive file exported from Google Takeout (.zip)',
+    instructions:
+      'Choose an archive file exported from Google Takeout (.zip) or individual notes (.json)',
+    multiple: true,
   },
   {
     name: 'Simplenote',

--- a/lib/dialogs/import/sources.ts
+++ b/lib/dialogs/import/sources.ts
@@ -17,6 +17,7 @@ const sources = [
     electronOnly: true,
     instructions:
       'Choose an archive file exported from Google Takeout (.zip) or individual notes (.json)',
+    optionsHint: 'Images and other media will not be imported.',
     multiple: true,
   },
   {

--- a/lib/utils/import/googlekeep/index.ts
+++ b/lib/utils/import/googlekeep/index.ts
@@ -38,26 +38,28 @@ class GoogleKeepImporter extends EventEmitter {
       let textContent = title ? title + '\n\n' : '';
       textContent += get(importedNote, 'textContent', '');
 
-      const note = {
-        content: textContent,
-        // note: the exported files don't tell us the creation date...
-        modificationDate: importedNote.userEditedTimestampUsec / 1e6,
-        pinned: importedNote.isPinned,
-        tags: get(importedNote, 'labels', []).map(item => item.name),
-      };
-
       if (importedNote.listContent) {
         // Note has checkboxes
-        note.content += importedNote.listContent
+        textContent += importedNote.listContent
           .map(item => `- [${item.isChecked ? 'x' : ' '}] ${item.text}`)
           .join('\n');
       }
 
-      const opts = { ...this.options, isTrashed: importedNote.isTrashed };
-      return coreImporter.importNote(note, opts).then(() => {
-        importedNoteCount++;
-        this.emit('status', 'progress', importedNoteCount);
-      });
+      return coreImporter
+        .importNote(
+          {
+            content: textContent,
+            // note: the exported files don't tell us the creation date...
+            modificationDate: importedNote.userEditedTimestampUsec / 1e6,
+            pinned: importedNote.isPinned,
+            tags: get(importedNote, 'labels', []).map(item => item.name),
+          },
+          { ...this.options, isTrashed: importedNote.isTrashed }
+        )
+        .then(() => {
+          importedNoteCount++;
+          this.emit('status', 'progress', importedNoteCount);
+        });
     };
 
     const importZipFile = fileData =>

--- a/lib/utils/import/googlekeep/index.ts
+++ b/lib/utils/import/googlekeep/index.ts
@@ -47,15 +47,16 @@ class GoogleKeepImporter extends EventEmitter {
       }
 
       const title = importedNote.title;
-      let textContent = title ? title + '\n\n' : '';
-      textContent += get(importedNote, 'textContent', '');
 
-      if (importedNote.listContent) {
-        // Note has checkboxes
-        textContent += importedNote.listContent
-          .map(item => `- [${item.isChecked ? 'x' : ' '}] ${item.text}`)
-          .join('\n');
-      }
+      const importedContent = importedNote.listContent
+        ? importedNote.listContent // Note has checkboxes, no text content
+            .map(item => `- [${item.isChecked ? 'x' : ' '}] ${item.text}`)
+            .join('\n')
+        : importedNote.textContent;
+
+      const textContent = title
+        ? `${title}\n\n${importedContent}`
+        : importedContent;
 
       return coreImporter
         .importNote(

--- a/lib/utils/import/googlekeep/index.ts
+++ b/lib/utils/import/googlekeep/index.ts
@@ -48,7 +48,7 @@ class GoogleKeepImporter extends EventEmitter {
       const note = {
         content: textContent,
         // note: the exported files don't tell us the creation date...
-        modificationDate: importedNote.userEditedTimestampUsec / 1000000,
+        modificationDate: importedNote.userEditedTimestampUsec / 1e6,
         pinned: importedNote.isPinned,
         tags: get(importedNote, 'labels', []).map(item => item.name),
       };

--- a/lib/utils/import/googlekeep/index.ts
+++ b/lib/utils/import/googlekeep/index.ts
@@ -1,0 +1,30 @@
+import { EventEmitter } from 'events';
+import { endsWith, isEmpty } from 'lodash';
+
+class GoogleKeepImporter extends EventEmitter {
+  constructor({ noteBucket, tagBucket, options }) {
+    super();
+    this.noteBucket = noteBucket;
+    this.tagBucket = tagBucket;
+    this.options = options;
+  }
+
+  importNotes = filesArray => {
+    if (isEmpty(filesArray)) {
+      this.emit('status', 'error', 'No file to import.');
+      return;
+    }
+
+    const file = filesArray[0];
+
+    if (!endsWith(file.name.toLowerCase(), '.zip')) {
+      this.emit('status', 'error', 'File name does not end in ".zip".');
+      return;
+    }
+
+    //TODO: JSZip
+    this.emit('status', 'error', 'Feature not implemented yet.');
+  }
+}
+
+export default GoogleKeepImporter;

--- a/lib/utils/import/googlekeep/index.ts
+++ b/lib/utils/import/googlekeep/index.ts
@@ -68,16 +68,15 @@ class GoogleKeepImporter extends EventEmitter {
         return Promise.all(promises);
       });
 
-    const importJsonFile = fileData => {
-      //TODO
-    };
-
     const promises = filesArray.map(file =>
       fs.promises
         .readFile(file.path)
         .then(data => {
           if (endsWith(file.name.toLowerCase(), '.zip')) {
             return importZipFile(data);
+          } else if (endsWith(file.name.toLowerCase(), '.json')) {
+            // The data is a string, import it directly
+            return importJsonString(data);
           } else {
             this.emit(
               'status',

--- a/lib/utils/import/googlekeep/index.ts
+++ b/lib/utils/import/googlekeep/index.ts
@@ -62,7 +62,8 @@ class GoogleKeepImporter extends EventEmitter {
         .importNote(
           {
             content: textContent,
-            // note: the exported files don't tell us the creation date...
+            // Keep doesn't store the creation date...
+            creationDate: importedNote.userEditedTimestampUsec / 1e6,
             modificationDate: importedNote.userEditedTimestampUsec / 1e6,
             pinned: importedNote.isPinned,
             tags: get(importedNote, 'labels', []).map(item => item.name),

--- a/lib/utils/import/googlekeep/index.ts
+++ b/lib/utils/import/googlekeep/index.ts
@@ -37,6 +37,15 @@ class GoogleKeepImporter extends EventEmitter {
       // by the next progress update anyway.
       const importedNote = JSON.parse(jsonString);
 
+      if (
+        !importedNote.title &&
+        !importedNote.textContent &&
+        !importedNote.listContent
+      ) {
+        // empty note, skip
+        return;
+      }
+
       const title = importedNote.title;
       let textContent = title ? title + '\n\n' : '';
       textContent += get(importedNote, 'textContent', '');

--- a/lib/utils/import/googlekeep/index.ts
+++ b/lib/utils/import/googlekeep/index.ts
@@ -32,6 +32,9 @@ class GoogleKeepImporter extends EventEmitter {
     let importedNoteCount = 0;
 
     const importJsonString = jsonString => {
+      // note: If importing the note fails, it is silently ignored by the
+      // promise below. This is okay since the warning message would be hidden
+      // by the next progress update anyway.
       const importedNote = JSON.parse(jsonString);
 
       const title = importedNote.title;

--- a/lib/utils/import/googlekeep/index.ts
+++ b/lib/utils/import/googlekeep/index.ts
@@ -55,9 +55,7 @@ class GoogleKeepImporter extends EventEmitter {
 
       if (importedNote.listContent) {
         note.content += importedNote.listContent
-          .map(item => {
-            return '- [' + (item.isChecked ? 'x' : ' ') + '] ' + item.text;
-          })
+          .map(item => `- [${item.isChecked ? 'x' : ' '}] ${item.text}`)
           .join('\n');
       }
 

--- a/lib/utils/import/googlekeep/index.ts
+++ b/lib/utils/import/googlekeep/index.ts
@@ -1,5 +1,14 @@
 import { EventEmitter } from 'events';
-import { endsWith, isEmpty } from 'lodash';
+import { endsWith, isEmpty, get, has } from 'lodash';
+import JSZip from 'jszip';
+
+import CoreImporter from '../';
+
+let fs = null;
+const isElectron = has(window, 'process.type');
+if (isElectron) {
+  fs = __non_webpack_require__('fs'); // eslint-disable-line no-undef
+}
 
 class GoogleKeepImporter extends EventEmitter {
   constructor({ noteBucket, tagBucket, options }) {
@@ -22,9 +31,54 @@ class GoogleKeepImporter extends EventEmitter {
       return;
     }
 
-    //TODO: JSZip
-    this.emit('status', 'error', 'Feature not implemented yet.');
-  }
+    const coreImporter = new CoreImporter({
+      noteBucket: this.noteBucket,
+      tagBucket: this.tagBucket,
+    });
+
+    let importedNoteCount = 0;
+
+    const extractAndImport = zipObj => {
+      return zipObj
+        .async('string')
+        .then(content => {
+          const importedNote = JSON.parse(content);
+
+          //TODO: checkboxes...
+          const title = importedNote.title;
+          const note = {
+            content: (title ? title + '\n\n' : '') + importedNote.textContent,
+            // note: the exported files don't tell us the creation date...
+            modificationDate: importedNote.userEditedTimestampUsec / 1000000,
+            pinned: importedNote.isPinned,
+            tags: get(importedNote, 'labels', []).map(item => item.name),
+          };
+
+          return coreImporter.importNote(note, {
+            ...this.options,
+            isTrashed: importedNote.isTrashed,
+          });
+        })
+        .then(() => {
+          importedNoteCount++;
+          this.emit('status', 'progress', importedNoteCount);
+        });
+    };
+
+    fs.readFile(file.path, (err, data) => {
+      if (err) {
+        this.emit('status', 'error', 'Error reading file');
+        return;
+      }
+
+      JSZip.loadAsync(data).then(zip => {
+        const promises = zip.file(/.*\/Keep\/.*\.json/).map(extractAndImport);
+        Promise.all(promises).then(() => {
+          this.emit('status', 'complete', importedNoteCount);
+        });
+      });
+    });
+  };
 }
 
 export default GoogleKeepImporter;

--- a/lib/utils/import/googlekeep/index.ts
+++ b/lib/utils/import/googlekeep/index.ts
@@ -35,7 +35,7 @@ class GoogleKeepImporter extends EventEmitter {
       const importedNote = JSON.parse(jsonString);
 
       const title = importedNote.title;
-      let textContent = title ? title + '\n' : '';
+      let textContent = title ? title + '\n\n' : '';
       textContent += get(importedNote, 'textContent', '');
 
       const note = {


### PR DESCRIPTION
### Fix
This PR adds the option to import notes from Google Keep. Notes can be either imported from a zip file exported from Google Takeout, or as individual JSON files. [Attached](https://github.com/Automattic/simplenote-electron/files/4499355/takeout-20200412T094422Z-001-test.zip) is a small test file that contains notes with various features (check boxes, tags, etc.).

A couple of things to note:
- Images and other attachments are not imported. I played around a bit with embedding the images as base64 in the markdown, but that is maybe not a very good idea with large images. It's also a bit of a hassle with the zipped files.
- Archived notes get imported as just regular notes. I think the best way to handle this would be to add an option to the modal (next to 'enable markdown on all notes'), where the user could choose to move archived notes to the trash, add an user-specified tag or to import them regularly. I'm not familiar enough with react/redux to implement this myself.
- It would be cool to parse links in notes and enable markdown on them (using e.g. [linkify](https://soapbox.github.io/linkifyjs/)), not sure if it's worth it to add another dependency. The notes also have the `annotations` attribute that could be used for this.

I'm fairly new to typescript, so let me know if something looks wrong in the code!

### Test
1. Go to File-> Import Notes -> Google Keep
2. Drag and drop e.g. [this](https://github.com/Automattic/simplenote-electron/files/4499355/takeout-20200412T094422Z-001-test.zip) test zip file
3. Observe that the notes have been imported

### Release
`RELEASE-NOTES.txt` was updated with:
- Added possibility to import notes from Google Keep