### PR TITLE
Fix: About dialog while logged out

### DIFF
--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -46,6 +46,10 @@ class AppWithoutAuth extends Component<Props, State> {
     window.electron?.receive('appCommand', this.onAppCommand);
   }
 
+  componentWillUnmount() {
+    window.electron?.removeListener('appCommand');
+  }
+
   onAppCommand = (event) => {
     if ('showDialog' === event.action && 'ABOUT' === event.dialog) {
       this.setState({ showAbout: true });

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -1,6 +1,4 @@
 import React, { Component } from 'react';
-import { createStore } from 'redux';
-import { Provider } from 'react-redux';
 import { render } from 'react-dom';
 import { Auth as AuthApp } from './auth';
 import { Auth as SimperiumAuth } from 'simperium';
@@ -164,13 +162,6 @@ class AppWithoutAuth extends Component<Props, State> {
 export const boot = (
   onAuth: (token: string, username: string, createWelcomeNote: boolean) => any
 ) => {
-  const reducer = (state, action) => state;
-  const store = createStore(reducer);
   Modal.setAppElement('#root');
-  render(
-    <Provider store={store}>
-      <AppWithoutAuth onAuth={onAuth} />
-    </Provider>,
-    document.getElementById('root')
-  );
+  render(<AppWithoutAuth onAuth={onAuth} />, document.getElementById('root'));
 };

--- a/lib/dialog-renderer/index.tsx
+++ b/lib/dialog-renderer/index.tsx
@@ -48,7 +48,7 @@ export class DialogRenderer extends Component<Props> {
             portalClassName={classNames('dialog-renderer__portal', themeClass)}
           >
             {'ABOUT' === dialog ? (
-              <AboutDialog key="about" />
+              <AboutDialog key="about" closeDialog={closeDialog} />
             ) : 'IMPORT' === dialog ? (
               <ImportDialog key="import" buckets={buckets} />
             ) : 'KEYBINDINGS' === dialog ? (

--- a/lib/dialogs/about/index.tsx
+++ b/lib/dialogs/about/index.tsx
@@ -4,17 +4,14 @@ import SimplenoteLogo from '../../icons/simplenote';
 import CrossIcon from '../../icons/cross';
 import TopRightArrowIcon from '../../icons/arrow-top-right';
 import Dialog from '../../dialog';
-import { closeDialog } from '../../state/ui/actions';
-
-import * as S from '../../state';
 
 const appVersion = config.version; // eslint-disable-line no-undef
 
-type DispatchProps = {
+type OwnProps = {
   closeDialog: () => any;
 };
 
-type Props = DispatchProps;
+type Props = OwnProps;
 
 export class AboutDialog extends Component<Props> {
   render() {
@@ -134,8 +131,4 @@ export class AboutDialog extends Component<Props> {
   }
 }
 
-const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
-  closeDialog,
-};
-
-export default connect(null, mapDispatchToProps)(AboutDialog);
+export default AboutDialog;


### PR DESCRIPTION
### Fix

The About dialog should be accessible whether logged in or logged out.

Penultimate fix for #2137 (complementary to #2228 ); still need to fix the keybindings one way or the other (either show the dialog now that I've figured out how to do it, or hide the menu item when logged out)

### Release

Not updated: Restore ability to view About while logged out