### PR TITLE
Fix: disable keyboard shortcuts menu when logged out

### DIFF
--- a/desktop/menus/help-menu.js
+++ b/desktop/menus/help-menu.js
@@ -8,7 +8,8 @@ const zipLogs = require('../logger/zip-logs');
 
 const { appCommandSender } = require('./utils');
 
-const buildHelpMenu = (mainWindow) => {
+const buildHelpMenu = (mainWindow, isAuthenticated) => {
+  isAuthenticated = isAuthenticated || false;
   const submenu = [
     {
       label: 'Help && &Support',
@@ -17,6 +18,7 @@ const buildHelpMenu = (mainWindow) => {
     },
     {
       label: '&Keyboard Shortcuts',
+      visible: isAuthenticated,
       click: appCommandSender({ action: 'showDialog', dialog: 'KEYBINDINGS' }),
     },
     { type: 'separator' },

--- a/desktop/menus/index.js
+++ b/desktop/menus/index.js
@@ -26,7 +26,7 @@ function createMenuTemplate(settings, mainWindow) {
     buildViewMenu(settings, isAuthenticated),
     buildFormatMenu(isAuthenticated),
     platform.isOSX() ? windowMenu : null,
-    buildHelpMenu(mainWindow),
+    buildHelpMenu(mainWindow, isAuthenticated),
   ].filter((menu) => menu !== null);
 }
 


### PR DESCRIPTION
### Fix

Missed this one in #2228. Keyboard shortcuts dialog should only be visible if user is logged in.

Last fix for https://github.com/Automattic/simplenote-electron/issues/2137