### PR TITLE
Add beta invitation banner

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -9,6 +9,7 @@ import browserShell from './browser-shell';
 import NoteInfo from './note-info';
 import NavigationBar from './navigation-bar';
 import AppLayout from './app-layout';
+import BetaBar from './components/beta-bar';
 import DevBadge from './components/dev-badge';
 import DialogRenderer from './dialog-renderer';
 import exportZipArchive from './utils/export';
@@ -452,6 +453,7 @@ export const App = connect(
       return (
         <div className={appClasses}>
           {isDevConfig && <DevBadge />}
+          <BetaBar />
           <div className={mainClasses}>
             {showNavigation && <NavigationBar />}
             <AppLayout

--- a/lib/components/beta-bar/index.tsx
+++ b/lib/components/beta-bar/index.tsx
@@ -1,0 +1,17 @@
+import React, { useState } from 'react';
+import SmallCrossIcon from '../../icons/cross-small';
+
+const BetaBar = () => {
+  const [isVisible, setIsVisible] = useState(true);
+  return isVisible ? (
+    <div className="beta-bar">
+      You&lsquo;re invited to try Simplenote Beta.
+      <a href="https://staging.simplenote.com">Try it now.</a>
+      <a className="icon" onClick={() => setIsVisible(false)}>
+        <SmallCrossIcon />
+      </a>
+    </div>
+  ) : null;
+};
+
+export default BetaBar;

--- a/lib/components/beta-bar/index.tsx
+++ b/lib/components/beta-bar/index.tsx
@@ -2,35 +2,34 @@ import React, { useState } from 'react';
 import SmallCrossIcon from '../../icons/cross-small';
 import { isElectron } from '../../utils/platform';
 
+const loadOptOut = (): boolean => {
+  try {
+    const stored = localStorage.getItem('betaBannerDismissedAt');
+    const dismissedAt = stored ? parseInt(stored, 10) : -Infinity;
+
+    return (
+      isNaN(dismissedAt) || Date.now() - dismissedAt > 7 * 24 * 60 * 60 * 1000
+    );
+  } catch (e) {
+    return true;
+  }
+};
+
+const storeOptOut = () => {
+  try {
+    localStorage.setItem('betaBannerDismissedAt', Date.now().toString());
+  } catch (e) {
+    // pass
+  }
+};
+
 const BetaBar = () => {
-  const [isVisible, setIsVisible] = useState(true);
-
-  const shouldShowBanner = () => {
-    if (isElectron) {
-      return false;
-    }
-    try {
-      const stored = localStorage.getItem('betaBannerDismissedAt');
-      const dismissedAt = stored ? parseInt(stored, 10) : -Infinity;
-
-      return (
-        isNaN(dismissedAt) || Date.now() - dismissedAt > 7 * 24 * 60 * 60 * 1000
-      );
-    } catch (e) {
-      return true;
-    }
-  };
-
+  const [isVisible, setIsVisible] = useState(loadOptOut());
   const dismissBanner = () => {
-    setIsVisible(false);
-    try {
-      localStorage.setItem('betaBannerDismissedAt', Date.now().toString());
-    } catch (e) {
-      // pass
-    }
+    storeOptOut(), setIsVisible(false);
   };
 
-  return isVisible && shouldShowBanner() ? (
+  return !isElectron && isVisible ? (
     <div className="beta-bar">
       You&lsquo;re invited to try Simplenote Beta.
       <a href="https://staging.simplenote.com">Try it now.</a>

--- a/lib/components/beta-bar/index.tsx
+++ b/lib/components/beta-bar/index.tsx
@@ -5,11 +5,36 @@ import { isElectron } from '../../utils/platform';
 const BetaBar = () => {
   const [isVisible, setIsVisible] = useState(true);
 
-  return !isElectron && isVisible ? (
+  const shouldShowBanner = () => {
+    if (isElectron) {
+      return false;
+    }
+    try {
+      const stored = localStorage.getItem('betaBannerDismissedAt');
+      const dismissedAt = stored ? parseInt(stored, 10) : -Infinity;
+
+      return (
+        isNaN(dismissedAt) || Date.now() - dismissedAt > 7 * 24 * 60 * 60 * 1000
+      );
+    } catch (e) {
+      return true;
+    }
+  };
+
+  const dismissBanner = () => {
+    setIsVisible(false);
+    try {
+      localStorage.setItem('betaBannerDismissedAt', Date.now().toString());
+    } catch (e) {
+      // pass
+    }
+  };
+
+  return isVisible && shouldShowBanner() ? (
     <div className="beta-bar">
       You&lsquo;re invited to try Simplenote Beta.
       <a href="https://staging.simplenote.com">Try it now.</a>
-      <a className="icon" onClick={() => setIsVisible(false)}>
+      <a className="icon" onClick={dismissBanner}>
         <SmallCrossIcon />
       </a>
     </div>

--- a/lib/components/beta-bar/index.tsx
+++ b/lib/components/beta-bar/index.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import SmallCrossIcon from '../../icons/cross-small';
+import { isElectron } from '../../utils/platform';
 
 const BetaBar = () => {
   const [isVisible, setIsVisible] = useState(true);
-  return isVisible ? (
+
+  return !isElectron && isVisible ? (
     <div className="beta-bar">
       You&lsquo;re invited to try Simplenote Beta.
       <a href="https://staging.simplenote.com">Try it now.</a>

--- a/lib/components/beta-bar/index.tsx
+++ b/lib/components/beta-bar/index.tsx
@@ -26,7 +26,8 @@ const storeOptOut = () => {
 const BetaBar = () => {
   const [isVisible, setIsVisible] = useState(loadOptOut());
   const dismissBanner = () => {
-    storeOptOut(), setIsVisible(false);
+    storeOptOut();
+    setIsVisible(false);
   };
 
   return !isElectron && isVisible ? (

--- a/lib/components/beta-bar/style.scss
+++ b/lib/components/beta-bar/style.scss
@@ -1,0 +1,23 @@
+.beta-bar {
+  position: absolute;
+  width: 100%;
+  height: 36px;
+  bottom: 0;
+  box-shadow: 0 2px 7px 0 rgba(0, 0, 0, 0.2);
+  background-color: #3d3f41;
+  color: #fff;
+  text-align: center;
+  line-height: 32px;
+  z-index: 1;
+
+  a {
+    color: #fff !important;
+    margin-left: 5px;
+  }
+  svg {
+    position: absolute;
+    right: 12px;
+    bottom: 7px;
+    cursor: pointer;
+  }
+}

--- a/scss/_components.scss
+++ b/scss/_components.scss
@@ -1,6 +1,7 @@
 @import 'app-layout/style';
 @import 'auth/style';
 @import 'components/checkbox/style';
+@import 'components/beta-bar/style';
 @import 'components/dev-badge/style';
 @import 'components/panel-title/style';
 @import 'components/progress-bar/style';


### PR DESCRIPTION
### Fix

This adds a banner to the bottom of the page that links to the beta on staging.simplenote.com.

### Screenshots

<img width="795" alt="Screen Shot 2020-07-16 at 12 17 35 AM" src="https://user-images.githubusercontent.com/52152/87639435-20a48d00-c6fa-11ea-93ec-f73bc6aec8ef.png">

### Release

Not updated: Add beta invitation banner