### PR TITLE
Fix/search case sensitivity

### DIFF
--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -91,7 +91,7 @@ const renderNote = (
     ) : (
       <CellMeasurer
         cache={heightCache}
-        columnIndex={-3}
+        columnIndex={0}
         key="notes-header"
         parent={parent}
         rowIndex={index}

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -203,7 +203,7 @@ export const middleware: S.Middleware = (store) => {
 
       if (
         searchTerms.length > 0 &&
-        !searchTerms.every((term) => note.content.includes(term))
+        !searchTerms.every((term) => note.content.match(RegExp(term, 'gi')))
       ) {
         continue;
       }

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -203,7 +203,9 @@ export const middleware: S.Middleware = (store) => {
 
       if (
         searchTerms.length > 0 &&
-        !searchTerms.every((term) => note.content.match(RegExp(term, 'gi')))
+        !searchTerms.every((term) =>
+          note.content.includes(term.toLocaleLowerCase())
+        )
       ) {
         continue;
       }


### PR DESCRIPTION
### Fix

1. Fix: a search string containing uppercase letters would return no matches (e.g. "Markdown").
2. Fix: Some search results were hidden; react-virtualized was pushing them far to the right of the screen because of a negative column offset in a previous header.

See https://github.com/Automattic/simplenote-electron/pull/2148

### Test

Search for notes and ensure that all notes get matched and appear in the notes list properly.

### Follow-up tasks

There is still something funky with the note-list cache/renderer, I can't reproduce it consistently but occasionally I was able to get glitches like this:

<img width="333" alt="Screen Shot 2020-07-03 at 12 31 55 AM" src="https://user-images.githubusercontent.com/52152/86444132-28f5d480-bcc5-11ea-9023-2eaadaa93ad8.png">
