### PR TITLE
[rewrite branch] Make condensed style actually condensed

### DIFF
--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -21,6 +21,13 @@
     white-space: nowrap;
   }
 
+  .condensed .note-list-item {
+    min-height: 16px;
+  }
+  .condensed .note-list-item-text {
+    padding-bottom: 0;
+  }
+
   .condensed .note-list-item-excerpt {
     display: none;
   }


### PR DESCRIPTION
### Fix

The note list condensed style was just removing the preview text but not actually condensing anything. Now it does.

I couldn't easily figure out how to make it less than 49px because `CellMeasurer` hates me, but this is an improvement anyway.

### Before

<img width="372" alt="Screen Shot 2020-07-20 at 11 36 12 PM" src="https://user-images.githubusercontent.com/52152/88021143-d2203580-cae1-11ea-9be5-f056c6f7f9da.png">

### After

<img width="368" alt="Screen Shot 2020-07-20 at 11 32 44 PM" src="https://user-images.githubusercontent.com/52152/88021089-b452d080-cae1-11ea-8fd5-e0e4af9ea562.png">

<img width="366" alt="Screen Shot 2020-07-20 at 11 32 06 PM" src="https://user-images.githubusercontent.com/52152/88021095-b9b01b00-cae1-11ea-89ea-49ed8ad13be4.png">
