### PR TITLE
Fix note selection

### DIFF
--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -228,28 +228,15 @@ export class NoteList extends Component<Props> {
       heightCache.clearAll();
     }
 
-    // reselect when a note is removed
-    if (
-      !this.props.selectedNote &&
-      this.state.selectedIndex !== null &&
-      this.props.notes[this.state.selectedIndex]
-    ) {
-      this.props.onSelectNote(this.props.notes[this.state.selectedIndex]);
-    }
-
     // reselect when a note should be removed
     if (
-      this.props.selectedNote &&
-      this.props.selectedNote.data.deleted !== this.props.showTrash &&
+      prevProps.selectedNote &&
+      prevProps.selectedNote.data.deleted &&
+      prevProps.selectedNote.data.deleted !== this.props.showTrash &&
       this.state.selectedIndex &&
       this.props.notes[this.state.selectedIndex]
     ) {
       this.props.onSelectNote(this.props.notes[this.state.selectedIndex]);
-    } else if (
-      this.props.selectedNote &&
-      this.props.selectedNote.data.deleted !== this.props.showTrash
-    ) {
-      this.props.onSelectNote(this.props.notes[0]);
     }
   }
 
@@ -363,7 +350,7 @@ export class NoteList extends Component<Props> {
 
     const specialRows = compositeNoteList.length - notes.length;
     const highlightedIndex =
-      selectedIndex !== null ? selectedIndex + specialRows : 0;
+      selectedIndex !== null ? selectedIndex + specialRows : null;
 
     const renderNoteRow = renderNote(compositeNoteList, {
       searchQuery,

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -222,7 +222,8 @@ export class NoteList extends Component<Props> {
       prevProps.tagResultsFound !== this.props.tagResultsFound ||
       prevProps.selectedNoteContent !== this.props.selectedNoteContent ||
       prevProps.showNoteList !== this.props.showNoteList ||
-      prevProps.searchQuery !== this.props.searchQuery
+      prevProps.searchQuery !== this.props.searchQuery ||
+      prevProps.showTrash !== this.props.showTrash
     ) {
       heightCache.clearAll();
     }
@@ -244,6 +245,11 @@ export class NoteList extends Component<Props> {
       this.props.notes[this.state.selectedIndex]
     ) {
       this.props.onSelectNote(this.props.notes[this.state.selectedIndex]);
+    } else if (
+      this.props.selectedNote &&
+      this.props.selectedNote.data.deleted !== this.props.showTrash
+    ) {
+      this.props.onSelectNote(this.props.notes[0]);
     }
   }
 

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -96,7 +96,7 @@ const renderNote = (
     noteDisplay: T.ListDisplayMode;
     highlightedIndex: number;
     onPinNote: DispatchProps['onPinNote'];
-    openNote: DispatchProps['openNote'];
+    openNote: (index: number) => any;
   }
 ): ListRowRenderer => ({ index, key, parent, style }) => {
   const note = notes[index];
@@ -156,7 +156,7 @@ const renderNote = (
         <div
           className="note-list-item-text theme-color-border"
           tabIndex={0}
-          onClick={() => openNote(note)}
+          onClick={() => openNote(index)}
         >
           <div className="note-list-item-title">
             <span>{decorateWith(decorators, title)}</span>
@@ -215,86 +215,47 @@ export class NoteList extends Component<Props> {
     this.toggleShortcuts(true);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: Props): void {
-    const {
-      notes,
-      noteDisplay,
-      openedTag,
-      selectedNote,
-      selectedNoteContent,
-      showNoteList,
-      showTrash,
-      tagResultsFound,
-    } = nextProps;
-    const { selectedIndex } = this.state;
-
-    if (
-      noteDisplay !== this.props.noteDisplay ||
-      notes !== this.props.notes ||
-      tagResultsFound !== this.props.tagResultsFound ||
-      selectedNoteContent !== this.props.selectedNoteContent ||
-      showNoteList !== this.props.showNoteList
-    ) {
-      heightCache.clearAll();
-    }
-
-    // jump to top of note list
-    if (
-      openedTag !== this.props.openedTag ||
-      showTrash !== this.props.showTrash
-    ) {
-      const hasNotes = notes.length > 0;
-      this.setState({ selectedIndex: hasNotes ? 0 : null });
-      this.props.onSelectNote(hasNotes ? notes[0] : null);
-      return;
-    }
-
-    if (notes.length === 0 && selectedNote) {
-      // unselect active note if it doesn't match search
-      this.props.closeNote();
-      this.setState({ selectedIndex: null });
-    }
-
-    // nothing has changed, so don't change anything
-    if (
-      selectedIndex &&
-      selectedNote &&
-      notes[selectedIndex]?.id === selectedNote.id &&
-      showTrash === this.props.showTrash &&
-      openedTag === this.props.openedTag
-    ) {
-      return;
-    }
-
-    const nextIndex = this.getHighlightedIndex(nextProps);
-
-    if (null === nextIndex) {
-      return this.setState({ selectedIndex: null });
-    }
-
-    if (
-      notes.length &&
-      (!selectedNote || selectedNote.id !== notes[nextIndex]?.id)
-    ) {
-      // select the note that should be selected, if it isn't already
-      this.props.onSelectNote(
-        notes[Math.max(0, Math.min(notes.length - 1, nextIndex))]
-      );
-    }
-
-    this.setState({ selectedIndex: nextIndex });
-  }
-
   componentDidUpdate(prevProps: Props) {
     if (
       prevProps.noteDisplay !== this.props.noteDisplay ||
       prevProps.notes !== this.props.notes ||
       prevProps.tagResultsFound !== this.props.tagResultsFound ||
       prevProps.selectedNoteContent !== this.props.selectedNoteContent ||
-      prevProps.showNoteList !== this.props.showNoteList
+      prevProps.showNoteList !== this.props.showNoteList ||
+      prevProps.searchQuery !== this.props.searchQuery
     ) {
       heightCache.clearAll();
     }
+
+    // reselect when a note is removed
+    if (
+      !this.props.selectedNote &&
+      this.state.selectedIndex !== null &&
+      this.props.notes[this.state.selectedIndex]
+    ) {
+      this.props.onSelectNote(this.props.notes[this.state.selectedIndex]);
+    }
+
+    // reselect when a note should be removed
+    if (
+      this.props.selectedNote &&
+      this.props.selectedNote.data.deleted !== this.props.showTrash &&
+      this.state.selectedIndex &&
+      this.props.notes[this.state.selectedIndex]
+    ) {
+      this.props.onSelectNote(this.props.notes[this.state.selectedIndex]);
+    }
+  }
+
+  static getDerivedStateFromProps(props: Props) {
+    if (props.selectedNote) {
+      const noteAt = props.notes.findIndex(
+        ({ id }) => id === props.selectedNote!.id
+      );
+
+      return { selectedIndex: -1 === noteAt ? null : noteAt };
+    }
+    return {};
   }
 
   componentWillUnmount() {
@@ -307,32 +268,36 @@ export class NoteList extends Component<Props> {
     }
     const { ctrlKey, code, metaKey, shiftKey } = event;
     const { isSmallScreen, notes, showNoteList } = this.props;
-    const { selectedIndex: index } = this.state;
-
-    const highlightedIndex = this.getHighlightedIndex(this.props);
+    const { selectedIndex } = this.state;
 
     const cmdOrCtrl = ctrlKey || metaKey;
     if (cmdOrCtrl && shiftKey && code === 'KeyK') {
-      if (-1 === highlightedIndex || index < 0 || !notes[index - 1]?.id) {
-        return false;
+      if (!notes.length) {
+        this.setState({ selectedIndex: null });
+      } else {
+        const nextIndex =
+          selectedIndex !== null ? Math.max(0, selectedIndex - 1) : 0;
+        const nextNote = notes[nextIndex];
+        this.props.onSelectNote(nextNote);
       }
 
-      this.props.onSelectNote(notes[index - 1]);
       event.stopPropagation();
       event.preventDefault();
       return false;
     }
 
     if (cmdOrCtrl && shiftKey && code === 'KeyJ') {
-      if (
-        -1 === highlightedIndex ||
-        index >= notes.length ||
-        !notes[index + 1]?.id
-      ) {
-        return false;
+      if (!notes.length) {
+        this.setState({ selectedIndex: null });
+      } else {
+        const nextIndex =
+          selectedIndex !== null
+            ? Math.min(notes.length - 1, selectedIndex + 1)
+            : 0;
+        const nextNote = notes[nextIndex];
+        this.props.onSelectNote(nextNote);
       }
 
-      this.props.onSelectNote(notes[index + 1]);
       event.stopPropagation();
       event.preventDefault();
       return false;
@@ -350,9 +315,9 @@ export class NoteList extends Component<Props> {
       isSmallScreen &&
       showNoteList &&
       code === 'Enter' &&
-      highlightedIndex !== null
+      selectedIndex !== null
     ) {
-      this.props.openNote(notes[highlightedIndex]);
+      this.props.openNote(notes[selectedIndex]);
 
       event.stopPropagation();
       event.preventDefault();
@@ -368,45 +333,6 @@ export class NoteList extends Component<Props> {
     } else {
       window.removeEventListener('keydown', this.handleShortcut, true);
     }
-  };
-
-  getHighlightedIndex = (props: Props) => {
-    const { notes, selectedNote } = props;
-    const { selectedIndex: index } = this.state;
-
-    // Cases:
-    //   - the notes list is empty
-    //   - nothing has been selected -> select the first item if it exists
-    //   - the selected note matches the index -> use the index
-    //   - selected note is in the list -> use the index where it's found
-    //   - selected note isn't in the list -> previous index?
-
-    if (notes.length === 0) {
-      return null;
-    }
-
-    if (!selectedNote && !index) {
-      const firstNote = notes.findIndex((item) => item?.id);
-
-      return firstNote > -1 ? firstNote : null;
-    }
-
-    if (selectedNote && selectedNote.id === notes[index]?.id) {
-      return index;
-    }
-
-    const noteAt = notes.findIndex((item) => item?.id === selectedNote?.id);
-
-    if (selectedNote && noteAt > -1) {
-      return noteAt;
-    }
-
-    if (selectedNote) {
-      return Math.min(index, notes.length - 1); // different note, same index
-    }
-
-    // we have no selected note here, but we do have a previous index
-    return index;
   };
 
   render() {
@@ -431,14 +357,17 @@ export class NoteList extends Component<Props> {
 
     const specialRows = compositeNoteList.length - notes.length;
     const highlightedIndex =
-      selectedIndex !== null ? selectedIndex + specialRows : null;
+      selectedIndex !== null ? selectedIndex + specialRows : 0;
 
     const renderNoteRow = renderNote(compositeNoteList, {
       searchQuery,
       highlightedIndex,
       noteDisplay,
       onPinNote,
-      openNote,
+      openNote: (index: number) =>
+        this.setState({ selectedIndex: index - specialRows }, () =>
+          openNote(notes[index - specialRows])
+        ),
     });
 
     const isEmptyList = compositeNoteList.length === 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplenote",
-  "version": "1.17.0-beta1",
+  "version": "1.17.0-beta3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplenote",
-  "version": "1.17.0-beta3",
+  "version": "1.17.0-beta1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This work was mostly done by @dmsnell in https://github.com/Automattic/simplenote-electron/pull/2111

### Fix

This changes the selection logic to stop notes being unselected unintentionally.

### Test

1. Cycle through the app searching, trashing, un-trashing, delete forever, selecting trash, selecting tags
2. Is the selected note what you expect?
3. Is the height of items in the note list correct?

### Release

Fixed bug where notes could be unintentionally unselected.
