### PR TITLE
Update tag chip to make it a bit cleaner

### DIFF
--- a/lib/components/tag-chip/index.tsx
+++ b/lib/components/tag-chip/index.tsx
@@ -2,9 +2,7 @@ import React, { FunctionComponent } from 'react';
 import classNames from 'classnames';
 
 type OwnProps = {
-  onSelect?: (
-    event: React.MouseEvent<HTMLDivElement, globalThis.MouseEvent>
-  ) => any;
+  onSelect?: (event: React.MouseEvent<HTMLDivElement>) => any;
   selected: boolean;
   tagName: string;
 };
@@ -12,7 +10,7 @@ type OwnProps = {
 const TagChip: FunctionComponent<OwnProps> = ({
   onSelect,
   selected,
-  tagName,
+  tagName
 }) => (
   <div
     className={classNames('tag-chip', { selected })}

--- a/lib/components/tag-chip/index.tsx
+++ b/lib/components/tag-chip/index.tsx
@@ -2,18 +2,24 @@ import React, { FunctionComponent } from 'react';
 import classNames from 'classnames';
 
 type OwnProps = {
-  onSelect: () => any;
+  onSelect?: (
+    event: React.MouseEvent<HTMLDivElement, globalThis.MouseEvent>
+  ) => any;
   selected: boolean;
-  tag: string;
+  tagName: string;
 };
 
-const TagChip: FunctionComponent<OwnProps> = ({ onSelect, selected, tag }) => (
+const TagChip: FunctionComponent<OwnProps> = ({
+  onSelect,
+  selected,
+  tagName,
+}) => (
   <div
     className={classNames('tag-chip', { selected })}
-    data-tag-name={tag}
+    data-tag-name={tagName}
     onClick={onSelect}
   >
-    {tag}
+    {tagName}
   </div>
 );
 

--- a/lib/components/tag-chip/test.tsx
+++ b/lib/components/tag-chip/test.tsx
@@ -8,7 +8,7 @@ describe('TagChip', () => {
   it('should select tag when clicked', () => {
     const selectIt = jest.fn();
 
-    const chip = mount(<TagChip tag="spline" onSelect={selectIt} />);
+    const chip = mount(<TagChip tagName="spline" onSelect={selectIt} />);
 
     expect(selectIt).not.toHaveBeenCalled();
     chip.simulate('click');
@@ -16,19 +16,19 @@ describe('TagChip', () => {
   });
 
   it('should not include the `selected` class by default', () => {
-    const chip = shallow(<TagChip tag="spline" />);
+    const chip = shallow(<TagChip tagName="spline" />);
 
     expect(chip.hasClass('selected')).toBe(false);
   });
 
   it('should include the `selected` class when selected', () => {
-    const chip = shallow(<TagChip tag="spline" selected />);
+    const chip = shallow(<TagChip tagName="spline" selected />);
 
     expect(chip.hasClass('selected')).toBe(true);
   });
 
   it('should toggle the `selected` class with prop changes', () => {
-    const chip = shallow(<TagChip tag="spline" />);
+    const chip = shallow(<TagChip tagName="spline" />);
 
     expect(chip.hasClass('selected')).toBe(false);
 
@@ -42,7 +42,7 @@ describe('TagChip', () => {
   });
 
   it('should not introduce visual regressions', () => {
-    const component = renderer.create(<TagChip tag="spline" />).toJSON();
+    const component = renderer.create(<TagChip tagName="spline" />).toJSON();
 
     expect(component).toMatchSnapshot();
   });

--- a/lib/tag-field/index.tsx
+++ b/lib/tag-field/index.tsx
@@ -249,7 +249,7 @@ export class TagField extends Component<Props, OwnState> {
           {tags.filter(negate(isEmailTag)).map((tag) => (
             <TagChip
               key={tag}
-              tag={tag}
+              tagName={tag}
               selected={tag === selectedTag}
               onSelect={this.selectTag}
             />


### PR DESCRIPTION
### Fix

- changes the property name to tagName from tag to make it clearer
- make onClick type accurate
- make onSelect an optional type

### Test

1. Test the TagChip
