### PR TITLE
Add protection against insecure passwords

### DIFF
--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -92,8 +92,8 @@ export class Auth extends Component<Props> {
               >
                 reset
               </a>
-              . The password requirements are: Password cannot match email,
-              Between 8 and 64 characters, No new lines, and No tabs
+              . Passwords must be between 8 and 64 characters long and may not
+              include your email address, new lines, or tabs.
             </p>
           )}
           {this.props.hasInvalidCredentials && (

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -85,7 +85,10 @@ export class Auth extends Component<Props> {
               Your password is insecure and must be{' '}
               <a
                 className="login__reset"
-                href="https://app.simplenote.com/reset/"
+                href={
+                  'https://app.simplenote.com/reset/?email=' +
+                  encodeURIComponent(get(this.usernameInput, 'value'))
+                }
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={this.onForgot}

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -11,6 +11,7 @@ import { viewExternalUrl } from '../utils/url-utils';
 
 type OwnProps = {
   authPending: boolean;
+  hasInsecurePassword: boolean;
   hasInvalidCredentials: boolean;
   hasLoginError: boolean;
   login: (username: string, password: string) => any;
@@ -75,6 +76,25 @@ export class Auth extends Component<Props> {
           <h1>{buttonLabel}</h1>
           {!this.state.onLine && (
             <p className="login__auth-message is-error">Offline</p>
+          )}
+          {this.props.hasInsecurePassword && (
+            <p
+              className="login__auth-message is-error"
+              data-error-name="invalid-login"
+            >
+              Your password is insecure and must be
+              <a
+                className="login__reset"
+                href="https://app.simplenote.com/reset/"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={this.onForgot}
+              >
+                reset
+              </a>
+              . The password requirements are: Password cannot match email,
+              Between 8 and 64 characters, No new lines, and No tabs
+            </p>
           )}
           {this.props.hasInvalidCredentials && (
             <p

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -82,7 +82,7 @@ export class Auth extends Component<Props> {
               className="login__auth-message is-error"
               data-error-name="invalid-login"
             >
-              Your password is insecure and must be
+              Your password is insecure and must be{' '}
               <a
                 className="login__reset"
                 href="https://app.simplenote.com/reset/"

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -3,7 +3,7 @@ import { render } from 'react-dom';
 import { Auth as AuthApp } from './auth';
 import { Auth as SimperiumAuth } from 'simperium';
 import analytics from './analytics';
-import { validatePassword } from '../utils/validate-password';
+import { validatePassword } from './utils/validate-password';
 
 import getConfig from '../get-config';
 

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -3,6 +3,7 @@ import { render } from 'react-dom';
 import { Auth as AuthApp } from './auth';
 import { Auth as SimperiumAuth } from 'simperium';
 import analytics from './analytics';
+import { validatePassword } from '../utils/validate-password';
 
 import getConfig from '../get-config';
 
@@ -16,6 +17,7 @@ type State = {
   authStatus:
     | 'unsubmitted'
     | 'submitting'
+    | 'insecure-password'
     | 'invalid-credentials'
     | 'unknown-error';
 };
@@ -42,6 +44,9 @@ class AppWithoutAuth extends Component<Props, State> {
       auth
         .authorize(username, password)
         .then((user: User) => {
+          if (!validatePassword(password, username)) {
+            this.setState({ authStatus: 'insecure-password' });
+          }
           if (!user.access_token) {
             throw new Error('missing access token');
           }
@@ -96,6 +101,7 @@ class AppWithoutAuth extends Component<Props, State> {
       <div className={`app theme-${systemTheme}`}>
         <AuthApp
           authPending={this.state.authStatus === 'submitting'}
+          hasInsecurePassword={this.state.authStatus === 'insecure-password'}
           hasInvalidCredentials={
             this.state.authStatus === 'invalid-credentials'
           }

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -46,6 +46,7 @@ class AppWithoutAuth extends Component<Props, State> {
         .then((user: User) => {
           if (!validatePassword(password, username)) {
             this.setState({ authStatus: 'insecure-password' });
+            return;
           }
           if (!user.access_token) {
             throw new Error('missing access token');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplenote",
-  "version": "1.16.0-2073",
+  "version": "1.16.0-2078",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### Fix

If the user has a password that does not meet the strength requirements we are now displaying an error message that they need to reset their password.

### Test

1. Have insecure password (less than 8 characters)
2. In the electron app, try to login
3. Observe you are redirected to the reset form with email pre-filled

![Screen Shot 2020-05-15 at 2 27 41 PM](https://user-images.githubusercontent.com/6817400/82085310-ce73cb00-96ba-11ea-87f0-75cf01c7dd61.jpg)

