### PR TITLE
Fixes line wrap in markdown view

### DIFF
--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -55,9 +55,9 @@
   font-size: 16px;
   color: $studio-gray-60;
   background: $studio-white;
-
   resize: none;
   -webkit-tap-highlight-color: transparent;
+  word-break: break-word;
 
   &:focus {
     outline: none;


### PR DESCRIPTION
### Fix

When you have a really really long word it can cause a horizontal scroll in markdown view. This will make words wrap.

Before:

<img width="482" alt="Screen Shot 2020-08-24 at 7 30 38 PM" src="https://user-images.githubusercontent.com/6817400/91106315-5d8c6980-e640-11ea-8160-9688272de006.png">

After:

<img width="569" alt="Screen Shot 2020-08-24 at 7 30 50 PM" src="https://user-images.githubusercontent.com/6817400/91106328-62e9b400-e640-11ea-8dbb-668bac64b287.png">

### Test
1. Have note with markdown enabled and really long words
2. Observe markdown preview on staging
3. Observe markdown preview on this branch

