### PR TITLE
Fix: Note title sometimes missing characters in note list

### DIFF
--- a/lib/note-list/get-note-title-and-preview.ts
+++ b/lib/note-list/get-note-title-and-preview.ts
@@ -25,7 +25,7 @@ export const withCache = (getKey, getValue) => (note) => {
 export const clearCache = () => noteCache.clear();
 
 const getNoteTitleAndPreview = withCache(
-  (note) => note.data.modificationDate,
+  (note) => note.data.content,
   getNoteExcerpt
 );
 


### PR DESCRIPTION
### Fix
A user reported an issue (2932709-zen) that's been present for months, where sometimes edits to the note title aren't properly reflected in the notes list, usually missing the last character.

In my testing this was inconsistent but usually easy to trigger within about 30 seconds of rapid typing/deleting in the note title and eliminating the caching for the note excerpt fixed it. At @dmsnell's suggestion this PR switches to using `content` rather than `modificationDate` as the cache key. For me this seems to completely eliminate the problem.

### Test
1. Add a new note
2. Type rapidly in the note title, adding and deleting text quickly
3. Verify that the notes list always displays the correct title.

### Release

Not updated: Fixed a bug causing the note title to sometimes be missing characters in the note list