### PR TITLE
Add 32 bit version for Windows Store

### DIFF
--- a/electron-builder-appx.json
+++ b/electron-builder-appx.json
@@ -10,7 +10,8 @@
     "icon": "resources/images/simplenote.ico",
     "target": [
       {
-        "target": "appx"
+        "target": "appx",
+        "arch": ["ia32", "x64"]
       }
     ]
   },


### PR DESCRIPTION
### Fix

This will build both a 32 and 64-bit version for the app store. I don't this is entirely needed but since we are moving to 64-bit we should have a fallback for 32 bit.

### Test

1. Create a tag, push it
2. Observe builds for win-store being created.
