### PR TITLE
[rewrite branch] Fix plain-text revision preview

### DIFF
--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -21,6 +21,7 @@ type StateProps = {
   note: T.Note | null;
   noteId: T.EntityId | null;
   searchQuery: string;
+  showRevisions: boolean;
 };
 
 type DispatchProps = {
@@ -38,6 +39,7 @@ export const NotePreview: FunctionComponent<Props> = ({
   noteId,
   openNote,
   searchQuery,
+  showRevisions,
 }) => {
   const previewNode = useRef<HTMLDivElement>();
 
@@ -132,7 +134,11 @@ export const NotePreview: FunctionComponent<Props> = ({
       return;
     }
 
-    if (note?.content && note?.systemTags.includes('markdown')) {
+    if (
+      note?.content &&
+      note?.systemTags.includes('markdown') &&
+      !showRevisions
+    ) {
       renderToNode(previewNode.current, note!.content, searchQuery);
     } else {
       previewNode.current.innerText = withCheckboxCharacters(
@@ -165,6 +171,7 @@ const mapStateToProps: S.MapState<StateProps, OwnProps> = (state, props) => ({
   note: props.note ?? state.data.notes.get(props.noteId),
   noteId: props.noteId ?? state.ui.openedNote,
   searchQuery: state.ui.searchQuery,
+  showRevisions: state.ui.showRevisions,
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -16,12 +16,12 @@ type OwnProps = {
 };
 
 type StateProps = {
-  editMode: boolean;
   fontSize: number;
   isFocused: boolean;
   note: T.Note | null;
   noteId: T.EntityId | null;
   searchQuery: string;
+  showRenderedView: boolean;
 };
 
 type DispatchProps = {
@@ -32,7 +32,6 @@ type DispatchProps = {
 type Props = OwnProps & StateProps & DispatchProps;
 
 export const NotePreview: FunctionComponent<Props> = ({
-  editMode,
   editNote,
   fontSize,
   isFocused,
@@ -40,6 +39,7 @@ export const NotePreview: FunctionComponent<Props> = ({
   noteId,
   openNote,
   searchQuery,
+  showRenderedView,
 }) => {
   const previewNode = useRef<HTMLDivElement>();
 
@@ -134,7 +134,7 @@ export const NotePreview: FunctionComponent<Props> = ({
       return;
     }
 
-    if (note?.content && note?.systemTags.includes('markdown') && !editMode) {
+    if (note?.content && showRenderedView) {
       renderToNode(previewNode.current, note!.content, searchQuery);
     } else {
       previewNode.current.innerText = withCheckboxCharacters(
@@ -167,7 +167,8 @@ const mapStateToProps: S.MapState<StateProps, OwnProps> = (state, props) => ({
   note: props.note ?? state.data.notes.get(props.noteId),
   noteId: props.noteId ?? state.ui.openedNote,
   searchQuery: state.ui.searchQuery,
-  editMode: state.ui.editMode,
+  showRenderedView:
+    props.note?.systemTags.includes('markdown') && !state.ui.editMode,
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -16,12 +16,12 @@ type OwnProps = {
 };
 
 type StateProps = {
+  editMode: boolean;
   fontSize: number;
   isFocused: boolean;
   note: T.Note | null;
   noteId: T.EntityId | null;
   searchQuery: string;
-  showRevisions: boolean;
 };
 
 type DispatchProps = {
@@ -32,6 +32,7 @@ type DispatchProps = {
 type Props = OwnProps & StateProps & DispatchProps;
 
 export const NotePreview: FunctionComponent<Props> = ({
+  editMode,
   editNote,
   fontSize,
   isFocused,
@@ -39,7 +40,6 @@ export const NotePreview: FunctionComponent<Props> = ({
   noteId,
   openNote,
   searchQuery,
-  showRevisions,
 }) => {
   const previewNode = useRef<HTMLDivElement>();
 
@@ -134,11 +134,7 @@ export const NotePreview: FunctionComponent<Props> = ({
       return;
     }
 
-    if (
-      note?.content &&
-      note?.systemTags.includes('markdown') &&
-      !showRevisions
-    ) {
+    if (note?.content && note?.systemTags.includes('markdown') && !editMode) {
       renderToNode(previewNode.current, note!.content, searchQuery);
     } else {
       previewNode.current.innerText = withCheckboxCharacters(
@@ -171,7 +167,7 @@ const mapStateToProps: S.MapState<StateProps, OwnProps> = (state, props) => ({
   note: props.note ?? state.data.notes.get(props.noteId),
   noteId: props.noteId ?? state.ui.openedNote,
   searchQuery: state.ui.searchQuery,
-  showRevisions: state.ui.showRevisions,
+  editMode: state.ui.editMode,
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {


### PR DESCRIPTION
### Fix

We're overloading the preview component to preview revisions as well as rendered Markdown, so it needs to be aware of whether we're in `editMode`. This allows viewing revisions of Markdown notes either rendered or plain-text, depending on whether preview was selected when opening the history viewer.

### Test

1. Open a Markdown note with some history
2. Open revision history and scrub through
3. Verify that the revisions are shown in plain-text
4. Toggle Markdown preview and open revision history again
5. Verify that revisions are previewed in Markdown
6. Verify that revision history works as expected for a non-Markdown note

