### PR TITLE
Update height of note list item when condensed

### DIFF
--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -31,7 +31,7 @@
   }
 
   .condensed .note-list-item {
-    min-height: 16px;
+    min-height: 43px;
   }
   .condensed .note-list-item-text {
     padding-bottom: 0;


### PR DESCRIPTION
### Fix

Fixes height of condensed note list item.
Before:
<img width="312" alt="Screen Shot 2020-07-28 at 3 26 58 PM" src="https://user-images.githubusercontent.com/6817400/88711889-dacaca00-d0e6-11ea-8ac5-fc1b52da3da5.png">
After:
<img width="309" alt="Screen Shot 2020-07-28 at 3 26 49 PM" src="https://user-images.githubusercontent.com/6817400/88711890-db636080-d0e6-11ea-94a6-266ef23e63f8.png">

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1. Make note list condensed
2. Observe note list
3. Does it look better?

