### PR TITLE
Removes bottom border in the tag list

### DIFF
--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -18,7 +18,6 @@
     align-items: center;
     line-height: 1.25em;
     margin-bottom: 0.25em;
-    box-shadow: 0 1px 1px lightgray;
 
     h2 {
       margin-bottom: 0;


### PR DESCRIPTION
### Fix

After:
<img width="220" alt="Screen Shot 2020-07-17 at 12 53 40 PM" src="https://user-images.githubusercontent.com/6817400/87811416-a88ab400-c82c-11ea-8839-fbda2f0ef2d2.png">

Before:
<img width="220" alt="Screen Shot 2020-07-17 at 12 53 59 PM" src="https://user-images.githubusercontent.com/6817400/87811417-a9234a80-c82c-11ea-8cb2-ec802f60af45.png">

### Test

1. Is the odd underline in the tags list removed? 

