### PR TITLE
Preview: Block internal links

### DIFF
--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -143,7 +143,12 @@ export class NoteDetail extends Component<Props> {
       // open markdown preview links in a new window
       if (node.tagName === 'A') {
         event.preventDefault();
-        viewExternalUrl(node.href);
+
+        // skip internal note links (e.g. anchor links, footnotes)
+        if (!node.href.startsWith('http://localhost')) {
+          viewExternalUrl(node.href);
+        }
+
         break;
       }
 


### PR DESCRIPTION
### Fix

Right now if you have a note with intra-note links (such as anchor tags) it will open a broken `localhost` link. This disallows those links from opening.

### Test

1. Create a Markdown note containing some relative links, e.g.`* [first section](#first)`
2. Preview
3. Try to click on the links. They should not do anything

### Release

Not updated: Prevent internal links from opening in a new browser window