### PR TITLE
Change hotkey for focusing on tag field

### DIFF
--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -117,7 +117,7 @@ export class AboutDialog extends Component<DispatchProps> {
                   </Keys>
                 </li>
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'T']}>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'Y']}>
                     Toggle editing content/tags
                   </Keys>
                 </li>

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -89,12 +89,7 @@ export class NoteEditor extends Component<Props> {
     }
 
     // toggle between tag editor and note editor
-    if (
-      !shiftKey &&
-      cmdOrCtrl &&
-      'KeyT' === code &&
-      this.props.isEditorActive
-    ) {
+    if (shiftKey && cmdOrCtrl && 'KeyY' === code && this.props.isEditorActive) {
       // prefer focusing the edit field first
       if (!this.editFieldHasFocus()) {
         this.focusNoteEditor?.();

--- a/lib/tag-field/index.tsx
+++ b/lib/tag-field/index.tsx
@@ -164,10 +164,11 @@ export class TagField extends Component<Props, OwnState> {
     }
   };
 
-  preventStealingFocus = ({ ctrlKey, metaKey, code }: KeyboardEvent) => {
+  preventStealingFocus = (event: KeyboardEvent) => {
+    const { code, ctrlKey, metaKey, shiftKey } = event;
     const cmdOrCtrl = ctrlKey || metaKey;
 
-    if (cmdOrCtrl && 'KeyT' === code) {
+    if (cmdOrCtrl && shiftKey && 'KeyY' === code) {
       this.setState({ selectedTag: '' });
     }
 


### PR DESCRIPTION
### Fix

Updates the hotkey to toggle focus on tag field from ctrl/cmd + t to ctrl/cmd + shift + y.

ctrl/cmd + t is browser hotkey to open a new tab.

### Test

1. Test ctrl/cmd + t opens a new tab
2. Test ctrl/cmd + shift + y toggles focus on tag field