### PR TITLE
Harmonize menu bar and settings in sidebar

### DIFF
--- a/desktop/menus/mac-app-menu.js
+++ b/desktop/menus/mac-app-menu.js
@@ -21,6 +21,13 @@ const buildMacAppMenu = (isAuthenticated) => {
     { role: 'hide' },
     { role: 'hideothers' },
     { role: 'unhide' },
+    ...(isAuthenticated
+      ? [
+          { type: 'separator' },
+          menuItems.emptyTrash(isAuthenticated),
+          menuItems.signout(isAuthenticated),
+        ]
+      : []),
     { type: 'separator' },
     { role: 'quit' },
   ];

--- a/desktop/menus/menu-items.js
+++ b/desktop/menus/menu-items.js
@@ -16,6 +16,14 @@ const checkForUpdates = {
   click: updater.pingAndShowProgress.bind(updater),
 };
 
+const emptyTrash = (isAuthenticated) => {
+  return {
+    label: '&Empty Trash',
+    visible: isAuthenticated,
+    click: appCommandSender({ action: 'emptyTrash' }),
+  };
+};
+
 const preferences = (isAuthenticated) => {
   return {
     label: 'P&references…',
@@ -28,8 +36,20 @@ const preferences = (isAuthenticated) => {
   };
 };
 
+const signout = (isAuthenticated) => {
+  return {
+    label: '&Sign Out',
+    visible: isAuthenticated,
+    click: appCommandSender({
+      action: 'logout',
+    }),
+  };
+};
+
 module.exports = {
   about,
   checkForUpdates,
+  emptyTrash,
   preferences,
+  signout,
 };

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -1,8 +1,7 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import onClickOutside from 'react-onclickoutside';
 
-import { isElectron } from '../utils/platform';
 import ConnectionStatus from '../connection-status';
 import NavigationBarItem from './item';
 import TagList from '../tag-list';
@@ -91,42 +90,38 @@ export class NavigationBar extends Component<Props> {
           </div>
         </div>
 
-        {(!isElectron || autoHideMenuBar) && (
-          <Fragment>
-            <div className="navigation-bar__tools theme-color-border">
-              <NavigationBarItem
-                icon={<SettingsIcon />}
-                label="Settings"
-                onClick={onSettings}
-              />
-            </div>
-            <div className="navigation-bar__footer">
-              <button
-                type="button"
-                className="navigation-bar__footer-item theme-color-fg-dim"
-                onClick={this.props.showKeyboardShortcuts}
-              >
-                Keyboard Shortcuts
-              </button>
-            </div>
-            <div className="navigation-bar__footer">
-              <button
-                type="button"
-                className="navigation-bar__footer-item theme-color-fg-dim"
-                onClick={this.onHelpClicked}
-              >
-                Help &amp; Support
-              </button>
-              <button
-                type="button"
-                className="navigation-bar__footer-item theme-color-fg-dim"
-                onClick={onAbout}
-              >
-                About
-              </button>
-            </div>
-          </Fragment>
-        )}
+        <div className="navigation-bar__tools theme-color-border">
+          <NavigationBarItem
+            icon={<SettingsIcon />}
+            label="Settings"
+            onClick={onSettings}
+          />
+        </div>
+        <div className="navigation-bar__footer">
+          <button
+            type="button"
+            className="navigation-bar__footer-item theme-color-fg-dim"
+            onClick={this.props.showKeyboardShortcuts}
+          >
+            Keyboard Shortcuts
+          </button>
+        </div>
+        <div className="navigation-bar__footer">
+          <button
+            type="button"
+            className="navigation-bar__footer-item theme-color-fg-dim"
+            onClick={this.onHelpClicked}
+          >
+            Help &amp; Support
+          </button>
+          <button
+            type="button"
+            className="navigation-bar__footer-item theme-color-fg-dim"
+            onClick={onAbout}
+          >
+            About
+          </button>
+        </div>
       </div>
     );
   }

--- a/lib/state/electron/middleware.ts
+++ b/lib/state/electron/middleware.ts
@@ -5,8 +5,16 @@ import * as S from '../';
 export const middleware: S.Middleware = ({ dispatch, getState }) => {
   window.electron.receive('appCommand', (command) => {
     switch (command.action) {
+      case 'emptyTrash':
+        dispatch(actions.ui.emptyTrash());
+        return;
+
       case 'exportNotes':
         dispatch(actions.data.exportNotes());
+        return;
+
+      case 'logout':
+        dispatch({ type: 'LOGOUT' });
         return;
 
       case 'printNote':


### PR DESCRIPTION
The web app has settings/keyboard shortcuts/about items in the navigation bar but those are absent from Electron.
Electron already provides access to the settings through the OS menu but it's confusing to jump between the web and
the electron app to discover those items are missing in one place.

In this PR we stop hiding the settings and other items in the navigation sidebar when running in Electron.

The Electron OS menu has also been missing "Empty Trash" and "Sign Out" as the native apps have. "Sign Out" is particularly
convenient to have there and its absence makes logging-out particularly inconvenient.

As a result of the overall state refactor in the app we're adding those menu items to make it more convenient again.

**Before**

<img width="932" alt="Screen Shot 2020-08-05 at 6 11 56 PM" src="https://user-images.githubusercontent.com/5431237/89469343-39c3bb00-d747-11ea-8bbd-bb5ff4189235.png">
<img width="269" alt="Screen Shot 2020-08-05 at 6 12 00 PM" src="https://user-images.githubusercontent.com/5431237/89469344-3af4e800-d747-11ea-88a3-43c8237a282a.png">

**After**

<img width="931" alt="Screen Shot 2020-08-05 at 6 11 20 PM" src="https://user-images.githubusercontent.com/5431237/89469436-6677d280-d747-11ea-8c65-9da6261a656d.png">
<img width="268" alt="Screen Shot 2020-08-05 at 6 11 29 PM" src="https://user-images.githubusercontent.com/5431237/89469439-67106900-d747-11ea-9962-8119df04f2ec.png">

