### PR TITLE
Add/inter note link searching

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -602,6 +602,38 @@ class NoteContentEditor extends Component<Props> {
       window.electron ? false : true
     );
 
+    editor.addCommand(
+      monaco.KeyMod.WinCtrl | monaco.KeyCode.Space,
+      function () {
+        // only show suggestions if we have an open bracket
+        const model = editor.getModel();
+        if (!model) {
+          return;
+        }
+        // @todo DRY - code duplicated from the completion handler
+        const position = editor.getPosition();
+        const line = model.getLineContent(position.lineNumber);
+        if (!line.includes('[')) {
+          return;
+        }
+        const precedingOpener = line.lastIndexOf('[', position.column);
+        const precedingCloser = line.lastIndexOf(']', position.column);
+        const precedingBracket =
+          precedingOpener >= 0 && precedingCloser < precedingOpener
+            ? precedingOpener
+            : -1;
+
+        const soFar =
+          precedingBracket >= 0
+            ? line.slice(precedingBracket + 1, position.column)
+            : '';
+
+        if (soFar) {
+          editor.trigger('suggestions', 'editor.action.triggerSuggest', null);
+        }
+      }
+    );
+
     editor.addAction({
       id: 'context_undo',
       label: 'Undo',

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -164,8 +164,6 @@ class NoteContentEditor extends Component<Props> {
     window.electron?.removeListener('editorCommand');
     window.removeEventListener('input', this.handleUndoRedo, true);
     this.toggleShortcuts(false);
-
-    this.completionProviderHandle?.dispose();
   }
 
   toggleShortcuts = (doEnable: boolean) => {
@@ -530,11 +528,6 @@ class NoteContentEditor extends Component<Props> {
         'textLink.foreground': '#ced9f2', // studio-simplenote-blue-5
       },
     });
-
-    this.completionProviderHandle = monaco.languages.registerCompletionItemProvider(
-      'plaintext',
-      this.completionProvider()
-    );
   };
 
   editorReady: EditorDidMount = (editor, monaco) => {
@@ -753,6 +746,13 @@ class NoteContentEditor extends Component<Props> {
     // make component rerender after the decorators are set.
     this.setState({});
     editor.onDidChangeModelContent(() => this.setDecorators());
+
+    // register completion provider for internal links
+    this.completionProviderHandle = monaco.languages.registerCompletionItemProvider(
+      'plaintext',
+      this.completionProvider()
+    );
+    editor.onDidDispose(() => this.completionProviderHandle?.dispose());
 
     document.oncopy = (event) => {
       // @TODO: This is selecting everything in the app but we should only

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -201,10 +201,6 @@ class NoteContentEditor extends Component<Props> {
       provideCompletionItems(model, position, context, token) {
         const line = model.getLineContent(position.lineNumber);
         const precedingOpener = line.lastIndexOf('[', position.column);
-        if (-1 === precedingOpener) {
-          editor.trigger('completions', 'hideSuggestWidget', null);
-          return null;
-        }
         const precedingCloser = line.lastIndexOf(']', position.column);
         const precedingBracket =
           precedingOpener >= 0 && precedingCloser < precedingOpener
@@ -231,12 +227,6 @@ class NoteContentEditor extends Component<Props> {
           isPinned: note.systemTags.includes('pinned'),
           ...noteTitleAndPreview(note),
         }));
-
-        if (0 === notes.length) {
-          // dismiss the widget if we don't have anything to suggest
-          editor.trigger('completions', 'hideSuggestWidget', null);
-          return null;
-        }
 
         const additionalTextEdits =
           precedingBracket >= 0
@@ -776,6 +766,11 @@ class NoteContentEditor extends Component<Props> {
       this.completionProvider(this.state.noteId, editor)
     );
     editor.onDidDispose(() => completionProviderHandle?.dispose());
+    monaco.languages.setLanguageConfiguration('plaintext', {
+      // Allow any non-whitespace character to be part of a "word"
+      // This prevents the dictionary suggestions from taking over our autosuggest
+      wordPattern: /[^\s]+/g,
+    });
 
     document.oncopy = (event) => {
       // @TODO: This is selecting everything in the app but we should only

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -174,8 +174,9 @@ class NoteContentEditor extends Component<Props> {
     }
   };
 
-  completionProvider: () => languages.CompletionItemProvider = () => {
-    const selectedNoteId = this.state.noteId;
+  completionProvider: (
+    selectedNoteId: T.EntityId
+  ) => languages.CompletionItemProvider = (selectedNoteId) => {
     return {
       triggerCharacters: ['['],
 
@@ -750,7 +751,7 @@ class NoteContentEditor extends Component<Props> {
     // register completion provider for internal links
     this.completionProviderHandle = monaco.languages.registerCompletionItemProvider(
       'plaintext',
-      this.completionProvider()
+      this.completionProvider(this.state.noteId)
     );
     editor.onDidDispose(() => this.completionProviderHandle?.dispose());
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -202,6 +202,7 @@ class NoteContentEditor extends Component<Props> {
           openedTag: null,
           showTrash: false,
           searchTags: tagsFromSearch(soFar),
+          titleOnly: true,
         },
         5
       ).map(([noteId, note]) => ({

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -100,7 +100,6 @@ type OwnState = {
 
 class NoteContentEditor extends Component<Props> {
   bootTimer: ReturnType<typeof setTimeout> | null = null;
-  completionProviderHandle: ReturnType<typeof IDisposable> | null = null;
   editor: Editor.IStandaloneCodeEditor | null = null;
   monaco: Monaco | null = null;
   contentDiv = createRef<HTMLDivElement>();
@@ -175,7 +174,7 @@ class NoteContentEditor extends Component<Props> {
   };
 
   completionProvider: (
-    selectedNoteId: T.EntityId
+    selectedNoteId: T.EntityId | null
   ) => languages.CompletionItemProvider = (selectedNoteId) => {
     return {
       triggerCharacters: ['['],
@@ -781,11 +780,11 @@ class NoteContentEditor extends Component<Props> {
     editor.onDidChangeModelContent(() => this.setDecorators());
 
     // register completion provider for internal links
-    this.completionProviderHandle = monaco.languages.registerCompletionItemProvider(
+    const completionProviderHandle = monaco.languages.registerCompletionItemProvider(
       'plaintext',
       this.completionProvider(this.state.noteId)
     );
-    editor.onDidDispose(() => this.completionProviderHandle?.dispose());
+    editor.onDidDispose(() => completionProviderHandle?.dispose());
 
     document.oncopy = (event) => {
       // @TODO: This is selecting everything in the app but we should only

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -92,11 +92,14 @@ type Props = OwnProps & StateProps & DispatchProps;
 type OwnState = {
   content: string;
   editor: 'fast' | 'full';
+  hasCompletionProvider: boolean;
   noteId: T.EntityId | null;
   overTodo: boolean;
   searchQuery: string;
   selectedSearchMatchIndex: number | null;
 };
+
+let hasCompletionProvider = false;
 
 class NoteContentEditor extends Component<Props> {
   bootTimer: ReturnType<typeof setTimeout> | null = null;
@@ -521,10 +524,14 @@ class NoteContentEditor extends Component<Props> {
         'textLink.foreground': '#ced9f2', // studio-simplenote-blue-5
       },
     });
-    monaco.languages.registerCompletionItemProvider(
-      'plaintext',
-      this.completionProvider
-    );
+
+    if (!hasCompletionProvider) {
+      hasCompletionProvider = true;
+      monaco.languages.registerCompletionItemProvider(
+        'plaintext',
+        this.completionProvider
+      );
+    }
   };
 
   editorReady: EditorDidMount = (editor, monaco) => {

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -227,6 +227,7 @@ class NoteContentEditor extends Component<Props> {
           : [];
 
       return {
+        incomplete: true,
         suggestions: notes.map((note, index) => ({
           additionalTextEdits,
           kind: note.isPinned

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1054,7 +1054,7 @@ class NoteContentEditor extends Component<Props> {
               minimap: { enabled: false },
               occurrencesHighlight: false,
               overviewRulerBorder: false,
-              quickSuggestions: true,
+              quickSuggestions: false,
               renderIndentGuides: false,
               renderLineHighlight: 'none',
               scrollbar: {
@@ -1064,6 +1064,7 @@ class NoteContentEditor extends Component<Props> {
               },
               scrollBeyondLastLine: false,
               selectionHighlight: false,
+              suggestOnTriggerCharacters: true,
               wordWrap: 'bounded',
               wrappingStrategy: isSafari ? 'simple' : 'advanced',
               wordWrapColumn: 400,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -92,7 +92,6 @@ type Props = OwnProps & StateProps & DispatchProps;
 type OwnState = {
   content: string;
   editor: 'fast' | 'full';
-  hasCompletionProvider: boolean;
   noteId: T.EntityId | null;
   overTodo: boolean;
   searchQuery: string;

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -98,8 +98,6 @@ type OwnState = {
   selectedSearchMatchIndex: number | null;
 };
 
-let hasCompletionProvider = false;
-
 class NoteContentEditor extends Component<Props> {
   bootTimer: ReturnType<typeof setTimeout> | null = null;
   editor: Editor.IStandaloneCodeEditor | null = null;
@@ -176,6 +174,8 @@ class NoteContentEditor extends Component<Props> {
   };
 
   completionProvider: languages.CompletionItemProvider = {
+    triggerCharacters: ['['],
+
     provideCompletionItems(model, position, context, token) {
       const line = model.getLineContent(position.lineNumber);
       if (!line.includes('[')) {
@@ -521,6 +521,10 @@ class NoteContentEditor extends Component<Props> {
         'textLink.foreground': '#ced9f2', // studio-simplenote-blue-5
       },
     });
+    monaco.languages.registerCompletionItemProvider(
+      'plaintext',
+      this.completionProvider
+    );
   };
 
   editorReady: EditorDidMount = (editor, monaco) => {
@@ -561,13 +565,6 @@ class NoteContentEditor extends Component<Props> {
         return { ...link, url: '#' }; // tell Monaco to do nothing and not complain about it
       },
     });
-    if (!hasCompletionProvider) {
-      hasCompletionProvider = true;
-      monaco.languages.registerCompletionItemProvider(
-        'plaintext',
-        this.completionProvider
-      );
-    }
 
     // remove keybindings; see https://github.com/microsoft/monaco-editor/issues/287
     const shortcutsToDisable = [

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -659,6 +659,7 @@ class NoteContentEditor extends Component<Props> {
       id: 'cancel_selection',
       label: 'Cancel Selection',
       keybindings: [monaco.KeyCode.Escape],
+      keybindingContext: '!suggestWidgetVisible',
       run: this.cancelSelectionOrSearch,
     });
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -5,12 +5,18 @@ import Monaco, {
   EditorDidMount,
   EditorWillMount,
 } from 'react-monaco-editor';
-import { editor as Editor, Selection, SelectionDirection } from 'monaco-editor';
-import { search } from './state/ui/actions';
+import {
+  editor as Editor,
+  languages,
+  Selection,
+  SelectionDirection,
+} from 'monaco-editor';
 
+import { searchNotes, tagsFromSearch } from './search';
 import actions from './state/actions';
 import * as selectors from './state/selectors';
 import { getTerms } from './utils/filter-notes';
+import { noteTitleAndPreview } from './utils/note-utils';
 import { isSafari } from './utils/platform';
 import {
   withCheckboxCharacters,
@@ -92,6 +98,8 @@ type OwnState = {
   selectedSearchMatchIndex: number | null;
 };
 
+let hasCompletionProvider = false;
+
 class NoteContentEditor extends Component<Props> {
   bootTimer: ReturnType<typeof setTimeout> | null = null;
   editor: Editor.IStandaloneCodeEditor | null = null;
@@ -165,6 +173,77 @@ class NoteContentEditor extends Component<Props> {
     } else {
       window.removeEventListener('keydown', this.handleShortcut, true);
     }
+  };
+
+  completionProvider: languages.CompletionItemProvider = {
+    provideCompletionItems(model, position, context, token) {
+      const line = model.getLineContent(position.lineNumber);
+      if (!line.includes('[')) {
+        return null;
+      }
+
+      const precedingOpener = line.lastIndexOf('[', position.column);
+      const precedingCloser = line.lastIndexOf(']', position.column);
+      const precedingBracket =
+        precedingOpener >= 0 && precedingCloser < precedingOpener
+          ? precedingOpener
+          : -1;
+
+      const soFar =
+        precedingBracket >= 0
+          ? line.slice(precedingBracket + 1, position.column)
+          : '';
+
+      const notes = searchNotes(
+        {
+          searchTerms: getTerms(soFar),
+          openedTag: null,
+          showTrash: false,
+          searchTags: tagsFromSearch(soFar),
+        },
+        5
+      ).map(([noteId, note]) => ({
+        noteId,
+        content: note.content,
+        isPinned: note.systemTags.includes('pinned'),
+        ...noteTitleAndPreview(note),
+      }));
+
+      const additionalTextEdits =
+        precedingBracket >= 0
+          ? [
+              {
+                text: '',
+                range: {
+                  startLineNumber: position.lineNumber,
+                  startColumn: precedingBracket,
+                  endLineNumber: position.lineNumber,
+                  endColumn: position.column,
+                },
+              },
+            ]
+          : [];
+
+      return {
+        suggestions: notes.map((note, index) => ({
+          additionalTextEdits,
+          kind: note.isPinned
+            ? languages.CompletionItemKind.Snippet
+            : languages.CompletionItemKind.File,
+          label: note.title,
+          // detail: note.preview,
+          documentation: note.content,
+          insertText: `[${note.title}](simplenote://note/${note.noteId})`,
+          sortText: index.toString(),
+          range: {
+            startLineNumber: position.lineNumber,
+            startColumn: position.column,
+            endLineNumber: position.lineNumber,
+            endColumn: position.column,
+          },
+        })),
+      };
+    },
   };
 
   handleShortcut = (event: KeyboardEvent) => {
@@ -482,6 +561,13 @@ class NoteContentEditor extends Component<Props> {
         return { ...link, url: '#' }; // tell Monaco to do nothing and not complain about it
       },
     });
+    if (!hasCompletionProvider) {
+      hasCompletionProvider = true;
+      monaco.languages.registerCompletionItemProvider(
+        'plaintext',
+        this.completionProvider
+      );
+    }
 
     // remove keybindings; see https://github.com/microsoft/monaco-editor/issues/287
     const shortcutsToDisable = [
@@ -970,7 +1056,7 @@ class NoteContentEditor extends Component<Props> {
               minimap: { enabled: false },
               occurrencesHighlight: false,
               overviewRulerBorder: false,
-              quickSuggestions: false,
+              quickSuggestions: true,
               renderIndentGuides: false,
               renderLineHighlight: 'none',
               scrollbar: {
@@ -1035,7 +1121,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
-  clearSearch: () => dispatch(search('')),
+  clearSearch: () => actions.ui.search(''),
   editNote: actions.data.editNote,
   insertTask: () => ({ type: 'INSERT_TASK' }),
   openNote: actions.ui.selectNote,

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -22,6 +22,7 @@ type SearchNote = {
 
 type SearchState = {
   hasSelectedFirstNote: boolean;
+  excludeIDs: Array<T.EntityId> | null;
   notes: Map<T.EntityId, SearchNote>;
   openedTag: T.TagHash | null;
   searchQuery: string;
@@ -30,7 +31,7 @@ type SearchState = {
   showTrash: boolean;
   sortType: T.SortType;
   sortReversed: boolean;
-  titleOnly: boolean;
+  titleOnly: boolean | null;
 };
 
 const toSearchNote = (note: Partial<T.Note>): SearchNote => ({
@@ -60,6 +61,7 @@ export let searchNotes: (
 
 export const middleware: S.Middleware = (store) => {
   const searchState: SearchState = {
+    excludeIDs: [],
     hasSelectedFirstNote: false,
     notes: new Map(),
     openedTag: null,
@@ -69,6 +71,7 @@ export const middleware: S.Middleware = (store) => {
     showTrash: false,
     sortType: store.getState().settings.sortType,
     sortReversed: store.getState().settings.sortReversed,
+    titleOnly: false,
   };
 
   const indexAlphabetical: T.EntityId[] = [];
@@ -174,6 +177,7 @@ export const middleware: S.Middleware = (store) => {
     maxResults = Infinity
   ): T.EntityId[] => {
     const {
+      excludeIDs,
       notes,
       openedTag,
       searchTags,
@@ -199,8 +203,11 @@ export const middleware: S.Middleware = (store) => {
       i++
     ) {
       const noteId = sortIndex[sortReversed ? sortIndex.length - i - 1 : i];
-      const note = notes.get(noteId);
+      if (excludeIDs?.includes(noteId)) {
+        continue;
+      }
 
+      const note = notes.get(noteId);
       if (!note) {
         continue;
       }

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -1,6 +1,7 @@
 import { filterTags } from '../tag-suggestions';
 import { getTerms } from '../utils/filter-notes';
 import { tagHashOf as t } from '../utils/tag-hash';
+import { getTitle } from '../utils/note-utils';
 
 import type * as A from '../state/action-types';
 import type * as S from '../state';
@@ -231,17 +232,12 @@ export const middleware: S.Middleware = (store) => {
         continue;
       }
 
+      const searchText = titleOnly ? getTitle(note.content) : note.content;
+
       if (
-        titleOnly &&
-        !searchTerms.every((term) =>
-          note.content.split('\n', 1)[0].includes(term.toLocaleLowerCase())
-        )
-      ) {
-        continue;
-      } else if (
         searchTerms.length > 0 &&
         !searchTerms.every((term) =>
-          note.content.includes(term.toLocaleLowerCase())
+          searchText.includes(term.toLocaleLowerCase())
         )
       ) {
         continue;

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -58,7 +58,7 @@ export const tagsFromSearch = (query: string) => {
 export let searchNotes: (
   args: Partial<SearchState>,
   maxResults: number
-) => [T.EntityId, T.Note][] = () => [];
+) => [T.EntityId, T.Note | undefined][] = () => [];
 
 export const middleware: S.Middleware = (store) => {
   const searchState: SearchState = {

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -30,6 +30,7 @@ type SearchState = {
   showTrash: boolean;
   sortType: T.SortType;
   sortReversed: boolean;
+  titleOnly: boolean;
 };
 
 const toSearchNote = (note: Partial<T.Note>): SearchNote => ({
@@ -180,6 +181,7 @@ export const middleware: S.Middleware = (store) => {
       sortReversed,
       sortType,
       showTrash,
+      titleOnly,
     } = { ...searchState, ...args };
     const matches = new Set<T.EntityId>();
     const pinnedMatches = new Set<T.EntityId>();
@@ -223,6 +225,13 @@ export const middleware: S.Middleware = (store) => {
       }
 
       if (
+        titleOnly &&
+        !searchTerms.every((term) =>
+          note.content.split('\n', 1)[0].includes(term.toLocaleLowerCase())
+        )
+      ) {
+        continue;
+      } else if (
         searchTerms.length > 0 &&
         !searchTerms.every((term) =>
           note.content.includes(term.toLocaleLowerCase())

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -190,6 +190,7 @@ export const middleware: S.Middleware = (store) => {
     } = { ...searchState, ...args };
     const matches = new Set<T.EntityId>();
     const pinnedMatches = new Set<T.EntityId>();
+    const storeNotes = store.getState().data.notes;
 
     const sortIndex =
       sortType === 'alphabetical'
@@ -209,7 +210,7 @@ export const middleware: S.Middleware = (store) => {
       }
 
       const note = notes.get(noteId);
-      if (!note) {
+      if (!note || !storeNotes.has(noteId)) {
         continue;
       }
 
@@ -254,9 +255,10 @@ export const middleware: S.Middleware = (store) => {
   };
 
   searchNotes = (args, maxResults) =>
-    runSearch(args, maxResults)
-      .map((noteId) => [noteId, store.getState().data.notes.get(noteId)])
-      .filter(([, a]) => 'undefined' !== typeof a) as [T.EntityId, T.Note][];
+    runSearch(args, maxResults).map((noteId) => [
+      noteId,
+      store.getState().data.notes.get(noteId),
+    ]);
 
   const setFilteredNotes = (
     noteIds: T.EntityId[]

--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -24,7 +24,7 @@ const removeMarkdownWithFix = (inputString) => {
   });
 };
 
-const getTitle = (content) => {
+export const getTitle = (content) => {
   const titlePattern = new RegExp(`\\s*([^\n]{1,${maxTitleChars}})`, 'g');
   const titleMatch = titlePattern.exec(content);
   if (!titleMatch) {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -113,9 +113,9 @@ span[dir='ltr'] {
 /* Hide the suggestion popup
   See: https://github.com/microsoft/monaco-editor/issues/1681#issuecomment-580751164
 */
-.monaco-editor .suggest-widget {
-  display: none !important;
-}
+//.monaco-editor .suggest-widget {
+//  display: none !important;
+//}
 
 /* Safari requires that it be displayed absolute so that it takes the full height
 */

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -110,13 +110,6 @@ span[dir='ltr'] {
   display: none !important;
 }
 
-/* Hide the suggestion popup
-  See: https://github.com/microsoft/monaco-editor/issues/1681#issuecomment-580751164
-*/
-//.monaco-editor .suggest-widget {
-//  display: none !important;
-//}
-
 /* Safari requires that it be displayed absolute so that it takes the full height
 */
 .note-content-editor-shell {


### PR DESCRIPTION
This PR adds an auto-complete handler to use the search index for the app to generate a list of inter-note links.

It triggers automatically after typing a `[`, or if you dismiss the popup via `ESC` or by typing until there are no matches, you can trigger it with <kbd>Ctrl</kbd> + <kbd>Space</kbd>.

~n.b. even if the key combo is used, it will only open if there is an open bracket!~ Changed this to allow inserting a note link with Ctrl+Space at any time.

## Notes

 - ~Can use the full note list search query syntax. E.g. to search for notes with tag `classes` you type `[tag:classes` and then hit the autocomplete trigger~
- Only searches the note title
 - Autocomplete results will match the sort settings for the note list
 - Limits matches so to find specific note you need to type more search to narrow the list
 - The icon for pinned notes is different. It can look weird in the sort order if they aren't distinguished from each other, but it needs a better icon.
 - ~We should do a better job adding the singleton autocompleter. It's easy but hacky here.~

**(Graphic somewhat outdated but gives a general idea)**
![interLinkAutoComplete mov](https://user-images.githubusercontent.com/5431237/90845993-e77cbf80-e32c-11ea-96e9-84990905e5e8.gif)
