### PR TITLE
Fixes missing ids in note export

### DIFF
--- a/lib/dialogs/logout-confirmation/index.tsx
+++ b/lib/dialogs/logout-confirmation/index.tsx
@@ -26,7 +26,7 @@ export class LogoutConfirmation extends Component<Props> {
   exportUnsyncedNotes = () => {
     const { closeDialog, notes } = this.props;
 
-    exportZipArchive([...notes.values()]).then(closeDialog);
+    exportZipArchive(notes).then(closeDialog);
   };
 
   render() {

--- a/lib/state/data/middleware.ts
+++ b/lib/state/data/middleware.ts
@@ -59,7 +59,7 @@ export const middleware: S.Middleware = (store) => (
     }
 
     case 'EXPORT_NOTES':
-      exportZipArchive([...state.data.notes.values()]);
+      exportZipArchive(state.data.notes);
       return next(action);
 
     case 'IMPORT_NOTE':

--- a/lib/utils/export/export-notes.ts
+++ b/lib/utils/export/export-notes.ts
@@ -7,11 +7,11 @@ import { ExportNote } from './types';
 
 export const LF_ONLY_NEWLINES = /(?!\r)\n/g;
 
-const exportNotes = (notes: T.Note[]) => {
+const exportNotes = (notes: Map<T.EntityId, T.Note>) => {
   const activeNotes: ExportNote[] = [];
   const trashedNotes: ExportNote[] = [];
-
-  notes.forEach((note, id) => {
+  [...notes.entries()].forEach((notePair) => {
+    const [id, note] = notePair;
     const [collaboratorEmails, tags] = partition(
       sortBy(note.tags, (a) => a.toLocaleLowerCase()),
       isEmailTag

--- a/lib/utils/export/index.ts
+++ b/lib/utils/export/index.ts
@@ -8,7 +8,7 @@ import * as T from '../../types';
 
 const filename = 'notes.zip';
 
-const exportZipArchive = (notes: T.Note[]) => {
+const exportZipArchive = (notes: Map<T.EntityId, T.Note>) => {
   return exportNotes(notes)
     .then(exportToZip)
     .then((zip) =>


### PR DESCRIPTION
### Fix

Exported notes were missing ids. This occurred because we were passing the values from the note Map. We need to pass the notes Map and iterate using entries to retain the ids.  The manipulation of the notes Map should occur as close to where it is being used. This reduces complexity upstream.

### Test

1. Have notes
2. Export them
3. Look in the source folder
4. In the json file
5. Do notes have ids?
