### PR TITLE
Keyboard shortcuts: L key needs modifiers

### DIFF
--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -334,7 +334,7 @@ export class NoteList extends Component<Props> {
       return false;
     }
 
-    if (isSmallScreen && code === 'KeyL') {
+    if (isSmallScreen && cmdOrCtrl && shiftKey && code === 'KeyL') {
       this.props.toggleNoteList();
 
       event.stopPropagation();


### PR DESCRIPTION
### Fix
On the release branch the plain L key currently opens the note list in a narrow window. It should require Shift and a modifier (cmd or ctrl)

### Test
1. Load in narrow window
2. Verify you can type the letter L in a note
3. Verify Ctrl+Shift+L or Cmd+Shift+L toggles between note and note list

### Release
Not updated: Fixed a bug causing the letter L to toggle into the note list in narrow window
