### PR TITLE
Update `node-simperium` to fix some duplicate-write issues

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,6 +11,7 @@
 
 - Highlight all search matches in Markdown previews and in note list [#1987](https://github.com/Automattic/simplenote-electron/pull/1987)
 - Fix for blurry fonts on LCD screens [#2003](https://github.com/Automattic/simplenote-electron/pull/2003)
+- Prevent duplicate writes/changes while multiple WebSockets are open [#2039](https://github.com/Automattic/simplenote-electron/pull/2039)
 
 ### Other Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16098,9 +16098,9 @@
       "dev": true
     },
     "simperium": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/simperium/-/simperium-1.1.0.tgz",
-      "integrity": "sha512-xBjZSgM6bLE8SmXEXbL18iUO+V7DfT1s1pnGZVChhBsiLgeISXTZZa5tN+1u6rijAoSajWTbl855JT5umX0RQQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/simperium/-/simperium-1.1.1.tgz",
+      "integrity": "sha512-p2sjaGLl2i6fCKTUcIXhTj0UKaqYvQ5dUMFrfmD9TYDSMc8tpMm7CVkoWw/LKhJYtFrzTnJeG9VkZr0JOd8zuQ==",
       "requires": {
         "@babel/polyfill": "7.7.0",
         "events": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "sax": "1.2.4",
     "semver": "7.2.2",
     "showdown": "1.9.1",
-    "simperium": "1.1.0",
+    "simperium": "1.1.1",
     "string-replace-to-array": "1.0.3",
     "turndown": "5.0.3",
     "unorm": "1.6.0",


### PR DESCRIPTION
In certain situations we can find more than one WebSocket connection to
Simperium open and messages come back from the server over both. This
tends to happen when the network connection is spotty: `node-simperium`
thinks the WebSocket is closed but the browser still flushes out the
last messages on it as soon as network connectivity returns.

In the update to `node-simperium` it guards against certain kinds of
"ghost writing" in these situations by making sure that duplicate or
out-of-order messages from the server don't get applied more than once.