### PR TITLE
Clean up disable restore note button when is newset revision

### DIFF
--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -36,7 +36,6 @@ export class RevisionSelector extends Component<Props> {
 
   onAcceptRevision = () => {
     const { noteId, openedRevision, restoreRevision } = this.props;
-
     restoreRevision(noteId, openedRevision);
   };
 
@@ -66,7 +65,9 @@ export class RevisionSelector extends Component<Props> {
       revisions && openedRevision
         ? [...revisions.keys()].indexOf(openedRevision)
         : -1;
-    const isNewest = openedRevision && selectedIndex === revisions?.size - 1;
+    const isNewest =
+      !openedRevision ||
+      (openedRevision && selectedIndex === revisions?.size - 1);
 
     const revisionDate = format(
       (openedRevision
@@ -74,10 +75,6 @@ export class RevisionSelector extends Component<Props> {
         : note.modificationDate) * 1000,
       'MMM d, yyyy h:mm a'
     );
-
-    const revisionButtonStyle: CSSProperties = isNewest
-      ? { opacity: '0.5', pointerEvents: 'none' }
-      : {};
 
     const mainClasses = classNames('revision-selector', {
       'is-visible': isViewingRevisions,
@@ -105,7 +102,7 @@ export class RevisionSelector extends Component<Props> {
             Cancel
           </button>
           <button
-            style={revisionButtonStyle}
+            disabled={isNewest}
             className="button button-primary button-compact"
             onClick={this.onAcceptRevision}
           >


### PR DESCRIPTION
### Fix

The disable on the restore note button when you are currently on the most recent revision is CSS and was not actually disabling the functionality. Additionally, the logic failed when you first opened the revisions panel. This gets everything into tip top.

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1. Open the revisions panel for a note.
2. Is button disabled?
3. Move revisions slider around
4. Can you restore a revision?
5. When you slide the slider all the way to the right does it become disabled again?

