### PR TITLE
Enable system theme for Electron builds

### DIFF
--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -99,6 +99,10 @@ const buildViewMenu = (settings) => {
         label: 'T&heme',
         submenu: [
           {
+            label: '&System',
+            id: 'system',
+          },
+          {
             label: '&Light',
             id: 'light',
           },

--- a/lib/dialogs/settings/panels/display.tsx
+++ b/lib/dialogs/settings/panels/display.tsx
@@ -104,9 +104,7 @@ const DisplayPanel = (props) => {
         onChange={actions.activateTheme}
         renderer={RadioGroup}
       >
-        {navigator.userAgent.toLowerCase().indexOf(' electron/') === -1 && (
-          <Item title="System" slug="system" />
-        )}
+        <Item title="System" slug="system" />
         <Item title="Light" slug="light" />
         <Item title="Dark" slug="dark" />
       </SettingsGroup>


### PR DESCRIPTION
### Fix

When we added System theme (follow OS light/dark setting), the version of Electron didn't support it. As of Electron 7.0.0, it seems that it does:

https://www.electronjs.org/docs/tutorial/mojave-dark-mode-guide

This PR enables the System theme setting in both the menu bar and Settings dialog.

Will fix #2134 

### Test

1. Set Electron to "System" theme and verify that it changes to whatever the OS is set to
2. Change the OS setting and verify that Electron also changes to follow
3. Use the light/dark themes and make sure they don't change
4. We need to test this on Windows and Linux! I am not sure of the cross-platform support or if we need to be special-casing it.

### Review

It looks to me like we're not following the docs here and accessing this property via Electron's `nativeTheme` API:

https://www.electronjs.org/docs/api/native-theme

However, what we're doing appears to work fine, at least on OSX. Possibly @belcherj knows more.

### Release

Not updated: Add System theme for Electron builds