### PR TITLE
[rewrite branch] Use custom styles for Monaco; fixes colors of various editor components

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1,6 +1,10 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Monaco, { ChangeHandler, EditorDidMount } from 'react-monaco-editor';
+import Monaco, {
+  ChangeHandler,
+  EditorDidMount,
+  EditorWillMount,
+} from 'react-monaco-editor';
 import { editor as Editor, Selection, SelectionDirection } from 'monaco-editor';
 
 import actions from './state/actions';
@@ -148,6 +152,37 @@ class NoteContentEditor extends Component<Props> {
     }
 
     return true;
+  };
+
+  editorInit: EditorWillMount = () => {
+    Editor.defineTheme('simplenote', {
+      base: 'vs',
+      inherit: true,
+      rules: [{ background: 'FFFFFF' }],
+      colors: {
+        'editor.foreground': '#2c3338', // $studio-gray-80 AKA theme-color-fg
+        'editor.background': '#ffffff',
+        'editor.selectionBackground': '#ced9f2', // $studio-simplenote-blue-5
+        'scrollbarSlider.activeBackground': '#8c8f94', // $studio-gray-30
+        'scrollbarSlider.background': '#c3c4c7', // $studio-gray-10
+        'scrollbarSlider.hoverBackground': '#a7aaad', // $studio-gray-20
+        'textLink.foreground': '#1d4fc4', // $studio-simplenote-blue-60
+      },
+    });
+    Editor.defineTheme('simplenote-dark', {
+      base: 'vs-dark',
+      inherit: true,
+      rules: [{ background: '1d2327' }],
+      colors: {
+        'editor.foreground': '#ffffff',
+        'editor.background': '#1d2327', // $studio-gray-90
+        'editor.selectionBackground': '#50575e', // $studio-gray-60
+        'scrollbarSlider.activeBackground': '#646970', // $studio-gray-50
+        'scrollbarSlider.background': '#2c3338', // $studio-gray-80
+        'scrollbarSlider.hoverBackground': '#1d2327', // $studio-gray-90
+        'textLink.foreground': '#ced9f2', // studio-simplenote-blue-5
+      },
+    });
   };
 
   editorReady: EditorDidMount = (editor, monaco) => {
@@ -398,8 +433,9 @@ class NoteContentEditor extends Component<Props> {
           <Monaco
             key={noteId}
             editorDidMount={this.editorReady}
+            editorWillMount={this.editorInit}
             language="plaintext"
-            theme={theme === 'dark' ? 'vs-dark' : 'vs'}
+            theme={theme === 'dark' ? 'simplenote-dark' : 'simplenote'}
             onChange={this.updateNote}
             options={{
               autoClosingBrackets: 'never',
@@ -423,7 +459,7 @@ class NoteContentEditor extends Component<Props> {
               quickSuggestions: false,
               renderIndentGuides: false,
               renderLineHighlight: 'none',
-              scrollbar: { horizontal: 'hidden' },
+              scrollbar: { horizontal: 'hidden', useShadows: false },
               scrollBeyondLastLine: false,
               selectionHighlight: false,
               wordWrap: 'on',

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -63,13 +63,6 @@
   .search-field {
     border-color: $studio-gray-10;
   }
-
-  .monaco-editor-background,
-  .monaco-editor .margin,
-  .monaco-editor .scroll-decoration {
-    background-color: $studio-white;
-    box-shadow: none;
-  }
 }
 
 .theme-dark {
@@ -194,7 +187,7 @@
 
   .note-list-item {
     &.note-list-item-selected {
-      background: #2c3338;
+      background: $studio-gray-80;
     }
 
     .note-list-item-excerpt {
@@ -231,12 +224,5 @@
         background-color: $studio-gray-80;
       }
     }
-  }
-
-  .monaco-editor-background,
-  .monaco-editor .margin,
-  .monaco-editor .scroll-decoration {
-    background-color: $studio-gray-90;
-    box-shadow: none;
   }
 }


### PR DESCRIPTION
### Fix

Monaco can accept custom theming; instead of using the default `vs` and `vs-dark` themes, we can create Simplenote light and dark themes to pass in.

Options are documented over here: https://microsoft.github.io/monaco-editor/playground.html#customizing-the-appearence-exposed-colors and scrollbars here: https://microsoft.github.io/monaco-editor/playground.html#customizing-the-appearence-scrollbars

This fixes #2265 as well as other oddities such as the highlight colors not matching.

### Test

Observe the colors of various things within the editor component (text color, highlight, scrollbar). They should match the rest of the app (and, hopefully, production).

### Release

Not updated: Use Monaco styles to pass Simplenote theme to editor component