### PR TITLE
Remove duplicate selectNote dispatch declaration

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -98,7 +98,6 @@ const mapDispatchToProps: S.MapDispatch<
     focusSearchField: () => dispatch(actions.ui.focusSearchField()),
     setSimperiumConnectionStatus: (connected) =>
       dispatch(toggleSimperiumConnectionStatus(connected)),
-    selectNote: (note) => dispatch(actions.ui.selectNote(note)),
     setUnsyncedNoteIds: (noteIds) => dispatch(setUnsyncedNoteIds(noteIds)),
     showDialog: (dialog) => dispatch(actions.ui.showDialog(dialog)),
     trashNote: (previousIndex) => dispatch(actions.ui.trashNote(previousIndex)),


### PR DESCRIPTION
### Fix

selectNote is already declared on L97 

### Test

1. Build app
2. Test that app loads and selections in the note list work