### PR TITLE
Fixes autocomplete filling search field with username

### DIFF
--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -79,6 +79,7 @@ export class SearchField extends Component<Props> {
       <div className="search-field">
         <input
           aria-label={screenReaderLabel}
+          autoComplete="off"
           ref={this.inputField}
           type="text"
           placeholder={placeholder}

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -79,9 +79,8 @@ export class SearchField extends Component<Props> {
       <div className="search-field">
         <input
           aria-label={screenReaderLabel}
-          autoComplete="off"
           ref={this.inputField}
-          type="text"
+          type="search"
           placeholder={placeholder}
           onChange={this.update}
           onKeyUp={this.interceptEsc}


### PR DESCRIPTION
### Fix

User reported in https://github.com/Automattic/simplenote-electron/issues/2011 that the search field was getting autopopulated with their username in Firefox.

I was not able to replicate but I do not see why this would have a negative impact

### Test

1. Cannot replicate bug
