### PR TITLE
Remove delete note shortcut

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -237,20 +237,6 @@ export const App = connect(
         return false;
       }
 
-      if (this.props.ui.note && cmdOrCtrl && 'Delete' === code) {
-        this.props.actions.trashNote({
-          noteBucket: this.props.noteBucket,
-          note: this.props.ui.note,
-          previousIndex: this.props.appState.notes.findIndex(
-            ({ id }) => this.props.ui.note.id === id
-          ),
-        });
-
-        event.stopPropagation();
-        event.preventDefault();
-        return false;
-      }
-
       // prevent default browser behavior for search
       // will bubble up from note-detail
       if (cmdOrCtrl && 'KeyG' === code) {

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -135,17 +135,6 @@ export class AboutDialog extends Component<DispatchProps> {
                 <li>
                   <Keys keys={[CmdOrCtrl, 'Shift', 'N']}>Create new note</Keys>
                 </li>
-                <li>
-                  <Keys
-                    keys={
-                      isMac
-                        ? ['fn', CmdOrCtrl, 'Delete']
-                        : [CmdOrCtrl, 'Delete']
-                    }
-                  >
-                    Trash note
-                  </Keys>
-                </li>
                 {isElectron && (
                   <li>
                     <Keys keys={[CmdOrCtrl, 'P']}>Print note</Keys>

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -118,7 +118,7 @@ export class NoteToolbar extends Component<Props> {
             <IconButton
               icon={<TrashIcon />}
               onClick={this.props.onTrashNote.bind(null, note)}
-              title="Trash • Ctrl+Delete"
+              title="Trash"
             />
           </div>
           <div className="note-toolbar__button">


### PR DESCRIPTION
### Fix

Removes the delete note shortcut

### Test

1. Use the delete note shortcut: ctrl+fn+delete
2. It should not work
