### PR TITLE
Add missing style to fix react-virtualized autoSizing

### DIFF
--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -87,7 +87,7 @@ const renderNote = (
         parent={parent}
         rowIndex={index}
       >
-        <TagSuggestions />
+        <TagSuggestions style={{ ...style }} />
       </CellMeasurer>
     ) : (
       <CellMeasurer
@@ -97,7 +97,9 @@ const renderNote = (
         parent={parent}
         rowIndex={index}
       >
-        <div className="note-list-header">Notes</div>
+        <div className="note-list-header" style={{ ...style }}>
+          Notes
+        </div>
       </CellMeasurer>
     );
   }


### PR DESCRIPTION
### Fix

This PR adds the styles to the tags and note list header so that they resize properly. Before, as the number of tags appearing in the note list changed the vertical layout was broken.

I have no idea why this fixes it but react-virtualized was throwing a warning so it seemed like a good place to start.

### Test
1. Have notes with the word "said"
2. Add tags for "s", "sa", "sai", and "said"
3. Type and delete the letters: s, a, i, and d into the search
4. Do the note list heights resize properly?
