### PR TITLE
Updates the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,29 +1,39 @@
 ---
 name: "\U0001F41E Bug Report"
-about: "Report a bug if something isn't working as expected in the Simplenote Electron app."
+about: "Report a bug if something isn't working as expected in a Simplenote app."
 title: ""
 labels: bug
 assignees: ""
 ---
 
-Please, be as descriptive as possible.  Issues lacking detail, or for any other reason than to report a bug, may be closed without action.
+<!-- Please, be as descriptive as possible.  Issues lacking detail, or for any other reason than to report a bug, may be closed without action. -->
 
 ### Expected
-***(Required)*** Add a concise description of what you expected.
+<!-- ***(Required)*** Add a concise description of what you expected. -->
 
 ### Observed
-***(Required)*** Add a concise description of what you observed.
+<!-- ***(Required)*** Add a concise description of what you observed. -->
 
 ### Reproduced
-***(Required)*** If you cannot reproduce this bug consistently, please elaborate.  List the steps to reproduce the behavior.  For example:
-> 1. Go to...
-> 2. Click on...
-> 3. See error...
+<!--
+***(Required)*** If you cannot reproduce this bug consistently, please elaborate.  List the steps to reproduce the behavior.  For example: 
+1. Go to...
+2. Click on...
+3. See error...
+-->
 
-***(Optional)*** If applicable, add screenshots, animations, or videos to help illustrate your problem.
+1.
+2.
+3.
 
-***(Optional)*** If you reproduced the bug on a specific system, please replace SYSTEM_MAKE, SYSTEM_MODEL, OS_VERSION, and APP_VERSION below with the details for that system.  If you reproduced the bug on multiple systems, please add a row for each system.
+<!-- ***(Optional)*** If applicable, add screenshots, animations, or videos to help illustrate your problem. -->
 
-Make|Model|OS Version|App Version
--|-|-|-
-SYSTEM_MAKE|SYSTEM_MODEL|OS_VERSION|APP_VERSION
+### Where did you see the bug
+<!-- ***(Required)*** -->
+- System Make:
+- System Model:
+- OS:
+- OS version: 
+- Browser (if applicable): 
+- Browser version (if applicable): 
+- Simplenote app version: 

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: "\U0001F41E Bug Report"
-about: "Report a bug if something isn't working as expected in a Simplenote app."
+about: "Report a bug if something isn't working as expected in the Windows, Linux, or Web Simplenote app."
 title: ""
 labels: bug
 assignees: ""


### PR DESCRIPTION
### Fix

We changed the bug report template here: https://github.com/Automattic/Simplenote-United/pull/78

<img width="932" alt="Screen Shot 2020-07-27 at 1 49 53 PM" src="https://user-images.githubusercontent.com/6817400/88574607-95d46400-d010-11ea-8ced-17dfbdba580d.png">
<img width="906" alt="Screen Shot 2020-07-27 at 1 50 04 PM" src="https://user-images.githubusercontent.com/6817400/88574608-95d46400-d010-11ea-8410-98196e832e9a.png">
