### PR TITLE
Add document highlight provider to highlight search results

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -210,6 +210,8 @@ class NoteContentEditor extends Component<Props> {
         'editor.foreground': '#2c3338', // $studio-gray-80 AKA theme-color-fg
         'editor.background': '#ffffff',
         'editor.selectionBackground': '#ced9f2', // $studio-simplenote-blue-5
+        'editor.selectionHighlightBackground': '#3361cc', // $studio-simplenote-blue-50
+        'editorOverviewRuler.selectionHighlightForeground': '#3361cc', // $studio-simplenote-blue-50
         'scrollbarSlider.activeBackground': '#8c8f94', // $studio-gray-30
         'scrollbarSlider.background': '#c3c4c7', // $studio-gray-10
         'scrollbarSlider.hoverBackground': '#a7aaad', // $studio-gray-20
@@ -224,6 +226,8 @@ class NoteContentEditor extends Component<Props> {
         'editor.foreground': '#ffffff',
         'editor.background': '#1d2327', // $studio-gray-90
         'editor.selectionBackground': '#50575e', // $studio-gray-60
+        'editor.selectionHighlightBackground': '#3361cc', // $studio-simplenote-blue-50
+        'editorOverviewRuler.selectionHighlightForeground': '#3361cc', // $studio-simplenote-blue-50
         'scrollbarSlider.activeBackground': '#646970', // $studio-gray-50
         'scrollbarSlider.background': '#2c3338', // $studio-gray-80
         'scrollbarSlider.hoverBackground': '#1d2327', // $studio-gray-90


### PR DESCRIPTION
In this patch we're adding a new document highlight provider to highlight the
search results in a note. This may be a useful approach because it relies
entirely on Monaco's API to provide the functionality. Unfortunately in my
exploration it wasn't clear to me to how get this to highlight when the cursor
isn't on any word. The API appears to be designed to highlight related words to
the word under the cursor. If the cursor is on an empty line then nothing else
gets highlighted and the provider never gets called.

If we can force-trigger the highlighting to run this might be workable. We need
to do that and also be able to select an active highlight if we want to use
this for search.

We might have `editor.action.wordHighlight.trigger` as an action to call but I
gave up trying to figure out how to properly call it.

![highlightProvider mov](https://user-images.githubusercontent.com/5431237/90988829-8f77d000-e55b-11ea-8318-9e803e272e5b.gif)
