### PR TITLE
Fix deep-linking for Windows app store

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -27,6 +27,14 @@ module.exports = function main() {
   // be closed automatically when the JavaScript object is GCed.
   let mainWindow = null;
 
+  app.on('will-finish-launching', function () {
+    setTimeout(updater.ping.bind(updater), config.updater.delay);
+    app.on('open-url', function (event, url) {
+      event.preventDefault();
+      mainWindow.webContents.send('wpLogin', url);
+    });
+  });
+
   const url =
     isDev && process.env.DEV_SERVER
       ? 'http://localhost:4000' // TODO: find a solution to use host and port based on make config.
@@ -155,14 +163,6 @@ module.exports = function main() {
     // wait until window is presentable
     mainWindow.once('ready-to-show', mainWindow.show);
   };
-
-  app.on('will-finish-launching', function () {
-    setTimeout(updater.ping.bind(updater), config.updater.delay);
-    app.on('open-url', function (event, url) {
-      event.preventDefault();
-      mainWindow.webContents.send('wpLogin', url);
-    });
-  });
 
   const gotTheLock = app.requestSingleInstanceLock();
   if (gotTheLock) {

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -170,6 +170,14 @@ module.exports = function main() {
   }
 
   app.on('second-instance', (e, argv) => {
+    // Someone tried to run a second instance, we should focus our window.
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) {
+        mainWindow.restore();
+      }
+      mainWindow.focus();
+    }
+
     if (process.platform === 'darwin') {
       // macOS communicates deep-linking via the `open-url` event (see above)
       // but we might still end up with this message so ignore it if we do
@@ -179,14 +187,6 @@ module.exports = function main() {
     // argv: An array of the second instance’s (command line / deep linked) arguments
     // The last index of argv is the full deeplink url (simplenote://SOME_URL)
     mainWindow.webContents.send('wpLogin', argv[argv.length - 1]);
-
-    // Someone tried to run a second instance, we should focus our window.
-    if (mainWindow) {
-      if (mainWindow.isMinimized()) {
-        mainWindow.restore();
-      }
-      mainWindow.focus();
-    }
   });
 
   if (!app.isDefaultProtocolClient('simplenote')) {

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -167,14 +167,15 @@ module.exports = function main() {
   const gotTheLock = app.requestSingleInstanceLock();
   if (gotTheLock) {
     app.on('second-instance', (e, argv) => {
+      if (process.platform === 'darwin') {
+        // macOS communicates deep-linking via the `open-url` event (see above)
+        // but we might still end up with this message so ignore it if we do
+        return;
+      }
       // Protocol handler for platforms other than macOS
       // argv: An array of the second instance’s (command line / deep linked) arguments
       // The last index of argv is the full deeplink url (simplenote://SOME_URL)
-      // second-instance should not be called by macOS however we should check
-      if (process.platform !== 'darwin') {
-        const url = argv[argv.length - 1] || '';
-        mainWindow.webContents.send('wpLogin', url);
-      }
+      mainWindow.webContents.send('wpLogin', argv[argv.length - 1]);
 
       // Someone tried to run a second instance, we should focus our window.
       if (mainWindow) {

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -165,9 +165,6 @@ module.exports = function main() {
   };
 
   const gotTheLock = app.requestSingleInstanceLock();
-  if (!gotTheLock) {
-    return app.quit();
-  }
 
   app.on('second-instance', (e, argv) => {
     // Someone tried to run a second instance, we should focus our window.
@@ -188,6 +185,10 @@ module.exports = function main() {
     // The last index of argv is the full deeplink url (simplenote://SOME_URL)
     mainWindow.webContents.send('wpLogin', argv[argv.length - 1]);
   });
+
+  if (!gotTheLock) {
+    return app.quit();
+  }
 
   if (!app.isDefaultProtocolClient('simplenote')) {
     // Define custom protocol handler. This allows for deeplinking into the app from simplenote://

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -167,16 +167,16 @@ module.exports = function main() {
   const gotTheLock = app.requestSingleInstanceLock();
   if (gotTheLock) {
     app.on('second-instance', (e, argv) => {
-      // Someone tried to run a second instance, we should focus our window.
-      // Protocol handler for win32
+      // Protocol handler for platforms other than macOS
       // argv: An array of the second instance’s (command line / deep linked) arguments
+      // The last index of argv is the full deeplink url (simplenote://SOME_URL)
+      // second-instance should not be called by macOS however we should check
       if (process.platform !== 'darwin') {
-        // Keep only command line / deep linked arguments
-        const url =
-          (argv.slice(-1) && argv.slice(-1).length && argv.slice(-1)[0]) || '';
+        const url = argv[argv.length - 1] || '';
         mainWindow.webContents.send('wpLogin', url);
       }
 
+      // Someone tried to run a second instance, we should focus our window.
       if (mainWindow) {
         if (mainWindow.isMinimized()) {
           mainWindow.restore();

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -165,30 +165,29 @@ module.exports = function main() {
   };
 
   const gotTheLock = app.requestSingleInstanceLock();
-  if (gotTheLock) {
-    app.on('second-instance', (e, argv) => {
-      if (process.platform === 'darwin') {
-        // macOS communicates deep-linking via the `open-url` event (see above)
-        // but we might still end up with this message so ignore it if we do
-        return;
-      }
-      // Protocol handler for platforms other than macOS
-      // argv: An array of the second instance’s (command line / deep linked) arguments
-      // The last index of argv is the full deeplink url (simplenote://SOME_URL)
-      mainWindow.webContents.send('wpLogin', argv[argv.length - 1]);
-
-      // Someone tried to run a second instance, we should focus our window.
-      if (mainWindow) {
-        if (mainWindow.isMinimized()) {
-          mainWindow.restore();
-        }
-        mainWindow.focus();
-      }
-    });
-  } else {
-    app.quit();
-    return;
+  if (!gotTheLock) {
+    return app.quit();
   }
+
+  app.on('second-instance', (e, argv) => {
+    if (process.platform === 'darwin') {
+      // macOS communicates deep-linking via the `open-url` event (see above)
+      // but we might still end up with this message so ignore it if we do
+      return;
+    }
+    // Protocol handler for platforms other than macOS
+    // argv: An array of the second instance’s (command line / deep linked) arguments
+    // The last index of argv is the full deeplink url (simplenote://SOME_URL)
+    mainWindow.webContents.send('wpLogin', argv[argv.length - 1]);
+
+    // Someone tried to run a second instance, we should focus our window.
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) {
+        mainWindow.restore();
+      }
+      mainWindow.focus();
+    }
+  });
 
   if (!app.isDefaultProtocolClient('simplenote')) {
     // Define custom protocol handler. This allows for deeplinking into the app from simplenote://

--- a/electron-builder-appx.json
+++ b/electron-builder-appx.json
@@ -23,6 +23,12 @@
     "backgroundColor": "transparent",
     "artifactName": "Simplenote-win-store-${version}-${arch}.${ext}"
   },
+  "protocols": [
+    {
+      "name": "simplenote",
+      "schemes": ["simplenote"]
+    }
+  ],
   "afterSign": "./after_sign_hook.js",
   "afterAllArtifactBuild": "./after_sign_hook.js"
 }

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -89,6 +89,12 @@
     "vendor": "Automattic, Inc.",
     "maintainer": "Automattic, Inc. <support@simplenote.com>"
   },
+  "protocols": [
+    {
+      "name": "simplenote",
+      "schemes": ["simplenote"]
+    }
+  ],
   "deb": {
     "depends": ["gconf2"]
   },


### PR DESCRIPTION
### Fix

Fixes wpcom login on the Windows store.

The appx deeplinking was broken due to the way that appx registers itself. You have to specify the protocol in the app registry which means it needs to be moved to the electron builder config.

I moved the `will-finish-launching` below the instantiation of mainWindow as I managed to catch an error that mainWindow was null. This ensures that we won't get into that error state because the watcher isn't set up until mainWindow is no longer null.

Additionally, I added some code to the ''second-instance' to correctly send the URL that we get back from wpcom to windows.

### Test
1. Download the appx from circleCI for this PR
2. Login via wpcom login
3. Login via email and password

### Release

Fixes WordPress.com login
