### PR TITLE
[rewrite branch] Fix select all / undo / redo in non-editor text fields

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -283,13 +283,25 @@ class NoteContentEditor extends Component<Props> {
           editor.trigger('editorCommand', 'insertChecklist', null);
           return;
         case 'redo':
-          editor.trigger('editorCommand', 'redo', null);
+          if (editor.hasTextFocus()) {
+            editor.trigger('editorCommand', 'redo', null);
+          } else {
+            document.execCommand('redo');
+          }
           return;
         case 'selectAll':
-          editor.setSelection(editor.getModel().getFullModelRange());
+          if (editor.hasTextFocus()) {
+            editor.setSelection(editor.getModel().getFullModelRange());
+          } else {
+            document.execCommand('selectAll');
+          }
           return;
         case 'undo':
-          editor.trigger('editorCommand', 'undo', null);
+          if (editor.hasTextFocus()) {
+            editor.trigger('editorCommand', 'undo', null);
+          } else {
+            document.execCommand('undo');
+          }
           return;
       }
     });


### PR DESCRIPTION
### Fix
**Electron only**

Some commands in the Edit menu should affect whichever text area has focus, not just the editor. Right now `selectAll` selects all the editor text regardless of what has focus, so for example you can't select all text in the search or tag fields.

This PR checks to see if the editor has focus before responding to undo, redo, or selectAll. If it doesn't have focus it fires the `document.execCommand` function which triggers the native functionality.

See https://github.com/electron/electron/issues/22456

### Test
1. In Electron enter text in the search field.
2. Use menu item and keyboard shortcuts to select all, undo, and redo and verify that they all work within that field.
3. Verify these functions still work in the editor if the editor has focus.
4. Be sure to test both keyboard shortcuts and menu actions as they have different listeners.

