### PR TITLE
Fixes the width of content in the editor

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -10,6 +10,7 @@ import { editor as Editor, Selection, SelectionDirection } from 'monaco-editor';
 import actions from './state/actions';
 import * as selectors from './state/selectors';
 import { getTerms } from './utils/filter-notes';
+import { isSafari } from './utils/platform';
 import {
   withCheckboxCharacters,
   withCheckboxSyntax,
@@ -676,7 +677,7 @@ class NoteContentEditor extends Component<Props> {
               scrollBeyondLastLine: false,
               selectionHighlight: false,
               wordWrap: 'bounded',
-              wrappingStrategy: 'advanced',
+              wrappingStrategy: isSafari ? 'simple' : 'advanced',
               wordWrapColumn: 400,
             }}
             value={content}

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -675,8 +675,9 @@ class NoteContentEditor extends Component<Props> {
               scrollbar: { horizontal: 'hidden', useShadows: false },
               scrollBeyondLastLine: false,
               selectionHighlight: false,
-              wordWrap: 'on',
-              wrappingStrategy: 'simple',
+              wordWrap: 'bounded',
+              wrappingStrategy: 'advanced',
+              wordWrapColumn: 400,
             }}
             value={content}
           />

--- a/lib/utils/platform.ts
+++ b/lib/utils/platform.ts
@@ -2,3 +2,7 @@
 export const isElectron = !!window?.electron;
 
 export const isMac = window?.electron?.isMac;
+
+export const isSafari = /^((?!chrome|android).)*safari/i.test(
+  window.navigator.userAgent
+);


### PR DESCRIPTION
### Fix

Notes have a maximum width which is incorrect. This makes the max column width 400. Using the bounded strategy it will fill viewport till it hits 400 columns. By using advanced it fills in available space better.

Before:

<img width="1329" alt="Screen Shot 2020-08-24 at 10 13 43 PM" src="https://user-images.githubusercontent.com/6817400/91114997-31c8ae00-e657-11ea-9cff-81615c106cd2.png">

After:

<img width="1343" alt="Screen Shot 2020-08-24 at 10 13 06 PM" src="https://user-images.githubusercontent.com/6817400/91115006-368d6200-e657-11ea-8fd7-669f413d3a4b.png">

### Test
1. Have note with long line length
2. Make your screen really wide
3. Observe that note grows.
