### PR TITLE
Fix keyboard shortcut issues identified in release testing

### DIFF
--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -137,7 +137,6 @@ const buildViewMenu = settings => {
       },
       {
         label: 'Focus Mode',
-        accelerator: 'CommandOrControl+Shift+F',
         type: 'checkbox',
         checked: settings.focusModeEnabled,
         click: appCommandSender({ action: 'toggleFocusMode' }),

--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -68,6 +68,9 @@ export class AppLayout extends Component<Props> {
       keyboardShortcutsAreOpen
         ? hideKeyboardShortcuts()
         : showKeyboardShortcuts();
+
+      event.stopPropagation();
+      event.preventDefault();
     }
   };
 

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -256,8 +256,16 @@ export const App = connect(
         return false;
       }
 
-      if (cmdOrCtrl && shiftKey && 'KeyF' === code) {
+      if (cmdOrCtrl && !shiftKey && 'KeyF' === code) {
         this.props.focusSearchField();
+
+        event.stopPropagation();
+        event.preventDefault();
+        return false;
+      }
+
+      if (cmdOrCtrl && shiftKey && 'KeyF' === code) {
+        this.props.toggleFocusMode();
 
         event.stopPropagation();
         event.preventDefault();
@@ -275,11 +283,7 @@ export const App = connect(
         return false;
       }
 
-      if (
-        this.props.ui.note &&
-        cmdOrCtrl &&
-        ('Delete' === code || 'Backspace' === code)
-      ) {
+      if (this.props.ui.note && cmdOrCtrl && 'Delete' === code) {
         this.props.actions.trashNote({
           noteBucket: this.props.noteBucket,
           note: this.props.ui.note,
@@ -291,6 +295,13 @@ export const App = connect(
         event.stopPropagation();
         event.preventDefault();
         return false;
+      }
+
+      // prevent default browser behavior for search
+      // will bubble up from note-detail
+      if (cmdOrCtrl && 'KeyG' === code) {
+        event.stopPropagation();
+        event.preventDefault();
       }
 
       return true;

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -46,8 +46,8 @@ const Keys = ({
 export class AboutDialog extends Component<Props> {
   render() {
     const { closeDialog, isElectron, isMacApp } = this.props;
-
-    const CmdOrCtrl = isMacApp ? 'Cmd' : 'Ctrl';
+    const isMac = isMacApp || navigator.userAgent.indexOf('Mac OS X');
+    const CmdOrCtrl = isMac ? 'Cmd' : 'Ctrl';
 
     return (
       <div className="keybindings">
@@ -145,7 +145,7 @@ export class AboutDialog extends Component<Props> {
                 <li>
                   <Keys
                     keys={
-                      isMacApp
+                      isMac
                         ? ['fn', CmdOrCtrl, 'Delete']
                         : [CmdOrCtrl, 'Delete']
                     }

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -61,11 +61,21 @@ export class AboutDialog extends Component<Props> {
                 </li>
                 <li>
                   <Keys keys={[CmdOrCtrl, 'Shift', 'F']}>
-                    Focus search field
+                    Toggle focus mode
                   </Keys>
                 </li>
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'G']}>Search within note</Keys>
+                  <Keys keys={[CmdOrCtrl, 'F']}>Focus search field</Keys>
+                </li>
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'G']}>
+                    Jump to next match in note
+                  </Keys>
+                </li>
+                <li>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'G']}>
+                    Jump to previous match in note
+                  </Keys>
                 </li>
                 {isElectron && (
                   <li>
@@ -105,11 +115,13 @@ export class AboutDialog extends Component<Props> {
                 </li>
                 <li>
                   <Keys keys={[CmdOrCtrl, 'Shift', 'K']}>
-                    Select previous note
+                    Open note above current one
                   </Keys>
                 </li>
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'Shift', 'J']}>Select next note</Keys>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'J']}>
+                    Open note below current one
+                  </Keys>
                 </li>
                 <li>
                   <Keys keys={[CmdOrCtrl, 'T']}>
@@ -118,9 +130,7 @@ export class AboutDialog extends Component<Props> {
                 </li>
                 <li>
                   <Keys keys={[CmdOrCtrl, 'Shift', 'L']}>
-                    Toggle note list
-                    <br />
-                    (on narrow screens)
+                    Toggle note list (on narrow screens)
                   </Keys>
                 </li>
               </ul>

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -143,7 +143,15 @@ export class AboutDialog extends Component<Props> {
                   <Keys keys={[CmdOrCtrl, 'Shift', 'N']}>Create new note</Keys>
                 </li>
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'Delete']}>Trash note</Keys>
+                  <Keys
+                    keys={
+                      isMacApp
+                        ? ['fn', CmdOrCtrl, 'Delete']
+                        : [CmdOrCtrl, 'Delete']
+                    }
+                  >
+                    Trash note
+                  </Keys>
                 </li>
                 {isElectron && (
                   <li>

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -47,7 +47,7 @@ export class AboutDialog extends Component<Props> {
   render() {
     const { closeDialog, isElectron, isMacApp } = this.props;
     const isMac = isMacApp || navigator.userAgent.indexOf('Mac OS X');
-    const CmdOrCtrl = isMac ? 'Cmd' : 'Ctrl';
+    const CmdOrCtrl = isMacApp ? 'Cmd' : 'Ctrl';
 
     return (
       <div className="keybindings">

--- a/lib/dialogs/keybindings/style.scss
+++ b/lib/dialogs/keybindings/style.scss
@@ -43,7 +43,7 @@
 }
 
 .keybindings__key-list {
-  min-width: 160px;
+  min-width: 180px;
   display: inline-block;
   text-align: right;
 }

--- a/lib/dialogs/keybindings/style.scss
+++ b/lib/dialogs/keybindings/style.scss
@@ -1,15 +1,7 @@
 .keybindings {
   .dialog {
-    max-width: 1120px;
+    max-width: 500px;
     margin: auto;
-
-    @media only screen and (max-width: 1150px) {
-      max-width: 760px;
-    }
-
-    @media only screen and (max-width: 780px) {
-      max-width: 480px;
-    }
   }
 
   .dialog-content {
@@ -51,8 +43,9 @@
 }
 
 .keybindings__key-list {
-  min-width: 80px;
+  min-width: 160px;
   display: inline-block;
+  text-align: right;
 }
 
 .keybindings__key-description {
@@ -64,11 +57,6 @@
   position: relative;
   max-height: 480px;
   overflow-y: scroll;
-
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
 
   section {
     margin-right: 2em;

--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -63,7 +63,7 @@ export class NoteDetail extends Component<Props> {
     // Ensures note gets saved if user abruptly quits the app
     window.addEventListener('beforeunload', this.queueNoteSync.flush);
 
-    window.addEventListener('keydown', this.handlePreviewKeydown, false);
+    window.addEventListener('keydown', this.handlePreviewKeydown, true);
 
     if (previewingMarkdown) {
       this.updateMarkdown();
@@ -104,7 +104,7 @@ export class NoteDetail extends Component<Props> {
   componentWillUnmount() {
     window.removeEventListener('beforeunload', this.queueNoteSync.flush);
     document.removeEventListener('copy', this.copyRenderedNote, false);
-    window.removeEventListener('keydown', this.handlePreviewKeydown, false);
+    window.removeEventListener('keydown', this.handlePreviewKeydown, true);
   }
 
   copyRenderedNote = event => {
@@ -209,6 +209,9 @@ export class NoteDetail extends Component<Props> {
       cmdOrCtrl &&
       code === 'KeyG'
     ) {
+      event.stopPropagation();
+      event.preventDefault();
+
       const matches = this.noteDetail.current.querySelectorAll(
         'span.search-match'
       );

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -88,14 +88,6 @@ export class NoteEditor extends Component<Props> {
       return false;
     }
 
-    // open note list
-    if (this.props.isSmallScreen && cmdOrCtrl && shiftKey && 'KeyL' === code) {
-      this.props.toggleNoteList();
-      event.stopPropagation();
-      event.preventDefault();
-      return false;
-    }
-
     // toggle between tag editor and note editor
     if (
       !shiftKey &&

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -51,6 +51,7 @@ type DispatchProps = {
   onSelectNote: (note: T.NoteEntity | null) => any;
   onPinNote: (note: T.NoteEntity, shouldPin: boolean) => any;
   openNote: (note: T.NoteEntity) => any;
+  toggleNoteList: () => any;
 };
 
 type Props = Readonly<OwnProps & StateProps & DispatchProps>;
@@ -330,10 +331,18 @@ export class NoteList extends Component<Props> {
       return false;
     }
 
+    if (isSmallScreen && code === 'KeyL') {
+      this.props.toggleNoteList();
+
+      event.stopPropagation();
+      event.preventDefault();
+      return false;
+    }
+
     if (
       isSmallScreen &&
       showNoteList &&
-      (code === 'Enter' || code === 'KeyL') &&
+      code === 'Enter' &&
       highlightedIndex !== null
     ) {
       this.props.openNote(notes[highlightedIndex]);
@@ -537,6 +546,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (
   },
   onPinNote: (note, shouldPin) => dispatch(actions.ui.pinNote(note, shouldPin)),
   openNote: (note: T.NoteEntity) => dispatch(actions.ui.openNote(note)),
+  toggleNoteList: () => dispatch(actions.ui.toggleNoteList()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteList);

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -307,7 +307,7 @@ export class NoteList extends Component<Props> {
     const cmdOrCtrl = ctrlKey || metaKey;
     if (cmdOrCtrl && shiftKey && code === 'KeyK') {
       if (-1 === highlightedIndex || index < 0 || !notes[index - 1]?.id) {
-        return true;
+        return false;
       }
 
       this.props.onSelectNote(notes[index - 1]);
@@ -322,7 +322,7 @@ export class NoteList extends Component<Props> {
         index >= notes.length ||
         !notes[index + 1]?.id
       ) {
-        return true;
+        return false;
       }
 
       this.props.onSelectNote(notes[index + 1]);

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -333,7 +333,7 @@ export class NoteList extends Component<Props> {
     if (
       isSmallScreen &&
       showNoteList &&
-      code === 'Enter' &&
+      (code === 'Enter' || code === 'KeyL') &&
       highlightedIndex !== null
     ) {
       this.props.openNote(notes[highlightedIndex]);

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -221,6 +221,7 @@ export class NoteList extends Component<Props> {
       openedTag,
       selectedNote,
       selectedNoteContent,
+      showNoteList,
       showTrash,
       tagResultsFound,
     } = nextProps;
@@ -230,7 +231,8 @@ export class NoteList extends Component<Props> {
       noteDisplay !== this.props.noteDisplay ||
       notes !== this.props.notes ||
       tagResultsFound !== this.props.tagResultsFound ||
-      selectedNoteContent !== this.props.selectedNoteContent
+      selectedNoteContent !== this.props.selectedNoteContent ||
+      showNoteList !== this.props.showNoteList
     ) {
       heightCache.clearAll();
     }
@@ -287,7 +289,8 @@ export class NoteList extends Component<Props> {
       prevProps.noteDisplay !== this.props.noteDisplay ||
       prevProps.notes !== this.props.notes ||
       prevProps.tagResultsFound !== this.props.tagResultsFound ||
-      prevProps.selectedNoteContent !== this.props.selectedNoteContent
+      prevProps.selectedNoteContent !== this.props.selectedNoteContent ||
+      prevProps.showNoteList !== this.props.showNoteList
     ) {
       heightCache.clearAll();
     }

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -88,7 +88,7 @@ export class NoteToolbar extends Component<Props> {
             <IconButton
               icon={<BackIcon />}
               onClick={this.props.toggleNoteList}
-              title="Back"
+              title="Back • Ctrl+Shift+L"
             />
           </div>
           {markdownEnabled && (
@@ -142,7 +142,7 @@ export class NoteToolbar extends Component<Props> {
           <IconButton
             icon={<BackIcon />}
             onClick={this.props.toggleNoteList}
-            title="Back"
+            title="Back • Ctrl+Shift+L"
           />
         </div>
         <div className="note-toolbar__column-right">


### PR DESCRIPTION
Resolves #2025
Resolves #2026

Changes:
 - restores "focus mode" hotkey to Ctrl + Shift + F
 - resets "focus search field" hotkey to Ctrl + F
 - rewords description of Ctrl + G
 - rewords "select previous/next" to "above/below"
 - disables browser default behavior on Ctrl + G
 - removes hotkey Ctrl + Backspace to prevent accidentally trashing note
 - inlines keyboard shortcut explainer to one column only for visual styling purposes