### PR TITLE
[Rewrite Branch] Add debounce of 2 seconds to analytics for note edit

### DIFF
--- a/lib/state/analytics/middleware.ts
+++ b/lib/state/analytics/middleware.ts
@@ -1,8 +1,8 @@
+import { debounce } from 'lodash';
+
 import analytics from '../../analytics';
 import getConfig from '../../../get-config';
 import isDevConfig from '../../utils/is-dev-config';
-
-import { debounce } from 'lodash';
 
 const config = getConfig();
 
@@ -36,6 +36,7 @@ export const middleware: S.Middleware = (store) => {
         return;
     }
   };
+
   const recordNoteEdit = debounce(() => record('editor_note_edited'), 2000);
 
   return (next) => (action: A.ActionType) => {

--- a/lib/state/analytics/middleware.ts
+++ b/lib/state/analytics/middleware.ts
@@ -2,6 +2,8 @@ import analytics from '../../analytics';
 import getConfig from '../../../get-config';
 import isDevConfig from '../../utils/is-dev-config';
 
+import { debounce } from 'lodash';
+
 const config = getConfig();
 
 import type * as A from '../action-types';
@@ -34,6 +36,7 @@ export const middleware: S.Middleware = (store) => {
         return;
     }
   };
+  const recordNoteEdit = debounce(() => record('editor_note_edited'), 2000);
 
   return (next) => (action: A.ActionType) => {
     const result = next(action);
@@ -87,7 +90,7 @@ export const middleware: S.Middleware = (store) => {
         record('list_note_created');
         break;
       case 'EDIT_NOTE':
-        record('editor_note_edited');
+        recordNoteEdit();
         break;
       case 'INSERT_TASK':
         record('editor_checklist_inserted');


### PR DESCRIPTION
### Fix

Current production has a debounce of 2 seconds on `editor_note_edited`. Additionally, it could have a performance impact sending analytics on every key press. I was not able to see any performance impact on staging.

Note we are not sending what was written only that an edit was made.

### Test
1. Analytics does not run on dev so you will have to comment out: https://github.com/Automattic/simplenote-electron/blob/develop/lib/analytics/index.ts#L58 to test locally
2. Turn on analytics
3. Open Chrome dev tools to the network panel
4. Type something in a note
5. Notice there was a 2-second delay before network call gets sent