### PR TITLE
Adds highlighting in note for search query

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -267,8 +267,6 @@ class NoteContentEditor extends Component<Props> {
         'editor.foreground': '#2c3338', // $studio-gray-80 AKA theme-color-fg
         'editor.background': '#ffffff',
         'editor.selectionBackground': '#ced9f2', // $studio-simplenote-blue-5
-        'editor.selectionHighlightBackground': '#3361cc', // $studio-simplenote-blue-50
-        'editorOverviewRuler.selectionHighlightForeground': '#3361cc', // $studio-simplenote-blue-50
         'scrollbarSlider.activeBackground': '#8c8f94', // $studio-gray-30
         'scrollbarSlider.background': '#c3c4c7', // $studio-gray-10
         'scrollbarSlider.hoverBackground': '#a7aaad', // $studio-gray-20
@@ -283,8 +281,6 @@ class NoteContentEditor extends Component<Props> {
         'editor.foreground': '#ffffff',
         'editor.background': '#1d2327', // $studio-gray-90
         'editor.selectionBackground': '#50575e', // $studio-gray-60
-        'editor.selectionHighlightBackground': '#3361cc', // $studio-simplenote-blue-50
-        'editorOverviewRuler.selectionHighlightForeground': '#3361cc', // $studio-simplenote-blue-50
         'scrollbarSlider.activeBackground': '#646970', // $studio-gray-50
         'scrollbarSlider.background': '#2c3338', // $studio-gray-80
         'scrollbarSlider.hoverBackground': '#1d2327', // $studio-gray-90

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -159,10 +159,15 @@ class NoteContentEditor extends Component<Props> {
   }
 
   setDecorators = () => {
-    decorations = this.editor.deltaDecorations(decorations, [
-      ...this.searchMatches(),
-      this.getTitleDecoration(),
-    ]);
+    const searchMatches = this.searchMatches();
+    const titleDecoration = this.getTitleDecoration();
+    if (!searchMatches.length && !titleDecoration) {
+      return;
+    }
+    if (titleDecoration) {
+      searchMatches.push(titleDecoration);
+    }
+    decorations = this.editor.deltaDecorations(decorations, [...searchMatches]);
   };
 
   getTitleDecoration = () => {
@@ -185,6 +190,7 @@ class NoteContentEditor extends Component<Props> {
         return titleDecoration(i);
       }
     }
+    return;
   };
 
   searchMatches = () => {

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -191,7 +191,7 @@ class NoteContentEditor extends Component<Props> {
 
           matches.push({
             options: {
-              inlineClassName: 'myInlineDecoration',
+              inlineClassName: 'search-decoration',
               overviewRuler: { color: '#3361cc' },
             },
             range: {

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -210,6 +210,8 @@ class NoteContentEditor extends Component<Props> {
         'editor.foreground': '#2c3338', // $studio-gray-80 AKA theme-color-fg
         'editor.background': '#ffffff',
         'editor.selectionBackground': '#ced9f2', // $studio-simplenote-blue-5
+        'editor.selectionHighlightBackground': '#3361cc', // $studio-simplenote-blue-50
+        'editorOverviewRuler.selectionHighlightForeground': '#3361cc', // $studio-simplenote-blue-50
         'scrollbarSlider.activeBackground': '#8c8f94', // $studio-gray-30
         'scrollbarSlider.background': '#c3c4c7', // $studio-gray-10
         'scrollbarSlider.hoverBackground': '#a7aaad', // $studio-gray-20
@@ -224,6 +226,8 @@ class NoteContentEditor extends Component<Props> {
         'editor.foreground': '#ffffff',
         'editor.background': '#1d2327', // $studio-gray-90
         'editor.selectionBackground': '#50575e', // $studio-gray-60
+        'editor.selectionHighlightBackground': '#3361cc', // $studio-simplenote-blue-50
+        'editorOverviewRuler.selectionHighlightForeground': '#3361cc', // $studio-simplenote-blue-50
         'scrollbarSlider.activeBackground': '#646970', // $studio-gray-50
         'scrollbarSlider.background': '#2c3338', // $studio-gray-80
         'scrollbarSlider.hoverBackground': '#1d2327', // $studio-gray-90

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -162,7 +162,11 @@ class NoteContentEditor extends Component<Props> {
       }, 400);
     }
 
-    if (this.editor && prevProps.searchQuery !== this.props.searchQuery) {
+    if (
+      this.editor &&
+      this.state.editor === 'full' &&
+      prevProps.searchQuery !== this.props.searchQuery
+    ) {
       this.setDecorators();
     }
   }

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -646,7 +646,7 @@ class NoteContentEditor extends Component<Props> {
               links: true,
               matchBrackets: 'never',
               minimap: { enabled: false },
-              occurrencesHighlight: true,
+              occurrencesHighlight: false,
               overviewRulerBorder: false,
               quickSuggestions: false,
               renderIndentGuides: false,

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -58,6 +58,10 @@
     border-radius: 10px;
     border: 3px solid gray;
   }
+
+  .search-decoration {
+    background-color: $studio-simplenote-blue-50 !important;
+  }
 }
 
 .note-detail-textarea .note-content-editor-shell.cursor-pointer div {
@@ -258,8 +262,4 @@
       }
     }
   }
-}
-
-.myInlineDecoration {
-  background-color: $studio-simplenote-blue-50 !important;
 }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -259,3 +259,7 @@
     }
   }
 }
+
+.myInlineDecoration {
+  background-color: $studio-simplenote-blue-50 !important;
+}

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -100,6 +100,10 @@
   .search-field {
     border-color: $studio-gray-10;
   }
+
+  .search-decoration {
+    color: $studio-white;
+  }
 }
 
 .theme-dark {


### PR DESCRIPTION
### Fix

Alternative to: https://github.com/Automattic/simplenote-electron/pull/2290 and https://github.com/Automattic/simplenote-electron/pull/2276

In this approach to search highlighting we are using Monaco decorations. We have added a search function that will find all of the terms we want to decorate. We create decorations from their ranges and combine that with the note title decoration.

The decoration function is run when editor is ready, on editor.onDidChangeModelContent, and in componentDidUpdate when the search query does not equal the previous search query.

```
{
  options: {
    inlineClassName: 'searchDecoration',
    overviewRuler: { color: '#3361cc' },
  },
  range: {
    startLineNumber: start.lineNumber,
    startColumn: start.column,
    endLineNumber: end.lineNumber,
    endColumn: end.column,
  },
}
```

### Test
1. Enter a search term
2. Search using a tag
3. Cancel search
4. Edit a result in the note so it is no longer a match, does highlight disappear?
5. Add a match, does it get highlighted?