### PR TITLE
Disable remote module in electron

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -64,6 +64,7 @@ module.exports = function main() {
       show: false,
       webPreferences: {
         contextIsolation: true,
+        enableRemoteModule: false,
         nodeIntegration: false,
         preload: path.join(__dirname, './preload.js'),
       },


### PR DESCRIPTION
### Fix

The remote module in Electron carries security issues. We don't use it so why not disable it. https://github.com/doyensec/electronegativity/wiki/REMOTE_MODULE_JS_CHECK

### Test
1. Open app
2. Click around
3. Try an Evernote import

### Release

Security: Disabled Electron remote module
