### PR TITLE
Display unknown in last updated when it is unknown

### DIFF
--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -124,11 +124,12 @@ export class NoteEditor extends Component<Props> {
 
     const isTrashed = !!note.deleted;
 
+    const lastUpdatedDate =
+      (lastUpdated && new Date(lastUpdated).toLocaleString()) || 'Unknown';
+
     return (
       <div className="note-editor theme-color-bg theme-color-fg">
-        <div className="last-sync">
-          Last synced: {new Date(lastUpdated).toLocaleString()}
-        </div>
+        <div className="last-sync">Last synced: {lastUpdatedDate}</div>
         {editMode || !note.systemTags.includes('markdown') ? (
           <NoteDetail
             storeFocusEditor={this.storeFocusEditor}

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -124,8 +124,9 @@ export class NoteEditor extends Component<Props> {
 
     const isTrashed = !!note.deleted;
 
-    const lastUpdatedDate =
-      (lastUpdated && new Date(lastUpdated).toLocaleString()) || 'Unknown';
+    const lastUpdatedDate = lastUpdated
+      ? new Date(lastUpdated).toLocaleString()
+      : 'Unknown';
 
     return (
       <div className="note-editor theme-color-bg theme-color-fg">


### PR DESCRIPTION
### Fix

Display unknown in the last synced indicator when we do not know when it was last synced.

<img width="183" alt="Screen Shot 2020-07-17 at 12 28 33 PM" src="https://user-images.githubusercontent.com/6817400/87809289-22b93980-c829-11ea-8655-3db77a3535e8.png">

### Test

1. Load app
2. Observe that the Last Synced displays unknown until you make an edit

