### PR TITLE
Update coloured elements to match new design guidelines

### DIFF
--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -88,7 +88,7 @@
 
   .login__signup a,
   .terms a {
-    color: $studio-simplenote-blue-60;
+    color: $studio-simplenote-blue-50;
     margin-left: 5px;
     text-decoration: none;
   }
@@ -151,7 +151,7 @@
 
   .login__signup a,
   .terms a {
-    color: $studio-simplenote-blue-20;
+    color: $studio-simplenote-blue-30;
   }
 
   .login__auth-message.is-error {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -101,7 +101,7 @@
     button {
       color: $studio-simplenote-blue-30;
     }
-    svg {
+    svg[class^='icon-'] {
       fill: $studio-simplenote-blue-30;
     }
   }


### PR DESCRIPTION
### Fix

After noticing that icons and text were slightly different colors under the old guidelines, @SylvesterWilmott simplified to using the same color for both colored elements and text. They should all be `simplenote-blue-50` in light mode and `simplenote-blue-30` in dark mode.

### Screenshots

<img width="222" alt="Screen Shot 2020-06-05 at 3 18 19 PM" src="https://user-images.githubusercontent.com/52152/83926844-e7165480-a73f-11ea-9d92-db8c3a9db8a2.png">

<img width="212" alt="Screen Shot 2020-06-05 at 3 18 06 PM" src="https://user-images.githubusercontent.com/52152/83926858-eda4cc00-a73f-11ea-9c06-40265e5c93fb.png">