### PR TITLE
Feature/support markdown inline code highlight

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,9 @@
 
 ## [v1.15.1]
 
+### Enhancements
+- Highlight inline code in markdown preview
+
 ### Other Changes
 
 - Fix application signing to generate proper appx for Windows Store [#1960](https://github.com/Automattic/simplenote-electron/pull/1960)

--- a/lib/note-detail/render-to-node.ts
+++ b/lib/note-detail/render-to-node.ts
@@ -47,12 +47,12 @@ export const renderToNode = (
     })
     .then((node) => {
       if (!searchQuery) {
-        return node.querySelectorAll('pre code');
+        return node.querySelectorAll('code');
       }
 
       const terms = getTerms(searchQuery).map((s) => s.toLocaleLowerCase());
       if (!terms.length) {
-        return node.querySelectorAll('pre code');
+        return node.querySelectorAll('code');
       }
 
       const treeWalker = document.createTreeWalker(
@@ -80,14 +80,22 @@ export const renderToNode = (
 
       nodes.forEach((textNode) => markMatches(textNode, terms));
 
-      return node.querySelectorAll('pre code');
+      return node.querySelectorAll('code');
     })
     .then((codeElements) => {
       // Only load syntax highlighter if code blocks exist
       if (codeElements.length) {
         return import(/* webpackChunkName: 'highlight' */ 'highlight.js')
           .then(({ default: highlight }) => {
-            codeElements.forEach(highlight.highlightBlock);
+            codeElements.forEach((codeElement) => {
+              highlight.highlightBlock(codeElement);
+              if (
+                !codeElement.parentNode ||
+                codeElement.parentNode.nodeName !== 'pre'
+              ) {
+                codeElement.setAttribute('style', 'display:inline');
+              }
+            });
           })
           .catch();
       }

--- a/lib/note-detail/render-to-node.ts
+++ b/lib/note-detail/render-to-node.ts
@@ -91,7 +91,7 @@ export const renderToNode = (
               highlight.highlightBlock(codeElement);
               if (
                 !codeElement.parentNode ||
-                codeElement.parentNode.nodeName !== 'pre'
+                codeElement.parentNode.nodeName !== 'PRE'
               ) {
                 codeElement.setAttribute('style', 'display:inline');
               }


### PR DESCRIPTION
### Fix
Support inline code highlight mode in markdown preview
[Inline code in markdown preview](https://github.com/Automattic/simplenote-electron/issues/1891)
* A quick development for inline codes feature.
* Apply `highlight.js` to all code tags, set `display: inline` CSS style attribute to those who are not under `pre` tag

### Test
1. Click "INFO" and enable Markdown
2. Add inline codes with signs or code tag
3. Add code blocks
4. Click "Preview"
5. Successfully display both inline codes and code blocks

### Release
RELEASE-NOTES.txt was updated with:
- Highlight inline code in markdown preview
