### PR TITLE
Update new note hotkey

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -226,7 +226,7 @@ export const App = connect(
         return false;
       }
 
-      if (cmdOrCtrl && shiftKey && 'KeyN' === code) {
+      if (cmdOrCtrl && shiftKey && 'KeyI' === code) {
         this.props.actions.newNote({
           noteBucket: this.props.noteBucket,
         });

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -133,7 +133,7 @@ export class AboutDialog extends Component<DispatchProps> {
               <h1>Note Editing</h1>
               <ul>
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'Shift', 'N']}>Create new note</Keys>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'I']}>Create new note</Keys>
                 </li>
                 <li>
                   <Keys


### PR DESCRIPTION
### Fix

Updates the hotkey to create a new note from ctrl/cmd + shift + n to ctrl/cmd + shift + i.

ctrl/cmd + shift + n is browser hotkey to open a new incognito tab.

### Test

1. Test ctrl/cmd + shift + n opens new incognito tab
2. Test ctrl/cmd + shift + i created new note