### PR TITLE
Dont scroll editor past last line

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -327,6 +327,7 @@ class NoteContentEditor extends Component<Props> {
               renderIndentGuides: false,
               renderLineHighlight: 'none',
               scrollbar: { horizontal: 'hidden' },
+              scrollBeyondLastLine: false,
               selectionHighlight: false,
               wordWrap: 'on',
               wrappingStrategy: 'simple',


### PR DESCRIPTION
### Fix

When you scroll a note it currently scrolls the note completely off the screen. This PR changes it so it does not scroll past the end of the note. I like the current behavior and think we should add this back as an option.

### Test

1. Have long note
2. Scroll to bottom
3. You should not be able to scroll past the end of the note.