### PR TITLE
Allow scroll bar to be any height fixing it only scrolling partially to the bottom

### DIFF
--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -6,7 +6,6 @@
   max-width: $max-content-width;
   padding: 0; // IE11
   appearance: none;
-  max-height: 18px;
 
   // Track
   &::-webkit-slider-runnable-track {


### PR DESCRIPTION
### Fix

We had a fixed height on the scroll bar. This caused it to look like it hadn't scrolled all the way to the bottom. This removes that max height so that the scroll bar displays correctly.

<img width="236" alt="Screen Shot 2020-07-27 at 1 00 08 PM" src="https://user-images.githubusercontent.com/6817400/88571034-0a0c0900-d00b-11ea-8180-3e1f5355f8a6.png">
<img width="206" alt="Screen Shot 2020-07-27 at 12 59 57 PM" src="https://user-images.githubusercontent.com/6817400/88571037-0aa49f80-d00b-11ea-9120-22c7d52c17be.png">

### Test

1. Open long note and scroll
