### PR TITLE
Fix: Properly filter deleted flag

### DIFF
--- a/lib/search/worker.ts
+++ b/lib/search/worker.ts
@@ -103,6 +103,7 @@ export const updateNote = (noteId: T.EntityId, data) => {
     {
       ...data,
       content: data.content.toLocaleLowerCase(),
+      deleted: !!data.deleted,
       tags: noteTags,
     },
   ]);


### PR DESCRIPTION
After deploying the release candidate to app.simplenote.com we noticed
a surge in support requests for missing notes.

Upon investigation we discovered that notes with `deleted: 0` were being
excluded from the search results; this was due to a strict type comparison
of the `deleted` property with the boolean `showTrash` flag.

To resolve this issue we have coerced the `deleted` property to a boolean
value when inserting a note into the index.

Co-authored by @codebykat 