### PR TITLE
Fix: Table alignment and strikethrough in Markdown preview

### DIFF
--- a/lib/utils/render-note-to-html.ts
+++ b/lib/utils/render-note-to-html.ts
@@ -17,6 +17,9 @@ export const renderNoteToHtml = (content: string) => {
       markdownConverter.setOption('simpleLineBreaks', false); // override GFM
       markdownConverter.setOption('ghMentions', false);
       markdownConverter.setOption('smoothLivePreview', true);
+      markdownConverter.setOption('tables', true); // table syntax
+      markdownConverter.setOption('strikethrough', true); // ~~strikethrough~~
+      // markdownConverter.setOption('emoji', true); // emoji support like :smile:
 
       const withNormalizedBullets = content.replace(
         /([ \t\u2000-\u200a]*)\u2022(\s)/gm,

--- a/lib/utils/render-note-to-html.ts
+++ b/lib/utils/render-note-to-html.ts
@@ -19,7 +19,6 @@ export const renderNoteToHtml = (content: string) => {
       markdownConverter.setOption('smoothLivePreview', true);
       markdownConverter.setOption('tables', true); // table syntax
       markdownConverter.setOption('strikethrough', true); // ~~strikethrough~~
-      // markdownConverter.setOption('emoji', true); // emoji support like :smile:
 
       const withNormalizedBullets = content.replace(
         /([ \t\u2000-\u200a]*)\u2022(\s)/gm,

--- a/lib/utils/sanitize-html.ts
+++ b/lib/utils/sanitize-html.ts
@@ -138,6 +138,22 @@ const isAllowedAttr = (tagName: string, attrName: string, value: string) => {
           return false;
       }
 
+    case 'th':
+    case 'td':
+      switch (attrName) {
+        case 'style':
+          switch (value) {
+            case 'text-align:center;':
+            case 'text-align:left;':
+            case 'text-align:right;':
+              return true;
+            default:
+              return false;
+          }
+        default:
+          return false;
+      }
+
     default:
       return false;
   }


### PR DESCRIPTION
### Fix

We were sanitizing the `text-aligns` into oblivion, so table alignment wasn't working properly. These changes mirror the ones we needed to make for published notes on App Engine.

~I also added the emoji module here, but in a comment, because I want to remind myself that it exists if we ever want to support those!~

### Test

Markdown example:

```| Tables        | Are           | Cool  |
| ------------- |:-------------:| -----:|
| **col 3 is**  | right-aligned | $1600 |
| col 2 is      | *centered*    |   $12 |
| zebra stripes | ~~are neat~~  |    $1 |
```

Should appear like:

<img width="356" alt="Screen Shot 2020-07-23 at 4 49 09 PM" src="https://user-images.githubusercontent.com/52152/88349264-71247780-cd04-11ea-9ee5-34114ff601e4.png">


### Release

Not updated: Support table alignment and strikethrough in Markdown preview