### PR TITLE
[rewrite branch] Fix keyboard shortcuts

### DIFF
--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -33,6 +33,7 @@ const buildEditMenu = (settings, isAuthenticated) => {
       {
         label: '&Select All',
         click: editorCommandSender({ action: 'selectAll' }),
+        role: 'selectAll',
       },
       { type: 'separator' },
       {

--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -10,10 +10,12 @@ const buildEditMenu = (settings, isAuthenticated) => {
       {
         label: '&Undo',
         click: editorCommandSender({ action: 'undo' }),
+        accelerator: 'CommandOrControl+Z',
       },
       {
         label: '&Redo',
         click: editorCommandSender({ action: 'redo' }),
+        accelerator: 'CommandOrControl+Shift+Z',
       },
       {
         type: 'separator',
@@ -33,7 +35,7 @@ const buildEditMenu = (settings, isAuthenticated) => {
       {
         label: '&Select All',
         click: editorCommandSender({ action: 'selectAll' }),
-        role: 'selectAll',
+        accelerator: 'CommandOrControl+A',
       },
       { type: 'separator' },
       {
@@ -46,6 +48,7 @@ const buildEditMenu = (settings, isAuthenticated) => {
         label: 'Search &Notes…',
         visible: isAuthenticated,
         click: appCommandSender({ action: 'focusSearchField' }),
+        accelerator: 'CommandOrControl+Shift+S',
       },
       { type: 'separator' },
       {

--- a/desktop/menus/format-menu.js
+++ b/desktop/menus/format-menu.js
@@ -1,4 +1,4 @@
-const { appCommandSender } = require('./utils');
+const { editorCommandSender } = require('./utils');
 
 const buildFormatMenu = (isAuthenticated) => {
   isAuthenticated = isAuthenticated || false;
@@ -6,7 +6,7 @@ const buildFormatMenu = (isAuthenticated) => {
     {
       label: 'Insert &Checklist',
       accelerator: 'CommandOrControl+Shift+C',
-      click: appCommandSender({ action: 'insertChecklist' }),
+      click: editorCommandSender({ action: 'insertChecklist' }),
     },
   ];
 

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -36,7 +36,6 @@ type DispatchProps = {
   closeNote: () => any;
   createNote: () => any;
   focusSearchField: () => any;
-  openTagList: () => any;
   setLineLength: (length: T.LineLength) => any;
   setNoteDisplay: (displayMode: T.ListDisplayMode) => any;
   setSortType: (sortType: T.SortType) => any;
@@ -45,6 +44,7 @@ type DispatchProps = {
   toggleSortOrder: () => any;
   toggleSortTagsAlpha: () => any;
   toggleSpellCheck: () => any;
+  toggleTagList: () => any;
 };
 
 type Props = OwnProps & StateProps & DispatchProps;
@@ -76,13 +76,8 @@ class AppComponent extends Component<Props> {
     const cmdOrCtrl = (ctrlKey || metaKey) && ctrlKey !== metaKey;
 
     // open tag list
-    if (
-      cmdOrCtrl &&
-      shiftKey &&
-      'KeyU' === code &&
-      !this.props.showNavigation
-    ) {
-      this.props.openTagList();
+    if (cmdOrCtrl && shiftKey && 'KeyU' === code) {
+      this.props.toggleTagList();
 
       event.stopPropagation();
       event.preventDefault();
@@ -186,7 +181,6 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => {
     closeNote: () => dispatch(closeNote()),
     createNote: () => dispatch(createNote()),
     focusSearchField: () => dispatch(actions.ui.focusSearchField()),
-    openTagList: () => dispatch(toggleNavigation()),
     setLineLength: (length) => dispatch(settingsActions.setLineLength(length)),
     setNoteDisplay: (displayMode) =>
       dispatch(settingsActions.setNoteDisplay(displayMode)),
@@ -197,6 +191,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => {
     toggleSortOrder: () => dispatch(settingsActions.toggleSortOrder()),
     toggleSortTagsAlpha: () => dispatch(settingsActions.toggleSortTagsAlpha()),
     toggleSpellCheck: () => dispatch(settingsActions.toggleSpellCheck()),
+    toggleTagList: () => dispatch(toggleNavigation()),
   };
 };
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -255,15 +255,22 @@ class NoteContentEditor extends Component<Props> {
       editor._standaloneKeybindingService.addDynamicKeybinding('-' + action);
     });
 
+    // disable editor keybindings for Electron since it is handled by appCommand
+    // doing it this way will always show the keyboard hint in the context menu!
+    editor.createContextKey(
+      'allowBrowserKeybinding',
+      window.electron ? false : true
+    );
+
     editor.addAction({
       id: 'insertChecklist',
       label: 'Insert Checklist',
-      // we don't need to add keybindings for Electron since it is handled by appCommand
-      keybindings: window.electron
-        ? []
-        : [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KEY_C],
-      contextMenuGroupId: '1_modification',
-      contextMenuOrder: 2.5,
+      keybindings: [
+        monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KEY_C,
+      ],
+      contextMenuGroupId: '9_cutcopypaste',
+      contextMenuOrder: 9,
+      keybindingContext: 'allowBrowserKeybinding',
       run: this.insertOrRemoveCheckboxes,
     });
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -108,7 +108,6 @@ class NoteContentEditor extends Component<Props> {
       clearTimeout(this.bootTimer);
     }
     window.electron?.removeListener('editorCommand');
-    window.electron?.removeListener('appCommand');
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -255,7 +254,7 @@ class NoteContentEditor extends Component<Props> {
       editor._standaloneKeybindingService.addDynamicKeybinding('-' + action);
     });
 
-    // disable editor keybindings for Electron since it is handled by appCommand
+    // disable editor keybindings for Electron since it is handled by editorCommand
     // doing it this way will always show the keyboard hint in the context menu!
     editor.createContextKey(
       'allowBrowserKeybinding',
@@ -276,6 +275,9 @@ class NoteContentEditor extends Component<Props> {
 
     window.electron?.receive('editorCommand', (command) => {
       switch (command.action) {
+        case 'insertChecklist':
+          editor.trigger('editorCommand', 'insertChecklist', null);
+          return;
         case 'redo':
           editor.trigger('', 'redo');
           return;
@@ -284,14 +286,6 @@ class NoteContentEditor extends Component<Props> {
           return;
         case 'undo':
           editor.trigger('', 'undo');
-          return;
-      }
-    });
-
-    window.electron?.receive('appCommand', (command) => {
-      switch (command.action) {
-        case 'insertChecklist':
-          editor.trigger('appCommand', 'insertChecklist', null);
           return;
       }
     });

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -200,6 +200,22 @@ class NoteContentEditor extends Component<Props> {
     this.editor = editor;
     this.monaco = monaco;
 
+    // remove keybindings; see https://github.com/microsoft/monaco-editor/issues/287
+    const shortcutsToDisable = [
+      'editor.action.commentLine', // meta+/
+      'editor.action.transposeLetters', // ctrl+T
+      'editor.action.triggerSuggest', // ctrl+space
+      'expandLineSelection',
+      // search shortcuts
+      'actions.find',
+      'actions.findWithSelection',
+      'editor.action.addSelectionToNextFindMatch',
+      'editor.action.nextMatchFindAction',
+    ];
+    shortcutsToDisable.forEach(function (action) {
+      editor._standaloneKeybindingService.addDynamicKeybinding('-' + action);
+    });
+
     window.electron?.receive('editorCommand', (command) => {
       switch (command.action) {
         case 'redo':

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -250,6 +250,10 @@ class NoteContentEditor extends Component<Props> {
       'editor.action.nextMatchFindAction',
       'editor.action.selectHighlights',
     ];
+    // let Electron menus trigger these
+    if (window.electron) {
+      shortcutsToDisable.push('undo', 'redo', 'editor.action.selectAll');
+    }
     shortcutsToDisable.forEach(function (action) {
       editor._standaloneKeybindingService.addDynamicKeybinding('-' + action);
     });
@@ -279,13 +283,13 @@ class NoteContentEditor extends Component<Props> {
           editor.trigger('editorCommand', 'insertChecklist', null);
           return;
         case 'redo':
-          editor.trigger('', 'redo');
+          editor.trigger('editorCommand', 'redo', null);
           return;
         case 'selectAll':
           editor.setSelection(editor.getModel().getFullModelRange());
           return;
         case 'undo':
-          editor.trigger('', 'undo');
+          editor.trigger('editorCommand', 'undo', null);
           return;
       }
     });

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -211,6 +211,7 @@ class NoteContentEditor extends Component<Props> {
       'actions.findWithSelection',
       'editor.action.addSelectionToNextFindMatch',
       'editor.action.nextMatchFindAction',
+      'editor.action.selectHighlights',
     ];
     shortcutsToDisable.forEach(function (action) {
       editor._standaloneKeybindingService.addDynamicKeybinding('-' + action);

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -202,10 +202,12 @@ class NoteContentEditor extends Component<Props> {
 
     // remove keybindings; see https://github.com/microsoft/monaco-editor/issues/287
     const shortcutsToDisable = [
+      'cursorUndo', // meta+U
       'editor.action.commentLine', // meta+/
+      'editor.action.jumpToBracket', // shift+meta+\
       'editor.action.transposeLetters', // ctrl+T
       'editor.action.triggerSuggest', // ctrl+space
-      'expandLineSelection',
+      'expandLineSelection', // meta+L
       // search shortcuts
       'actions.find',
       'actions.findWithSelection',

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -19,6 +19,11 @@ import * as T from './types';
 
 const SPEED_DELAY = 120;
 
+type OwnProps = {
+  storeFocusEditor: (focusSetter: () => any) => any;
+  storeHasFocus: (focusGetter: () => boolean) => any;
+};
+
 type StateProps = {
   editorSelection: [number, number, 'RTL' | 'LTR'];
   fontSize: number;
@@ -42,7 +47,7 @@ type DispatchProps = {
   ) => any;
 };
 
-type Props = StateProps & DispatchProps;
+type Props = OwnProps & StateProps & DispatchProps;
 
 type OwnState = {
   content: string;
@@ -94,6 +99,8 @@ class NoteContentEditor extends Component<Props> {
         });
       }
     }, SPEED_DELAY);
+    this.props.storeFocusEditor(this.focusEditor);
+    this.props.storeHasFocus(this.hasFocus);
   }
 
   componentWillUnmount() {
@@ -145,6 +152,10 @@ class NoteContentEditor extends Component<Props> {
       }, 400);
     }
   }
+
+  focusEditor = () => this.editor?.focus();
+
+  hasFocus = () => this.editor?.hasTextFocus();
 
   insertOrRemoveCheckboxes = (editor: Editor.IStandaloneCodeEditor) => {
     // todo: we're not disabling this if !this.props.keyboardShortcuts, do we want to?

--- a/lib/state/electron/middleware.ts
+++ b/lib/state/electron/middleware.ts
@@ -29,10 +29,6 @@ export const middleware: S.Middleware = ({ dispatch, getState }) => {
         dispatch(actions.ui.focusSearchField());
         return;
 
-      case 'insertChecklist':
-        dispatch({ type: 'INSERT_TASK' });
-        return;
-
       case 'showDialog':
         dispatch(actions.ui.showDialog(command.dialog));
         return;


### PR DESCRIPTION
Fixes a number of keyboard shortcut issues in staging:

### Disable Monaco keybindings
For why there is no better solution to this ridiculousness, see https://github.com/microsoft/monaco-editor/issues/287

- [x] `cmd` + `/`, conflicts with show keyboard shortcuts dialog
- [x] `cmd` + `L`, conflicts with jump to URL in browser
- [x] `ctrl` + `F`, find, let's disable so we can use the browser search
- [x] `ctrl` + `G` // jump to next match, pops up a window, let's suppress it
- [ ] ~`ctrl` + `shift` + `G` // jump to previous match~ (can't be triggered with no prior search)
- [x] `meta` + `U`, cursorUndo, conflicts with View Source in Firefox
- [x] `shift` + `meta` + `\`, jump to bracket
- [x] `ctrl` + `shift` + `L`, select highlights -- this is cool but it conflicts with our toggle note list (on narrow screens)

### Add a handler for Insert Checklist Item
- [x] insertChecklist as an editor action and appCommand listener

### Disable Monaco keybindings for menu items in Electron
I also added keyboard hints that were missing.
- Undo
- Redo
- SelectAll

I just like it when the menu bar flashes with a keypress. Without unbinding these combos, it fails to do so (because the keypress is picked up by Monaco and not bubbled to Electron menus).

### Tag list shortcut should be a toggle
- [x] toggle tag list (`ctrl` + `shift` + `U`) should both open and close the tag list, not just open it

### Select All in the search field (Electron)
- [x] Meta+A should select all when you're in the search field, tag field, etc

### Tag/editor toggle
- [x] `ctrl` + `shift` + `Y` -- toggle editing note/tags