### PR TITLE
Add option to disable hotkeys

### DIFF
--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -34,6 +34,7 @@ type OwnProps = {
 
 type StateProps = {
   isNoteOpen: boolean;
+  keyboardShortcuts: boolean;
   keyboardShortcutsAreOpen: boolean;
   showNoteList: boolean;
 };
@@ -55,6 +56,9 @@ export class AppLayout extends Component<Props> {
   }
 
   openKeybindingsHelp = (event: KeyboardEvent) => {
+    if (!this.props.keyboardShortcuts) {
+      return;
+    }
     const {
       hideKeyboardShortcuts,
       keyboardShortcutsAreOpen,
@@ -134,8 +138,10 @@ export class AppLayout extends Component<Props> {
 
 const mapStateToProps: S.MapState<StateProps> = ({
   ui: { dialogs, showNoteList },
+  settings: { keyboardShortcuts },
 }) => ({
   keyboardShortcutsAreOpen: dialogs.includes('KEYBINDINGS'),
+  keyboardShortcuts,
   isNoteOpen: !showNoteList,
   showNoteList,
 });

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -191,6 +191,12 @@ export const App = connect(
     }
 
     handleShortcut = (event: KeyboardEvent) => {
+      const {
+        settings: { keyboardShortcuts },
+      } = this.props;
+      if (!keyboardShortcuts) {
+        return;
+      }
       const { code, ctrlKey, metaKey, shiftKey } = event;
 
       // Is either cmd or ctrl pressed? (But not both)

--- a/lib/dialogs/settings/panels/tools.tsx
+++ b/lib/dialogs/settings/panels/tools.tsx
@@ -1,52 +1,80 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, Fragment } from 'react';
 import { connect } from 'react-redux';
 
 import exportZipArchive from '../../../utils/export';
 
 import PanelTitle from '../../../components/panel-title';
 import ButtonGroup from '../../button-group';
-
+import SettingsGroup, { Item } from '../../settings-group';
 import { showDialog } from '../../../state/ui/actions';
+import ToggleGroup from '../../toggle-settings-group';
+import { toggleKeyboardShortcuts } from '../../../state/settings/actions';
 
 import * as S from '../../../state';
 
 type DispatchProps = {
-  showDialog: () => any;
+  showImportDialog: () => any;
+  toggleShortcuts: () => any;
 };
 
-type Props = DispatchProps;
+type StateProps = {
+  keyboardShortcuts: boolean;
+};
 
-const ToolsPanel: FunctionComponent<Props> = ({ showDialog }) => {
+type Props = DispatchProps & StateProps;
+
+const ToolsPanel: FunctionComponent<Props> = ({
+  keyboardShortcuts,
+  showImportDialog,
+  toggleShortcuts,
+}) => {
   const onSelectItem = (item) => {
     if (item.slug === 'import') {
-      showDialog();
+      showImportDialog();
     } else if (item.slug === 'export') {
       exportZipArchive();
     }
   };
 
   return (
-    <div className="settings-tools">
-      <PanelTitle headingLevel="3">Tools</PanelTitle>
-      <ButtonGroup
-        items={[
-          {
-            name: 'Import Notes',
-            slug: 'import',
-          },
-          {
-            name: 'Export Notes',
-            slug: 'export',
-          },
-        ]}
-        onClickItem={onSelectItem}
-      />
-    </div>
+    <Fragment>
+      <div className="settings-tools">
+        <PanelTitle headingLevel={3}>Tools</PanelTitle>
+        <ButtonGroup
+          items={[
+            {
+              name: 'Import Notes',
+              slug: 'import',
+            },
+            {
+              name: 'Export Notes',
+              slug: 'export',
+            },
+          ]}
+          onClickItem={onSelectItem}
+        />
+      </div>
+      <SettingsGroup
+        slug="keyboardShortcuts"
+        activeSlug={keyboardShortcuts ? 'keyboardShortcuts' : ''}
+        onChange={toggleShortcuts}
+        renderer={ToggleGroup}
+      >
+        <Item title="Keyboard Shortcuts" slug="keyboardShortcuts" />
+      </SettingsGroup>
+    </Fragment>
   );
 };
 
+const mapStateToProps = ({ settings }) => {
+  return {
+    keyboardShortcuts: settings.keyboardShortcuts,
+  };
+};
+
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({
-  showDialog: () => dispatch(showDialog('IMPORT')),
+  showImportDialog: () => dispatch(showDialog('IMPORT')),
+  toggleShortcuts: () => dispatch(toggleKeyboardShortcuts()),
 });
 
 export default connect(null, mapDispatchToProps)(ToolsPanel);

--- a/lib/dialogs/settings/panels/tools.tsx
+++ b/lib/dialogs/settings/panels/tools.tsx
@@ -66,15 +66,15 @@ const ToolsPanel: FunctionComponent<Props> = ({
   );
 };
 
-const mapStateToProps = ({ settings }) => {
-  return {
-    keyboardShortcuts: settings.keyboardShortcuts,
-  };
-};
+const mapStateToProps: S.MapState<StateProps> = ({
+  settings: { keyboardShortcuts },
+}) => ({
+  keyboardShortcuts,
+});
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({
   showImportDialog: () => dispatch(showDialog('IMPORT')),
   toggleShortcuts: () => dispatch(toggleKeyboardShortcuts()),
 });
 
-export default connect(null, mapDispatchToProps)(ToolsPanel);
+export default connect(mapStateToProps, mapDispatchToProps)(ToolsPanel);

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -40,6 +40,7 @@ const isElectron = (() => {
 
 type StateProps = {
   editingEnabled: boolean;
+  keyboardShortcuts: boolean;
   searchQuery: string;
 };
 
@@ -331,6 +332,9 @@ class NoteContentEditor extends Component<Props> {
   };
 
   handleKeydown = (event: KeyboardEvent) => {
+    if (!this.props.keyboardShortcuts) {
+      return;
+    }
     const { code, ctrlKey, metaKey, shiftKey } = event;
     const cmdOrCtrl = ctrlKey || metaKey;
 
@@ -398,7 +402,9 @@ class NoteContentEditor extends Component<Props> {
 
 const mapStateToProps: S.MapState<StateProps> = ({
   ui: { searchQuery, showNoteList },
+  settings: { keyboardShortcuts },
 }) => ({
+  keyboardShortcuts,
   searchQuery,
 });
 

--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -20,6 +20,7 @@ type OwnProps = {
 
 type StateProps = {
   isDialogOpen: boolean;
+  keyboardShortcuts: boolean;
   note: T.NoteEntity | null;
   searchQuery: string;
   showNoteInfo: boolean;
@@ -199,6 +200,9 @@ export class NoteDetail extends Component<Props> {
   };
 
   handlePreviewKeydown = (event: KeyboardEvent) => {
+    if (!this.props.keyboardShortcuts) {
+      return;
+    }
     const { ctrlKey, code, metaKey, shiftKey } = event;
 
     const cmdOrCtrl = ctrlKey || metaKey;
@@ -305,6 +309,7 @@ export class NoteDetail extends Component<Props> {
 
 const mapStateToProps: S.MapState<StateProps> = ({ ui, settings }) => ({
   isDialogOpen: ui.dialogs.length > 0,
+  keyboardShortcuts: settings.keyboardShortcuts,
   note: ui.selectedRevision || ui.note,
   searchQuery: ui.searchQuery,
   showNoteInfo: ui.showNoteInfo,

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -16,6 +16,7 @@ type OwnProps = {
 };
 
 type StateProps = {
+  keyboardShortcuts: boolean;
   note: T.NoteEntity | null;
 };
 
@@ -67,6 +68,9 @@ export class NoteEditor extends Component<Props> {
   };
 
   handleShortcut = (event: KeyboardEvent) => {
+    if (!this.props.keyboardShortcuts) {
+      return;
+    }
     const { code, ctrlKey, metaKey, shiftKey } = event;
     const { note, revision, toggleMarkdown } = this.props;
 
@@ -169,6 +173,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
   allTags: tags,
   fontSize: settings.fontSize,
   editMode,
+  keyboardShortcuts: settings.keyboardShortcuts,
   isEditorActive: !state.showNavigation,
   note,
   revision: selectedRevision,

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -33,6 +33,7 @@ type OwnProps = {
 
 type StateProps = {
   hasLoaded: boolean;
+  keyboardShortcuts: boolean;
   noteDisplay: T.ListDisplayMode;
   notes: T.NoteEntity[];
   openedTag: T.TagEntity | null;
@@ -301,6 +302,9 @@ export class NoteList extends Component<Props> {
   }
 
   handleShortcut = (event: KeyboardEvent) => {
+    if (!this.props.keyboardShortcuts) {
+      return;
+    }
     const { ctrlKey, code, metaKey, shiftKey } = event;
     const { isSmallScreen, notes, showNoteList } = this.props;
     const { selectedIndex: index } = this.state;
@@ -498,7 +502,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
     showTrash,
     tagSuggestions,
   },
-  settings: { noteDisplay },
+  settings: { keyboardShortcuts, noteDisplay },
 }) => {
   /**
    * Although not used directly in the React component this value
@@ -524,6 +528,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
 
   return {
     hasLoaded: state.notes !== null,
+    keyboardShortcuts,
     noteDisplay,
     notes: filteredNotes,
     openedTag,

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -90,6 +90,7 @@ export type TagsLoaded = Action<
   { tags: T.TagEntity[]; sortTagsAlpha: boolean }
 >;
 export type ToggleEditMode = Action<'TOGGLE_EDIT_MODE'>;
+export type ToggleKeyboardShortcuts = Action<'KEYBOARD_SHORTCUTS_TOGGLE'>;
 export type ToggleNavigation = Action<'NAVIGATION_TOGGLE'>;
 export type ToggleNoteList = Action<'NOTE_LIST_TOGGLE'>;
 export type ToggleNoteInfo = Action<'NOTE_INFO_TOGGLE'>;
@@ -137,6 +138,7 @@ export type ActionType =
   | StoreRevisions
   | TagsLoaded
   | ToggleEditMode
+  | ToggleKeyboardShortcuts
   | ToggleNavigation
   | ToggleNoteList
   | ToggleNoteInfo

--- a/lib/state/settings/actions.ts
+++ b/lib/state/settings/actions.ts
@@ -49,6 +49,10 @@ export const setLineLength: A.ActionCreator<A.SetLineLength> = (
   lineLength,
 });
 
+export const toggleKeyboardShortcuts: A.ActionCreator<A.ToggleKeyboardShortcuts> = () => ({
+  type: 'KEYBOARD_SHORTCUTS_TOGGLE',
+});
+
 export const toggleSortOrder = () => (dispatch, getState) => {
   dispatch({
     type: 'setSortReversed',

--- a/lib/state/settings/reducer.ts
+++ b/lib/state/settings/reducer.ts
@@ -41,6 +41,15 @@ const fontSize: A.Reducer<number> = (state = 16, action) => {
   }
 };
 
+const keyboardShortcuts: A.Reducer<boolean> = (state = true, action) => {
+  switch (action.type) {
+    case 'KEYBOARD_SHORTCUTS_TOGGLE':
+      return !state;
+    default:
+      return state;
+  }
+};
+
 const lineLength: A.Reducer<T.LineLength> = (state = 'narrow', action) => {
   switch (action.type) {
     case 'setLineLength':
@@ -122,6 +131,7 @@ export default combineReducers({
   autoHideMenuBar,
   focusModeEnabled,
   fontSize,
+  keyboardShortcuts,
   lineLength,
   markdownEnabled,
   noteDisplay,

--- a/lib/tag-field/index.tsx
+++ b/lib/tag-field/index.tsx
@@ -45,7 +45,11 @@ type DispatchProps = {
   updateNoteTags: (args: { note: T.NoteEntity; tags: T.TagEntity[] }) => any;
 };
 
-type Props = OwnProps & DispatchProps;
+type StateProps = {
+  keyboardShortcuts: boolean;
+};
+
+type Props = OwnProps & DispatchProps & StateProps;
 
 const KEY_BACKSPACE = 8;
 const KEY_TAB = 9;
@@ -164,8 +168,15 @@ export class TagField extends Component<Props, OwnState> {
     }
   };
 
-  preventStealingFocus = (event: KeyboardEvent) => {
-    const { code, ctrlKey, metaKey, shiftKey } = event;
+  preventStealingFocus = ({
+    ctrlKey,
+    code,
+    metaKey,
+    shiftKey,
+  }: KeyboardEvent) => {
+    if (!this.props.keyboardShortcuts) {
+      return;
+    }
     const cmdOrCtrl = ctrlKey || metaKey;
 
     if (cmdOrCtrl && shiftKey && 'KeyY' === code) {
@@ -282,6 +293,12 @@ export class TagField extends Component<Props, OwnState> {
   }
 }
 
-export default connect(null, { updateNoteTags } as S.MapDispatch<
-  DispatchProps
->)(TagField);
+const mapStateToProps: S.MapState<StateProps> = ({
+  settings: { keyboardShortcuts },
+}) => ({
+  keyboardShortcuts,
+});
+
+export default connect(mapStateToProps, {
+  updateNoteTags,
+} as S.MapDispatch<DispatchProps>)(TagField);


### PR DESCRIPTION
### Fix

Adds setting to disable hotkeys

### Test

1. Load page
2. Try hotkeys, they should work
3. Disable in settings
4. They should not work

<img width="630" alt="Screen Shot 2020-05-13 at 10 10 49 PM" src="https://user-images.githubusercontent.com/6817400/81884776-bb4fe680-9566-11ea-9f44-137371a040fd.png">

