### PR TITLE
Fix logged-out Format menu on Windows

### DIFF
--- a/desktop/menus/format-menu.js
+++ b/desktop/menus/format-menu.js
@@ -13,10 +13,10 @@ const buildFormatMenu = (isAuthenticated) => {
   const formatMenu = {
     label: 'F&ormat',
     submenu,
-    visible: isAuthenticated,
   };
 
-  return formatMenu;
+  // we have nothing to show in this menu if not logged in
+  return isAuthenticated ? formatMenu : null;
 };
 
 module.exports = buildFormatMenu;


### PR DESCRIPTION
### Fix

Apparently Windows doesn't respect the `visible` option on a menu, so let's just not return it unless we're logged in. Follow-up to #2228 

### Test
1. Open app logged-out
2. Verify Format menu is not shown
3. Log in
4. Verify Format menu is shown