### PR TITLE
Refactors settings reducer to be seperate

### DIFF
--- a/lib/state/settings/reducer.ts
+++ b/lib/state/settings/reducer.ts
@@ -1,61 +1,139 @@
 import { clamp } from 'lodash';
 
+import { combineReducers } from 'redux';
+
 import * as A from '../action-types';
 import * as T from '../../types';
 
-export const initialState = {
-  accountName: null as string | null,
-  autoHideMenuBar: false,
-  focusModeEnabled: false,
-  fontSize: 16,
-  lineLength: 'narrow' as T.LineLength,
-  markdownEnabled: false,
-  noteDisplay: 'comfy' as T.ListDisplayMode,
-  sortReversed: false,
-  sortTagsAlpha: false,
-  sortType: 'modificationDate' as T.SortType,
-  spellCheckEnabled: true,
-  theme: 'system' as T.Theme,
-  wpToken: false as string | boolean,
-};
-
-const reducer: A.Reducer<typeof initialState> = (
-  state = initialState,
-  action
-) => {
+const accountName: A.Reducer<string | null> = (state = null, action) => {
   switch (action.type) {
     case 'setAccountName':
-      return { ...state, accountName: action.accountName };
-    case 'setAutoHideMenuBar':
-      return { ...state, autoHideMenuBar: action.autoHideMenuBar };
-    case 'setFocusMode':
-      return { ...state, focusModeEnabled: action.focusModeEnabled };
-    case 'setFontSize':
-      return {
-        ...state,
-        fontSize: clamp(action.fontSize || initialState.fontSize, 10, 30),
-      };
-    case 'setLineLength':
-      return { ...state, lineLength: action.lineLength };
-    case 'SET_SYSTEM_TAG':
-      return 'markdown' === action.tagName
-        ? { ...state, markdownEnabled: action.shouldHaveTag }
-        : state;
-    case 'setNoteDisplay':
-      return { ...state, noteDisplay: action.noteDisplay };
-    case 'setSortReversed':
-      return { ...state, sortReversed: action.sortReversed };
-    case 'setSortTagsAlpha':
-      return { ...state, sortTagsAlpha: action.sortTagsAlpha };
-    case 'setSortType':
-      return { ...state, sortType: action.sortType };
-    case 'setSpellCheck':
-      return { ...state, spellCheckEnabled: action.spellCheckEnabled };
-    case 'setTheme':
-      return { ...state, theme: action.theme };
+      return action.accountName;
     default:
       return state;
   }
 };
 
-export default reducer;
+const autoHideMenuBar: A.Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'setAutoHideMenuBar':
+      return action.autoHideMenuBar;
+    default:
+      return state;
+  }
+};
+
+const focusModeEnabled: A.Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'setFocusMode':
+      return action.focusModeEnabled;
+    default:
+      return state;
+  }
+};
+
+const fontSize: A.Reducer<number> = (state = 16, action) => {
+  switch (action.type) {
+    case 'setFontSize':
+      return clamp(action.fontSize || 16, 10, 30);
+    default:
+      return state;
+  }
+};
+
+const lineLength: A.Reducer<T.LineLength> = (state = 'narrow', action) => {
+  switch (action.type) {
+    case 'setLineLength':
+      return action.lineLength;
+    default:
+      return state;
+  }
+};
+
+const markdownEnabled: A.Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'SET_SYSTEM_TAG':
+      if ('markdown' === action.tagName) {
+        return action.shouldHaveTag;
+      }
+      return state;
+    default:
+      return state;
+  }
+};
+
+const noteDisplay: A.Reducer<T.ListDisplayMode> = (state = 'comfy', action) => {
+  switch (action.type) {
+    case 'setNoteDisplay':
+      return action.noteDisplay;
+    default:
+      return state;
+  }
+};
+const sortReversed: A.Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'setSortReversed':
+      return action.sortReversed;
+    default:
+      return state;
+  }
+};
+const sortTagsAlpha: A.Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'setSortTagsAlpha':
+      return action.sortTagsAlpha;
+    default:
+      return state;
+  }
+};
+const sortType: A.Reducer<T.SortType> = (
+  state = 'modificationDate',
+  action
+) => {
+  switch (action.type) {
+    case 'setSortType':
+      return action.sortType;
+    default:
+      return state;
+  }
+};
+const spellCheckEnabled: A.Reducer<boolean> = (state = true, action) => {
+  switch (action.type) {
+    case 'setSpellCheck':
+      return action.spellCheckEnabled;
+    default:
+      return state;
+  }
+};
+const theme: A.Reducer<T.Theme> = (state = 'system', action) => {
+  switch (action.type) {
+    case 'setTheme':
+      return action.theme;
+    default:
+      return state;
+  }
+};
+const wpToken: A.Reducer<string | boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'setAccountName':
+      return action.accountName;
+    default:
+      return state;
+  }
+};
+
+export default combineReducers({
+  accountName,
+  autoHideMenuBar,
+  focusModeEnabled,
+  fontSize,
+  lineLength,
+  markdownEnabled,
+  noteDisplay,
+  sortReversed,
+  sortTagsAlpha,
+  sortType,
+  spellCheckEnabled,
+  theme,
+  wpToken,
+});

--- a/lib/state/settings/reducer.ts
+++ b/lib/state/settings/reducer.ts
@@ -114,12 +114,7 @@ const theme: A.Reducer<T.Theme> = (state = 'system', action) => {
   }
 };
 const wpToken: A.Reducer<string | boolean> = (state = false, action) => {
-  switch (action.type) {
-    case 'setAccountName':
-      return action.accountName;
-    default:
-      return state;
-  }
+  return state;
 };
 
 export default combineReducers({


### PR DESCRIPTION
### Fix

Due to the way the reducer was structured adding a setting that must initialize is difficult since in most cases if the user is logged in the reducer is already initialized.

So adding a default value of True for Keyboard Shortcuts is darn near impossible without adding code to initialize users for that value until we can be sure redux state is reinitialized.

### Test

1. Load app before checking out branch
2. Check out branch
3. Refresh
4. Does app work as intended?
5. Clear site data
6. Refresh
7. login
8. Play with settings
9. Do settings work?

