### PR TITLE
Hotkeys: Always allow using the Ctrl-T shortcut to jump between note/…

### DIFF
--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -106,7 +106,7 @@ export class NoteEditor extends Component<Props> {
         event.stopPropagation();
         event.preventDefault();
         return false;
-      } else if (!this.tagFieldHasFocus()) {
+      } else {
         this.focusTagField && this.focusTagField();
 
         event.stopPropagation();

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -101,13 +101,13 @@ export class NoteEditor extends Component<Props> {
     ) {
       // prefer focusing the edit field first
       if (!this.editFieldHasFocus()) {
-        this.focusNoteEditor && this.focusNoteEditor();
+        this.focusNoteEditor?.();
 
         event.stopPropagation();
         event.preventDefault();
         return false;
       } else {
-        this.focusTagField && this.focusTagField();
+        this.focusTagField?.();
 
         event.stopPropagation();
         event.preventDefault();


### PR DESCRIPTION
Resolves #2028

Previously we were only allowing a switch _from_ the note editor _to_ the
tag editor, or _from_ the tag editor _to_ the note editor, but we really
want to allow jumping between these fields any time, even if none is
selected.

With the work to improve keyboard shortcut usability this is more important
since we're emphasizing keyboard navigation.

In this patch we change the conditional from one that gates the behavior
to one that uses the current focus to determine which to jump to.

See #2028 for testing instructions.