### PR TITLE
Fixes editor width when narrow line length is selected

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -294,7 +294,7 @@ class NoteContentEditor extends Component<Props> {
         }`}
       >
         {editor === 'fast' ? (
-          <div style={{ padding: '0.7em', whiteSpace: 'pre-wrap' }}>
+          <div style={{ padding: '0 10px', whiteSpace: 'pre-wrap' }}>
             {content}
           </div>
         ) : (

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -5,6 +5,22 @@
   unicode-range: U+E000-E001;
 }
 
+.note-detail {
+  padding: 0 calc((100% - 768px) / 2);
+}
+
+@media only screen and (max-width: 1400px) {
+  .note-detail {
+    padding: 0 10%;
+  }
+}
+
+.is-line-length-full {
+  .note-detail {
+    padding: 0 25px;
+  }
+}
+
 .note-content-editor-shell {
   height: 100%;
   width: 100%;
@@ -18,22 +34,6 @@
   .slider {
     border-radius: 10px;
     border: 3px solid gray;
-  }
-
-  .lines-content.monaco-editor-background {
-    padding: 0 calc((100% - 768px) / 2);
-  }
-
-  @media only screen and (max-width: 1400px) {
-    .lines-content.monaco-editor-background {
-      padding: 0 10%;
-    }
-  }
-}
-
-.is-line-length-full {
-  .lines-content.monaco-editor-background {
-    padding: 0 25px;
   }
 }
 


### PR DESCRIPTION
### Fix

My previous fix for the editor width only worked on the left margin. This fixes it so the editor width is constrained on both sides. It does however cause the scroll bar to be just inside the narrow view and not on the edge of the screen, see screenshot. I am not sure how to fix it to push it to the side.

This PR also fixes the jerkiness of the note when it opens. The padding applied to the content before the editor is ready is now the same as it is once Monaco renders.

<img width="1286" alt="Screen Shot 2020-07-27 at 1 03 48 PM" src="https://user-images.githubusercontent.com/6817400/88570293-cf55a100-d009-11ea-92c7-0310e13692b5.png">

Known issue, when you switch line length the editor does not update and requires you to resize the browser. To be handled in another PR.

### Test

1. Have a note with a long line length
2. Switch to a narrow line length
3. Resize screen
4. Observe note
