### PR TITLE
Add loading state for analytics toggle

### DIFF
--- a/lib/dialogs/settings-group.tsx
+++ b/lib/dialogs/settings-group.tsx
@@ -10,6 +10,7 @@ export const SettingsGroup = ({
   slug: groupSlug,
   activeSlug,
   description,
+  isEnabled,
   onChange,
   learnMoreURL,
   renderer,
@@ -47,7 +48,8 @@ export const SettingsGroup = ({
                 groupSlug,
                 slug,
                 title,
-                isEnabled: slug === activeSlug,
+                isEnabled:
+                  isEnabled === undefined ? slug === activeSlug : isEnabled,
                 onChange,
               })}
             </div>

--- a/lib/dialogs/settings/panels/account.tsx
+++ b/lib/dialogs/settings/panels/account.tsx
@@ -56,6 +56,7 @@ const AccountPanel: FunctionComponent<Props> = ({
             title="Privacy"
             slug="shareAnalytics"
             activeSlug={analyticsEnabled ? 'enabled' : ''}
+            isEnabled={analyticsEnabled}
             description="Help us improve Simplenote by sharing usage data with our analytics tool."
             onChange={toggleAnalytics}
             learnMoreURL="https://automattic.com/cookies"

--- a/lib/dialogs/toggle-settings-group.tsx
+++ b/lib/dialogs/toggle-settings-group.tsx
@@ -1,11 +1,11 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, Fragment } from 'react';
 
 import ToggleControl from '../controls/toggle';
 
 type OwnProps = {
   groupSlug: string;
   slug: string;
-  isEnabled: boolean;
+  isEnabled: boolean | null;
   onChange: () => any;
 };
 
@@ -17,13 +17,19 @@ const ToggleGroup: FunctionComponent<Props> = ({
   isEnabled,
   onChange,
 }) => (
-  <ToggleControl
-    name={groupSlug}
-    value={slug}
-    id={`settings-field-${groupSlug}-${slug}`}
-    checked={isEnabled}
-    onChange={onChange}
-  />
+  <Fragment>
+    {isEnabled === null ? (
+      <span>Loading</span>
+    ) : (
+      <ToggleControl
+        name={groupSlug}
+        value={slug}
+        id={`settings-field-${groupSlug}-${slug}`}
+        checked={isEnabled}
+        onChange={onChange}
+      />
+    )}
+  </Fragment>
 );
 
 export default ToggleGroup;


### PR DESCRIPTION
### Fix

This adds the ability to have a null state for a toggle in the settings dialog. This enables us to display `Loading` if we do not have the analytics enabled value.

I don't love this as it makes the settings code murkier but we have a project to clean up settings in the backlog so I think it is appropriate to address how settings work at that time.

### Test

This is hard to test until Analytics is loaded back into the app. It will always display as loading.

1. Open Settings dialog.
2. Observe that the analytics toggle does not display and that you see 'Loading'

