### PR TITLE
Update the hotkey to open the tag list

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -200,7 +200,7 @@ export const App = connect(
       if (
         cmdOrCtrl &&
         shiftKey &&
-        'KeyA' === code &&
+        'KeyU' === code &&
         !this.props.showNavigation
       ) {
         this.props.openTagList();

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -200,7 +200,7 @@ export const App = connect(
       if (
         cmdOrCtrl &&
         shiftKey &&
-        'KeyT' === code &&
+        'KeyA' === code &&
         !this.props.showNavigation
       ) {
         this.props.openTagList();

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -104,7 +104,7 @@ export class AboutDialog extends Component<DispatchProps> {
                   </li>
                 )}
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'Shift', 'A']}>Toggle tag list</Keys>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'U']}>Toggle tag list</Keys>
                 </li>
                 <li>
                   <Keys keys={[CmdOrCtrl, 'Shift', 'K']}>

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -104,7 +104,7 @@ export class AboutDialog extends Component<DispatchProps> {
                   </li>
                 )}
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'Shift', 'T']}>Toggle tag list</Keys>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'A']}>Toggle tag list</Keys>
                 </li>
                 <li>
                   <Keys keys={[CmdOrCtrl, 'Shift', 'K']}>


### PR DESCRIPTION
### Fix

Updates the hotkey to open the tag list from ctrl/cmd + shift + t to ctrl/cmd + shift + u.

ctrl/cmd + shift + t is browser hotkey to open last opened tab.

### Test

1. Test ctrl/cmd + shift + t opens last closed tab
2. Test ctrl/cmd + shift + u toggles tag list