### PR TITLE
Fix: Ability to log in with mixed case email address

### DIFF
--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -35,12 +35,12 @@ class AppWithoutAuth extends Component<Props, State> {
     authStatus: 'unsubmitted',
   };
 
-  authenticate = (username: string, password: string) => {
+  authenticate = (usernameArg: string, password: string) => {
+    const username = usernameArg.trim().toLowerCase();
+
     if (!(username && password)) {
       return;
     }
-
-    username = username.trim().toLowerCase();
 
     this.setState({ authStatus: 'submitting' }, () => {
       auth
@@ -68,12 +68,11 @@ class AppWithoutAuth extends Component<Props, State> {
     });
   };
 
-  createUser = (username: string, password: string) => {
+  createUser = (usernameArg: string, password: string) => {
+    const username = usernameArg.trim().toLowerCase();
     if (!(username && password)) {
       return;
     }
-
-    username = username.trim().toLowerCase();
 
     this.setState({ authStatus: 'submitting' }, () => {
       auth

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -40,6 +40,8 @@ class AppWithoutAuth extends Component<Props, State> {
       return;
     }
 
+    username = username.trim().toLowerCase();
+
     this.setState({ authStatus: 'submitting' }, () => {
       auth
         .authorize(username, password)
@@ -70,6 +72,8 @@ class AppWithoutAuth extends Component<Props, State> {
     if (!(username && password)) {
       return;
     }
+
+    username = username.trim().toLowerCase();
 
     this.setState({ authStatus: 'submitting' }, () => {
       auth


### PR DESCRIPTION
### Fix

This issue only arises in the Electron apps because App Engine authentication lowercases these arguments before creating or logging in to an account.

I also added a trim to match the App Engine logic.

Fixes #2193 

### Test

1. On the standalone Electron build (**not on web**)
2. Log in with any capital letters in your email address
3. You should still be able to log in
4. Ditto for sign up

### Release

Not updated: Fixed a bug that prevented login if capital letters were typed in the email address