### PR TITLE
Add hotkey to view menu for focus mode

### DIFF
--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -137,6 +137,7 @@ const buildViewMenu = (settings) => {
       },
       {
         label: 'Focus Mode',
+        accelerator: 'CommandOrControl+Shift+F',
         type: 'checkbox',
         checked: settings.focusModeEnabled,
         click: appCommandSender({ action: 'toggleFocusMode' }),


### PR DESCRIPTION
### Fix

Add hotkey description to the View menu for Focus Mode

### Test

1. Run branch
2. In electron open the view menu
3. Does Focus Mode have the hotkey in the menu?

<img width="237" alt="Screen Shot 2020-05-12 at 4 42 26 PM" src="https://user-images.githubusercontent.com/6817400/81743404-93ca2280-946f-11ea-954e-b33685685417.png">

