### PR TITLE
Fix: Defer re-decorating note when changing search

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import {
-  CompositeDecorator,
-  ContentState,
-  Editor,
-  EditorState,
-  Modifier,
-} from 'draft-js';
+import MultiDecorator from 'draft-js-multidecorators';
+import { ContentState, Editor, EditorState, Modifier } from 'draft-js';
 import { debounce, get, has, invoke, noop } from 'lodash';
 
 import {
@@ -33,7 +28,6 @@ import { getIpcRenderer } from './utils/electron';
 import analytics from './analytics';
 
 import * as S from './state';
-import * as T from './types';
 
 const TEXT_DELIMITER = '\n';
 
@@ -88,7 +82,7 @@ class NoteContentEditor extends Component<Props> {
     const queryHasTerms = filterHasText(searchQuery);
 
     if (queryHasTerms) {
-      return new CompositeDecorator([
+      return new MultiDecorator([
         matchingTextDecorator(searchPattern(searchQuery)),
         checkboxDecorator(this.replaceRangeWithText),
       ]);
@@ -217,7 +211,7 @@ class NoteContentEditor extends Component<Props> {
 
     // If searchQuery changes, re-set decorators
     if (searchQuery !== prevProps.searchQuery) {
-      this.queueDecoratorUpdate(noteId);
+      this.queueDecoratorUpdate();
     }
 
     // If a remote change comes in, push it to the existing editor state.
@@ -226,18 +220,12 @@ class NoteContentEditor extends Component<Props> {
     }
   }
 
-  queueDecoratorUpdate = debounce((noteId: T.EntityId) => {
+  queueDecoratorUpdate = debounce(() => {
     const { searchQuery } = this.props;
     const { editorState } = this.state;
 
-    if (noteId === null) {
+    if (this.props.noteId === null) {
       // oops, we unselected a note - don't recompute
-      return;
-    }
-
-    if (noteId !== this.props.noteId) {
-      // oops, we switched notes - requeue
-      this.queueDecoratorUpdate(this.props.noteId);
       return;
     }
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -93,8 +93,7 @@ class NoteContentEditor extends Component<Props> {
 
   createNewEditorState = (text: string, searchQuery: string) => {
     const newEditorState = EditorState.createWithContent(
-      ContentState.createFromText(text, TEXT_DELIMITER),
-      this.generateDecorators(searchQuery)
+      ContentState.createFromText(text, TEXT_DELIMITER)
     );
 
     // Focus the editor for a new, empty note when not searching
@@ -199,12 +198,20 @@ class NoteContentEditor extends Component<Props> {
         {
           editorState: this.createNewEditorState(content.text, searchQuery),
         },
-        () =>
-          __TEST__ &&
-          window.testEvents.push([
-            'editorNewNote',
-            plainTextContent(this.state.editorState),
-          ])
+        () => {
+          this.queueDecoratorUpdate();
+
+          if (content.text.length < 10000) {
+            this.queueDecoratorUpdate.flush();
+          }
+
+          if (__TEST__) {
+            window.testEvents.push([
+              'editorNewNote',
+              plainTextContent(this.state.editorState),
+            ]);
+          }
+        }
       );
       return;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplenote",
-  "version": "1.16.0",
+  "version": "1.16.0-2073",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6402,14 +6402,6 @@
         "fbjs": "^1.0.0",
         "immutable": "~3.7.4",
         "object-assign": "^4.1.1"
-      }
-    },
-    "draft-js-multidecorators": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/draft-js-multidecorators/-/draft-js-multidecorators-1.0.0.tgz",
-      "integrity": "sha1-bEvo17eN0rlm7lHubMF5ubU15hI=",
-      "requires": {
-        "immutable": "*"
       }
     },
     "draft-js-simpledecorator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6404,6 +6404,14 @@
         "object-assign": "^4.1.1"
       }
     },
+    "draft-js-multidecorators": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/draft-js-multidecorators/-/draft-js-multidecorators-1.0.0.tgz",
+      "integrity": "sha1-bEvo17eN0rlm7lHubMF5ubU15hI=",
+      "requires": {
+        "immutable": "*"
+      }
+    },
     "draft-js-simpledecorator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/draft-js-simpledecorator/-/draft-js-simpledecorator-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "core-js": "3.6.5",
     "date-fns": "2.12.0",
     "draft-js": "0.11.5",
+    "draft-js-multidecorators": "1.0.0",
     "draft-js-simpledecorator": "1.0.2",
     "electron-fetch": "1.4.0",
     "electron-progressbar": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "support@simplenote.com"
   },
   "productName": "Simplenote",
-  "version": "1.16.0-2066",
+  "version": "1.16.0-2073",
   "main": "desktop/index.js",
   "license": "GPL-2.0",
   "homepage": "https://simplenote.com",
@@ -124,7 +124,6 @@
     "core-js": "3.6.5",
     "date-fns": "2.12.0",
     "draft-js": "0.11.5",
-    "draft-js-multidecorators": "1.0.0",
     "draft-js-simpledecorator": "1.0.2",
     "electron-fetch": "1.4.0",
     "electron-progressbar": "1.2.0",


### PR DESCRIPTION
See #1941
See #1982

When we rebuilt the search to return instant results and removed the debounce
on the search filter we exposed an issue with note rendering performance that
ironically made the new instant search slower than the old one in certain
circumstances, namely when a note in the search results takes a very long time
to render.

The leading reason for the performance issue is that `draft-js` was applying
a new decorator to its note on every change to the search field. With the
search field updating instantly that left no time for the decorators to redraw
(and they were very inefficient to make it worse).

In this patch we're delaying the re-decoration until the search field settles.
This doesn't eliminate the problem but it should bring it roughly on par with
the behavior from before the search updates. <del>Further we have eliminated the
`MultiDecorator` dependency since that functionality is provided by `draft-js`
itself</del> <ins>Scratch that - there's a slight API change that would require more code to change</ins>. Since there's no need to create a composite decorator when the search
query doesn't contain any text terms we can futher skip it and only decorate
with the checkbox decorator.

These changes should make searching tolerant to slow notes and should
additionally cut the time it takes to decorate notes approximately in half.

## Changes

 - delays highlighting search results inside of the open note when making search changes or when switching notes. the delay is currently set at 500ms and only affects notes whose contents are longer than 10,000 code units

## Notes
 - Long notes may still render slowly due to the cost of initializing `draft-js`. Further work to improve this probably needs to involve replacing draft-js