### PR TITLE
Update blue to Simplenote Blue

### DIFF
--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -52,7 +52,7 @@
   }
 
   button[type='submit'] {
-    background-color: $studio-blue-50;
+    background-color: $studio-simplenote-blue-50;
     border: none;
     color: $studio-white;
     font-weight: 500;
@@ -65,7 +65,9 @@
     text-decoration: none;
   }
 
-  .login__forgot, .login__signup, .terms {
+  .login__forgot,
+  .login__signup,
+  .terms {
     color: $studio-gray-60;
     display: block;
     font-size: 14px;
@@ -74,8 +76,9 @@
     text-align: center;
   }
 
-  .login__signup a, .terms a {
-    color: $studio-blue-60;
+  .login__signup a,
+  .terms a {
+    color: $studio-simplenote-blue-60;
     margin-left: 5px;
     text-decoration: none;
   }
@@ -130,12 +133,15 @@
     color: $studio-gray-20;
   }
 
-  .login__forgot, .login__signup, .terms {
+  .login__forgot,
+  .login__signup,
+  .terms {
     color: $studio-gray-20;
   }
 
-  .login__signup a, .terms a {
-    color: $studio-blue-20;
+  .login__signup a,
+  .terms a {
+    color: $studio-simplenote-blue-20;
   }
 
   .login__auth-message.is-error {

--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -23,7 +23,7 @@
   }
   &::-ms-track {
     height: 2px;
-    border-color: $studio-blue-50;
+    border-color: $studio-simplenote-blue-50;
     border-width: 7px 0;
     color: transparent;
   }
@@ -39,7 +39,7 @@
     width: 14px;
     height: 14px;
     border-radius: 50%;
-    border: 2px solid $studio-blue-50;
+    border: 2px solid $studio-simplenote-blue-50;
     appearance: none;
     background: $studio-white;
     transition: 0.15s ease-in-out;
@@ -50,7 +50,7 @@
   }
   &::-moz-range-thumb {
     border-radius: 50%;
-    border: 2px solid $studio-blue-50;
+    border: 2px solid $studio-simplenote-blue-50;
     appearance: none;
     background: $studio-white;
     transition: 0.15s ease-in-out;
@@ -63,7 +63,7 @@
     width: 16px;
     height: 16px;
     border-radius: 50%;
-    border: 2px solid $studio-blue-50;
+    border: 2px solid $studio-simplenote-blue-50;
     appearance: none;
     background: $studio-white;
     transition: 0.15s ease-in-out;
@@ -77,4 +77,3 @@
     display: none;
   }
 }
-

--- a/lib/components/tab-panels/style.scss
+++ b/lib/components/tab-panels/style.scss
@@ -17,8 +17,8 @@
     border-radius: 0;
 
     &.is-active {
-      color: $studio-blue-50;
-      border-bottom-color: $studio-blue-50;
+      color: $studio-simplenote-blue-50;
+      border-bottom-color: $studio-simplenote-blue-50;
     }
   }
 }

--- a/lib/components/tab-panels/style.scss
+++ b/lib/components/tab-panels/style.scss
@@ -20,6 +20,9 @@
       color: $studio-simplenote-blue-50;
       border-bottom-color: $studio-simplenote-blue-50;
     }
+    &:active {
+      color: $studio-white;
+    }
   }
 }
 

--- a/lib/components/tag-chip/style.scss
+++ b/lib/components/tag-chip/style.scss
@@ -13,7 +13,7 @@
 
   &.selected,
   &:hover {
-    background: $studio-blue-5;
+    background: $studio-simplenote-blue-5;
   }
 }
 

--- a/lib/dialogs/about/style.scss
+++ b/lib/dialogs/about/style.scss
@@ -5,7 +5,7 @@
 
     // For overriding theme settings.
     // TODO: Improve theme management so this isn't necessary
-    background: $studio-blue-50 !important;
+    background: $studio-simplenote-blue-50 !important;
     color: $studio-white !important;
   }
 

--- a/lib/dialogs/about/style.scss
+++ b/lib/dialogs/about/style.scss
@@ -1,12 +1,28 @@
+.theme-light {
+  .about {
+    .dialog {
+      // For overriding theme settings.
+      // TODO: Improve theme management so this isn't necessary
+      background: $studio-simplenote-blue-50 !important;
+      color: $studio-white !important;
+    }
+  }
+}
+
+.theme-dark {
+  .about {
+    .dialog {
+      // For overriding theme settings.
+      // TODO: Improve theme management so this isn't necessary
+      background-color: $studio-gray-90 !important;
+    }
+  }
+}
+
 .about {
   .dialog {
     position: relative;
     max-width: 472px;
-
-    // For overriding theme settings.
-    // TODO: Improve theme management so this isn't necessary
-    background: $studio-simplenote-blue-50 !important;
-    color: $studio-white !important;
   }
 
   .dialog-content {

--- a/lib/dialogs/about/style.scss
+++ b/lib/dialogs/about/style.scss
@@ -1,28 +1,15 @@
-.theme-light {
-  .about {
-    .dialog {
-      // For overriding theme settings.
-      // TODO: Improve theme management so this isn't necessary
-      background: $studio-simplenote-blue-50 !important;
-      color: $studio-white !important;
-    }
-  }
-}
-
-.theme-dark {
-  .about {
-    .dialog {
-      // For overriding theme settings.
-      // TODO: Improve theme management so this isn't necessary
-      background-color: $studio-gray-90 !important;
-    }
-  }
-}
-
 .about {
   .dialog {
     position: relative;
     max-width: 472px;
+
+    // For overriding theme settings.
+    // TODO: Improve theme management so this isn't necessary
+    background: $studio-simplenote-blue-50 !important;
+    color: $studio-white !important;
+    a {
+      color: $studio-white;
+    }
   }
 
   .dialog-content {

--- a/lib/dialogs/import/dropzone/style.scss
+++ b/lib/dialogs/import/dropzone/style.scss
@@ -6,8 +6,8 @@
   padding: 24px;
   border-width: 2px;
   border-style: dashed;
-  background: $studio-blue-5;
-  transition: padding .2s ease-out, background .2s ease-out;
+  background: $studio-simplenote-blue-5;
+  transition: padding 0.2s ease-out, background 0.2s ease-out;
 
   &:focus-within {
     overflow: hidden;
@@ -19,7 +19,7 @@
   }
 
   &.is-active {
-    opacity: .75;
+    opacity: 0.75;
   }
 
   &.is-accepted {

--- a/lib/icon-button/style.scss
+++ b/lib/icon-button/style.scss
@@ -1,7 +1,7 @@
 .icon-button {
   width: 32px;
   height: 32px;
-  color: $studio-blue-50;
+  color: $studio-simplenote-blue-50;
 
   svg {
     transition: $anim-fast;

--- a/lib/icons/style.scss
+++ b/lib/icons/style.scss
@@ -4,7 +4,7 @@ svg[class^='icon-'] {
 
 // Color for the Simplenote logo
 .logo path {
-  fill: $studio-blue-50;
+  fill: $studio-simplenote-blue-50;
 }
 .logo circle {
   fill: $studio-white;

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -8,23 +8,23 @@
 
   &.is-selected {
     .button {
-      color: $studio-blue-50;
+      color: $studio-simplenote-blue-50;
     }
 
     svg[class^='icon-'] {
-      fill: $studio-blue-50;
+      fill: $studio-simplenote-blue-50;
     }
   }
 }
 
 .navigation-bar-item__icon {
   display: inline-block;
-  margin-right: .5em;
+  margin-right: 0.5em;
   vertical-align: middle;
 
   svg {
     vertical-align: middle;
     position: relative;
-    top: -.2em;
+    top: -0.2em;
   }
 }

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -6,8 +6,18 @@
   white-space: nowrap;
   text-align: left;
 
+  button:active {
+    color: $studio-white;
+  }
+
   &.is-selected {
     .button {
+      &:active {
+        color: $studio-white;
+        svg[class^='icon-'] {
+          fill: $studio-white;
+        }
+      }
       color: $studio-simplenote-blue-50;
     }
 

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -6,23 +6,24 @@
   white-space: nowrap;
   text-align: left;
 
-  button:active {
+  .button:active {
     color: $studio-white;
   }
 
   &.is-selected {
     .button {
+      color: $studio-simplenote-blue-50;
+
+      svg[class^='icon-'] {
+        fill: $studio-simplenote-blue-50;
+      }
+
       &:active {
         color: $studio-white;
         svg[class^='icon-'] {
           fill: $studio-white;
         }
       }
-      color: $studio-simplenote-blue-50;
-    }
-
-    svg[class^='icon-'] {
-      fill: $studio-simplenote-blue-50;
     }
   }
 }

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -110,7 +110,7 @@
   }
 
   &.note-list-item-selected {
-    background: $studio-blue-5;
+    background: $studio-simplenote-blue-5;
   }
 
   .note-list-item-published-icon {

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -1,5 +1,5 @@
 .revision-selector {
-  background: $studio-blue-50;
+  background: $studio-simplenote-blue-50;
   padding: 10px 20px 20px 20px;
   color: $studio-white;
   z-index: 1000;
@@ -25,12 +25,12 @@
 
   .button-primary {
     background: $studio-white;
-    color: $studio-blue-50;
+    color: $studio-simplenote-blue-50;
     border-color: $studio-white;
 
     &:active {
-      background: $studio-blue-5;
-      border-color: $studio-blue-5;
+      background: $studio-simplenote-blue-5;
+      border-color: $studio-simplenote-blue-5;
     }
   }
 
@@ -41,7 +41,7 @@
 
     &:active {
       background: $studio-white;
-      color: $studio-blue-50;
+      color: $studio-simplenote-blue-50;
     }
   }
 
@@ -50,7 +50,6 @@
     justify-content: center;
     margin-bottom: 20px;
   }
-
 
   .revision-date {
     width: 100%;

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -52,7 +52,7 @@
     appearance: none;
 
     &.is-selected {
-      color: $studio-blue-50;
+      color: $studio-simplenote-blue-50;
     }
 
     &:focus {

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -22,6 +22,9 @@
       .touch-enabled & {
         opacity: 1;
       }
+      &:active {
+        color: $studio-white;
+      }
     }
   }
 

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -9,7 +9,8 @@ a {
 }
 
 a[href^='http://'],
-a[href^='https://'] {
+a[href^='https://']
+{
   cursor: pointer; // Make all web links use pointer cursor
 }
 
@@ -32,7 +33,7 @@ svg {
 }
 
 a {
-  color: $studio-blue-50;
+  color: $studio-simplenote-blue-50;
 }
 
 b,
@@ -113,7 +114,7 @@ optgroup {
 }
 
 .search-match {
-  background-color: $studio-blue-50;
+  background-color: $studio-simplenote-blue-50;
   border-radius: 3px;
   padding-left: 2px;
   padding-right: 2px;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -12,7 +12,7 @@ $fade-alpha: 0.25;
 
 $border-radius: 3px;
 
-$focus-outline: 4px auto $studio-blue-5;
+$focus-outline: 4px auto $studio-simplenote-blue-5;
 
 // Global Measurements
 $navigation-bar-width: 216px;

--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -28,10 +28,10 @@ button {
   transition: $anim-fast;
   -webkit-tap-highlight-color: transparent;
   background: transparent;
-  border-color: $studio-blue-50;
+  border-color: $studio-simplenote-blue-50;
   border-style: solid;
   border-width: 2px;
-  color: $studio-blue-50;
+  color: $studio-simplenote-blue-50;
   font-size: 14px;
   line-height: 1.5;
   font-weight: $bold;
@@ -40,7 +40,7 @@ button {
 
   &:active,
   &.active {
-    background: $studio-blue-50;
+    background: $studio-simplenote-blue-50;
     color: $studio-white;
   }
   &[disabled],
@@ -51,7 +51,7 @@ button {
 
 // Primary buttons. Solid buttons.
 .button-primary {
-  background: $studio-blue-50;
+  background: $studio-simplenote-blue-50;
   color: white;
 }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -97,7 +97,7 @@
     color: $studio-gray-50;
 
     &.is-active {
-      color: $studio-blue-30;
+      color: $studio-simplenote-blue-30;
     }
   }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -64,7 +64,10 @@
     }
   }
 
-  .icon-button,
+  .icon-button {
+    color: $studio-gray-30;
+  }
+
   a {
     color: $studio-simplenote-blue-30;
   }
@@ -112,12 +115,19 @@
     color: $studio-gray-5;
   }
 
-  .tab-panels__tab-list li {
-    color: $studio-gray-50;
+  .tab-panels__tab-list {
+    li {
+      color: $studio-gray-50;
 
-    &.is-active {
-      color: $studio-simplenote-blue-30;
-      border-bottom-color: $studio-simplenote-blue-30;
+      &.is-active {
+        color: $studio-simplenote-blue-30;
+        border-bottom-color: $studio-simplenote-blue-30;
+      }
+    }
+
+    li.button:active {
+      background-color: $studio-simplenote-blue-30;
+      color: $studio-white;
     }
   }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -53,15 +53,9 @@
     background-color: $studio-gray-50;
   }
 
-  button {
-    color: $studio-simplenote-blue-30;
-    border-color: $studio-simplenote-blue-30;
-  }
-  .button-primary {
-    background: $studio-simplenote-blue-30;
-    color: $studio-white;
-  }
   .button-borderless {
+    color: $studio-simplenote-blue-30;
+
     &[disabled],
     &:disabled {
       svg[class^='icon-'] {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -53,6 +53,14 @@
     background-color: $studio-gray-50;
   }
 
+  button {
+    color: $studio-simplenote-blue-30;
+    border-color: $studio-simplenote-blue-30;
+  }
+  .button-primary {
+    background: $studio-simplenote-blue-30;
+    color: $studio-white;
+  }
   .button-borderless {
     &[disabled],
     &:disabled {
@@ -60,6 +68,11 @@
         fill: $studio-gray-60;
       }
     }
+  }
+
+  .icon-button,
+  a {
+    color: $studio-simplenote-blue-30;
   }
 
   input {
@@ -81,6 +94,18 @@
     border-color: $studio-gray-80;
   }
 
+  .navigation-bar-item.is-selected {
+    button {
+      color: $studio-simplenote-blue-30;
+    }
+    svg {
+      fill: $studio-simplenote-blue-30;
+    }
+  }
+  .tag-list .tag-list-input.is-selected {
+    color: $studio-simplenote-blue-30;
+  }
+
   .tag-field input {
     background: transparent;
 
@@ -98,6 +123,7 @@
 
     &.is-active {
       color: $studio-simplenote-blue-30;
+      border-bottom-color: $studio-simplenote-blue-30;
     }
   }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -64,10 +64,7 @@
     }
   }
 
-  .icon-button {
-    color: $studio-gray-30;
-  }
-
+  .icon-button,
   a {
     color: $studio-simplenote-blue-30;
   }
@@ -89,6 +86,15 @@
 
   .checkbox-control-base {
     border-color: $studio-gray-80;
+  }
+
+  .navigation-bar-item {
+    button {
+      color: $studio-white;
+    }
+    svg {
+      fill: $studio-white;
+    }
   }
 
   .navigation-bar-item.is-selected {


### PR DESCRIPTION
### Fix
With the update of Color Studio, we now have SImplenote Blue: https://github.com/Automattic/color-studio/blob/master/CHANGELOG.md#230

This changes all uses of blue in the app to Simplenote Blue

### Test
1. Run app and see the new blue

### Release
Update blue to use the Simplnote Blue

<img width="213" alt="Screen Shot 2020-04-27 at 1 28 31 PM" src="https://user-images.githubusercontent.com/6817400/80401845-04c3e480-888b-11ea-9fac-67809a45d25a.png">
<img width="457" alt="Screen Shot 2020-04-27 at 1 28 27 PM" src="https://user-images.githubusercontent.com/6817400/80401849-055c7b00-888b-11ea-8d6d-afe436c27b73.png">
<img width="256" alt="Screen Shot 2020-04-27 at 1 28 21 PM" src="https://user-images.githubusercontent.com/6817400/80401850-055c7b00-888b-11ea-8dc4-c932a92488b8.png">
<img width="473" alt="Screen Shot 2020-04-27 at 1 28 16 PM" src="https://user-images.githubusercontent.com/6817400/80401851-055c7b00-888b-11ea-97b6-3e465cd2cedd.png">
<img width="470" alt="Screen Shot 2020-04-27 at 1 28 03 PM" src="https://user-images.githubusercontent.com/6817400/80401852-05f51180-888b-11ea-9e5e-a4aade6da7b5.png">
<img width="488" alt="Screen Shot 2020-04-27 at 1 27 48 PM" src="https://user-images.githubusercontent.com/6817400/80401855-05f51180-888b-11ea-9174-fd8c17006b7f.png">
<img width="211" alt="Screen Shot 2020-04-27 at 1 27 31 PM" src="https://user-images.githubusercontent.com/6817400/80401857-05f51180-888b-11ea-977b-34731e24bd6c.png">
<img width="470" alt="Screen Shot 2020-04-27 at 1 27 22 PM" src="https://user-images.githubusercontent.com/6817400/80401858-05f51180-888b-11ea-9913-e588e86de4ca.png">
<img width="308" alt="Screen Shot 2020-04-27 at 1 27 17 PM" src="https://user-images.githubusercontent.com/6817400/80401859-068da800-888b-11ea-8548-818dc730763d.png">

