### PR TITLE
Fix: Logged out item separators

### DIFF
--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -34,19 +34,19 @@ const buildEditMenu = (settings, isAuthenticated) => {
         label: '&Select All',
         role: 'selectall',
       },
-      { type: 'separator' },
+      ...(isAuthenticated ? [{ type: 'separator' }] : []),
       {
         label: '&Trash Note',
         visible: isAuthenticated,
         click: appCommandSender({ action: 'trashNote' }),
       },
-      { type: 'separator' },
+      ...(isAuthenticated ? [{ type: 'separator' }] : []),
       {
         label: 'Search &Notes…',
         visible: isAuthenticated,
         click: appCommandSender({ action: 'focusSearchField' }),
       },
-      { type: 'separator' },
+      ...(isAuthenticated ? [{ type: 'separator' }] : []),
       {
         label: 'C&heck Spelling',
         visible: isAuthenticated,

--- a/desktop/menus/file-menu.js
+++ b/desktop/menus/file-menu.js
@@ -12,7 +12,7 @@ const buildFileMenu = (isAuthenticated) => {
       accelerator: 'CommandOrControl+Shift+I',
       click: appCommandSender({ action: 'newNote' }),
     },
-    { type: 'separator' },
+    ...(isAuthenticated ? [{ type: 'separator' }] : []),
     {
       label: '&Import Notes…',
       visible: isAuthenticated,
@@ -29,7 +29,7 @@ const buildFileMenu = (isAuthenticated) => {
         action: 'exportZipArchive',
       }),
     },
-    { type: 'separator' },
+    ...(isAuthenticated ? [{ type: 'separator' }] : []),
     {
       label: '&Print…',
       visible: isAuthenticated,
@@ -41,7 +41,7 @@ const buildFileMenu = (isAuthenticated) => {
   const defaultSubmenuAdditions = [
     { type: 'separator' },
     menuItems.preferences(isAuthenticated),
-    { type: 'separator' },
+    ...(isAuthenticated ? [{ type: 'separator' }] : []),
     { role: 'quit' },
   ];
 

--- a/desktop/menus/mac-app-menu.js
+++ b/desktop/menus/mac-app-menu.js
@@ -12,7 +12,7 @@ const buildMacAppMenu = (isAuthenticated) => {
     ...(build.isMAS() ? [] : [menuItems.checkForUpdates]),
     { type: 'separator' },
     menuItems.preferences(isAuthenticated),
-    { type: 'separator' },
+    ...(isAuthenticated ? [{ type: 'separator' }] : []),
     {
       role: 'services',
       submenu: [],

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -120,10 +120,7 @@ const buildViewMenu = (settings, isAuthenticated) => {
           })
         ),
       },
-      {
-        type: 'separator',
-        visible: isAuthenticated,
-      },
+      ...(isAuthenticated ? [{ type: 'separator' }] : []),
       {
         label: 'Zoom &In',
         visible: isAuthenticated,
@@ -142,10 +139,7 @@ const buildViewMenu = (settings, isAuthenticated) => {
         accelerator: 'CommandOrControl+0',
         click: appCommandSender({ action: 'resetFontSize' }),
       },
-      {
-        type: 'separator',
-        visible: isAuthenticated,
-      },
+      ...(isAuthenticated ? [{ type: 'separator' }] : []),
       {
         label: 'Focus Mode',
         visible: isAuthenticated,


### PR DESCRIPTION
### Fix

Turns out Windows doesn't combine multiple separators in a row, AND the `visible` argument doesn't apply to separators, so we have to do some logic on this.

### Test

1. Log out on Windows app and look at the menus
2. Verify there aren't two separators in a row anymore

