### PR TITLE
Update note list note status icons

### DIFF
--- a/lib/icons/attention.tsx
+++ b/lib/icons/attention.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function AlertIcon() {
+  return (
+    <svg
+      className="icon-attention"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+    >
+      <rect x="0" fill="none" width="16" height="16" />
+      <g>
+        <path d="M14.72,11.75,9.3,2.28a1.49,1.49,0,0,0-2.6,0L1.28,11.75A1.51,1.51,0,0,0,2.59,14H13.41A1.51,1.51,0,0,0,14.72,11.75ZM8,13a1,1,0,1,1,1-1A1,1,0,0,1,8,13ZM9,9A1,1,0,0,1,7,9V5A1,1,0,0,1,9,5Z" />
+      </g>
+    </svg>
+  );
+}

--- a/lib/icons/pinned.tsx
+++ b/lib/icons/pinned.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function PinnedIcon() {
+  return (
+    <svg
+      className="icon-pinned"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+    >
+      <rect x="0" fill="none" width="24" height="24" />
+      <g>
+        <path d="M21.93,10.56,13.44,2.07,12,3.49,13.44,4.9,10.16,8.19l-8.09.9L7.79,14.8,2.84,19.75l1.41,1.41L9.2,16.21l5.71,5.72.9-8.09,3.29-3.28L20.51,12Zm-8,2.37-.51,4.64-7-7,4.64-.51,3.79-3.79,2.83,2.83Z" />
+      </g>
+    </svg>
+  );
+}

--- a/lib/note-list/note-cell.tsx
+++ b/lib/note-list/note-cell.tsx
@@ -2,7 +2,9 @@ import React, { Component, CSSProperties } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 
+import AttentionIcon from '../icons/attention';
 import PublishIcon from '../icons/feed';
+import PinnedIcon from '../icons/pinned';
 import { decorateWith, makeFilterDecorator } from './decorators';
 import { getTerms } from '../utils/filter-notes';
 import { noteTitleAndPreview } from '../utils/note-utils';
@@ -86,25 +88,34 @@ export class NoteCell extends Component<Props> {
       'published-note': isPublished,
     });
 
+    const pinnerClasses = classNames('note-list-item-pinner', {
+      'note-list-item-pinned': isPinned,
+    });
+
     const decorators = getTerms(searchQuery).map(makeFilterDecorator);
 
     return (
       <div style={style} className={classes}>
-        <div
-          className="note-list-item-pinner"
-          tabIndex={0}
-          onClick={() => pinNote(noteId, !isPinned)}
-        />
+        <div className="note-list-item-status">
+          <div
+            className={pinnerClasses}
+            tabIndex={0}
+            onClick={() => pinNote(noteId, !isPinned)}
+          >
+            <PinnedIcon />
+          </div>
+          <div className="note-list-item-pending-changes">
+            {hasPendingChanges && <AttentionIcon />}
+          </div>
+        </div>
+
         <div
           className="note-list-item-text theme-color-border"
           tabIndex={0}
           onClick={() => openNote(noteId)}
         >
           <div className="note-list-item-title">
-            <span>
-              {hasPendingChanges && '⚠️ '}
-              {decorateWith(decorators, title)}
-            </span>
+            <span>{decorateWith(decorators, title)}</span>
             {isPublished && (
               <div className="note-list-item-published-icon">
                 <PublishIcon />

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -77,35 +77,33 @@
   padding-left: 8px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   font-family: 'Simplenote Tasks', sans-serif;
+  min-height: 64px;
 
-  .note-list-item-pinner {
-    flex: none;
+  .note-list-item-status {
+    padding: 11px 8px 0 0;
+  }
+
+  .note-list-item-pinner,
+  .note-list-item-pending-changes {
     height: 14px;
     width: 14px;
-    margin-right: 8px;
-    margin-top: 14px;
-    border-radius: 50%;
-
-    &:focus {
-      outline: none;
-    }
   }
 
-  &:hover .note-list-item-pinner {
-    box-shadow: inset 0 0 0 2px $studio-gray-10, inset 0 0 0 3px $studio-white;
-
-    &:hover {
-      background: $studio-gray-50;
-    }
+  .note-list-item-pinner {
+    color: transparent;
   }
 
-  &.note-list-item-pinned .note-list-item-pinner {
-    background: $studio-gray-80;
-    box-shadow: inset 0 0 0 2px $studio-gray-5, inset 0 0 0 3px $studio-white;
+  .note-list-item-pinner:hover {
+    color: $studio-simplenote-blue-50;
+  }
 
-    &:hover {
-      background: $studio-gray-10;
-    }
+  .note-list-item-pinner.note-list-item-pinned {
+    color: $studio-simplenote-blue-50;
+  }
+
+  .note-list-item-pending-changes {
+    color: $studio-orange-30;
+    margin-top: 10px;
   }
 
   .note-list-item-text {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -180,29 +180,12 @@
   }
 
   .note-list-item {
-    &.note-list-item-pinned .note-list-item-pinner {
-      background: $studio-white;
-      box-shadow: inset 0 0 0 2px $studio-gray-80,
-        inset 0 0 0 3px $studio-gray-80;
-
-      &:hover {
-        background: $studio-gray-80;
-      }
-    }
-
     &.note-list-item-selected {
       background: #2c3338;
     }
 
     .note-list-item-excerpt {
       color: $studio-gray-20;
-    }
-  }
-  &.note-list-item-selected .note-list-item-excerpt .note-list-item-pinner {
-    box-shadow: inset 0 0 0 2px $studio-gray-80, inset 0 0 0 3px $studio-gray-90;
-
-    &:hover {
-      background: $studio-gray-80;
     }
   }
 


### PR DESCRIPTION
### Fix

Notes:

1. When in condensed list mode or a note that does not have the content the icons took up too much space. I increased the minimum height to 64px; Another option would be to decrease the spacing between icons so that they fit.

Design:
![Screen Shot 2020-07-15 at 1 16 14 PM](https://user-images.githubusercontent.com/6817400/87575087-62ebb100-c69d-11ea-8d59-64b44cea3bbf.png)

This PR:

![NoteStatusIcons](https://user-images.githubusercontent.com/6817400/87575200-8e6e9b80-c69d-11ea-9881-ca14c0f525e1.gif)
![NoteStatusIconsDarkMode](https://user-images.githubusercontent.com/6817400/87575470-f8874080-c69d-11ea-8141-2e2258bef77d.gif)

### Test

- Open app
- Make a change, observe attention icon in the note list
- Hover over where the pin icon would observe it appears
- Click it, does it pin note?
- Do pinned notes show pin icon?
