### PR TITLE
Updates the color of the link in the logout confirm dialog

### DIFF
--- a/lib/dialogs/logout-confirmation/style.scss
+++ b/lib/dialogs/logout-confirmation/style.scss
@@ -80,4 +80,8 @@
   .change-list {
     border-color: #2c3338;
   }
+
+  .export-unsyncronized {
+    color: $studio-simplenote-blue-30;
+  }
 }


### PR DESCRIPTION
### Fix

In this comment: https://github.com/Automattic/simplenote-electron/pull/2206#issuecomment-661102532 @SylvesterWilmott let me know I was using the wrong color in dark mode.

<img width="380" alt="Screen Shot 2020-07-27 at 10 50 11 AM" src="https://user-images.githubusercontent.com/6817400/88557711-919c4c80-cff8-11ea-8616-5c33a713d9f7.png">

### Test

1. Go offline
2. Make a change
3. Try to log out
4. Is link color blue 30?
