### PR TITLE
Update keyboard shortcut hints/tooltips

### DIFF
--- a/desktop/menus/file-menu.js
+++ b/desktop/menus/file-menu.js
@@ -5,6 +5,7 @@ const { appCommandSender } = require('./utils');
 const submenu = [
   {
     label: '&New Note',
+    accelerator: 'CommandOrControl+Shift+I',
     click: appCommandSender({ action: 'newNote' }),
   },
   { type: 'separator' },

--- a/lib/search-bar/index.tsx
+++ b/lib/search-bar/index.tsx
@@ -48,14 +48,14 @@ export const SearchBar: Component<Props> = ({
     <IconButton
       icon={<MenuIcon />}
       onClick={toggleNavigation}
-      title="Menu • Ctrl+Shift+T"
+      title="Menu • Ctrl+Shift+U"
     />
     <SearchField />
     <IconButton
       disabled={showTrash}
       icon={<NewNoteIcon />}
       onClick={() => onNewNote(withoutTags(searchQuery))}
-      title="New Note • Ctrl+Shift+N"
+      title="New Note • Ctrl+Shift+I"
     />
   </div>
 );


### PR DESCRIPTION
### Fix

See #2106 

This PR updates the new note and menu tooltips to match the new keyboard shortcuts introduced in #2080 and #2079. It also adds a keyboard shortcut hint to the menu under File > New Note.

As discussed on that issue, there isn't any update to the debugging console shortcut/hint.

### Test

1. Open the File menu and confirm the correct keyboard shortcut appears for the New Note action.
2. Hover over the Menu icon and confirm the correct keyboard shortcut appears to toggle the sidebar menu.
3. Hover over the New Note icon and confirm the correct keyboard shortcut appears to create a new note.

### Release

No release notes needed for this change. I've targeted the `release/1.17` branch, which contains the changes to these shortcuts.