### PR TITLE
Move commands out of makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,11 +64,6 @@ dev-server:
 
 	@NODE_ENV=$(NODE_ENV) npx webpack-dev-server --config ./webpack.config.js --content-base dist --host $(HOST) --port $(PORT) --hot
 
-.PHONY: test
-test:
-	@npx jest --config=./jest.config.js
-
-
 # Build web app
 .PHONY: build
 build:
@@ -162,11 +157,3 @@ config-release: config.json install
 .PHONY: rebuild-deps
 rebuild-deps:
 	@npx electron-rebuild -v $(ELECTRON_VERSION)
-
-.PHONY: format
-format:
-	@npx prettier --ignore-path .gitignore --write "**/*.{js,jsx,json,sass,ts,tsx}"
-
-.PHONY: lint
-lint:
-	@npx eslint --ignore-path .gitignore "**/*.{js,jsx,ts,tsx}"

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   "scripts": {
     "dev": "make dev",
     "start": "make start NODE_ENV=development",
-    "test-e2e": "npx jest --config=./jest.config.e2e.js --runInBand",
-    "test": "npx jest --config=./jest.config.js",
-    "lint": "npx eslint --ignore-path .gitignore '**/*.{js,jsx,ts,tsx}'",
-    "format": "npx prettier --ignore-path .gitignore --write '**/*.{js,jsx,json,sass,ts,tsx}'",
+    "test-e2e": "jest --config=./jest.config.e2e.js --runInBand",
+    "test": "jest --config=./jest.config.js",
+    "lint": "eslint --ignore-path .gitignore '**/*.{js,jsx,ts,tsx}'",
+    "format": "prettier --ignore-path .gitignore --write '**/*.{js,jsx,json,sass,ts,tsx}'",
     "build": "make build",
     "deploy": "./bin/deploy.sh"
   },

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "dev": "make dev",
     "start": "make start NODE_ENV=development",
     "test-e2e": "npx jest --config=./jest.config.e2e.js --runInBand",
-    "test": "make test",
-    "lint": "make lint",
-    "format": "make format",
+    "test": "npx jest --config=./jest.config.js",
+    "lint": "npx eslint --ignore-path .gitignore '**/*.{js,jsx,ts,tsx}'",
+    "format": "npx prettier --ignore-path .gitignore --write '**/*.{js,jsx,json,sass,ts,tsx}'",
     "build": "make build",
     "deploy": "./bin/deploy.sh"
   },


### PR DESCRIPTION
### Fix

There is no reason to have these commands in the makefile. Moving to the package.json where is it easy to quickly see what they are doing.

### Test

1. Test `npm run lint`
2. Test `npm run format`
3. Test `npm test`