### PR TITLE
Use browser for authing a user via WP Login

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -22,18 +22,22 @@ const spellcheck = require('./spellchecker');
 require('module').globalPaths.push(path.resolve(path.join(__dirname)));
 
 module.exports = function main() {
+  // Keep a global reference of the window object, if you don't, the window will
+  // be closed automatically when the JavaScript object is GCed.
+  let mainWindow = null;
+
   app.on('will-finish-launching', function () {
     setTimeout(updater.ping.bind(updater), config.updater.delay);
+    app.on('open-url', function (event, url) {
+      event.preventDefault();
+      mainWindow.webContents.send('wpLogin', url);
+    });
   });
 
   const url =
     isDev && process.env.DEV_SERVER
       ? 'http://localhost:4000' // TODO: find a solution to use host and port based on make config.
       : 'file://' + path.join(__dirname, '..', 'dist', 'index.html');
-
-  // Keep a global reference of the window object, if you don't, the window will
-  // be closed automatically when the JavaScript object is GCed.
-  let mainWindow = null;
 
   const activateWindow = function () {
     // Only allow a single window
@@ -118,6 +122,10 @@ module.exports = function main() {
       mainWindow.setMenuBarVisibility(!autoHideMenuBar);
     });
 
+    ipcMain.on('wpLogin', function (event, url) {
+      shell.openExternal(url);
+    });
+
     mainWindowState.manage(mainWindow);
 
     mainWindow.webContents.on('new-window', function (event, linkUrl) {
@@ -165,6 +173,11 @@ module.exports = function main() {
 
   if (!gotTheLock) {
     return app.quit();
+  }
+
+  if (!app.isDefaultProtocolClient('simplenote')) {
+    // Define custom protocol handler. This allows for deeplinking into the app from simplenote://
+    app.setAsDefaultProtocolClient('simplenote');
   }
 
   // Quit when all windows are closed.

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -8,13 +8,14 @@ contextBridge.exposeInMainWorld('electron', {
       'clearCookies',
       'setAutoHideMenuBar',
       'settingsUpdate',
+      'wpLogin',
     ];
     if (validChannels.includes(channel)) {
       ipcRenderer.send(channel, data);
     }
   },
   receive: (channel, func) => {
-    let validChannels = ['appCommand'];
+    let validChannels = ['appCommand', 'wpLogin'];
     if (validChannels.includes(channel)) {
       // Deliberately strip event as it includes `sender`
       ipcRenderer.on(channel, (event, ...args) => {

--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -2,6 +2,9 @@ import React, { Component, Suspense } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 
+import NoteList from '../note-list';
+import NoteEditor from '../note-editor';
+
 import NoteToolbarContainer from '../note-toolbar-container';
 import NoteToolbar from '../note-toolbar';
 import RevisionSelector from '../revision-selector';
@@ -12,14 +15,6 @@ import actions from '../state/actions';
 
 import * as S from '../state';
 import * as T from '../types';
-
-const NoteList = React.lazy(() =>
-  import(/* webpackChunkName: 'note-list' */ '../note-list')
-);
-
-const NoteEditor = React.lazy(() =>
-  import(/* webpackChunkName: 'note-editor' */ '../note-editor')
-);
 
 type OwnProps = {
   isFocusMode: boolean;
@@ -100,37 +95,27 @@ export class AppLayout extends Component<Props> {
 
     const editorVisible = !(showNoteList && isSmallScreen);
 
-    const placeholder = (
-      <TransitionDelayEnter delay={1000}>
-        <div className="app-layout__placeholder">
-          <SimplenoteCompactLogo />
-        </div>
-      </TransitionDelayEnter>
-    );
-
     return (
       <div className={mainClasses}>
-        <Suspense fallback={placeholder}>
-          <div className="app-layout__source-column theme-color-bg theme-color-fg">
-            <SearchBar noteBucket={noteBucket} />
-            <NoteList noteBucket={noteBucket} isSmallScreen={isSmallScreen} />
+        <div className="app-layout__source-column theme-color-bg theme-color-fg">
+          <SearchBar noteBucket={noteBucket} />
+          <NoteList noteBucket={noteBucket} isSmallScreen={isSmallScreen} />
+        </div>
+        {editorVisible && (
+          <div className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border">
+            <RevisionSelector onUpdateContent={onUpdateContent} />
+            <NoteToolbarContainer
+              noteBucket={noteBucket}
+              toolbar={<NoteToolbar />}
+            />
+            <NoteEditor
+              isSmallScreen={isSmallScreen}
+              noteBucket={noteBucket}
+              onUpdateContent={onUpdateContent}
+              syncNote={syncNote}
+            />
           </div>
-          {editorVisible && (
-            <div className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border">
-              <RevisionSelector onUpdateContent={onUpdateContent} />
-              <NoteToolbarContainer
-                noteBucket={noteBucket}
-                toolbar={<NoteToolbar />}
-              />
-              <NoteEditor
-                isSmallScreen={isSmallScreen}
-                noteBucket={noteBucket}
-                onUpdateContent={onUpdateContent}
-                syncNote={syncNote}
-              />
-            </div>
-          )}
-        </Suspense>
+        )}
       </div>
     );
   };

--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -10,9 +10,11 @@ declare global {
     electron: {
       isMac: boolean;
       receive(command: 'appCommand', callback: (event: any) => any);
+      receive(command: 'wpLogin', callback: (event: any) => any);
       send(command: 'clearCookies'): void;
       send(command: 'setAutoHideMenuBar', newValue: boolean);
       send(command: 'settingsUpdate', settings: S.State['settings']);
+      send(command: 'wpLogin', url: string);
     };
     location: Location;
     testEvents: (string | [string, ...any[]])[];


### PR DESCRIPTION
Cherry-picked this [PR](https://github.com/Automattic/simplenote-electron/pull/2147) on top of the release. Approval on the PR was there.

See p2XJRt-1Y0-p2

### Fix

In order to pass the Windows store certification, we cannot do auth in the app. Instead, it needs to be pushed to a browser.

There is still uncertainty that this will resolve the issue with certification however this is the only solution that I can see as a path forward.

### Test

1. Run app
2. In Electron click the WordPress.com login button
3. Log in
4. Were you able to log in?