### PR TITLE
Fix note list toggle

### DIFF
--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -35,6 +35,7 @@ type OwnProps = {
 type StateProps = {
   isNoteOpen: boolean;
   keyboardShortcutsAreOpen: boolean;
+  showNoteList: boolean;
 };
 
 type DispatchProps = {
@@ -72,6 +73,7 @@ export class AppLayout extends Component<Props> {
 
   render = () => {
     const {
+      showNoteList,
       isFocusMode = false,
       isNavigationOpen,
       isNoteInfoOpen,
@@ -89,6 +91,8 @@ export class AppLayout extends Component<Props> {
       'is-showing-note-info': isNoteInfoOpen,
     });
 
+    const editorVisible = !(showNoteList && isSmallScreen);
+
     const placeholder = (
       <TransitionDelayEnter delay={1000}>
         <div className="app-layout__placeholder">
@@ -104,19 +108,21 @@ export class AppLayout extends Component<Props> {
             <SearchBar noteBucket={noteBucket} />
             <NoteList noteBucket={noteBucket} isSmallScreen={isSmallScreen} />
           </div>
-          <div className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border">
-            <RevisionSelector onUpdateContent={onUpdateContent} />
-            <NoteToolbarContainer
-              noteBucket={noteBucket}
-              toolbar={<NoteToolbar />}
-            />
-            <NoteEditor
-              isSmallScreen={isSmallScreen}
-              noteBucket={noteBucket}
-              onUpdateContent={onUpdateContent}
-              syncNote={syncNote}
-            />
-          </div>
+          {editorVisible && (
+            <div className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border">
+              <RevisionSelector onUpdateContent={onUpdateContent} />
+              <NoteToolbarContainer
+                noteBucket={noteBucket}
+                toolbar={<NoteToolbar />}
+              />
+              <NoteEditor
+                isSmallScreen={isSmallScreen}
+                noteBucket={noteBucket}
+                onUpdateContent={onUpdateContent}
+                syncNote={syncNote}
+              />
+            </div>
+          )}
         </Suspense>
       </div>
     );
@@ -128,6 +134,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
 }) => ({
   keyboardShortcutsAreOpen: dialogs.includes('KEYBINDINGS'),
   isNoteOpen: !showNoteList,
+  showNoteList,
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -118,7 +118,7 @@ export class AboutDialog extends Component<Props> {
                 </li>
                 <li>
                   <Keys keys={[CmdOrCtrl, 'Shift', 'L']}>
-                    Show note list
+                    Toggle note list
                     <br />
                     (on narrow screens)
                   </Keys>

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -38,16 +38,12 @@ const isElectron = (() => {
   return () => foundElectron;
 })();
 
-type OwnProps = {
-  isSmallScreen: boolean;
-};
-
 type StateProps = {
   editingEnabled: boolean;
   searchQuery: string;
 };
 
-type Props = OwnProps & StateProps;
+type Props = StateProps;
 
 class NoteContentEditor extends Component<Props> {
   static propTypes = {
@@ -366,7 +362,6 @@ class NoteContentEditor extends Component<Props> {
         <Editor
           key={this.editorKey}
           ref={this.saveEditorRef}
-          readOnly={!this.props.editingEnabled}
           spellCheck={this.props.spellCheckEnabled}
           stripPastedStyles
           onChange={this.handleEditorStateChange}
@@ -379,11 +374,9 @@ class NoteContentEditor extends Component<Props> {
   }
 }
 
-const mapStateToProps: S.MapState<StateProps, OwnProps> = (
-  { ui: { searchQuery, showNoteList } },
-  { isSmallScreen }
-) => ({
-  editingEnabled: !(isSmallScreen && showNoteList),
+const mapStateToProps: S.MapState<StateProps> = ({
+  ui: { searchQuery, showNoteList },
+}) => ({
   searchQuery,
 });
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -38,11 +38,16 @@ const isElectron = (() => {
   return () => foundElectron;
 })();
 
+type OwnProps = {
+  isSmallScreen: boolean;
+};
+
 type StateProps = {
+  editingEnabled: boolean;
   searchQuery: string;
 };
 
-type Props = StateProps;
+type Props = OwnProps & StateProps;
 
 class NoteContentEditor extends Component<Props> {
   static propTypes = {
@@ -352,6 +357,7 @@ class NoteContentEditor extends Component<Props> {
   };
 
   render() {
+    console.log(this.props.editingEnabled);
     return (
       <div
         onCopy={this.copyPlainText}
@@ -361,6 +367,7 @@ class NoteContentEditor extends Component<Props> {
         <Editor
           key={this.editorKey}
           ref={this.saveEditorRef}
+          readOnly={!this.props.editingEnabled}
           spellCheck={this.props.spellCheckEnabled}
           stripPastedStyles
           onChange={this.handleEditorStateChange}
@@ -373,7 +380,11 @@ class NoteContentEditor extends Component<Props> {
   }
 }
 
-const mapStateToProps: S.MapState<StateProps> = ({ ui: { searchQuery } }) => ({
+const mapStateToProps: S.MapState<StateProps, OwnProps> = (
+  { ui: { searchQuery, showNoteList } },
+  { isSmallScreen }
+) => ({
+  editingEnabled: !(isSmallScreen && showNoteList),
   searchQuery,
 });
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -357,7 +357,6 @@ class NoteContentEditor extends Component<Props> {
   };
 
   render() {
-    console.log(this.props.editingEnabled);
     return (
       <div
         onCopy={this.copyPlainText}

--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -249,7 +249,6 @@ export class NoteDetail extends Component<Props> {
     const {
       note,
       fontSize,
-      isSmallScreen,
       previewingMarkdown,
       spellCheckEnabled,
     } = this.props;
@@ -285,7 +284,6 @@ export class NoteDetail extends Component<Props> {
                 style={divStyle}
               >
                 <NoteContentEditor
-                  isSmallScreen={isSmallScreen}
                   spellCheckEnabled={spellCheckEnabled}
                   storeFocusEditor={this.storeFocusContentEditor}
                   storeHasFocus={this.storeEditorHasFocus}

--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -249,6 +249,7 @@ export class NoteDetail extends Component<Props> {
     const {
       note,
       fontSize,
+      isSmallScreen,
       previewingMarkdown,
       spellCheckEnabled,
     } = this.props;
@@ -284,6 +285,7 @@ export class NoteDetail extends Component<Props> {
                 style={divStyle}
               >
                 <NoteContentEditor
+                  isSmallScreen={isSmallScreen}
                   spellCheckEnabled={spellCheckEnabled}
                   storeFocusEditor={this.storeFocusContentEditor}
                   storeHasFocus={this.storeEditorHasFocus}

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -11,6 +11,10 @@ import { markdownNote, toggleNoteList } from '../state/ui/actions';
 import * as S from '../state';
 import * as T from '../types';
 
+type OwnProps = {
+  isSmallScreen: boolean;
+};
+
 type StateProps = {
   note: T.NoteEntity | null;
 };
@@ -21,7 +25,7 @@ type DispatchProps = {
   toggleEditMode: () => any;
 };
 
-type Props = DispatchProps & StateProps;
+type Props = OwnProps & DispatchProps & StateProps;
 
 export class NoteEditor extends Component<Props> {
   static displayName = 'NoteEditor';
@@ -29,7 +33,6 @@ export class NoteEditor extends Component<Props> {
   static propTypes = {
     allTags: PropTypes.array.isRequired,
     isEditorActive: PropTypes.bool.isRequired,
-    isSmallScreen: PropTypes.bool.isRequired,
     noteBucket: PropTypes.object.isRequired,
     fontSize: PropTypes.number,
     onUpdateContent: PropTypes.func.isRequired,
@@ -140,7 +143,7 @@ export class NoteEditor extends Component<Props> {
   };
 
   render() {
-    const { editMode, isSmallScreen, note, noteBucket, fontSize } = this.props;
+    const { editMode, note, noteBucket, fontSize } = this.props;
     const revision = this.props.revision || note;
     const tags = (revision && revision.data && revision.data.tags) || [];
     const isTrashed = !!(note && note.data.deleted);
@@ -148,7 +151,6 @@ export class NoteEditor extends Component<Props> {
     return (
       <div className="note-editor theme-color-bg theme-color-fg">
         <NoteDetail
-          isSmallScreen={isSmallScreen}
           storeFocusEditor={this.storeFocusEditor}
           storeHasFocus={this.storeEditorHasFocus}
           noteBucket={noteBucket}

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -140,7 +140,7 @@ export class NoteEditor extends Component<Props> {
   };
 
   render() {
-    const { editMode, note, noteBucket, fontSize } = this.props;
+    const { editMode, isSmallScreen, note, noteBucket, fontSize } = this.props;
     const revision = this.props.revision || note;
     const tags = (revision && revision.data && revision.data.tags) || [];
     const isTrashed = !!(note && note.data.deleted);
@@ -148,6 +148,7 @@ export class NoteEditor extends Component<Props> {
     return (
       <div className="note-editor theme-color-bg theme-color-fg">
         <NoteDetail
+          isSmallScreen={isSmallScreen}
           storeFocusEditor={this.storeFocusEditor}
           storeHasFocus={this.storeEditorHasFocus}
           noteBucket={noteBucket}

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -6,7 +6,7 @@ import { property } from 'lodash';
 import NoteDetail from '../note-detail';
 import { toggleEditMode } from '../state/ui/actions';
 
-import { closeNote, markdownNote } from '../state/ui/actions';
+import { markdownNote, toggleNoteList } from '../state/ui/actions';
 
 import * as S from '../state';
 import * as T from '../types';
@@ -17,6 +17,7 @@ type StateProps = {
 
 type DispatchProps = {
   toggleMarkdown: (note: T.NoteEntity, enableMarkdown: boolean) => any;
+  toggleNoteList: () => any;
   toggleEditMode: () => any;
 };
 
@@ -86,7 +87,7 @@ export class NoteEditor extends Component<Props> {
 
     // open note list
     if (this.props.isSmallScreen && cmdOrCtrl && shiftKey && 'KeyL' === code) {
-      this.props.closeNote();
+      this.props.toggleNoteList();
       event.stopPropagation();
       event.preventDefault();
       return false;
@@ -184,7 +185,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = dispatch => ({
-  closeNote: () => dispatch(closeNote()),
+  toggleNoteList: () => dispatch(toggleNoteList()),
   toggleMarkdown: (note, enableMarkdown) =>
     dispatch(markdownNote(note, enableMarkdown)),
   toggleEditMode: () => dispatch(toggleEditMode()),

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -49,6 +49,7 @@ type DispatchProps = {
   onEmptyTrash: () => any;
   onSelectNote: (note: T.NoteEntity | null) => any;
   onPinNote: (note: T.NoteEntity, shouldPin: boolean) => any;
+  toggleNoteList: () => any;
 };
 
 type Props = Readonly<OwnProps & StateProps & DispatchProps>;
@@ -301,7 +302,7 @@ export class NoteList extends Component<Props> {
 
   handleShortcut = (event: KeyboardEvent) => {
     const { ctrlKey, code, metaKey, shiftKey } = event;
-    const { notes } = this.props;
+    const { notes, toggleNoteList } = this.props;
     const { selectedIndex: index } = this.state;
 
     const highlightedIndex = this.getHighlightedIndex(this.props);
@@ -313,6 +314,7 @@ export class NoteList extends Component<Props> {
       }
 
       this.props.onSelectNote(notes[index - 1]);
+      toggleNoteList();
       event.stopPropagation();
       event.preventDefault();
       return false;
@@ -328,6 +330,7 @@ export class NoteList extends Component<Props> {
       }
 
       this.props.onSelectNote(notes[index + 1]);
+      toggleNoteList();
       event.stopPropagation();
       event.preventDefault();
       return false;
@@ -525,6 +528,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (
     analytics.tracks.recordEvent('list_note_opened');
   },
   onPinNote: (note, shouldPin) => dispatch(actions.ui.pinNote(note, shouldPin)),
+  toggleNoteList: () => dispatch(actions.ui.toggleNoteList()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteList);

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -130,7 +130,7 @@ const renderNote = (
   const isPinned = note.data.systemTags.includes('pinned');
   const isPublished = !!note.data.publishURL;
   const classes = classNames('note-list-item', {
-    'note-list-item-selected': !isSmallScreen && highlightedIndex === index,
+    'note-list-item-selected': highlightedIndex === index,
     'note-list-item-pinned': isPinned,
     'published-note': isPublished,
   });
@@ -249,6 +249,7 @@ export class NoteList extends Component<Props> {
     }
 
     if (notes.length === 0 && selectedNote) {
+      // unselect active note if it doesn't match search
       this.props.closeNote();
       this.setState({ selectedIndex: null });
     }
@@ -344,7 +345,7 @@ export class NoteList extends Component<Props> {
   };
 
   getHighlightedIndex = (props: Props) => {
-    const { notes, selectedNote } = props;
+    const { isSmallScreen, notes, selectedNote } = props;
     const { selectedIndex: index } = this.state;
 
     // Cases:

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -40,6 +40,7 @@ type StateProps = {
   selectedNote: T.NoteEntity | null;
   selectedNoteContent: string;
   selectedNotePreview: { title: string; preview: string };
+  showNoteList: boolean;
   showTrash: boolean;
   tagResultsFound: number;
 };
@@ -92,7 +93,6 @@ const renderNote = (
     searchQuery: string;
     noteDisplay: T.ListDisplayMode;
     highlightedIndex: number;
-    onSelectNote: DispatchProps['onSelectNote'];
     onPinNote: DispatchProps['onPinNote'];
     openNote: DispatchProps['openNote'];
   }
@@ -298,7 +298,7 @@ export class NoteList extends Component<Props> {
 
   handleShortcut = (event: KeyboardEvent) => {
     const { ctrlKey, code, metaKey, shiftKey } = event;
-    const { notes } = this.props;
+    const { isSmallScreen, notes, showNoteList } = this.props;
     const { selectedIndex: index } = this.state;
 
     const highlightedIndex = this.getHighlightedIndex(this.props);
@@ -325,6 +325,19 @@ export class NoteList extends Component<Props> {
       }
 
       this.props.onSelectNote(notes[index + 1]);
+      event.stopPropagation();
+      event.preventDefault();
+      return false;
+    }
+
+    if (
+      isSmallScreen &&
+      showNoteList &&
+      code === 'Enter' &&
+      highlightedIndex !== null
+    ) {
+      this.props.openNote(notes[highlightedIndex]);
+
       event.stopPropagation();
       event.preventDefault();
       return false;
@@ -468,6 +481,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
     note,
     openedTag,
     searchQuery,
+    showNoteList,
     showTrash,
     tagSuggestions,
   },
@@ -504,6 +518,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
     selectedNote: note,
     selectedNotePreview,
     selectedNoteContent: get(note, 'data.content'),
+    showNoteList,
     showTrash,
     tagResultsFound: tagSuggestions.length,
   };

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -49,6 +49,7 @@ type DispatchProps = {
   onEmptyTrash: () => any;
   onSelectNote: (note: T.NoteEntity | null) => any;
   onPinNote: (note: T.NoteEntity, shouldPin: boolean) => any;
+  openNote: (note: T.NoteEntity) => any;
 };
 
 type Props = Readonly<OwnProps & StateProps & DispatchProps>;
@@ -74,8 +75,8 @@ const heightCache = new CellMeasurerCache({
  * @param notes list of filtered notes
  * @param searchQuery search searchQuery
  * @param noteDisplay list view style: comfy, condensed, expanded
+ * @param openNote used to select a note and open it in the editor
  * @param selectedNoteId id of currently selected note
- * @param onSelectNote used to change the current note selection
  * @param onPinNote used to pin a note to the top of the list
  * @returns does the actual rendering for the List
  */
@@ -85,14 +86,15 @@ const renderNote = (
     searchQuery,
     noteDisplay,
     highlightedIndex,
-    onSelectNote,
     onPinNote,
+    openNote,
   }: {
     searchQuery: string;
     noteDisplay: T.ListDisplayMode;
     highlightedIndex: number;
     onSelectNote: DispatchProps['onSelectNote'];
     onPinNote: DispatchProps['onPinNote'];
+    openNote: DispatchProps['openNote'];
   }
 ): ListRowRenderer => ({ index, key, parent, style }) => {
   const note = notes[index];
@@ -135,8 +137,6 @@ const renderNote = (
   const terms = getTerms(searchQuery).map(makeFilterDecorator);
   const decorators = [checkboxDecorator, ...terms];
 
-  const selectNote = () => onSelectNote(note);
-
   return (
     <CellMeasurer
       cache={heightCache}
@@ -154,7 +154,7 @@ const renderNote = (
         <div
           className="note-list-item-text theme-color-border"
           tabIndex={0}
-          onClick={selectNote}
+          onClick={() => openNote(note)}
         >
           <div className="note-list-item-title">
             <span>{decorateWith(decorators, title)}</span>
@@ -385,7 +385,7 @@ export class NoteList extends Component<Props> {
       hasLoaded,
       noteDisplay,
       notes,
-      onSelectNote,
+      openNote,
       onEmptyTrash,
       onPinNote,
       searchQuery,
@@ -408,8 +408,8 @@ export class NoteList extends Component<Props> {
       searchQuery,
       highlightedIndex,
       noteDisplay,
-      onSelectNote,
       onPinNote,
+      openNote,
     });
 
     const isEmptyList = compositeNoteList.length === 0;
@@ -520,6 +520,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (
     analytics.tracks.recordEvent('list_note_opened');
   },
   onPinNote: (note, shouldPin) => dispatch(actions.ui.pinNote(note, shouldPin)),
+  openNote: (note: T.NoteEntity) => dispatch(actions.ui.openNote(note)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteList);

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -40,7 +40,6 @@ type StateProps = {
   selectedNote: T.NoteEntity | null;
   selectedNoteContent: string;
   selectedNotePreview: { title: string; preview: string };
-  showNoteList: boolean;
   showTrash: boolean;
   tagResultsFound: number;
 };
@@ -50,7 +49,6 @@ type DispatchProps = {
   onEmptyTrash: () => any;
   onSelectNote: (note: T.NoteEntity | null) => any;
   onPinNote: (note: T.NoteEntity, shouldPin: boolean) => any;
-  toggleNoteList: () => any;
 };
 
 type Props = Readonly<OwnProps & StateProps & DispatchProps>;
@@ -300,7 +298,7 @@ export class NoteList extends Component<Props> {
 
   handleShortcut = (event: KeyboardEvent) => {
     const { ctrlKey, code, metaKey, shiftKey } = event;
-    const { notes, showNoteList, toggleNoteList } = this.props;
+    const { notes } = this.props;
     const { selectedIndex: index } = this.state;
 
     const highlightedIndex = this.getHighlightedIndex(this.props);
@@ -312,9 +310,6 @@ export class NoteList extends Component<Props> {
       }
 
       this.props.onSelectNote(notes[index - 1]);
-      if (showNoteList) {
-        toggleNoteList();
-      }
       event.stopPropagation();
       event.preventDefault();
       return false;
@@ -330,9 +325,6 @@ export class NoteList extends Component<Props> {
       }
 
       this.props.onSelectNote(notes[index + 1]);
-      if (showNoteList) {
-        toggleNoteList();
-      }
       event.stopPropagation();
       event.preventDefault();
       return false;
@@ -476,7 +468,6 @@ const mapStateToProps: S.MapState<StateProps> = ({
     note,
     openedTag,
     searchQuery,
-    showNoteList,
     showTrash,
     tagSuggestions,
   },
@@ -513,7 +504,6 @@ const mapStateToProps: S.MapState<StateProps> = ({
     selectedNote: note,
     selectedNotePreview,
     selectedNoteContent: get(note, 'data.content'),
-    showNoteList,
     showTrash,
     tagResultsFound: tagSuggestions.length,
   };
@@ -530,7 +520,6 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (
     analytics.tracks.recordEvent('list_note_opened');
   },
   onPinNote: (note, shouldPin) => dispatch(actions.ui.pinNote(note, shouldPin)),
-  toggleNoteList: () => dispatch(actions.ui.toggleNoteList()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteList);

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -459,6 +459,7 @@ export class NoteList extends Component<Props> {
                     rowCount={compositeNoteList.length}
                     rowHeight={heightCache.rowHeight}
                     rowRenderer={renderNoteRow}
+                    scrollToIndex={highlightedIndex}
                     width={width}
                   />
                 )}

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -40,6 +40,7 @@ type StateProps = {
   selectedNote: T.NoteEntity | null;
   selectedNoteContent: string;
   selectedNotePreview: { title: string; preview: string };
+  showNoteList: boolean;
   showTrash: boolean;
   tagResultsFound: number;
 };
@@ -78,7 +79,6 @@ const heightCache = new CellMeasurerCache({
  * @param selectedNoteId id of currently selected note
  * @param onSelectNote used to change the current note selection
  * @param onPinNote used to pin a note to the top of the list
- * @param isSmallScreen whether we're in a narrow view
  * @returns does the actual rendering for the List
  */
 const renderNote = (
@@ -89,14 +89,12 @@ const renderNote = (
     highlightedIndex,
     onSelectNote,
     onPinNote,
-    isSmallScreen,
   }: {
     searchQuery: string;
     noteDisplay: T.ListDisplayMode;
     highlightedIndex: number;
     onSelectNote: DispatchProps['onSelectNote'];
     onPinNote: DispatchProps['onPinNote'];
-    isSmallScreen: boolean;
   }
 ): ListRowRenderer => ({ index, key, parent, style }) => {
   const note = notes[index];
@@ -352,7 +350,7 @@ export class NoteList extends Component<Props> {
   };
 
   getHighlightedIndex = (props: Props) => {
-    const { isSmallScreen, notes, selectedNote } = props;
+    const { notes, selectedNote } = props;
     const { selectedIndex: index } = this.state;
 
     // Cases:
@@ -393,7 +391,6 @@ export class NoteList extends Component<Props> {
   render() {
     const {
       hasLoaded,
-      isSmallScreen,
       noteDisplay,
       notes,
       onSelectNote,
@@ -421,7 +418,6 @@ export class NoteList extends Component<Props> {
       noteDisplay,
       onSelectNote,
       onPinNote,
-      isSmallScreen,
     });
 
     const isEmptyList = compositeNoteList.length === 0;
@@ -463,7 +459,7 @@ export class NoteList extends Component<Props> {
                 )}
               </AutoSizer>
             </div>
-            {!!showTrash && emptyTrashButton}
+            {showTrash && emptyTrashButton}
           </Fragment>
         )}
       </div>
@@ -471,7 +467,7 @@ export class NoteList extends Component<Props> {
   }
 }
 
-const { emptyTrash, loadAndSelectNote } = appState.actionCreators;
+const { emptyTrash } = appState.actionCreators;
 
 const mapStateToProps: S.MapState<StateProps> = ({
   appState: state,

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -302,7 +302,7 @@ export class NoteList extends Component<Props> {
 
   handleShortcut = (event: KeyboardEvent) => {
     const { ctrlKey, code, metaKey, shiftKey } = event;
-    const { notes, toggleNoteList } = this.props;
+    const { notes, showNoteList, toggleNoteList } = this.props;
     const { selectedIndex: index } = this.state;
 
     const highlightedIndex = this.getHighlightedIndex(this.props);
@@ -314,7 +314,9 @@ export class NoteList extends Component<Props> {
       }
 
       this.props.onSelectNote(notes[index - 1]);
-      toggleNoteList();
+      if (showNoteList) {
+        toggleNoteList();
+      }
       event.stopPropagation();
       event.preventDefault();
       return false;
@@ -330,7 +332,9 @@ export class NoteList extends Component<Props> {
       }
 
       this.props.onSelectNote(notes[index + 1]);
-      toggleNoteList();
+      if (showNoteList) {
+        toggleNoteList();
+      }
       event.stopPropagation();
       event.preventDefault();
       return false;
@@ -476,6 +480,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
     note,
     openedTag,
     searchQuery,
+    showNoteList,
     showTrash,
     tagSuggestions,
   },
@@ -512,6 +517,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
     selectedNote: note,
     selectedNotePreview,
     selectedNoteContent: get(note, 'data.content'),
+    showNoteList,
     showTrash,
     tagResultsFound: tagSuggestions.length,
   };

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -14,9 +14,9 @@ import ShareIcon from '../icons/share';
 import SidebarIcon from '../icons/sidebar';
 
 import {
-  closeNote,
   toggleEditMode,
   toggleNoteInfo,
+  toggleNoteList,
   toggleRevisions,
 } from '../state/ui/actions';
 
@@ -24,9 +24,9 @@ import * as S from '../state';
 import * as T from '../types';
 
 type DispatchProps = {
-  closeNote: () => any;
   toggleEditMode: () => any;
   toggleNoteInfo: () => any;
+  toggleNoteList: () => any;
   toggleRevisions: () => any;
 };
 
@@ -87,7 +87,7 @@ export class NoteToolbar extends Component<Props> {
           <div className="note-toolbar__button note-toolbar-back">
             <IconButton
               icon={<BackIcon />}
-              onClick={this.props.closeNote}
+              onClick={this.props.toggleNoteList}
               title="Back"
             />
           </div>
@@ -141,7 +141,7 @@ export class NoteToolbar extends Component<Props> {
         <div className="note-toolbar__column-left">
           <IconButton
             icon={<BackIcon />}
-            onClick={this.props.closeNote}
+            onClick={this.props.toggleNoteList}
             title="Back"
           />
         </div>
@@ -185,9 +185,9 @@ const mapStateToProps: S.MapState<StateProps> = ({
 };
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
-  closeNote,
   toggleEditMode,
   toggleNoteInfo,
+  toggleNoteList,
   toggleRevisions,
 };
 

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -87,6 +87,7 @@ export type TagsLoaded = Action<
   { tags: T.TagEntity[]; sortTagsAlpha: boolean }
 >;
 export type ToggleNavigation = Action<'NAVIGATION_TOGGLE'>;
+export type ToggleNoteList = Action<'NOTE_LIST_TOGGLE'>;
 export type ToggleNoteInfo = Action<'NOTE_INFO_TOGGLE'>;
 export type ToggleSimperiumConnectionStatus = Action<
   'SIMPERIUM_CONNECTION_STATUS_TOGGLE',
@@ -139,6 +140,7 @@ export type ActionType =
   | TagsLoaded
   | ToggleEditMode
   | ToggleNavigation
+  | ToggleNoteList
   | ToggleNoteInfo
   | ToggleRevisions
   | ToggleSimperiumConnectionStatus

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -56,6 +56,7 @@ export type FilterNotes = Action<
   { notes: T.NoteEntity[]; tags: T.TagEntity[] }
 >;
 export type FocusSearchField = Action<'FOCUS_SEARCH_FIELD'>;
+export type OpenNote = Action<'OPEN_NOTE', { note: T.NoteEntity }>;
 export type RemoteNoteUpdate = Action<
   'REMOTE_NOTE_UPDATE',
   { noteId: T.EntityId; data: T.Note }
@@ -113,6 +114,7 @@ export type ActionType =
   | FilterNotes
   | FocusSearchField
   | RemoteNoteUpdate
+  | OpenNote
   | OpenTag
   | RestoreNote
   | Search

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -135,6 +135,10 @@ export const toggleNavigation: A.ActionCreator<A.ToggleNavigation> = () => ({
   type: 'NAVIGATION_TOGGLE',
 });
 
+export const toggleNoteList: A.ActionCreator<A.ToggleNoteList> = () => ({
+  type: 'NOTE_LIST_TOGGLE',
+});
+
 export const toggleNoteInfo: A.ActionCreator<A.ToggleNoteInfo> = () => ({
   type: 'NOTE_INFO_TOGGLE',
 });

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -60,6 +60,11 @@ export const publishNote: A.ActionCreator<A.SetSystemTag> = (
   shouldHaveTag: shoudlPublish,
 });
 
+export const openNote: A.ActionCreator<A.OpenNote> = (note: T.NoteEntity) => ({
+  type: 'OPEN_NOTE',
+  note,
+});
+
 export const openTag: A.ActionCreator<A.OpenTag> = (tag: T.TagEntity) => ({
   type: 'OPEN_TAG',
   tag,

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -117,8 +117,8 @@ const selectedRevision: A.Reducer<T.NoteEntity | null> = (
 
 const showNoteList: A.Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
-    case 'CLOSE_NOTE':
-      return true;
+    case 'NOTE_LIST_TOGGLE':
+      return !state;
 
     case 'SELECT_NOTE':
       return false;

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -39,12 +39,12 @@ const editingTags: A.Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'TAG_EDITING_TOGGLE':
       return !state;
+    case 'OPEN_NOTE':
     case 'SELECT_NOTE':
     case 'OPEN_TAG':
     case 'SELECT_TRASH':
     case 'SHOW_ALL_NOTES':
     case 'NAVIGATION_TOGGLE':
-    case 'App.toggleNoteInfo':
       return false;
     default:
       return state;
@@ -80,6 +80,7 @@ const noteRevisions: A.Reducer<T.NoteEntity[]> = (
     case 'STORE_REVISIONS':
       return action.revisions;
     case 'CREATE_NOTE':
+    case 'OPEN_NOTE':
     case 'SELECT_NOTE':
       return emptyList as T.NoteEntity[];
     default:
@@ -107,6 +108,7 @@ const selectedRevision: A.Reducer<T.NoteEntity | null> = (
     case 'SELECT_REVISION':
       return action.revision;
     case 'CREATE_NOTE':
+    case 'OPEN_NOTE':
     case 'REVISIONS_TOGGLE':
     case 'SELECT_NOTE':
       return null;
@@ -120,7 +122,7 @@ const showNoteList: A.Reducer<boolean> = (state = true, action) => {
     case 'NOTE_LIST_TOGGLE':
       return !state;
 
-    case 'SELECT_NOTE':
+    case 'OPEN_NOTE':
       return false;
 
     default:
@@ -185,6 +187,7 @@ const showRevisions: A.Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'REVISIONS_TOGGLE':
       return !state;
+    case 'OPEN_NOTE':
     case 'SELECT_NOTE':
     case 'CREATE_NOTE':
       return false;
@@ -218,6 +221,7 @@ const note: A.Reducer<T.NoteEntity | null> = (state = null, action) => {
     case 'TRASH_NOTE':
     case 'OPEN_TAG':
       return null;
+    case 'OPEN_NOTE':
     case 'SELECT_NOTE':
       return action.options
         ? {

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -115,7 +115,7 @@ const selectedRevision: A.Reducer<T.NoteEntity | null> = (
   }
 };
 
-const showNoteList: A.Reducer<boolean> = (state = false, action) => {
+const showNoteList: A.Reducer<boolean> = (state = true, action) => {
   switch (action.type) {
     case 'NOTE_LIST_TOGGLE':
       return !state;


### PR DESCRIPTION
### Fix
When we refactored the previousIndex (#1989) and note list, we didn't account for behavior on small screens. This PR disentangles that by clarifying when we want `CLOSE_NOTE` (unselect the selected note) and when we want `TOGGLE_NOTE_LIST` (keep a note selected, but switch to list view).

This has the interesting side effect of making it possible to maintain a selected note on the small screen. I removed the check that disables the selected note highlight on small views. You can now use the note list keyboard command to toggle between list and note view without losing the selected note, and use next/previous note from either view to select and open a new note.

This will fix #2029 

### Test
1. Load the app on a narrow window and ensure the note list shows up (not a blank screen)
2. Select a note. The note should show
3. Ensure the back button on the note takes you back to the note list
4. Test keyboard commands to show/hide note list and move between next/previous notes

### Release
Not updated: Fix a bug that made it impossible to access the note list on small screens