### PR TITLE
Add UNSAFE_ to deprecated React lifecycle methods

### DIFF
--- a/lib/editable-list/index.tsx
+++ b/lib/editable-list/index.tsx
@@ -41,14 +41,14 @@ export class EditableList extends Component<Props> {
     reorderingId: null,
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.setState({
       items: this.props.items,
       reorderedItems: this.props.items ? this.props.items.slice() : [],
     });
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     if (nextProps.items !== this.state.items) {
       this.stopReordering();
 

--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -75,7 +75,7 @@ export class NoteDetail extends Component<Props> {
 
   isValidNote = (note) => note && note.id;
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const isEditingNote = get(this.props, ['note', 'id'], false);
     if (isEditingNote === false) {
       return;

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -54,7 +54,7 @@ export class RevisionSelector extends Component<Props, ComponentState> {
     };
   }
 
-  componentWillReceiveProps({ revisions: nextRevisions }: Props) {
+  UNSAFE_componentWillReceiveProps({ revisions: nextRevisions }: Props) {
     const { revisions: prevRevisions } = this.props;
 
     if (nextRevisions === prevRevisions) {


### PR DESCRIPTION
### Fix

Adds UNSAFE_ to deprecated React lifecycle methods

### Test

No actual change here.