### PR TITLE
[Rewrite Branch] Fix printing of notes

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -390,49 +390,50 @@ class NoteContentEditor extends Component<Props> {
           overTodo ? ' cursor-pointer' : ''
         }`}
       >
-        <div className="note-content-print">{content}</div>
-        {editor === 'fast' ? (
-          <div style={{ padding: '0 10px', whiteSpace: 'pre-wrap' }}>
-            {content}
-          </div>
-        ) : (
-          <Monaco
-            key={noteId}
-            editorDidMount={this.editorReady}
-            language="plaintext"
-            theme={theme === 'dark' ? 'vs-dark' : 'vs'}
-            onChange={this.updateNote}
-            options={{
-              autoClosingBrackets: 'never',
-              autoClosingQuotes: 'never',
-              autoIndent: 'keep',
-              autoSurround: 'never',
-              automaticLayout: true,
-              codeLens: false,
-              contextmenu: false,
-              folding: false,
-              fontFamily:
-                '"Simplenote Tasks", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
-              fontSize,
-              hideCursorInOverviewRuler: true,
-              lineHeight: fontSize > 20 ? 42 : 24,
-              lineNumbers: 'off',
-              links: true,
-              minimap: { enabled: false },
-              occurrencesHighlight: false,
-              overviewRulerBorder: false,
-              quickSuggestions: false,
-              renderIndentGuides: false,
-              renderLineHighlight: 'none',
-              scrollbar: { horizontal: 'hidden' },
-              scrollBeyondLastLine: false,
-              selectionHighlight: false,
-              wordWrap: 'on',
-              wrappingStrategy: 'simple',
-            }}
-            value={content}
-          />
-        )}
+        {/* <div
+          className={`note-content-print${
+            editor === 'fast' ? ' note-content-fast' : ''
+          }`}
+        >
+          {content}
+        </div> */}
+
+        <Monaco
+          key={noteId}
+          editorDidMount={this.editorReady}
+          language="plaintext"
+          theme={theme === 'dark' ? 'vs-dark' : 'vs'}
+          onChange={this.updateNote}
+          options={{
+            autoClosingBrackets: 'never',
+            autoClosingQuotes: 'never',
+            autoIndent: 'keep',
+            autoSurround: 'never',
+            automaticLayout: true,
+            codeLens: false,
+            contextmenu: false,
+            folding: false,
+            fontFamily:
+              '"Simplenote Tasks", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
+            fontSize,
+            hideCursorInOverviewRuler: true,
+            lineHeight: fontSize > 20 ? 42 : 24,
+            lineNumbers: 'off',
+            links: true,
+            minimap: { enabled: false },
+            occurrencesHighlight: false,
+            overviewRulerBorder: false,
+            quickSuggestions: false,
+            renderIndentGuides: false,
+            renderLineHighlight: 'none',
+            scrollbar: { horizontal: 'hidden' },
+            scrollBeyondLastLine: false,
+            selectionHighlight: false,
+            wordWrap: 'on',
+            wrappingStrategy: 'simple',
+          }}
+          value={content}
+        />
       </div>
     );
   }

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -391,9 +391,7 @@ class NoteContentEditor extends Component<Props> {
         }`}
       >
         <div
-          className={`note-content-print${
-            editor === 'fast' ? ' note-content-fast' : ''
-          }`}
+          className={`note-content-print${editor === 'fast' ? ' visible' : ''}`}
         >
           {content}
         </div>

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -391,7 +391,9 @@ class NoteContentEditor extends Component<Props> {
         }`}
       >
         <div
-          className={`note-content-print${editor === 'fast' ? ' visible' : ''}`}
+          className={`note-content-plaintext${
+            editor === 'fast' ? ' visible' : ''
+          }`}
         >
           {content}
         </div>

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -44,6 +44,7 @@ type OwnState = {
   editor: 'fast' | 'full';
   noteId: T.EntityId | null;
   overTodo: boolean;
+  print: boolean;
 };
 
 class NoteContentEditor extends Component<Props> {
@@ -56,6 +57,7 @@ class NoteContentEditor extends Component<Props> {
     editor: 'fast',
     noteId: null,
     overTodo: false,
+    print: false,
   };
 
   static getDerivedStateFromProps(props: Props, state: OwnState) {
@@ -90,6 +92,16 @@ class NoteContentEditor extends Component<Props> {
         });
       }
     }, SPEED_DELAY);
+    window.addEventListener('beforeprint', () => {
+      this.setState({
+        print: true,
+      });
+    });
+    window.addEventListener('afterprint', () => {
+      this.setState({
+        print: false,
+      });
+    });
   }
 
   componentWillUnmount() {
@@ -382,7 +394,7 @@ class NoteContentEditor extends Component<Props> {
 
   render() {
     const { fontSize, noteId, theme } = this.props;
-    const { content, editor, overTodo } = this.state;
+    const { content, editor, overTodo, print } = this.state;
 
     return (
       <div
@@ -390,7 +402,7 @@ class NoteContentEditor extends Component<Props> {
           overTodo ? ' cursor-pointer' : ''
         }`}
       >
-        {editor === 'fast' ? (
+        {editor === 'fast' || true ? (
           <div style={{ padding: '0 10px', whiteSpace: 'pre-wrap' }}>
             {content}
           </div>

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -44,7 +44,6 @@ type OwnState = {
   editor: 'fast' | 'full';
   noteId: T.EntityId | null;
   overTodo: boolean;
-  print: boolean;
 };
 
 class NoteContentEditor extends Component<Props> {
@@ -57,7 +56,6 @@ class NoteContentEditor extends Component<Props> {
     editor: 'fast',
     noteId: null,
     overTodo: false,
-    print: false,
   };
 
   static getDerivedStateFromProps(props: Props, state: OwnState) {
@@ -92,16 +90,6 @@ class NoteContentEditor extends Component<Props> {
         });
       }
     }, SPEED_DELAY);
-    window.addEventListener('beforeprint', () => {
-      this.setState({
-        print: true,
-      });
-    });
-    window.addEventListener('afterprint', () => {
-      this.setState({
-        print: false,
-      });
-    });
   }
 
   componentWillUnmount() {
@@ -394,7 +382,7 @@ class NoteContentEditor extends Component<Props> {
 
   render() {
     const { fontSize, noteId, theme } = this.props;
-    const { content, editor, overTodo, print } = this.state;
+    const { content, editor, overTodo } = this.state;
 
     return (
       <div
@@ -402,7 +390,8 @@ class NoteContentEditor extends Component<Props> {
           overTodo ? ' cursor-pointer' : ''
         }`}
       >
-        {editor === 'fast' || true ? (
+        <div className="note-content-print">{content}</div>
+        {editor === 'fast' ? (
           <div style={{ padding: '0 10px', whiteSpace: 'pre-wrap' }}>
             {content}
           </div>

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -390,50 +390,51 @@ class NoteContentEditor extends Component<Props> {
           overTodo ? ' cursor-pointer' : ''
         }`}
       >
-        {/* <div
+        <div
           className={`note-content-print${
             editor === 'fast' ? ' note-content-fast' : ''
           }`}
         >
           {content}
-        </div> */}
-
-        <Monaco
-          key={noteId}
-          editorDidMount={this.editorReady}
-          language="plaintext"
-          theme={theme === 'dark' ? 'vs-dark' : 'vs'}
-          onChange={this.updateNote}
-          options={{
-            autoClosingBrackets: 'never',
-            autoClosingQuotes: 'never',
-            autoIndent: 'keep',
-            autoSurround: 'never',
-            automaticLayout: true,
-            codeLens: false,
-            contextmenu: false,
-            folding: false,
-            fontFamily:
-              '"Simplenote Tasks", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
-            fontSize,
-            hideCursorInOverviewRuler: true,
-            lineHeight: fontSize > 20 ? 42 : 24,
-            lineNumbers: 'off',
-            links: true,
-            minimap: { enabled: false },
-            occurrencesHighlight: false,
-            overviewRulerBorder: false,
-            quickSuggestions: false,
-            renderIndentGuides: false,
-            renderLineHighlight: 'none',
-            scrollbar: { horizontal: 'hidden' },
-            scrollBeyondLastLine: false,
-            selectionHighlight: false,
-            wordWrap: 'on',
-            wrappingStrategy: 'simple',
-          }}
-          value={content}
-        />
+        </div>
+        {editor !== 'fast' && (
+          <Monaco
+            key={noteId}
+            editorDidMount={this.editorReady}
+            language="plaintext"
+            theme={theme === 'dark' ? 'vs-dark' : 'vs'}
+            onChange={this.updateNote}
+            options={{
+              autoClosingBrackets: 'never',
+              autoClosingQuotes: 'never',
+              autoIndent: 'keep',
+              autoSurround: 'never',
+              automaticLayout: true,
+              codeLens: false,
+              contextmenu: false,
+              folding: false,
+              fontFamily:
+                '"Simplenote Tasks", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
+              fontSize,
+              hideCursorInOverviewRuler: true,
+              lineHeight: fontSize > 20 ? 42 : 24,
+              lineNumbers: 'off',
+              links: true,
+              minimap: { enabled: false },
+              occurrencesHighlight: false,
+              overviewRulerBorder: false,
+              quickSuggestions: false,
+              renderIndentGuides: false,
+              renderLineHighlight: 'none',
+              scrollbar: { horizontal: 'hidden' },
+              scrollBeyondLastLine: false,
+              selectionHighlight: false,
+              wordWrap: 'on',
+              wrappingStrategy: 'simple',
+            }}
+            value={content}
+          />
+        )}
       </div>
     );
   }

--- a/scss/print.scss
+++ b/scss/print.scss
@@ -41,7 +41,7 @@
     }
   }
 
-  .note-content-print {
+  .note-content-plaintext {
     left: 0px;
     top: 0px;
     position: absolute;

--- a/scss/print.scss
+++ b/scss/print.scss
@@ -1,51 +1,51 @@
-.theme-dark .theme-color-bg {
-  background-color: #ffffff;
-  padding-top: 20px;
-}
+@media print {
+  .theme-dark .theme-color-bg {
+    background-color: #ffffff;
+  }
 
-.app-layout__source-column {
-  display: none;
-}
+  .app-layout__note-column {
+    border: 0;
+  }
 
-.app-layout__note-column {
-  border: 0;
-}
+  .dev-badge,
+  .app-layout__source-column,
+  .tag-field,
+  .note-toolbar-wrapper,
+  .last-sync,
+  .react-monaco-editor-container {
+    display: none;
+  }
 
-.dev-badge {
-  display: none;
-}
+  /* Firefox only prints the first page if any divs are display: flex */
+  .app,
+  .simplenote-app,
+  .app-layout,
+  .app-layout__note-column,
+  .note-editor,
+  .note-detail-wrapper,
+  .note-detail,
+  .note-detail-textarea,
+  .note-content-editor-shell,
+  .note-detail-wrapper {
+    overflow: visible;
+  }
 
-.tag-field,
-.note-toolbar-wrapper,
-.last-sync {
-  display: none;
-}
-
-/* Firefox only prints the first page if any divs are display: flex */
-.app,
-.simplenote-app,
-.app-layout,
-.app-layout__note-column,
-.note-editor,
-.note-detail-wrapper,
-.note-detail {
-  overflow: visible;
-}
-
-.note-detail-wrapper {
-  overflow: visible;
-}
-x .note-detail {
-  overflow: visible;
-}
-
-[class^='note-detail-'] {
-  max-width: 100%;
-  width: 100%;
-  color: $studio-black;
-
-  &.theme-color-fg {
+  [class^='note-detail-'] {
+    max-width: 100%;
+    width: 100%;
     color: $studio-black;
-    overflow-y: auto !important;
+
+    &.theme-color-fg {
+      color: $studio-black;
+      overflow-y: auto !important;
+    }
+  }
+
+  .note-content-print {
+    left: 0px;
+    top: 0px;
+    position: absolute;
+    display: inherit;
+    white-space: pre-wrap;
   }
 }

--- a/scss/print.scss
+++ b/scss/print.scss
@@ -42,9 +42,6 @@
   }
 
   .note-content-plaintext {
-    left: 0px;
-    top: 0px;
-    position: absolute;
     display: inherit;
     white-space: pre-wrap;
   }

--- a/scss/print.scss
+++ b/scss/print.scss
@@ -43,6 +43,5 @@
 
   .note-content-plaintext {
     display: inherit;
-    white-space: pre-wrap;
   }
 }

--- a/scss/print.scss
+++ b/scss/print.scss
@@ -1,48 +1,51 @@
-@media print {
-  .app-layout__source-column {
-    display: none;
-  }
+.theme-dark .theme-color-bg {
+  background-color: #ffffff;
+  padding-top: 20px;
+}
 
-  .app-layout__note-column {
-    border: 0;
-  }
+.app-layout__source-column {
+  display: none;
+}
 
-  .dev-badge {
-    display: none;
-  }
+.app-layout__note-column {
+  border: 0;
+}
 
-  .tag-field,
-  .note-toolbar-wrapper {
-    display: none;
-  }
+.dev-badge {
+  display: none;
+}
 
-  /* Firefox only prints the first page if any divs are display: flex */
-  .app,
-  .simplenote-app,
-  .app-layout,
-  .app-layout__note-column,
-  .note-editor,
-  .note-detail-wrapper,
-  .note-detail {
-    display: block;
-    overflow: visible;
-  }
+.tag-field,
+.note-toolbar-wrapper,
+.last-sync {
+  display: none;
+}
 
-  .note-detail-wrapper {
-    overflow: visible;
-  }
+/* Firefox only prints the first page if any divs are display: flex */
+.app,
+.simplenote-app,
+.app-layout,
+.app-layout__note-column,
+.note-editor,
+.note-detail-wrapper,
+.note-detail {
+  overflow: visible;
+}
 
-  .note-detail {
-    overflow: visible;
-  }
+.note-detail-wrapper {
+  overflow: visible;
+}
+x .note-detail {
+  overflow: visible;
+}
 
-  [class^='note-detail-'] {
-    max-width: 100%;
-    width: 100%;
+[class^='note-detail-'] {
+  max-width: 100%;
+  width: 100%;
+  color: $studio-black;
+
+  &.theme-color-fg {
     color: $studio-black;
-
-    &.theme-color-fg {
-      color: $studio-black;
-    }
+    overflow-y: auto !important;
   }
 }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -43,11 +43,11 @@
 
 .note-content-plaintext {
   display: none;
+  white-space: pre-wrap;
 
   &.visible {
     display: inherit;
     padding: 0 10px;
-    white-space: pre-wrap;
   }
 }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -43,12 +43,12 @@
 
 .note-content-print {
   display: none;
-}
 
-.note-content-fast {
-  display: inherit;
-  padding: 0 10px;
-  white-space: pre-wrap;
+  &.visible {
+    display: inherit;
+    padding: 0 10px;
+    white-space: pre-wrap;
+  }
 }
 
 .theme-light {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -45,6 +45,12 @@
   display: none;
 }
 
+.note-content-fast {
+  display: inherit;
+  padding: 0 10px;
+  white-space: pre-wrap;
+}
+
 .theme-light {
   background-color: $studio-white;
   color: $studio-gray-60;

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -41,6 +41,10 @@
   cursor: pointer;
 }
 
+.note-content-print {
+  display: none;
+}
+
 .theme-light {
   background-color: $studio-white;
   color: $studio-gray-60;

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -41,7 +41,7 @@
   cursor: pointer;
 }
 
-.note-content-print {
+.note-content-plaintext {
   display: none;
 
   &.visible {


### PR DESCRIPTION
### Fix

This PR adds a display none div that contains the content of a note. When the user prints it displays that div and hides other content on the page.

Adding a display none div with the content allows us to do this purely with CSS rather than watching for print events and potentially running into race conditions with React rendering.

### Test
1. Have a note
2. Print it
3. Save to pdf
4. Do this in Safari, Chrome, and Firefox

