### PR TITLE
Disable most menu items if user isn't logged in

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -91,7 +91,7 @@ module.exports = function main() {
 
     ipcMain.on('settingsUpdate', function (event, settings) {
       Menu.setApplicationMenu(
-        Menu.buildFromTemplate(createMenuTemplate(settings))
+        Menu.buildFromTemplate(createMenuTemplate(settings), mainWindow)
       );
     });
 

--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -49,6 +49,7 @@ const buildEditMenu = (settings, isAuthenticated) => {
       { type: 'separator' },
       {
         label: 'C&heck Spelling',
+        visible: isAuthenticated,
         type: 'checkbox',
         checked: settings.spellCheckEnabled,
         click: appCommandSender({ action: 'toggleSpellCheck' }),

--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -1,7 +1,8 @@
 const { appCommandSender } = require('./utils');
 
-const buildEditMenu = (settings) => {
+const buildEditMenu = (settings, isAuthenticated) => {
   settings = settings || {};
+  isAuthenticated = isAuthenticated || false;
 
   return {
     label: '&Edit',
@@ -36,11 +37,13 @@ const buildEditMenu = (settings) => {
       { type: 'separator' },
       {
         label: '&Trash Note',
+        visible: isAuthenticated,
         click: appCommandSender({ action: 'trashNote' }),
       },
       { type: 'separator' },
       {
         label: 'Search &Notes…',
+        visible: isAuthenticated,
         click: appCommandSender({ action: 'focusSearchField' }),
       },
       { type: 'separator' },

--- a/desktop/menus/file-menu.js
+++ b/desktop/menus/file-menu.js
@@ -3,7 +3,9 @@ const platform = require('../detect/platform');
 const { appCommandSender } = require('./utils');
 
 const buildFileMenu = (isAuthenticated) => {
+  var defaultSubmenuAdditions = [{ role: 'quit' }];
   isAuthenticated = isAuthenticated || false;
+
   const submenu = [
     {
       label: '&New Note',
@@ -35,8 +37,6 @@ const buildFileMenu = (isAuthenticated) => {
       click: appCommandSender({ action: 'printNote' }),
     },
   ];
-
-  var defaultSubmenuAdditions = [{ role: 'quit' }];
 
   if (isAuthenticated) {
     defaultSubmenuAdditions = [

--- a/desktop/menus/file-menu.js
+++ b/desktop/menus/file-menu.js
@@ -3,7 +3,6 @@ const platform = require('../detect/platform');
 const { appCommandSender } = require('./utils');
 
 const buildFileMenu = (isAuthenticated) => {
-  var defaultSubmenuAdditions = [{ role: 'quit' }];
   isAuthenticated = isAuthenticated || false;
 
   const submenu = [
@@ -33,19 +32,18 @@ const buildFileMenu = (isAuthenticated) => {
     { type: 'separator' },
     {
       label: '&Print…',
+      visible: isAuthenticated,
       accelerator: 'CommandOrControl+P',
       click: appCommandSender({ action: 'printNote' }),
     },
   ];
 
-  if (isAuthenticated) {
-    defaultSubmenuAdditions = [
-      { type: 'separator' },
-      menuItems.preferences,
-      { type: 'separator' },
-      { role: 'quit' },
-    ];
-  }
+  const defaultSubmenuAdditions = [
+    { type: 'separator' },
+    menuItems.preferences(isAuthenticated),
+    { type: 'separator' },
+    { role: 'quit' },
+  ];
 
   const fileMenu = {
     label: '&File',
@@ -53,6 +51,11 @@ const buildFileMenu = (isAuthenticated) => {
       ? submenu
       : submenu.concat(defaultSubmenuAdditions),
   };
+
+  // we have nothing to show in the File menu on OSX logged out
+  if (!isAuthenticated && platform.isOSX()) {
+    fileMenu.visible = false;
+  }
 
   return fileMenu;
 };

--- a/desktop/menus/file-menu.js
+++ b/desktop/menus/file-menu.js
@@ -2,45 +2,59 @@ const menuItems = require('./menu-items');
 const platform = require('../detect/platform');
 const { appCommandSender } = require('./utils');
 
-const submenu = [
-  {
-    label: '&New Note',
-    accelerator: 'CommandOrControl+Shift+I',
-    click: appCommandSender({ action: 'newNote' }),
-  },
-  { type: 'separator' },
-  {
-    label: '&Import Notes…',
-    click: appCommandSender({
-      action: 'showDialog',
-      dialog: 'IMPORT',
-    }),
-  },
-  {
-    label: '&Export Notes…',
-    accelerator: 'CommandOrControl+Shift+E',
-    click: appCommandSender({
-      action: 'exportZipArchive',
-    }),
-  },
-  { type: 'separator' },
-  {
-    label: '&Print…',
-    accelerator: 'CommandOrControl+P',
-    click: appCommandSender({ action: 'printNote' }),
-  },
-];
+const buildFileMenu = (isAuthenticated) => {
+  isAuthenticated = isAuthenticated || false;
+  const submenu = [
+    {
+      label: '&New Note',
+      visible: isAuthenticated,
+      accelerator: 'CommandOrControl+Shift+I',
+      click: appCommandSender({ action: 'newNote' }),
+    },
+    { type: 'separator' },
+    {
+      label: '&Import Notes…',
+      visible: isAuthenticated,
+      click: appCommandSender({
+        action: 'showDialog',
+        dialog: 'IMPORT',
+      }),
+    },
+    {
+      label: '&Export Notes…',
+      visible: isAuthenticated,
+      accelerator: 'CommandOrControl+Shift+E',
+      click: appCommandSender({
+        action: 'exportZipArchive',
+      }),
+    },
+    { type: 'separator' },
+    {
+      label: '&Print…',
+      accelerator: 'CommandOrControl+P',
+      click: appCommandSender({ action: 'printNote' }),
+    },
+  ];
 
-const defaultSubmenuAdditions = [
-  { type: 'separator' },
-  menuItems.preferences,
-  { type: 'separator' },
-  { role: 'quit' },
-];
+  var defaultSubmenuAdditions = [{ role: 'quit' }];
 
-const fileMenu = {
-  label: '&File',
-  submenu: platform.isOSX() ? submenu : submenu.concat(defaultSubmenuAdditions),
+  if (isAuthenticated) {
+    defaultSubmenuAdditions = [
+      { type: 'separator' },
+      menuItems.preferences,
+      { type: 'separator' },
+      { role: 'quit' },
+    ];
+  }
+
+  const fileMenu = {
+    label: '&File',
+    submenu: platform.isOSX()
+      ? submenu
+      : submenu.concat(defaultSubmenuAdditions),
+  };
+
+  return fileMenu;
 };
 
-module.exports = fileMenu;
+module.exports = buildFileMenu;

--- a/desktop/menus/format-menu.js
+++ b/desktop/menus/format-menu.js
@@ -1,15 +1,21 @@
 const { appCommandSender } = require('./utils');
 
-const submenu = [
-  {
-    label: 'Insert &Checklist',
-    click: appCommandSender({ action: 'insertChecklist' }),
-  },
-];
+const buildFormatMenu = (isAuthenticated) => {
+  isAuthenticated = isAuthenticated || false;
+  const submenu = [
+    {
+      label: 'Insert &Checklist',
+      click: appCommandSender({ action: 'insertChecklist' }),
+    },
+  ];
 
-const formatMenu = {
-  label: 'F&ormat',
-  submenu,
+  const formatMenu = {
+    label: 'F&ormat',
+    submenu,
+    visible: isAuthenticated,
+  };
+
+  return formatMenu;
 };
 
-module.exports = formatMenu;
+module.exports = buildFormatMenu;

--- a/desktop/menus/index.js
+++ b/desktop/menus/index.js
@@ -1,13 +1,14 @@
 const platform = require('../detect/platform');
 
-const macAppMenu = require('./mac-app-menu');
-const fileMenu = require('./file-menu');
+const buildMacAppMenu = require('./mac-app-menu');
+const buildFileMenu = require('./file-menu');
 const buildEditMenu = require('./edit-menu');
 const buildViewMenu = require('./view-menu');
-const formatMenu = require('./format-menu');
+const buildFormatMenu = require('./format-menu');
 const buildHelpMenu = require('./help-menu');
 
 function createMenuTemplate(settings, mainWindow) {
+  const isAuthenticated = settings && 'accountName' in settings;
   const windowMenu = {
     role: 'window',
     submenu: [
@@ -19,11 +20,11 @@ function createMenuTemplate(settings, mainWindow) {
   };
 
   return [
-    platform.isOSX() ? macAppMenu : null,
-    fileMenu,
-    buildEditMenu(settings),
-    buildViewMenu(settings),
-    formatMenu,
+    platform.isOSX() ? buildMacAppMenu(isAuthenticated) : null,
+    buildFileMenu(isAuthenticated),
+    buildEditMenu(settings, isAuthenticated),
+    buildViewMenu(settings, isAuthenticated),
+    buildFormatMenu(isAuthenticated),
     platform.isOSX() ? windowMenu : null,
     buildHelpMenu(mainWindow),
   ].filter((menu) => menu !== null);

--- a/desktop/menus/mac-app-menu.js
+++ b/desktop/menus/mac-app-menu.js
@@ -7,41 +7,23 @@ const buildMacAppMenu = (isAuthenticated) => {
   var submenu = [];
   isAuthenticated = isAuthenticated || false;
 
-  if (isAuthenticated) {
-    submenu = [
-      menuItems.about,
-      ...(build.isMAS() ? [] : [menuItems.checkForUpdates]),
-      { type: 'separator' },
-      menuItems.preferences,
-      { type: 'separator' },
-      {
-        role: 'services',
-        submenu: [],
-      },
-      { type: 'separator' },
-      { role: 'hide' },
-      { role: 'hideothers' },
-      { role: 'unhide' },
-      { type: 'separator' },
-      { role: 'quit' },
-    ];
-  } else {
-    submenu = [
-      menuItems.about,
-      ...(build.isMAS() ? [] : [menuItems.checkForUpdates]),
-      { type: 'separator' },
-      {
-        role: 'services',
-        submenu: [],
-      },
-      { type: 'separator' },
-      { role: 'hide' },
-      { role: 'hideothers' },
-      { role: 'unhide' },
-      { type: 'separator' },
-      { role: 'quit' },
-    ];
-  }
+  submenu = [
+    menuItems.about,
+    ...(build.isMAS() ? [] : [menuItems.checkForUpdates]),
+    { type: 'separator' },
+    menuItems.preferences(isAuthenticated),
+    { type: 'separator' },
+    {
+      role: 'services',
+      submenu: [],
+    },
+    { type: 'separator' },
+    { role: 'hide' },
+    { role: 'hideothers' },
+    { role: 'unhide' },
+    { type: 'separator' },
+    { role: 'quit' },
+  ];
 
   const menu = {
     label: app.name,

--- a/desktop/menus/mac-app-menu.js
+++ b/desktop/menus/mac-app-menu.js
@@ -3,25 +3,52 @@ const { app } = require('electron');
 const menuItems = require('./menu-items');
 const build = require('../detect/build');
 
-const macAppMenu = {
-  label: app.name,
-  submenu: [
-    menuItems.about,
-    ...(build.isMAS() ? [] : [menuItems.checkForUpdates]),
-    { type: 'separator' },
-    menuItems.preferences,
-    { type: 'separator' },
-    {
-      role: 'services',
-      submenu: [],
-    },
-    { type: 'separator' },
-    { role: 'hide' },
-    { role: 'hideothers' },
-    { role: 'unhide' },
-    { type: 'separator' },
-    { role: 'quit' },
-  ],
+const buildMacAppMenu = (isAuthenticated) => {
+  var submenu = [];
+  isAuthenticated = isAuthenticated || false;
+
+  if (isAuthenticated) {
+    submenu = [
+      menuItems.about,
+      ...(build.isMAS() ? [] : [menuItems.checkForUpdates]),
+      { type: 'separator' },
+      menuItems.preferences,
+      { type: 'separator' },
+      {
+        role: 'services',
+        submenu: [],
+      },
+      { type: 'separator' },
+      { role: 'hide' },
+      { role: 'hideothers' },
+      { role: 'unhide' },
+      { type: 'separator' },
+      { role: 'quit' },
+    ];
+  } else {
+    submenu = [
+      menuItems.about,
+      ...(build.isMAS() ? [] : [menuItems.checkForUpdates]),
+      { type: 'separator' },
+      {
+        role: 'services',
+        submenu: [],
+      },
+      { type: 'separator' },
+      { role: 'hide' },
+      { role: 'hideothers' },
+      { role: 'unhide' },
+      { type: 'separator' },
+      { role: 'quit' },
+    ];
+  }
+
+  const menu = {
+    label: app.name,
+    submenu: submenu,
+  };
+
+  return menu;
 };
 
-module.exports = macAppMenu;
+module.exports = buildMacAppMenu;

--- a/desktop/menus/menu-items.js
+++ b/desktop/menus/menu-items.js
@@ -16,13 +16,16 @@ const checkForUpdates = {
   click: updater.pingAndShowProgress.bind(updater),
 };
 
-const preferences = {
-  label: 'P&references…',
-  accelerator: 'CommandOrControl+,',
-  click: appCommandSender({
-    action: 'showDialog',
-    dialog: 'SETTINGS',
-  }),
+const preferences = (isAuthenticated) => {
+  return {
+    label: 'P&references…',
+    visible: isAuthenticated,
+    accelerator: 'CommandOrControl+,',
+    click: appCommandSender({
+      action: 'showDialog',
+      dialog: 'SETTINGS',
+    }),
+  };
 };
 
 module.exports = {

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -1,14 +1,16 @@
 const { buildRadioGroup, appCommandSender } = require('./utils');
 const platform = require('../detect/platform');
 
-const buildViewMenu = (settings) => {
+const buildViewMenu = (settings, isAuthenticated) => {
   settings = settings || {};
+  isAuthenticated = isAuthenticated || false;
 
   const menu = {
     label: '&View',
     submenu: [
       {
         label: '&Sort Type',
+        visible: isAuthenticated,
         submenu: [
           {
             label: 'Date &modified',
@@ -44,6 +46,7 @@ const buildViewMenu = (settings) => {
       },
       {
         label: '&Note Display',
+        visible: isAuthenticated,
         submenu: [
           {
             label: '&Comfy',
@@ -67,6 +70,7 @@ const buildViewMenu = (settings) => {
       },
       {
         label: '&Line Length',
+        visible: isAuthenticated,
         submenu: [
           {
             label: '&Narrow',
@@ -86,6 +90,7 @@ const buildViewMenu = (settings) => {
       },
       {
         label: '&Tags',
+        visible: isAuthenticated,
         submenu: [
           {
             label: '&Sort Alphabetically',
@@ -137,6 +142,7 @@ const buildViewMenu = (settings) => {
       },
       {
         label: 'Focus Mode',
+        visible: isAuthenticated,
         accelerator: 'CommandOrControl+Shift+F',
         type: 'checkbox',
         checked: settings.focusModeEnabled,

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -102,6 +102,7 @@ const buildViewMenu = (settings, isAuthenticated) => {
       },
       {
         label: 'T&heme',
+        visible: isAuthenticated,
         submenu: [
           {
             label: '&Light',
@@ -121,24 +122,29 @@ const buildViewMenu = (settings, isAuthenticated) => {
       },
       {
         type: 'separator',
+        visible: isAuthenticated,
       },
       {
         label: 'Zoom &In',
+        visible: isAuthenticated,
         accelerator: 'CommandOrControl+=',
         click: appCommandSender({ action: 'increaseFontSize' }),
       },
       {
         label: 'Zoom &Out',
+        visible: isAuthenticated,
         accelerator: 'CommandOrControl+-',
         click: appCommandSender({ action: 'decreaseFontSize' }),
       },
       {
         label: '&Actual Size',
+        visible: isAuthenticated,
         accelerator: 'CommandOrControl+0',
         click: appCommandSender({ action: 'resetFontSize' }),
       },
       {
         type: 'separator',
+        visible: isAuthenticated,
       },
       {
         label: 'Focus Mode',

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-const { isUndefined } = require('lodash');
 import 'focus-visible/dist/focus-visible.js';
 import appState from './flux/app-state';
 import { loadTags } from './state/domain/tags';

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+const { isUndefined } = require('lodash');
 import 'focus-visible/dist/focus-visible.js';
 import appState from './flux/app-state';
 import { loadTags } from './state/domain/tags';
@@ -303,6 +304,8 @@ export const App = connect(
       const {
         appState: { accountName },
       } = this.props;
+
+      window.electron?.send('settingsUpdate', this.props.settings);
 
       analytics.initialize(accountName);
       this.onLoadPreferences();

--- a/lib/boot.ts
+++ b/lib/boot.ts
@@ -21,6 +21,7 @@ const clearStorage = () =>
     indexedDB.deleteDatabase('ghost');
     indexedDB.deleteDatabase('simplenote');
     window.electron?.send('clearCookies');
+    window.electron?.send('settingsUpdate', {});
 
     // let everything settle
     setTimeout(() => resolve(), 500);


### PR DESCRIPTION
### Fix

Most menu items aren't applicable when logged out, and don't work anyhow, so let's hide them.

We could also gray them out instead of remove them entirely; anyone have a preference?

### Test

1. Open the app, signed out
2. Note that irrelevant menu options do not appear (Format menu, Preferences, etc)
3. Log in
4. Note that all menu items are now visible and work as intended
5. Log out again
6. Note that menu items are once again disabled

### Release

Not updated: Disable inapplicable menu items when logged out