### PR TITLE
Fix: Copy all html if nothing selected

### DIFF
--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -50,21 +50,13 @@ export const NotePreview: FunctionComponent<Props> = ({
 
       const div = document.createElement('div');
       renderToNode(div, note.content, searchQuery).then(() => {
-        // try {
-        /* this works in Chrome but not Firefox */
-        // event.clipboardData.setData('text/plain', div.innerHTML);
-        // } catch (DOMException) {
-        // console.log("that didn't work, trying something else");
-        /* try it the Firefox way - this works in Firefox and Chrome */
-        navigator.clipboard.writeText(div.innerHTML).then(
-          () => {
-            /* success */
-          },
-          () => {
-            console.log("it didn't work :(");
-          }
-        );
-        // }
+        try {
+          // this works in Chrome and Safari but not Firefox
+          event.clipboardData.setData('text/plain', div.innerHTML);
+        } catch (DOMException) {
+          // try it the Firefox way - this works in Firefox and Chrome
+          navigator.clipboard.writeText(div.innerHTML);
+        }
       });
 
       event.preventDefault();

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -48,22 +48,31 @@ export const NotePreview: FunctionComponent<Props> = ({
         return true;
       }
 
-      // const node = document.createDocumentFragment();
       const div = document.createElement('div');
-      renderToNode(div, note!.content, searchQuery);
-      // node.appendChild(div);
+      renderToNode(div, note.content, searchQuery).then(() => {
+        // try {
+        /* this works in Chrome but not Firefox */
+        // event.clipboardData.setData('text/plain', div.innerHTML);
+        // } catch (DOMException) {
+        // console.log("that didn't work, trying something else");
+        /* try it the Firefox way - this works in Firefox and Chrome */
+        navigator.clipboard.writeText(div.innerHTML).then(
+          () => {
+            /* success */
+          },
+          () => {
+            console.log("it didn't work :(");
+          }
+        );
+        // }
+      });
 
-      // TODO this is a bug
-      console.log(div); // innerHTML shows up here in console
-      console.log(div.innerHTML); // innerHTML is now an empty string???????
-
-      event.clipboardData.setData('text/plain', div.innerHTML);
       event.preventDefault();
     };
 
     document.addEventListener('copy', copyRenderedNote, false);
     return () => document.removeEventListener('copy', copyRenderedNote, false);
-  }, [isFocused]);
+  }, [isFocused, searchQuery]);
 
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -48,10 +48,10 @@ export const NotePreview: FunctionComponent<Props> = ({
         return true;
       }
 
-      const node = document.createDocumentFragment();
+      // const node = document.createDocumentFragment();
       const div = document.createElement('div');
       renderToNode(div, note!.content, searchQuery);
-      node.appendChild(div);
+      // node.appendChild(div);
 
       // TODO this is a bug
       console.log(div); // innerHTML shows up here in console

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -15,8 +15,7 @@ type OwnProps = {
 
 type StateProps = {
   fontSize: number;
-  isDialogOpen: boolean;
-  isNoteInfoOpen: boolean;
+  isFocused: boolean;
   note: T.Note | null;
   noteId: T.EntityId | null;
   searchQuery: string;
@@ -31,8 +30,7 @@ type Props = OwnProps & StateProps & DispatchProps;
 export const NotePreview: FunctionComponent<Props> = ({
   editNote,
   fontSize,
-  isDialogOpen,
-  isNoteInfoOpen,
+  isFocused,
   note,
   noteId,
   searchQuery,
@@ -41,11 +39,7 @@ export const NotePreview: FunctionComponent<Props> = ({
 
   useEffect(() => {
     const copyRenderedNote = (event: ClipboardEvent) => {
-      console.log(isNoteInfoOpen);
-      // TODO this isn't working - these are false when I log them, but in console they are true
-      // e.g. state.ui.showNoteInfo in console will print "true"
-      // Only copy if not viewing the note info panel or a dialog
-      if (isNoteInfoOpen || isDialogOpen) {
+      if (!isFocused) {
         return true;
       }
 
@@ -69,7 +63,7 @@ export const NotePreview: FunctionComponent<Props> = ({
 
     document.addEventListener('copy', copyRenderedNote, false);
     return () => document.removeEventListener('copy', copyRenderedNote, false);
-  }, []);
+  }, [isFocused]);
 
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
@@ -142,8 +136,7 @@ export const NotePreview: FunctionComponent<Props> = ({
 
 const mapStateToProps: S.MapState<StateProps, OwnProps> = (state, props) => ({
   fontSize: state.settings.fontSize,
-  isDialogOpen: state.ui.dialogs.length > 0,
-  isNoteInfoOpen: state.ui.showNoteInfo,
+  isFocused: state.ui.dialogs.length === 0 && !state.ui.showNoteInfo,
   note: props.note ?? state.data.notes.get(props.noteId),
   noteId: props.noteId ?? state.ui.openedNote,
   searchQuery: state.ui.searchQuery,

--- a/lib/note-detail/render-to-node.ts
+++ b/lib/note-detail/render-to-node.ts
@@ -39,7 +39,7 @@ export const renderToNode = (
   node: Element,
   content: string,
   searchQuery: string
-) => {
+) =>
   renderNoteToHtml(content)
     .then((html) => {
       node.innerHTML = html;
@@ -92,6 +92,5 @@ export const renderToNode = (
           .catch();
       }
     });
-};
 
 export default renderToNode;


### PR DESCRIPTION
### Fix

Copy all HTML from preview if nothing is selected.

See https://github.com/Automattic/simplenote-electron/blob/776002ead9548132de01142cfd888d25b1fa146d/lib/note-detail/index.tsx#L111

#2148

In porting this over I realized that the existing functionality doesn't work in Firefox and needed to use the Clipboard API instead. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard

### Test

1. Preview a Markdown note
2. Hit Ctrl+C to copy
3. Paste and verify it is in your clipboard
4. Test that you can still copy and paste a smaller selection
5. Test that it does not copy all content if not in preview mode
6. It should not copy all content if the note info or any dialogs are showing on top of the preview