### PR TITLE
Add Privacy Notice

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Updated all icons to use the new Simplenote Blue [#2158](https://github.com/Automattic/simplenote-electron/pull/2158)
+- Added Privacy Notice for California Users [#2177](https://github.com/Automattic/simplenote-electron/pull/2177)
 
 ### Fixes
 

--- a/lib/dialogs/about/index.tsx
+++ b/lib/dialogs/about/index.tsx
@@ -103,6 +103,15 @@ export class AboutDialog extends Component<Props> {
             <p>
               <a
                 target="_blank"
+                href="https://automattic.com/privacy/#california-consumer-privacy-act-ccpa"
+                rel="noopener noreferrer"
+              >
+                Privacy Notice for California Users
+              </a>
+            </p>
+            <p>
+              <a
+                target="_blank"
                 href="https://automattic.com/"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
### Fix

<img width="465" alt="Screen Shot 2020-06-29 at 4 41 08 PM" src="https://user-images.githubusercontent.com/6817400/86053981-5a517480-ba27-11ea-9fcb-de0a7cf2e831.png">

### Test

Click to the about page, do you see `Privacy Notice for California Users`
