### PR TITLE
Update: Passwords can contain but not equal email, remove max character limit

### DIFF
--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -358,7 +358,7 @@ export class Auth extends Component<Props> {
     if (!validatePassword(password, username)) {
       this.setState({
         passwordErrorMessage:
-          'Sorry, that password is not strong enough. Passwords must be at least 8 characters long and may not include your email address.',
+          'Sorry, that password is not strong enough. Passwords must be at least 8 characters long and may not be the same as your email address.',
       });
       return;
     }

--- a/lib/utils/validate-password/index.ts
+++ b/lib/utils/validate-password/index.ts
@@ -1,10 +1,10 @@
 export const validatePassword = function (password: string, email: string) {
-  // does not contain username (i.e. email address)
-  if (email !== '' && password.includes(email)) {
+  // does not equal username (i.e. email address)
+  if (password === email) {
     return false;
   }
-  // minimum of 8 characters, max of 64
+  // minimum of 8 characters
   // allow symbols ~!@#$%^&*_-+=`|(){}[]:;"',.?/
-  const re = /^[a-zA-Z0-9~ !@#$%^&*_\-+=`|()[\]:;"',.?/]{8,64}$/;
+  const re = /^[a-zA-Z0-9~ !@#$%^&*_\-+=`|()[\]:;"',.?/]{8,}$/;
   return re.test(password);
 };

--- a/lib/utils/validate-password/test.ts
+++ b/lib/utils/validate-password/test.ts
@@ -1,26 +1,21 @@
 import { validatePassword } from './';
 
-describe('validatePaswword', () => {
+describe('validatePassword', () => {
   it('should return false for password that is too short', () => {
     expect(validatePassword('foo', 'bar@bang.com')).toBeFalsy();
   });
 
-  it('should return false for password that contains email that would otherwise be valid', () => {
-    expect(
-      validatePassword(
-        'bar@bang.com*xz8-X6uskm8ZjhLXvTTw2m8YxgvgujuWpEqUqqdT!H4',
-        'bar@bang.com'
-      )
-    ).toBeFalsy();
+  it('should return false for password that equals email that would otherwise be valid', () => {
+    expect(validatePassword('bar@bang.com', 'bar@bang.com')).toBeFalsy();
   });
 
-  it('should return false for password that is more than 64 characters', () => {
+  it('should return true for password that is more than 64 characters', () => {
     expect(
       validatePassword(
         'y93HywVqX6sXbsyZiAAZ*xz8-X6uskm8ZjhLXvTTw2m8YxgvgujuWpEqUqqdT!H41111',
         'bar@bang.com'
       )
-    ).toBeFalsy();
+    ).toBeTruthy();
   });
 
   it('should return true for password that is numbers only', () => {


### PR DESCRIPTION
### Fix

Passwords can contain the email but cannot equal it (this avoids copy-paste errors). No max length.

### Test

1. Run `make test`
2. Try to sign up with a password the same as email, should fail
3. Try to sign up with a password that includes email but is otherwise valid, should succeed
4. Try to sign up with a password over 64 characters long, should succeed

### Release

Release notes not required, since this is a minor update to a change already listed in this release.