### PR TITLE
[rewrite branch] Align the scrollbar to the right

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -617,6 +617,11 @@ class NoteContentEditor extends Component<Props> {
         return;
       }
 
+      // a range spanning more than one column means we're over the gutter
+      if (range.endColumn - range.startColumn > 1) {
+        return;
+      }
+
       const model = editor.getModel();
       if (!model) {
         return;
@@ -640,6 +645,11 @@ class NoteContentEditor extends Component<Props> {
       } = event;
 
       if (!range) {
+        return;
+      }
+
+      // a range spanning more than one column means we're over the gutter
+      if (range.endColumn - range.startColumn > 1) {
         return;
       }
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, createRef, RefObject } from 'react';
 import { connect } from 'react-redux';
 import Monaco, {
   ChangeHandler,
@@ -75,6 +75,7 @@ class NoteContentEditor extends Component<Props> {
   bootTimer: ReturnType<typeof setTimeout> | null = null;
   editor: Editor.IStandaloneCodeEditor | null = null;
   monaco: Monaco | null = null;
+  contentDiv: RefObject<HTMLDivElement> = createRef();
   decorations: string[] = [];
   matchesInNote: [] = [];
 
@@ -811,8 +812,23 @@ class NoteContentEditor extends Component<Props> {
     const { fontSize, noteId, searchQuery, theme } = this.props;
     const { content, editor, overTodo, selectedSearchMatchIndex } = this.state;
     const searchMatches = searchQuery ? this.searchMatches() : [];
+
+    let editorPadding = 25;
+
+    if (lineLength === 'narrow' && this.contentDiv?.current) {
+      const width = this.contentDiv.current?.offsetWidth;
+      if (width <= 1400) {
+        // should be 10% up to 1400px wide
+        editorPadding = width * 0.1;
+      } else {
+        // after 1400, calc((100% - 768px) / 2);
+        editorPadding = (width - 768) / 2;
+      }
+    }
+
     return (
       <div
+        ref={this.contentDiv}
         className={`note-content-editor-shell${
           overTodo ? ' cursor-pointer' : ''
         }`}
@@ -844,6 +860,7 @@ class NoteContentEditor extends Component<Props> {
                 '"Simplenote Tasks", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
               fontSize,
               hideCursorInOverviewRuler: true,
+              lineDecorationsWidth: 0,
               lineHeight: fontSize > 20 ? 42 : 24,
               lineNumbers: 'off',
               links: true,
@@ -854,7 +871,11 @@ class NoteContentEditor extends Component<Props> {
               quickSuggestions: false,
               renderIndentGuides: false,
               renderLineHighlight: 'none',
-              scrollbar: { horizontal: 'hidden', useShadows: false },
+              scrollbar: {
+                horizontal: 'hidden',
+                useShadows: false,
+                verticalScrollbarSize: editorPadding,
+              },
               scrollBeyondLastLine: false,
               selectionHighlight: false,
               wordWrap: 'bounded',

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -860,7 +860,7 @@ class NoteContentEditor extends Component<Props> {
                 '"Simplenote Tasks", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
               fontSize,
               hideCursorInOverviewRuler: true,
-              lineDecorationsWidth: 0,
+              lineDecorationsWidth: editorPadding,
               lineHeight: fontSize > 20 ? 42 : 24,
               lineNumbers: 'off',
               links: true,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -632,9 +632,11 @@ class NoteContentEditor extends Component<Props> {
         column: range.startColumn,
       });
 
-      this.setState({
-        overTodo: content[offset] === '\ue000' || content[offset] === '\ue001',
-      });
+      const overTodo =
+        content[offset] === '\ue000' || content[offset] === '\ue001';
+      if (this.state.overTodo !== overTodo) {
+        this.setState({ overTodo });
+      }
     });
 
     editor.onMouseDown((event) => {
@@ -819,7 +821,7 @@ class NoteContentEditor extends Component<Props> {
   };
 
   render() {
-    const { fontSize, noteId, searchQuery, theme } = this.props;
+    const { fontSize, lineLength, noteId, searchQuery, theme } = this.props;
     const { content, editor, overTodo, selectedSearchMatchIndex } = this.state;
     const searchMatches = searchQuery ? this.searchMatches() : [];
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1,4 +1,4 @@
-import React, { Component, createRef, RefObject } from 'react';
+import React, { Component, createRef } from 'react';
 import { connect } from 'react-redux';
 import Monaco, {
   ChangeHandler,
@@ -31,6 +31,20 @@ const titleDecorationForLine = (line: number) => ({
     stickiness: Editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
   },
 });
+
+const getEditorPadding = (lineLength: T.LineLength, width?: number) => {
+  if (lineLength === 'full' || 'undefined' === typeof width) {
+    return 25;
+  }
+
+  if (width <= 1400) {
+    // should be 10% up to 1400px wide
+    return width * 0.1;
+  } else {
+    // after 1400, calc((100% - 768px) / 2);
+    return (width - 768) / 2;
+  }
+};
 
 type OwnProps = {
   storeFocusEditor: (focusSetter: () => any) => any;
@@ -75,7 +89,7 @@ class NoteContentEditor extends Component<Props> {
   bootTimer: ReturnType<typeof setTimeout> | null = null;
   editor: Editor.IStandaloneCodeEditor | null = null;
   monaco: Monaco | null = null;
-  contentDiv: RefObject<HTMLDivElement> = createRef();
+  contentDiv = createRef<HTMLDivElement>();
   decorations: string[] = [];
   matchesInNote: [] = [];
 
@@ -825,18 +839,10 @@ class NoteContentEditor extends Component<Props> {
     const { content, editor, overTodo, selectedSearchMatchIndex } = this.state;
     const searchMatches = searchQuery ? this.searchMatches() : [];
 
-    let editorPadding = 25;
-
-    if (lineLength === 'narrow' && this.contentDiv?.current) {
-      const width = this.contentDiv.current?.offsetWidth;
-      if (width <= 1400) {
-        // should be 10% up to 1400px wide
-        editorPadding = width * 0.1;
-      } else {
-        // after 1400, calc((100% - 768px) / 2);
-        editorPadding = (width - 768) / 2;
-      }
-    }
+    const editorPadding = getEditorPadding(
+      lineLength,
+      this.contentDiv.current?.offsetWidth
+    );
 
     return (
       <div

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -68,7 +68,6 @@
 }
 
 .note-detail-textarea {
-  overflow-x: hidden;
   min-height: 100%;
   cursor: text;
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -66,10 +66,6 @@
 
   font-family: 'Simplenote Tasks', sans-serif;
 
-  .note-title {
-    // font-size: 120%;
-  }
-
   .slider {
     border-radius: 10px;
     border: 3px solid gray;

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -27,21 +27,49 @@
   unicode-range: U+E000-E001;
 }
 
-.note-detail,
-.note-content-editor-shell {
+/*.note-detail,
+.note-content-editor-shell {*/
+.note-detail-textarea {
+  padding-left: calc((100% - 768px) / 2);
+}
+.note-detail-preview {
   padding: 0 calc((100% - 768px) / 2);
 }
 
 @media only screen and (max-width: 1400px) {
-  .note-detail,
-  .note-content-editor-shell {
+/*  .note-detail,
+  .note-content-editor-shell {*/
+  .note-detail-textarea {
+    padding-left: 10%;
+  }
+  .note-detail-preview {
     padding: 0 10%;
   }
 }
 
+.react-monaco-editor-container {
+  .scrollbar.vertical {
+    width: 10px !important;
+    right: 0 !important;
+
+    .slider {
+      width: 10px !important;
+    }
+  }
+}
+// scrollbar search highlights
+.decorationsOverviewRuler {
+  width: 10px !important;
+  right: -2px !important;
+}
+
 .is-line-length-full {
-  .note-detail,
-  .note-content-editor-shell {
+/*  .note-detail,
+  .note-content-editor-shell { */
+  .note-detail-textarea {
+    padding-left: 25px;
+  }
+  .note-detail-preview {
     padding: 0 25px;
   }
 }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -27,21 +27,11 @@
   unicode-range: U+E000-E001;
 }
 
-/*.note-detail,
-.note-content-editor-shell {*/
-.note-detail-textarea {
-  padding-left: calc((100% - 768px) / 2);
-}
 .note-detail-preview {
   padding: 0 calc((100% - 768px) / 2);
 }
 
 @media only screen and (max-width: 1400px) {
-/*  .note-detail,
-  .note-content-editor-shell {*/
-  .note-detail-textarea {
-    padding-left: 10%;
-  }
   .note-detail-preview {
     padding: 0 10%;
   }
@@ -64,11 +54,6 @@
 }
 
 .is-line-length-full {
-/*  .note-detail,
-  .note-content-editor-shell { */
-  .note-detail-textarea {
-    padding-left: 25px;
-  }
   .note-detail-preview {
     padding: 0 25px;
   }
@@ -82,7 +67,7 @@
   font-family: 'Simplenote Tasks', sans-serif;
 
   .note-title {
-    font-size: 120%;
+    // font-size: 120%;
   }
 
   .slider {


### PR DESCRIPTION
### Fix
The huge gutter to the right of the scrollbar was really bothering me. I tried a million things but there's seriously no good way to do this with padding of the parent containers...

So, this is maybe terrible, but we can trick Monaco by claiming the scrollbar is as wide as we want our padding, then use CSS to resize it back down. (Props to https://github.com/microsoft/monaco-editor/issues/1368 for this idea.)

I originally tried to (ab)use the `lineDecorationsWidth` for left padding, but noticed that checkbox lines are clickable anywhere in that margin, which is kind of annoying. So I removed it.

We'll need to test and see if this messes up the search highlights or anything else.

### Test
1. Set line width of both narrow and full
2. Look at some long notes with long lines
3. Make sure the right scrollbar is always flush to the right
4. Make sure Markdown preview is scrollable and has scrollbars that make sense

### Screenshots

Before:
<img width="1066" alt="Screen Shot 2020-08-25 at 12 00 45 AM" src="https://user-images.githubusercontent.com/52152/91142730-1fa23c00-e666-11ea-9fb0-6b02981f48c2.png">

After (this will also look better after #2297):

<img width="876" alt="Screen Shot 2020-08-24 at 11 59 46 PM" src="https://user-images.githubusercontent.com/52152/91142628-f386bb00-e665-11ea-8e23-5a672deaa15c.png">
