### PR TITLE
Fix: Render checkboxes on initial note load

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -123,6 +123,9 @@ class NoteContentEditor extends Component<Props> {
     }
 
     window.addEventListener('keydown', this.handleKeydown, false);
+
+    this.queueDecoratorUpdate();
+    this.queueDecoratorUpdate.flush();
   }
 
   handleEditorStateChange = (editorState) => {


### PR DESCRIPTION
### Fix

This fixes https://github.com/Automattic/simplenote-electron/issues/2141, an issue causing checkboxes to be rendered as plain-text when the note is first loaded.

However, I am pretty sure we deferred decorating the note for performance reasons so this may leave us in a bind. I'm not sure if `componentDidMount` is the best place to put this call.

### Test

1. Create a note with checkboxes (doesn't matter if it's a Markdown or plain-text note)
1. Close and re-open app
1. Open the note and verify that the checkboxes are rendered correctly

### Release

Not updated: Fixed an issue causing checkboxes to be rendered incorrectly when a note was first opened