### PR TITLE
Fix: restore tag icons and scrolling

### DIFF
--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -10,6 +10,7 @@
   flex-direction: column;
   flex: 1 1 auto;
   overflow: hidden;
+  overflow-y: scroll;
 
   .tag-list-title {
     display: flex;
@@ -46,14 +47,14 @@
 .tag-list-items {
   flex: 1 1 auto;
   list-style: none;
-  //padding-inline-start: 20px;
+  padding-inline-start: 20px;
 }
 
 .tag-list-input {
   cursor: pointer;
   flex: 1 1 auto;
   display: block;
-  //width: 50px;
+  width: 50px;
   height: 2em;
   line-height: 2em;
   margin: 8px 0;


### PR DESCRIPTION
### Fix

Trash and reorder icons were invisible on Firefox and improperly-sized on Chrome. Restored commented-out styles to fix this.

n.b. If a width isn't set, the flex-box will grow out-of-bounds greedily, and the svgs will be resized to 0 width. This is fixable by telling flex not to shrink them (`flex-shrink: 0`). Setting an explicit width on the container removes the need for this by telling flex not to expand it beyond the sidebar.

I can't get overflow scrolling to work on just the `<ul>` for the tag list, I put it on the parent div for now. Someone who understands CSS should look at this. This at least makes it usable again.

See #2148 

### Test

1. Open tag sidebar
2. Verify you can scroll through tags
3. Click edit
4. Verify that icons are displayed to trash and reorder tags, and that they work
