### PR TITLE
Disable aux click so middle clicks will not trigger

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -64,6 +64,7 @@ module.exports = function main() {
       show: false,
       webPreferences: {
         contextIsolation: true,
+        disableBlinkFeatures: 'Auxclick',
         nodeIntegration: false,
         preload: path.join(__dirname, './preload.js'),
       },


### PR DESCRIPTION
### Fix

Disables middle clicks: https://github.com/doyensec/electronegativity/wiki/AUXCLICK_JS_CHECK

### Test
1. Nothing visible should change
2. Click around app
3. Does it work?

### Release

Security: Disabled middle clicks
