### PR TITLE
Updates unsynced notes log out dialog

### DIFF
--- a/lib/dialog/index.tsx
+++ b/lib/dialog/index.tsx
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import CrossIcon from '../icons/cross';
+
 export class Dialog extends Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
@@ -41,7 +43,7 @@ export class Dialog extends Component {
                   className="button button-borderless"
                   onClick={onDone}
                 >
-                  {closeBtnLabel}
+                  <CrossIcon />
                 </button>
               )}
             </div>

--- a/lib/dialog/style.scss
+++ b/lib/dialog/style.scss
@@ -16,7 +16,7 @@
 .dialog-title-side {
   display: flex;
   flex: none;
-  width: 6.5em;
+  width: 3.5em;
 
   button {
     width: 100%;

--- a/lib/dialogs/logout-confirmation/index.tsx
+++ b/lib/dialogs/logout-confirmation/index.tsx
@@ -1,5 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
+
+import AttentionIcon from '../../icons/attention';
 import Dialog from '../../dialog';
 import { closeDialog } from '../../state/ui/actions';
 import { getUnconfirmedChanges } from '../../state/simperium/functions/unconfirmed-changes';
@@ -32,55 +34,44 @@ export class LogoutConfirmation extends Component<Props> {
 
     return (
       <div className="logoutConfirmation">
-        <Dialog onDone={closeDialog} title="Unsynchronized Notes Found">
-          <section>
-            <h1>Are you sure you want to logout?</h1>
-          </section>
+        <Dialog onDone={closeDialog} title="Unsynced Notes">
+          <p className="explanation">
+            {notes.size > 0
+              ? 'Logging out will delete any unsynced notes.'
+              : 'All notes have syncronized!'}
+          </p>
 
+          <p className="explanation-secondary">
+            {notes.size > 0 && 'Possibly unsynchronized notes'}
+          </p>
           {notes.size > 0 && (
-            <p className="explanation">
-              If you logout now Simplenote will not be able to remember any of
-              your unsynchronized changes. If you wait a few more seconds it
-              might catch up with the changes but if it doesn&apos;t you can
-              always export a copy of the notes with those changes just to be
-              safe.
-            </p>
+            <section className="change-list">
+              <ul>
+                {[...notes.entries()].map(([noteId, note]) => {
+                  const { title, preview } = noteTitleAndPreview(note);
+
+                  return (
+                    <li key={noteId}>
+                      <AttentionIcon />
+                      <span className="note-title">{title}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
           )}
-
-          <section className="change-list">
-            {notes.size > 0 ? (
-              <Fragment>
-                <h2>Possibly unsynchronized notes</h2>
-                <ul>
-                  {[...notes.entries()].map(([noteId, note]) => {
-                    const { title, preview } = noteTitleAndPreview(note);
-
-                    return (
-                      <li key={noteId}>
-                        <span className="note-title">{title}</span>
-                        {preview.replace(/\n/g, ' ¶ ')}
-                      </li>
-                    );
-                  })}
-                </ul>
-              </Fragment>
-            ) : (
-              <h2 style={{ textAlign: 'center' }}>
-                All notes have syncronized!
-              </h2>
-            )}
-          </section>
-
-          <section className="action-buttons">
-            <button onClick={reallyLogout}>
-              {notes.size > 0 ? 'Lose changes and logout' : 'Safely logout'}
-            </button>
-            <button onClick={closeDialog}>Don&apos;t logout yet</button>
+          {notes.size > 0 && (
             <button
+              className="export-unsyncronized"
               onClick={this.exportUnsyncedNotes}
-              disabled={notes.size === 0}
             >
               Export unsynchronized notes
+            </button>
+          )}
+
+          <section className="action-button">
+            <button className="log-out" onClick={reallyLogout}>
+              {notes.size > 0 ? 'Log out' : 'Safely log out'}
             </button>
           </section>
         </Dialog>

--- a/lib/dialogs/logout-confirmation/index.tsx
+++ b/lib/dialogs/logout-confirmation/index.tsx
@@ -34,31 +34,33 @@ export class LogoutConfirmation extends Component<Props> {
 
     return (
       <div className="logoutConfirmation">
-        <Dialog onDone={closeDialog} title="Unsynced Notes">
+        <Dialog onDone={closeDialog} title="Unsynchronized Notes">
           <p className="explanation">
             {notes.size > 0
-              ? 'Logging out will delete any unsynced notes.'
-              : 'All notes have syncronized!'}
+              ? 'Logging out will delete any unsynchronized notes.'
+              : 'All notes have synchronized!'}
           </p>
 
-          <p className="explanation-secondary">
-            {notes.size > 0 && 'Possibly unsynchronized notes'}
-          </p>
           {notes.size > 0 && (
-            <section className="change-list">
-              <ul>
-                {[...notes.entries()].map(([noteId, note]) => {
-                  const { title, preview } = noteTitleAndPreview(note);
+            <Fragment>
+              <p className="explanation-secondary">
+                Possibly unsynchronized notes
+              </p>
+              <section className="change-list">
+                <ul>
+                  {[...notes.entries()].map(([noteId, note]) => {
+                    const { title, preview } = noteTitleAndPreview(note);
 
-                  return (
-                    <li key={noteId}>
-                      <AttentionIcon />
-                      <span className="note-title">{title}</span>
-                    </li>
-                  );
-                })}
-              </ul>
-            </section>
+                    return (
+                      <li key={noteId}>
+                        <AttentionIcon />
+                        <span className="note-title">{title}</span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            </Fragment>
           )}
           {notes.size > 0 && (
             <button

--- a/lib/dialogs/logout-confirmation/style.scss
+++ b/lib/dialogs/logout-confirmation/style.scss
@@ -1,79 +1,83 @@
-.logoutConfirmation {
-  .dialog {
-    max-height: 600px;
-    max-width: 640px;
-    margin: auto;
+.logoutConfirmation .dialog {
+  max-width: 360px;
 
-    h1 {
-      font-size: 18px;
-      text-align: center;
+  .dialog-title-side:first-child {
+    display: none;
+  }
+
+  .dialog-title-text {
+    font-size: 16px;
+    font-weight: 600;
+    padding-left: 16px;
+    text-align: left;
+  }
+
+  .dialog-title-side svg {
+    height: 16px;
+    width: 16px;
+    color: $studio-gray-50;
+  }
+
+  .explanation,
+  .explanation-secondary {
+    font-size: 14px;
+    margin: 12px 0;
+    padding-left: 16px;
+  }
+
+  .explanation-secondary {
+    color: $studio-gray-50;
+  }
+
+  .change-list {
+    border-bottom: 1px solid #dcdcde;
+    border-top: 1px solid #dcdcde;
+
+    ul {
+      list-style: none;
+      padding: 6px 0 6px 17px;
+      margin: 0;
     }
 
-    h2 {
-      margin-left: 16px;
-      font-size: 16px;
+    li {
+      display: flex;
+      padding: 4px 0;
     }
 
-    p.explanation {
-      max-width: 90%;
-      margin: auto;
-      margin-bottom: 16px;
+    li span {
+      padding-left: 17px;
     }
 
-    section.change-list {
-      height: 60%;
-      max-height: 400px;
-      overflow-y: scroll;
-
-      ul {
-        list-style: none;
-      }
-
-      li {
-        max-width: 90%;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        margin-bottom: 8px;
-
-        .note-title {
-          color: $studio-blue;
-          margin-right: 6px;
-        }
-      }
+    .icon-attention {
+      color: $studio-orange-30;
+      height: 25px;
+      width: 19px;
     }
+  }
 
-    section.action-buttons {
-      margin: auto;
-      margin-top: 24px;
-      margin-bottom: 24px;
+  .export-unsyncronized {
+    color: $studio-simplenote-blue-50;
+    padding: 17px;
+    text-align: left;
+  }
 
-      button {
-        margin: 12px;
+  .action-button {
+    display: flex;
+    justify-content: flex-end;
 
-        background-color: $studio-blue;
-        padding: 2px 4px;
-        border-radius: 4px;
-        border: 1px solid $studio-blue;
-
-        &[disabled] {
-          opacity: 0.2;
-
-          &:hover {
-            background-color: $studio-blue;
-            border: 1px solid $studio-blue;
-          }
-        }
-
-        &:last-child {
-          margin-right: 0;
-        }
-
-        &:hover {
-          background-color: $studio-blue-30;
-          border: 1px solid $studio-blue-90;
-        }
-      }
+    .log-out {
+      border-radius: 4px;
+      background-color: #3361cc;
+      color: #ffffff;
+      font-size: 14px;
+      padding: 6px 12px;
+      margin: 14px 12px;
     }
+  }
+}
+
+.theme-dark .logoutConfirmation .dialog {
+  .change-list {
+    border-color: #2c3338;
   }
 }


### PR DESCRIPTION
### Fix

Notes:

- Font is off but I don't think we should change that here
- Much of this dialog is hardcoded css that should apply to all dialogs. I think this should wait till spring cleaning
- I did change "Close" to the "X" icon on all dialogs.
- Some of the line heights are off from a bug that stems from the editor font used to render checkboxes.

Design:

![Screen Shot 2020-07-15 at 2 54 59 PM](https://user-images.githubusercontent.com/6817400/87590730-4491af80-c6b5-11ea-9554-3519017fb2be.png)

This PR:

<img width="429" alt="Screen Shot 2020-07-15 at 4 03 51 PM" src="https://user-images.githubusercontent.com/6817400/87590748-4b202700-c6b5-11ea-907b-251d0a8192ac.png">
<img width="376" alt="Screen Shot 2020-07-15 at 4 05 07 PM" src="https://user-images.githubusercontent.com/6817400/87590751-4bb8bd80-c6b5-11ea-8d92-9fca6c033d24.png">
<img width="427" alt="Screen Shot 2020-07-15 at 4 05 34 PM" src="https://user-images.githubusercontent.com/6817400/87590754-4c515400-c6b5-11ea-9489-d2534d0c8646.png">

### Test

1. Turn off wifi
2. Make changes to a note
3. Try logging out. 
