### PR TITLE
Change search hotkey so it does not replace the native find

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -210,7 +210,7 @@ export const App = connect(
         return false;
       }
 
-      if (cmdOrCtrl && !shiftKey && 'KeyF' === code) {
+      if (cmdOrCtrl && shiftKey && 'KeyS' === code) {
         this.props.focusSearchField();
 
         event.stopPropagation();

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -210,7 +210,10 @@ export const App = connect(
         return false;
       }
 
-      if (cmdOrCtrl && shiftKey && 'KeyS' === code) {
+      if (
+        (cmdOrCtrl && shiftKey && 'KeyS' === code) ||
+        (isElectron && cmdOrCtrl && !shiftKey && 'KeyF' === code)
+      ) {
         this.props.focusSearchField();
 
         event.stopPropagation();

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -58,7 +58,9 @@ export class AboutDialog extends Component<DispatchProps> {
                   </Keys>
                 </li>
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'F']}>Focus search field</Keys>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'S']}>
+                    Focus search field
+                  </Keys>
                 </li>
                 <li>
                   <Keys keys={[CmdOrCtrl, 'G']}>


### PR DESCRIPTION
### Fix

Change the search hotkey to ctrl + shift + s so that it does not conflict with the native browser find.

### Test

1. Goto app
2. Use cmd/ctrl + f, does it open browser find?
3. Use cmd/ctrl + shift + s, does it focus search field?
