### PR TITLE
show pointer cursor on checkboxes in the editor view

### DIFF
--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -81,6 +81,10 @@
     cursor: inherit;
   }
 
+  .checkbox {
+    cursor: pointer;
+  }
+
   &::first-line {
     font-size: 120%;
   }


### PR DESCRIPTION
### Fix

This PR adds a fix to show the `pointer` type cursor for checkboxes rendered in the editor view.

### Test

> 1. Create a new note with content that contains markdown style checkboxes. You can use the below as an example
```md
### Shopping List
- [ ] Teas
- [x] Brownie
- [x] Cookies
- [x] Notepad
```
> 2. The editor view should show a pointer icon over checkboxes. See below for an example of how this should look
 
![simplenote-cursor-fix](https://user-images.githubusercontent.com/21967563/86596435-d57ed180-bfb7-11ea-8d97-b09248f45cc3.gif)
