### PR TITLE
Added armv7l and arm64 build targets to Linux build

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -60,19 +60,19 @@
     "target": [
       {
         "target": "AppImage",
-        "arch": ["x64", "ia32"]
+        "arch": ["x64", "ia32", "armv7l", "arm64"]
       },
       {
         "target": "deb",
-        "arch": ["x64", "ia32"]
+        "arch": ["x64", "ia32", "armv7l", "arm64"]
       },
       {
         "target": "rpm",
-        "arch": ["x64", "ia32"]
+        "arch": ["x64", "ia32", "armv7l", "arm64"]
       },
       {
         "target": "tar.gz",
-        "arch": ["x64", "ia32"]
+        "arch": ["x64", "ia32", "armv7l", "arm64"]
       }
     ],
     "synopsis": "The simplest way to keep notes",


### PR DESCRIPTION
### Fix
Add Linux armv7l and arm64 build target support for Linux build. Standard Linux build environment  worked for me. I build on Ubuntu LTS 18.0.4.3 x64 and tested build packages on arm64 (Pinebook Pro running Manjaro 20.04) and armv7l (Raspberry Pi running Debian 10.3).

PR asked for by @dmsnell on https://github.com/Automattic/simplenote-electron/issues/1986

### Test

Linux build now creates armv7 and arm64 packages:

`make package-linux`

### Release

Simplenote now supports armv7l (aka armhf on Debian) and arm64 platforms
