### PR TITLE
[rewrite branch] Disable bracket highlighting

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -495,6 +495,7 @@ class NoteContentEditor extends Component<Props> {
               lineHeight: fontSize > 20 ? 42 : 24,
               lineNumbers: 'off',
               links: true,
+              matchBrackets: 'never',
               minimap: { enabled: false },
               occurrencesHighlight: false,
               overviewRulerBorder: false,


### PR DESCRIPTION
### Fix

Disables the Monaco behavior where brackets and parentheses are highlighted.

### Screenshots

Before:
<img width="488" alt="Screen Shot 2020-08-18 at 2 19 36 PM" src="https://user-images.githubusercontent.com/52152/90596928-e7ea4e80-e1a4-11ea-8255-5881041aa5c6.png">

After:
<img width="551" alt="Screen Shot 2020-08-18 at 10 48 29 PM" src="https://user-images.githubusercontent.com/52152/90596962-f89ac480-e1a4-11ea-8396-f95b8ba19631.png">
