### PR TITLE
[rewrite branch] update note list status icons

### DIFF
--- a/lib/icons/pinned-small.tsx
+++ b/lib/icons/pinned-small.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function SmallPinnedIcon() {
+  return (
+    <svg
+      className="icon-pinned-small"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+    >
+      <rect x="0" fill="none" width="16" height="16" />
+      <g>
+        <path d="M4.41,10.17l-4-4,5.65-.52L8.65,3.1,7.24,1.69,8.66.27l7.07,7.07L14.31,8.76,12.89,7.33,10.33,9.91l-.52,5.66-4-4L3,14.41,1.59,13Zm3.8,1L8.4,9l3.07-3.1-1.4-1.41L7,7.6l-2.13.19Z" />
+      </g>
+    </svg>
+  );
+}

--- a/lib/icons/published-small.tsx
+++ b/lib/icons/published-small.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function SmallPublishedIcon() {
+  return (
+    <svg
+      className="icon-published-small"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+    >
+      <rect x="0" fill="none" width="16" height="16" />
+      <g>
+        <polygon points="7.38 10.25 5.13 8.11 6.16 7.02 7.36 8.17 9.82 5.75 10.87 6.82 7.38 10.25" />
+        <path d="M13,.93H3a1.5,1.5,0,0,0-1.5,1.5V12.57A1.5,1.5,0,0,0,3,14.07H13a1.5,1.5,0,0,0,1.5-1.5V2.43A1.5,1.5,0,0,0,13,.93ZM3.5,12.07V4h9v8.07Z" />
+      </g>
+    </svg>
+  );
+}

--- a/lib/icons/sync-small.tsx
+++ b/lib/icons/sync-small.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function SmallSyncIcon() {
+  return (
+    <svg
+      className="icon-sync-small"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+    >
+      <rect x="0" fill="none" width="16" height="16" />
+      <g>
+        <path d="M14,9v5l-1.78-1.78C11.14,13.31,9.66,14,8,14c-2.97,0-5.43-2.16-5.91-5h2.05c0.45,1.72,2,3,3.86,3c1.11,0,2.1-0.46,2.82-1.18L9,9h2.86h2.05H14z M4.14,7H7L5.18,5.18C5.9,4.46,6.89,4,8,4c1.86,0,3.41,1.28,3.86,3h2.05C13.43,4.16,10.97,2,8,2C6.34,2,4.86,2.69,3.78,3.78L2,2v5h0.09H4.14z" />
+      </g>
+    </svg>
+  );
+}

--- a/lib/note-list/note-cell.tsx
+++ b/lib/note-list/note-cell.tsx
@@ -139,7 +139,7 @@ export class NoteCell extends Component<Props> {
             </div>
           )}
         </div>
-        <div className="note-list-item-status-right">
+        <div className="note-list-item-status-right theme-color-border">
           {hasPendingChanges && (
             <span className="note-list-item-pending-changes">
               <SmallSyncIcon />

--- a/lib/note-list/note-cell.tsx
+++ b/lib/note-list/note-cell.tsx
@@ -2,9 +2,9 @@ import React, { Component, CSSProperties } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 
-import CloudSyncIcon from '../icons/cloud-sync';
-import PublishIcon from '../icons/feed';
-import PinnedIcon from '../icons/pinned';
+import PublishIcon from '../icons/published-small';
+import SmallPinnedIcon from '../icons/pinned-small';
+import SmallSyncIcon from '../icons/sync-small';
 import { decorateWith, makeFilterDecorator } from './decorators';
 import { getTerms } from '../utils/filter-notes';
 import { noteTitleAndPreview } from '../utils/note-utils';
@@ -104,10 +104,7 @@ export class NoteCell extends Component<Props> {
             tabIndex={0}
             onClick={() => pinNote(noteId, !isPinned)}
           >
-            <PinnedIcon />
-          </div>
-          <div className="note-list-item-pending-changes">
-            {hasPendingChanges && <CloudSyncIcon />}
+            <SmallPinnedIcon />
           </div>
         </div>
 
@@ -120,11 +117,6 @@ export class NoteCell extends Component<Props> {
             <span>
               {decorateWith(decorators, withCheckboxCharacters(title))}
             </span>
-            {isPublished && (
-              <div className="note-list-item-published-icon">
-                <PublishIcon />
-              </div>
-            )}
           </div>
           {'expanded' === displayMode && preview.length > 0 && (
             <div className="note-list-item-excerpt">
@@ -145,6 +137,18 @@ export class NoteCell extends Component<Props> {
                 withCheckboxCharacters(preview).slice(0, 200)
               )}
             </div>
+          )}
+        </div>
+        <div className="note-list-item-status-right">
+          {hasPendingChanges && (
+            <span className="note-list-item-pending-changes">
+              <SmallSyncIcon />
+            </span>
+          )}
+          {isPublished && (
+            <span className="note-list-item-published-icon">
+              <PublishIcon />
+            </span>
           )}
         </div>
       </div>

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -126,13 +126,13 @@
 
   .note-list-item-status-right {
     display: flex;
-    padding: 9px 10px 0 0;
+    padding: 9px 6px 0 0; // we want 10px total to the right side, but the icon has 4px padding already
     border-bottom: 1px solid $studio-gray-5;
   }
 
   .note-list-item-pending-changes,
   .note-list-item-published-icon {
-    margin-left: 8px;
+    padding: 0 4px;
 
     & svg {
       fill: $studio-gray-50;

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -80,13 +80,12 @@
   min-height: 64px;
 
   .note-list-item-status {
-    padding: 11px 8px 0 0;
+    padding: 9px 8px 0 0;
   }
 
-  .note-list-item-pinner,
-  .note-list-item-pending-changes {
-    height: 14px;
-    width: 14px;
+  .note-list-item-pinner {
+    height: 12px;
+    width: 12px;
   }
 
   .note-list-item-pinner {
@@ -94,13 +93,8 @@
   }
 
   .note-list-item-pinner:hover,
-  .note-list-item-pinner.note-list-item-pinned,
-  .note-list-item-pending-changes {
+  .note-list-item-pinner.note-list-item-pinned {
     color: $studio-simplenote-blue-50;
-  }
-
-  .note-list-item-pending-changes {
-    margin-top: 10px;
   }
 
   .note-list-item-text {
@@ -130,9 +124,16 @@
     animation-iteration-count: 3;
   }
 
+  .note-list-item-status-right {
+    margin-right: 10px;
+    display: flex;
+    padding: 9px 8px 0 0;
+    border-bottom: 1px solid $studio-gray-5;
+  }
+
+  .note-list-item-pending-changes,
   .note-list-item-published-icon {
     margin-left: 4px;
-    margin-right: 10px;
 
     & svg {
       fill: $studio-gray-50;

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -84,8 +84,8 @@
   }
 
   .note-list-item-pinner {
-    height: 12px;
-    width: 12px;
+    height: 16px;
+    width: 16px;
   }
 
   .note-list-item-pinner {
@@ -125,20 +125,19 @@
   }
 
   .note-list-item-status-right {
-    margin-right: 10px;
     display: flex;
-    padding: 9px 8px 0 0;
+    padding: 9px 10px 0 0;
     border-bottom: 1px solid $studio-gray-5;
   }
 
   .note-list-item-pending-changes,
   .note-list-item-published-icon {
-    margin-left: 4px;
+    margin-left: 8px;
 
     & svg {
       fill: $studio-gray-50;
-      height: 12px;
-      width: 12px;
+      height: 16px;
+      width: 16px;
     }
   }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -203,8 +203,7 @@
   }
 
   .note-list-item-pinner:hover,
-  .note-list-item-pinner.note-list-item-pinned,
-  .note-list-item-pending-changes {
+  .note-list-item-pinner.note-list-item-pinned {
     color: $studio-simplenote-blue-20;
   }
 


### PR DESCRIPTION
### Fix
Follow-up to #2218 

Moves the sync icon to the right, updates to new publish icon, changes all icon sizes to 16px

<img width="338" alt="Screen Shot 2020-07-20 at 10 45 33 PM" src="https://user-images.githubusercontent.com/52152/88019216-26291b00-cade-11ea-9ec5-23ed841045de.png">

<img width="368" alt="Screen Shot 2020-07-20 at 11 13 28 PM" src="https://user-images.githubusercontent.com/52152/88019451-b0717f00-cade-11ea-8671-5483a09a3601.png">

  

