### PR TITLE
Fix: restore keyboard hint for insert checklist

### DIFF
--- a/desktop/menus/format-menu.js
+++ b/desktop/menus/format-menu.js
@@ -5,6 +5,7 @@ const buildFormatMenu = (isAuthenticated) => {
   const submenu = [
     {
       label: 'Insert &Checklist',
+      accelerator: 'CommandOrControl+Shift+C',
       click: appCommandSender({ action: 'insertChecklist' }),
     },
   ];


### PR DESCRIPTION
### Fix

Fixes #2186

This hint [was removed](https://github.com/Automattic/simplenote-electron/pull/1983/files#diff-a851bc179b8f264a1135cd1b05688049L6) in #1983 I think by mistake? cc @dmsnell

### Release

Not updated: Restore missing keyboard hint for Insert Checklist