### PR TITLE
Fix scroll bars on narrow line length

### DIFF
--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -50,25 +50,17 @@
 .note-detail-markdown {
   width: 100%;
   height: 100%;
-  max-width: 780px;
-  padding: 24px;
   border: 0;
   line-height: 1.5em;
   font-size: 16px;
   color: $studio-gray-60;
   background: $studio-white;
+
   resize: none;
   -webkit-tap-highlight-color: transparent;
 
   &:focus {
     outline: none;
-  }
-}
-
-.is-line-length-full {
-  .note-detail-textarea,
-  .note-detail-markdown {
-    max-width: none;
   }
 }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -23,11 +23,23 @@
     height: 100%;
     width: 100%;
     margin: 0;
-    padding: 0;
     border: none;
     box-shadow: none;
     outline: none;
+    padding: 0 calc((100% - 768px) / 2);
     resize: none;
+  }
+
+  @media only screen and (max-width: 1400px) {
+    textarea {
+      padding: 0 10%;
+    }
+  }
+}
+
+.is-line-length-full {
+  .note-content-editor-shell textarea {
+    padding: 25px;
   }
 }
 


### PR DESCRIPTION
### Fix

When the narrow line length is set the scroll bar was not on the edge of the screen. This moves it back to the edge.

### Test

1. Have narrow line length set
2. Resize screen to multiple widths
3. Have wide line length set
4. Resize screen to multiple widths
