### PR TITLE
Fix: App bootup fails in browser due to missing isElectron checks

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -127,12 +127,14 @@ export const App = connect(
     }
 
     componentDidMount() {
-      window.electron.receive('appCommand', this.onAppCommand);
-      window.electron.send(
-        'setAutoHideMenuBar',
-        this.props.settings.autoHideMenuBar
-      );
-      window.electron.send('settingsUpdate', this.props.settings);
+      if (isElectron) {
+        window.electron.receive('appCommand', this.onAppCommand);
+        window.electron.send(
+          'setAutoHideMenuBar',
+          this.props.settings.autoHideMenuBar
+        );
+        window.electron.send('settingsUpdate', this.props.settings);
+      }
 
       this.props.noteBucket
         .on('index', this.onNotesIndex)
@@ -178,7 +180,7 @@ export const App = connect(
     componentDidUpdate(prevProps) {
       const { settings } = this.props;
 
-      if (settings !== prevProps.settings) {
+      if (settings !== prevProps.settings && isElectron) {
         window.electron.send('settingsUpdate', settings);
       }
     }

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -127,14 +127,12 @@ export const App = connect(
     }
 
     componentDidMount() {
-      if (isElectron) {
-        window.electron.receive('appCommand', this.onAppCommand);
-        window.electron.send(
-          'setAutoHideMenuBar',
-          this.props.settings.autoHideMenuBar
-        );
-        window.electron.send('settingsUpdate', this.props.settings);
-      }
+      window.electron?.receive('appCommand', this.onAppCommand);
+      window.electron?.send(
+        'setAutoHideMenuBar',
+        this.props.settings.autoHideMenuBar
+      );
+      window.electron?.send('settingsUpdate', this.props.settings);
 
       this.props.noteBucket
         .on('index', this.onNotesIndex)
@@ -180,8 +178,8 @@ export const App = connect(
     componentDidUpdate(prevProps) {
       const { settings } = this.props;
 
-      if (settings !== prevProps.settings && isElectron) {
-        window.electron.send('settingsUpdate', settings);
+      if (settings !== prevProps.settings) {
+        window.electron?.send('settingsUpdate', settings);
       }
     }
 

--- a/lib/boot.ts
+++ b/lib/boot.ts
@@ -20,9 +20,7 @@ const clearStorage = () =>
     localStorage.removeItem('stored_user');
     indexedDB.deleteDatabase('ghost');
     indexedDB.deleteDatabase('simplenote');
-    if (isElectron) {
-      window.electron.send('clearCookies');
-    }
+    window.electron?.send('clearCookies');
 
     // let everything settle
     setTimeout(() => resolve(), 500);

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -109,9 +109,7 @@ class NoteContentEditor extends Component<Props> {
     this.props.storeHasFocus(this.hasFocus);
     this.editor.blur();
 
-    if (isElectron) {
-      window.electron.receive('appCommand', this.onAppCommand);
-    }
+    window.electron?.receive('appCommand', this.onAppCommand);
 
     window.addEventListener('keydown', this.handleKeydown, false);
   }


### PR DESCRIPTION
### Fix

Introduced in #2102. Right now loading in browser yields the following error: `TypeError: window.electron is undefined`

fyi @belcherj 