### PR TITLE
Add notices to logged out screen

### DIFF
--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -209,6 +209,39 @@ export class Auth extends Component<Props> {
             </a>
           </p>
         </form>
+        <div className="footer">
+          <a
+            target="_blank"
+            href="https://simplenote.com/privacy/"
+            rel="noopener noreferrer"
+          >
+            Privacy Policy
+          </a>
+          &nbsp;&bull;&nbsp;
+          <a
+            target="_blank"
+            href="https://simplenote.com/terms/"
+            rel="noopener noreferrer"
+          >
+            Terms of Service
+          </a>
+          &nbsp;&bull;&nbsp;
+          <a
+            target="_blank"
+            href="https://automattic.com/privacy/#california-consumer-privacy-act-ccpa"
+            rel="noopener noreferrer"
+          >
+            Privacy Notice for California Users
+          </a>
+          &nbsp;&bull;&nbsp;
+          <a
+            target="_blank"
+            href="https://automattic.com/"
+            rel="noopener noreferrer"
+          >
+            &copy; {new Date().getFullYear()} Automattic, Inc.
+          </a>
+        </div>
       </div>
     );
   }

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -12,6 +12,16 @@
   }
 }
 
+.footer {
+  position: absolute;
+  bottom: 20px;
+  text-decoration: none;
+
+  a {
+    text-decoration: none;
+  }
+}
+
 .login {
   display: flex;
   flex: 1 1 auto;


### PR DESCRIPTION
### Fix
Not entirely sure that this is needed:

<img width="1032" alt="Screen Shot 2020-06-29 at 5 11 16 PM" src="https://user-images.githubusercontent.com/6817400/86057233-cda9b500-ba2c-11ea-8851-198ead76ab4a.png">


### Test

Open app to login screen, do you see footer.