### PR TITLE
Update/offline badge

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -24,7 +24,6 @@ type OwnProps = {
 type StateProps = {
   autoHideMenuBar: boolean;
   hotkeysEnabled: boolean;
-  isOffline: boolean;
   isSmallScreen: boolean;
   lineLength: T.LineLength;
   showNavigation: boolean;
@@ -137,7 +136,6 @@ class AppComponent extends Component<Props> {
   render() {
     const {
       isDevConfig,
-      isOffline,
       lineLength,
       showNavigation,
       showNoteInfo,
@@ -159,7 +157,6 @@ class AppComponent extends Component<Props> {
     return (
       <div className={appClasses}>
         {isDevConfig && <DevBadge />}
-        {isOffline && <div className="dev-badge">OFFLINE</div>}
         <div className={mainClasses}>
           {showNavigation && <NavigationBar />}
           <AppLayout />
@@ -174,7 +171,6 @@ class AppComponent extends Component<Props> {
 const mapStateToProps: S.MapState<StateProps> = (state) => ({
   autoHideMenuBar: state.settings.autoHideMenuBar,
   hotkeysEnabled: state.settings.keyboardShortcuts,
-  isOffline: state.simperium.connectionStatus === 'offline',
   isSmallScreen: selectors.isSmallScreen(state),
   lineLength: state.settings.lineLength,
   showNavigation: state.ui.showNavigation,

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -64,7 +64,7 @@ export class NoteToolbar extends Component<Props> {
     ) : (
       <div className="note-toolbar">
         <div className="note-toolbar__column-left">
-          <div className="note-toolbar__button">
+          <div className="note-toolbar__button note-toolbar__button-sidebar">
             <IconButton
               icon={<SidebarIcon />}
               onClick={this.props.toggleFocusMode}

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -18,6 +18,7 @@ import * as T from '../types';
 type StateProps = {
   editMode: boolean;
   hasRevisions: boolean;
+  isOffline: boolean;
   markdownEnabled: boolean;
   note: T.Note | null;
 };
@@ -40,7 +41,7 @@ export class NoteToolbar extends Component<Props> {
   static displayName = 'NoteToolbar';
 
   render() {
-    const { note } = this.props;
+    const { isOffline, note } = this.props;
 
     return (
       <div className="note-toolbar-wrapper theme-color-border">
@@ -53,6 +54,7 @@ export class NoteToolbar extends Component<Props> {
     const {
       editMode,
       hasRevisions,
+      isOffline,
       markdownEnabled,
       note,
       toggleNoteInfo,
@@ -70,6 +72,7 @@ export class NoteToolbar extends Component<Props> {
             />
           </div>
         </div>
+        {isOffline && <div className="offline-badge">OFFLINE</div>}
         <div className="note-toolbar__column-right">
           <div className="note-toolbar__button note-toolbar-back">
             <IconButton
@@ -131,6 +134,7 @@ export class NoteToolbar extends Component<Props> {
             title="Back • Ctrl+Shift+L"
           />
         </div>
+        {isOffline && <div className="offline-badge">OFFLINE</div>}
         <div className="note-toolbar__column-right">
           <div className="note-toolbar__button">
             <button
@@ -159,12 +163,14 @@ export class NoteToolbar extends Component<Props> {
 const mapStateToProps: S.MapState<StateProps> = ({
   data,
   ui: { editMode, openedNote, selectedRevision },
+  simperium: { connectionStatus },
 }) => {
   const note = openedNote ? data.notes.get(openedNote) ?? null : null;
 
   return {
     editMode,
     hasRevisions: !!data.noteRevisions.get(openedNote)?.size,
+    isOffline: connectionStatus === 'offline',
     markdownEnabled: note?.systemTags.includes('markdown') || false,
     note,
   };

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -71,9 +71,6 @@ export class NoteToolbar extends Component<Props> {
               title="Toggle Sidebar"
             />
           </div>
-        </div>
-        {isOffline && <div className="offline-badge">OFFLINE</div>}
-        <div className="note-toolbar__column-right">
           <div className="note-toolbar__button note-toolbar-back">
             <IconButton
               icon={<BackIcon />}
@@ -81,6 +78,9 @@ export class NoteToolbar extends Component<Props> {
               title="Back • Ctrl+Shift+L"
             />
           </div>
+        </div>
+        {isOffline && <div className="offline-badge">OFFLINE</div>}
+        <div className="note-toolbar__column-right">
           {markdownEnabled && (
             <div className="note-toolbar__button">
               <IconButton

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -53,12 +53,16 @@
 }
 
 @media only screen and (max-width: $single-column) {
+  .offline-badge {
+    margin-right: 25px;
+  }
+
   .note-toolbar__column-left {
     display: none;
   }
 
   .note-toolbar__column-right {
-    width: 100%;
+    width: 80%;
     justify-content: space-between;
   }
 }

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -6,6 +6,24 @@
   border-bottom: 1px solid $studio-gray-5;
 }
 
+.note-toolbar-wrapper .offline-badge {
+  border: solid 1px $studio-gray-5;
+  border-radius: 2px;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.05);
+  color: $studio-gray-50;
+  font-size: 12px;
+  height: 24px;
+  margin-top: 16px;
+  text-align: center;
+  width: 64px;
+}
+
+.theme-dark .note-toolbar-wrapper .offline-badge {
+  border: solid 1px $studio-gray-80;
+  box-shadow: 0 2px 4px 0 rgba(255, 255, 255, 0.02);
+  color: $studio-gray-50;
+}
+
 .note-toolbar {
   display: flex;
   justify-content: space-between;

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -54,10 +54,10 @@
 
 @media only screen and (max-width: $single-column) {
   .offline-badge {
-    margin-right: 25px;
+    margin: 0 25px;
   }
 
-  .note-toolbar__column-left {
+  .note-toolbar__button-sidebar {
     display: none;
   }
 


### PR DESCRIPTION
### Fix

Moves the offline badge from the bottom right to the note toolbar.

On mobile and smaller screens the badge will look quite odd and will not be visible when the note list is open. I think we should consider leaving it where it is.

Design:
<img width="693" alt="Screen Shot 2020-07-14 at 4 05 58 PM" src="https://user-images.githubusercontent.com/6817400/87471194-f49ae600-c5eb-11ea-9b18-b5696e23c497.png">

This PR:
<img width="1081" alt="Screen Shot 2020-07-14 at 3 55 36 PM" src="https://user-images.githubusercontent.com/6817400/87471210-fb295d80-c5eb-11ea-89a0-653dbcaa664d.png">
<img width="1084" alt="Screen Shot 2020-07-14 at 3 55 53 PM" src="https://user-images.githubusercontent.com/6817400/87471215-fd8bb780-c5eb-11ea-9b41-50f504abcaa0.png">
<img width="354" alt="Screen Shot 2020-07-14 at 4 03 10 PM" src="https://user-images.githubusercontent.com/6817400/87471224-ff557b00-c5eb-11ea-94ea-69cdebc7c95f.png">


### Test

1. Load app
2. Turn off wifi
