### PR TITLE
Fixes styling of offline badge

### DIFF
--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -13,9 +13,14 @@
   color: $studio-gray-50;
   font-size: 12px;
   height: 24px;
+  line-height: 24px;
   margin-top: 16px;
   text-align: center;
   width: 64px;
+}
+
+.is-electron .note-toolbar-wrapper .offline-badge {
+  margin-top: -11px;
 }
 
 .theme-dark .note-toolbar-wrapper .offline-badge {


### PR DESCRIPTION
### Fix

The offline badge line height was not right and it displayed incorrectly in Electron.

<img width="1376" alt="Screen Shot 2020-07-27 at 10 57 37 AM" src="https://user-images.githubusercontent.com/6817400/88557492-44b87600-cff8-11ea-8a27-bd7a3ffc74c2.png">

### Test

1. Go offline
2. View on web
3. View on Electron
4. Does it look good?

