### PR TITLE
Remove loadAndSelectNote from app-state

### DIFF
--- a/lib/flux/app-state.ts
+++ b/lib/flux/app-state.ts
@@ -119,16 +119,6 @@ export const actionMap = new ActionMap({
       });
     },
 
-    loadAndSelectNote: {
-      creator({ noteBucket, noteId, hasRemoteUpdate = false }) {
-        return (dispatch) => {
-          noteBucket.get(noteId, (e, note) => {
-            dispatch(actions.ui.selectNote(note, { hasRemoteUpdate }));
-          });
-        };
-      },
-    },
-
     /**
      * A note is being changed from somewhere else! If the same
      * note is also open and being edited, we need to make sure

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -160,14 +160,6 @@ type LegacyAction =
       }
     >
   | Action<
-      'App.loadAndSelectNote',
-      {
-        noteBucket: T.Bucket<T.Note>;
-        noteId: T.EntityId;
-        hasRemoteUpdate: boolean;
-      }
-    >
-  | Action<
       'App.loadPreferences',
       { callback?: Function; preferencesBucket: T.Bucket<T.Preferences> }
     >


### PR DESCRIPTION
### Fix

Removes unused app-state action. It is not referenced anywhere in the code.

### Test

1. Does app run as expected?
2. Does app build as expected?
