### PR TITLE
[Rewrite Branch] Use Monaco context menu for editor actions

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -327,9 +327,9 @@ class NoteContentEditor extends Component<Props> {
 
   editorReady: EditorDidMount = (editor, monaco) => {
     this.editor = editor;
-    this.monaco = monaco;
-
     window.editor = editor;
+
+    this.monaco = monaco;
     window.monaco = monaco;
 
     // remove keybindings; see https://github.com/microsoft/monaco-editor/issues/287
@@ -363,14 +363,52 @@ class NoteContentEditor extends Component<Props> {
     );
 
     editor.addAction({
+      id: 'SelectAll',
+      label: 'Select All',
+      contextMenuGroupId: '9_cutcopypaste',
+      contextMenuOrder: 5,
+      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_A],
+      keybindingContext: 'allowBrowserKeybinding',
+      run: () => {
+        editor.setSelection(editor.getModel().getFullModelRange());
+      },
+    });
+    editor.addAction({
+      id: 'undo_model',
+      label: 'Undo',
+      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_Z],
+      keybindingContext: 'allowBrowserKeybinding',
+      contextMenuGroupId: '9_cutcopypaste',
+      contextMenuOrder: 3,
+      // precondition: 'undo',
+      run: () => {
+        editor.trigger('contextMenu', 'undo', null);
+      },
+    });
+    editor.addAction({
+      id: 'redo_model',
+      label: 'Redo',
+      keybindings: [
+        monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KEY_Z,
+      ],
+      keybindingContext: 'allowBrowserKeybinding',
+      contextMenuGroupId: '9_cutcopypaste',
+      contextMenuOrder: 4,
+      // precondition: 'redo',
+      run: () => {
+        editor.trigger('contextMenu', 'redo', null);
+      },
+    });
+
+    editor.addAction({
       id: 'insertChecklist',
       label: 'Insert Checklist',
       keybindings: [
         monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KEY_C,
       ],
+      keybindingContext: 'allowBrowserKeybinding',
       contextMenuGroupId: '9_cutcopypaste',
       contextMenuOrder: 9,
-      keybindingContext: 'allowBrowserKeybinding',
       run: this.insertOrRemoveCheckboxes,
     });
 
@@ -511,39 +549,6 @@ class NoteContentEditor extends Component<Props> {
           ),
         });
       }
-    });
-
-    editor.addAction({
-      id: 'SelectAll',
-      label: 'Select All',
-      contextMenuGroupId: 'z',
-      run: () => {
-        editor.setSelection(editor.getModel().getFullModelRange());
-      },
-    });
-    editor.addAction({
-      id: 'undo_model',
-      label: 'Undo',
-      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_Z],
-      contextMenuGroupId: 'undoredo',
-      contextMenuOrder: 0,
-      // precondition: 'undo',
-      run: () => {
-        editor.trigger('', 'undo');
-      },
-    });
-    editor.addAction({
-      id: 'redo_model',
-      label: 'Redo',
-      keybindings: [
-        monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KEY_Z,
-      ],
-      contextMenuGroupId: 'undoredo',
-      contextMenuOrder: 0,
-      // precondition: 'redo',
-      run: () => {
-        editor.trigger('', 'redo');
-      },
     });
   };
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -329,6 +329,9 @@ class NoteContentEditor extends Component<Props> {
     this.editor = editor;
     this.monaco = monaco;
 
+    window.editor = editor;
+    window.monaco = monaco;
+
     // remove keybindings; see https://github.com/microsoft/monaco-editor/issues/287
     const shortcutsToDisable = [
       'cursorUndo', // meta+U
@@ -509,6 +512,39 @@ class NoteContentEditor extends Component<Props> {
         });
       }
     });
+
+    editor.addAction({
+      id: 'SelectAll',
+      label: 'Select All',
+      contextMenuGroupId: 'z',
+      run: () => {
+        editor.setSelection(editor.getModel().getFullModelRange());
+      },
+    });
+    editor.addAction({
+      id: 'undo_model',
+      label: 'Undo',
+      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_Z],
+      contextMenuGroupId: 'undoredo',
+      contextMenuOrder: 0,
+      // precondition: 'undo',
+      run: () => {
+        editor.trigger('', 'undo');
+      },
+    });
+    editor.addAction({
+      id: 'redo_model',
+      label: 'Redo',
+      keybindings: [
+        monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KEY_Z,
+      ],
+      contextMenuGroupId: 'undoredo',
+      contextMenuOrder: 0,
+      // precondition: 'redo',
+      run: () => {
+        editor.trigger('', 'redo');
+      },
+    });
   };
 
   updateNote: ChangeHandler = (value, event) => {
@@ -657,7 +693,6 @@ class NoteContentEditor extends Component<Props> {
               autoSurround: 'never',
               automaticLayout: true,
               codeLens: false,
-              contextmenu: false,
               folding: false,
               fontFamily:
                 '"Simplenote Tasks", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -434,16 +434,21 @@ class NoteContentEditor extends Component<Props> {
         );
       },
     });
-    editor.addAction({
-      id: 'paste',
-      label: 'Paste',
-      contextMenuGroupId: '9_cutcopypaste',
-      contextMenuOrder: 3,
-      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_V],
-      run: () => {
-        document.execCommand('paste');
-      },
-    });
+
+    /* paste doesn't work in the browser due to security issues */
+    if (window.electron) {
+      editor.addAction({
+        id: 'paste',
+        label: 'Paste',
+        contextMenuGroupId: '9_cutcopypaste',
+        contextMenuOrder: 3,
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_V],
+        keybindingContext: 'allowBrowserKeybinding',
+        run: () => {
+          document.execCommand('paste');
+        },
+      });
+    }
 
     editor.addAction({
       id: 'select_all',

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -379,19 +379,19 @@ class NoteContentEditor extends Component<Props> {
     );
 
     editor.addAction({
-      id: 'undo_model',
+      id: 'context_undo',
       label: 'Undo',
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_Z],
       keybindingContext: 'allowBrowserKeybinding',
-      contextMenuGroupId: '1_undoredo',
-      contextMenuOrder: 1,
+      contextMenuGroupId: '1_modification',
+      contextMenuOrder: 2,
       // precondition: 'undo',
       run: () => {
         editor.trigger('contextMenu', 'undo', null);
       },
     });
     editor.addAction({
-      id: 'redo_model',
+      id: 'context_redo',
       label: 'Redo',
       keybindings: [
         monaco.KeyMod.WinCtrl | monaco.KeyCode.KEY_Y,
@@ -399,11 +399,41 @@ class NoteContentEditor extends Component<Props> {
         // @todo can we switch these so Windows displays the default ^Y?
       ],
       keybindingContext: 'allowBrowserKeybinding',
-      contextMenuGroupId: '1_undoredo',
-      contextMenuOrder: 2,
+      contextMenuGroupId: '1_modification',
+      contextMenuOrder: 3,
       // precondition: 'redo',
       run: () => {
         editor.trigger('contextMenu', 'redo', null);
+      },
+    });
+
+    // add a new Cut and Copy that show keyboard shortcuts
+    editor.addAction({
+      id: 'context_cut',
+      label: 'Cut',
+      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_X],
+      keybindingContext: 'allowBrowserKeybinding',
+      contextMenuGroupId: '9_cutcopypaste',
+      contextMenuOrder: 1,
+      // precondition: 'undo',
+      run: () => {
+        editor.trigger('contextMenu', 'editor.action.clipboardCutAction', null);
+      },
+    });
+    editor.addAction({
+      id: 'context_copy',
+      label: 'Copy',
+      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_C],
+      keybindingContext: 'allowBrowserKeybinding',
+      contextMenuGroupId: '9_cutcopypaste',
+      contextMenuOrder: 2,
+      // precondition: 'undo',
+      run: () => {
+        editor.trigger(
+          'contextMenu',
+          'editor.action.clipboardCopyAction',
+          null
+        );
       },
     });
     editor.addAction({
@@ -436,8 +466,8 @@ class NoteContentEditor extends Component<Props> {
         monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KEY_C,
       ],
       keybindingContext: 'allowBrowserKeybinding',
-      contextMenuGroupId: '9_cutcopypaste',
-      contextMenuOrder: 9,
+      contextMenuGroupId: '10_checklist',
+      contextMenuOrder: 1,
       run: this.insertOrRemoveCheckboxes,
     });
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -343,10 +343,7 @@ class NoteContentEditor extends Component<Props> {
 
   editorReady: EditorDidMount = (editor, monaco) => {
     this.editor = editor;
-    window.editor = editor;
-
     this.monaco = monaco;
-    window.monaco = monaco;
 
     // remove keybindings; see https://github.com/microsoft/monaco-editor/issues/287
     const shortcutsToDisable = [

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -415,7 +415,6 @@ class NoteContentEditor extends Component<Props> {
       keybindingContext: 'allowBrowserKeybinding',
       contextMenuGroupId: '9_cutcopypaste',
       contextMenuOrder: 1,
-      // precondition: 'undo',
       run: () => {
         editor.trigger('contextMenu', 'editor.action.clipboardCutAction', null);
       },
@@ -427,7 +426,6 @@ class NoteContentEditor extends Component<Props> {
       keybindingContext: 'allowBrowserKeybinding',
       contextMenuGroupId: '9_cutcopypaste',
       contextMenuOrder: 2,
-      // precondition: 'undo',
       run: () => {
         editor.trigger(
           'contextMenu',

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -363,23 +363,12 @@ class NoteContentEditor extends Component<Props> {
     );
 
     editor.addAction({
-      id: 'SelectAll',
-      label: 'Select All',
-      contextMenuGroupId: '9_cutcopypaste',
-      contextMenuOrder: 5,
-      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_A],
-      keybindingContext: 'allowBrowserKeybinding',
-      run: () => {
-        editor.setSelection(editor.getModel().getFullModelRange());
-      },
-    });
-    editor.addAction({
       id: 'undo_model',
       label: 'Undo',
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_Z],
       keybindingContext: 'allowBrowserKeybinding',
-      contextMenuGroupId: '9_cutcopypaste',
-      contextMenuOrder: 3,
+      contextMenuGroupId: '1_undoredo',
+      contextMenuOrder: 1,
       // precondition: 'undo',
       run: () => {
         editor.trigger('contextMenu', 'undo', null);
@@ -389,14 +378,38 @@ class NoteContentEditor extends Component<Props> {
       id: 'redo_model',
       label: 'Redo',
       keybindings: [
+        monaco.KeyMod.WinCtrl | monaco.KeyCode.KEY_Y,
         monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KEY_Z,
+        // @todo can we switch these so Windows displays the default ^Y?
       ],
       keybindingContext: 'allowBrowserKeybinding',
-      contextMenuGroupId: '9_cutcopypaste',
-      contextMenuOrder: 4,
+      contextMenuGroupId: '1_undoredo',
+      contextMenuOrder: 2,
       // precondition: 'redo',
       run: () => {
         editor.trigger('contextMenu', 'redo', null);
+      },
+    });
+    editor.addAction({
+      id: 'paste',
+      label: 'Paste',
+      contextMenuGroupId: '9_cutcopypaste',
+      contextMenuOrder: 3,
+      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_V],
+      run: () => {
+        document.execCommand('paste');
+      },
+    });
+
+    editor.addAction({
+      id: 'select_all',
+      label: 'Select All',
+      contextMenuGroupId: '9_cutcopypaste',
+      contextMenuOrder: 4,
+      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_A],
+      keybindingContext: 'allowBrowserKeybinding',
+      run: () => {
+        editor.setSelection(editor.getModel().getFullModelRange());
       },
     });
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -511,37 +511,6 @@ class NoteContentEditor extends Component<Props> {
     this.setDecorators();
     editor.onDidChangeModelContent(() => this.setDecorators());
 
-    const titleDecoration = (line: number) => ({
-      range: new monaco.Range(line, 1, line, 1),
-      options: {
-        isWholeLine: true,
-        inlineClassName: 'note-title',
-        stickiness: Editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-      },
-    });
-
-    let decorations: string[] = [];
-    const decorateFirstLine = () => {
-      const model = editor.getModel();
-      if (!model) {
-        decorations = [];
-        return;
-      }
-
-      for (let i = 1; i <= model.getLineCount(); i++) {
-        const line = model.getLineContent(i);
-        if (line.trim().length > 0) {
-          decorations = editor.deltaDecorations(decorations, [
-            titleDecoration(i),
-          ]);
-          break;
-        }
-      }
-    };
-
-    decorateFirstLine();
-    editor.onDidChangeModelContent(() => decorateFirstLine());
-
     document.oncopy = (event) => {
       // @TODO: This is selecting everything in the app but we should only
       //        need to intercept copy events coming from the editor

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -64,6 +64,17 @@
   }
 }
 
+.monaco-editor .editor-widget {
+  display: none !important;
+}
+
+.monaco-menu .monaco-action-bar.vertical .action-item:first-child,
+.monaco-menu .monaco-action-bar.vertical .action-item:last-child,
+.monaco-menu .monaco-action-bar.vertical .action-label.separator:first-child,
+.monaco-menu .monaco-action-bar.vertical .action-label.separator:last-child {
+  display: none !important;
+}
+
 .note-detail-textarea .note-content-editor-shell.cursor-pointer div {
   cursor: pointer;
 }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -66,12 +66,16 @@
 
 /* Hide unwanted items in the context menu.
    This removes the first item (Change All Occurrences) and the last (Command Palette).
-   We may need to adjust these rules if a Monaco update adds more default items!
+   The nth-child's remove Cut(7) and Copy(9) so we can add keybindings to them.
+   We may need to adjust these rules if a Monaco update adds more default items,
+   OR if we add/remove/reorder menu items sometime in the future :(
    See: https://github.com/microsoft/monaco-editor/issues/1280
 */
 .monaco-menu .monaco-action-bar.vertical .action-item:first-child,
-.monaco-menu .monaco-action-bar.vertical .action-item:last-child,
-.monaco-menu .action-label.separator {
+.monaco-menu .monaco-action-bar.vertical .action-item:nth-child(7),
+.monaco-menu .monaco-action-bar.vertical .action-item:nth-child(9),
+.monaco-menu .monaco-action-bar.vertical .action-item:nth-last-child(2),
+.monaco-menu .monaco-action-bar.vertical .action-item:last-child {
   display: none !important;
 }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -64,14 +64,21 @@
   }
 }
 
-.monaco-editor .editor-widget {
+/* Hide unwanted items in the context menu.
+   This removes the first item (Change All Occurrences) and the last (Command Palette).
+   We may need to adjust these rules if a Monaco update adds more default items!
+   See: https://github.com/microsoft/monaco-editor/issues/1280
+*/
+.monaco-menu .monaco-action-bar.vertical .action-item:first-child,
+.monaco-menu .monaco-action-bar.vertical .action-item:last-child,
+.monaco-menu .action-label.separator {
   display: none !important;
 }
 
-.monaco-menu .monaco-action-bar.vertical .action-item:first-child,
-.monaco-menu .monaco-action-bar.vertical .action-item:last-child,
-.monaco-menu .monaco-action-bar.vertical .action-label.separator:first-child,
-.monaco-menu .monaco-action-bar.vertical .action-label.separator:last-child {
+/* Hide the suggestion popup
+  See: https://github.com/microsoft/monaco-editor/issues/1681#issuecomment-580751164
+*/
+.monaco-editor .suggest-widget {
   display: none !important;
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,7 +97,6 @@ module.exports = () => {
           '!codelens',
           '!colorDetector',
           '!comment',
-          '!contextmenu',
           '!folding',
           '!gotoError',
           '!gotoLine',


### PR DESCRIPTION
### Fix

Moves to the Monaco context menu. This enables undo/redo/select all/copy/cut from the context menu.

<img width="181" alt="Screen Shot 2020-08-25 at 10 01 13 AM" src="https://user-images.githubusercontent.com/6817400/91183840-f4493c80-e6b9-11ea-825b-6423ef23d2b6.png">

### Test
1. Test all the items in the context menu on multiple browsers
2. Test all the items in the edit menu on multiple browsers
