### PR TITLE
Fix tag list CSS

### DIFF
--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -48,6 +48,7 @@
   list-style: none;
   padding-inline-start: 20px;
   overflow-y: scroll;
+  padding-right: 20px;
 }
 
 .tag-list-input {

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -18,6 +18,7 @@
     align-items: center;
     line-height: 1.25em;
     margin-bottom: 0.25em;
+    box-shadow: 0 1px 1px lightgray;
 
     h2 {
       margin-bottom: 0;
@@ -41,14 +42,34 @@
       opacity: 1;
     }
   }
+
+  &.tag-list-editing .tag-list-items {
+    padding-inline-start: 6px;
+  }
 }
 
 .tag-list-items {
   flex: 1 1 auto;
   list-style: none;
   padding-inline-start: 20px;
+  padding-inline-end: 16px;
+  padding-top: 0;
+  padding-bottom: 0;
   overflow-y: scroll;
-  padding-right: 20px;
+  margin: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+
+  svg {
+    cursor: pointer;
+  }
+
+  .icon-trash {
+    margin-right: 5px;
+    &:hover {
+      color: red;
+    }
+  }
 }
 
 .tag-list-input {

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -10,7 +10,6 @@
   flex-direction: column;
   flex: 1 1 auto;
   overflow: hidden;
-  overflow-y: scroll;
 
   .tag-list-title {
     display: flex;
@@ -48,6 +47,7 @@
   flex: 1 1 auto;
   list-style: none;
   padding-inline-start: 20px;
+  overflow-y: scroll;
 }
 
 .tag-list-input {


### PR DESCRIPTION
### Fix
* The tag list should scroll while still keeping the header and edit button visible. Follow-up to https://github.com/Automattic/simplenote-electron/pull/2183
* Add some padding on the right so long tags don't go right up to the edge and the grab icons aren't under the scrollbar
* Remove top/bottom margins from the tag list since we have a bit less space now
* Make trash icon turn red on hover
* Pointer cursors over trash and grab icons
* Added a shadow to the tag title (possibly controversial!! but I think it looks better when you're scrolling tags)

### Screenshots

<img width="214" alt="Screen Shot 2020-07-16 at 3 18 26 PM" src="https://user-images.githubusercontent.com/52152/87728388-d104a680-c777-11ea-88c0-d813ba98e410.png">
<img width="214" alt="Screen Shot 2020-07-16 at 3 18 29 PM" src="https://user-images.githubusercontent.com/52152/87728392-d4982d80-c777-11ea-8dde-5b4028a0acf8.png">
<img width="213" alt="Screen Shot 2020-07-16 at 3 18 30 PM" src="https://user-images.githubusercontent.com/52152/87728397-d6fa8780-c777-11ea-8b84-4f5f91d6356f.png">
