### PR TITLE
Remove Simplenote font from body fixing line height

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,5 +1,5 @@
-$sans: 'Simplenote Tasks', -apple-system, 'Segoe UI', 'Roboto', 'Oxygen-Sans',
-  'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+$sans: -apple-system, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell',
+  'Helvetica Neue', sans-serif;
 $normal: 400;
 $bold: 600;
 $light: 300;


### PR DESCRIPTION
### Fix

The 'Simplenote Tasks' font causes line-height issues in Safari and Firefox. This remove the font from the body tag. It is explicitly added to the editor and the note list. This means there is no benefit to adding it to the body tag.

### Test
1. Safari or Firefox
2. Observe buttons in the History panel
3. Does the line-height look off?
