### PR TITLE
Fixes note underline in firefox

### DIFF
--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -212,3 +212,7 @@
     box-shadow: inset 0 0 0 #959da5;
   }
 }
+
+.monaco-editor.monaco-editor .detected-link {
+  text-underline-position: initial;
+}


### PR DESCRIPTION
### Fix

Fixes the underline on detected links in Firefox.

![image](https://user-images.githubusercontent.com/6817400/89436484-50045380-d714-11ea-8087-e29cfb32fb2a.png)

### Test
1. Open branch in firefox
2. Add a link: https://app.simplenote.com
3. Observe underline is shown correctly.
