### PR TITLE
Allow all special characters in passwords

### DIFF
--- a/lib/utils/validate-password/index.ts
+++ b/lib/utils/validate-password/index.ts
@@ -6,6 +6,6 @@ export const validatePassword = function (password: string, email: string) {
 
   // minimum of 8 characters; no tabs or newlines
   // (letters, numbers, special characters and spaces allowed)
-  var re = /^[^\r\n\t]{8,}$/;
+  const re = /^[^\r\n\t]{8,}$/;
   return re.test(password);
 };

--- a/lib/utils/validate-password/index.ts
+++ b/lib/utils/validate-password/index.ts
@@ -6,6 +6,6 @@ export const validatePassword = function (password: string, email: string) {
 
   // minimum of 8 characters; no tabs or newlines
   // (letters, numbers, special characters and spaces allowed)
-  var re = /^[^\n\t]{8,}$/;
+  var re = /^[^\r\n\t]{8,}$/;
   return re.test(password);
 };

--- a/lib/utils/validate-password/index.ts
+++ b/lib/utils/validate-password/index.ts
@@ -3,8 +3,9 @@ export const validatePassword = function (password: string, email: string) {
   if (password === email) {
     return false;
   }
-  // minimum of 8 characters
-  // allow symbols ~!@#$%^&*_-+=`|(){}[]:;"',.?/
-  const re = /^[a-zA-Z0-9~ !@#$%^&*_\-+=`|()[\]:;"',.?/]{8,}$/;
+
+  // minimum of 8 characters; no tabs or newlines
+  // (letters, numbers, special characters allowed)
+  var re = /^[^\n\t]{8,}$/;
   return re.test(password);
 };

--- a/lib/utils/validate-password/index.ts
+++ b/lib/utils/validate-password/index.ts
@@ -5,7 +5,7 @@ export const validatePassword = function (password: string, email: string) {
   }
 
   // minimum of 8 characters; no tabs or newlines
-  // (letters, numbers, special characters allowed)
+  // (letters, numbers, special characters and spaces allowed)
   var re = /^[^\n\t]{8,}$/;
   return re.test(password);
 };

--- a/lib/utils/validate-password/test.ts
+++ b/lib/utils/validate-password/test.ts
@@ -44,4 +44,10 @@ describe('validatePassword', () => {
       )
     ).toBeTruthy();
   });
+
+  it('should allow all special characters', () => {
+    expect(
+      validatePassword('~ !@#$%^&*_-+=`|(){}[]:;"\',.?/', 'bar@bang.com')
+    ).toBeTruthy();
+  });
 });


### PR DESCRIPTION
### Fix

Change regex from inclusive (listing allowed characters) to exclusive (only disallowing tabs and newlines). Also adds a test for symbols.

### Test

1. `make test`
2. Try to sign up with a variety of passwords

### Release

No release notes required