### PR TITLE
Hides last syncd message when it is unknown

### DIFF
--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -124,13 +124,13 @@ export class NoteEditor extends Component<Props> {
 
     const isTrashed = !!note.deleted;
 
-    const lastUpdatedDate = lastUpdated
-      ? new Date(lastUpdated).toLocaleString()
-      : 'Unknown';
-
     return (
       <div className="note-editor theme-color-bg theme-color-fg">
-        <div className="last-sync">Last synced: {lastUpdatedDate}</div>
+        <div className="last-sync">
+          {lastUpdated && (
+            <span>Last synced: {new Date(lastUpdated).toLocaleString()}</span>
+          )}
+        </div>
         {editMode || !note.systemTags.includes('markdown') ? (
           <NoteDetail
             storeFocusEditor={this.storeFocusEditor}

--- a/lib/note-editor/style.scss
+++ b/lib/note-editor/style.scss
@@ -7,6 +7,7 @@
   .last-sync {
     color: $studio-gray-50;
     font-size: 14px;
+    height: 22px;
     margin-top: 11px;
     text-align: center;
   }


### PR DESCRIPTION
### Fix

Hides the last syncd when it is unknown

<img width="819" alt="Screen Shot 2020-07-27 at 11 08 37 AM" src="https://user-images.githubusercontent.com/6817400/88559978-872f8200-cffb-11ea-8482-3c890b248086.png">
<img width="819" alt="Screen Shot 2020-07-27 at 11 08 44 AM" src="https://user-images.githubusercontent.com/6817400/88559986-88f94580-cffb-11ea-9819-cdd6f08e131f.png">

### Test

1. Open app
2. Make change observe last sync'd
3. Open another not that did not have changes
4. Should not see last sync'd
5. Make change
6. Last sync'd should appear after sync

@SylvesterWilmott should we keep the padding so when last sync'd appears the note doesn't shift down?
