### PR TITLE
Style the last synced indicator

### DIFF
--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -126,9 +126,8 @@ export class NoteEditor extends Component<Props> {
 
     return (
       <div className="note-editor theme-color-bg theme-color-fg">
-        <div>
-          Note last updated: {Math.floor((Date.now() - lastUpdated) / 1000)}s
-          ago ({new Date(lastUpdated).toLocaleTimeString()})
+        <div className="last-sync">
+          Last synced: {new Date(lastUpdated).toLocaleString()}
         </div>
         {editMode || !note.systemTags.includes('markdown') ? (
           <NoteDetail

--- a/lib/note-editor/style.scss
+++ b/lib/note-editor/style.scss
@@ -3,4 +3,11 @@
   flex-direction: column;
   flex: 1 0 auto;
   user-select: text;
+
+  .last-sync {
+    color: $studio-gray-50;
+    font-size: 14px;
+    margin-top: 11px;
+    text-align: center;
+  }
 }


### PR DESCRIPTION
### Fix

Design:
<img width="705" alt="Screen Shot 2020-07-14 at 4 20 11 PM" src="https://user-images.githubusercontent.com/6817400/87472426-e948ba00-c5ed-11ea-8746-41fc87ede09f.png">

This PR:
<img width="778" alt="Screen Shot 2020-07-14 at 4 17 53 PM" src="https://user-images.githubusercontent.com/6817400/87472440-eea60480-c5ed-11ea-8d95-590d3d02bd55.png">
<img width="772" alt="Screen Shot 2020-07-14 at 4 18 15 PM" src="https://user-images.githubusercontent.com/6817400/87472441-ef3e9b00-c5ed-11ea-88c1-91c407af4efd.png">

Note: The indicator is currently broken when you first open app since it doesn't have the last updated.

Another Note: How important is it that is say "Today". This is more difficult since it is not localized. The code here will put the date/time in a localized format.

### Test

1. Open a note
2. Observe the last synced indicator

