### PR TITLE
Update: release notes canonical URL is on develop

### DIFF
--- a/desktop/config-updater.json
+++ b/desktop/config-updater.json
@@ -1,7 +1,7 @@
 {
   "updater": {
     "downloadUrl": "https://github.com/Automattic/simplenote-electron/releases/latest",
-    "changelogUrl": "https://github.com/Automattic/simplenote-electron/blob/master/RELEASE-NOTES.md",
+    "changelogUrl": "https://github.com/Automattic/simplenote-electron/blob/develop/RELEASE-NOTES.md",
     "apiUrl": "https://api.github.com/repos/automattic/simplenote-electron/releases/latest",
     "delay": 2000,
     "interval": 600000


### PR DESCRIPTION
Since we deprecated the `master` branch, this should point to `develop` for the changelog URL