### PR TITLE
[rewrite branch] Too many scrollbars

### DIFF
--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -145,7 +145,7 @@ export const NotePreview: FunctionComponent<Props> = ({
 
   return (
     <div className="note-detail-wrapper">
-      <div className="note-detail">
+      <div className="note-detail note-detail-preview">
         <div
           ref={previewNode}
           className="note-detail-markdown theme-color-bg theme-color-fg"

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -13,7 +13,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  overflow-y: scroll;
+  overflow: hidden;
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -53,6 +53,7 @@
   border: 0;
   line-height: 1.5em;
   font-size: 16px;
+  overflow-x: hidden;
   color: $studio-gray-60;
   background: $studio-white;
 

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -13,7 +13,6 @@
   left: 0;
   width: 100%;
   height: 100%;
-  overflow: hidden;
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -22,6 +21,10 @@
   div[data-contents] {
     padding-bottom: 20px;
   }
+}
+
+.note-detail-preview {
+  overflow: auto;
 }
 
 .note-detail-placeholder {
@@ -53,7 +56,6 @@
   border: 0;
   line-height: 1.5em;
   font-size: 16px;
-  overflow-x: hidden;
   color: $studio-gray-60;
   background: $studio-white;
 

--- a/scss/print.scss
+++ b/scss/print.scss
@@ -22,7 +22,6 @@
   .app-layout,
   .app-layout__note-column,
   .note-editor,
-  .note-detail-wrapper,
   .note-detail,
   .note-detail-textarea,
   .note-content-editor-shell,


### PR DESCRIPTION
### Fix

I was testing on Windows/Edge and noticed we've got some scrollbars on note-detail and friends that are cluttering up the place.

The Monaco container is inside of .note-detail, and handles its own overflows and scrolling, so we don't need these.

Special-cased the Markdown preview; make sure you can scroll in preview if necessary!

### Screenshots

Before:

<img width="493" alt="Screen Shot 2020-08-24 at 9 17 14 PM" src="https://user-images.githubusercontent.com/52152/91143086-ce467c80-e666-11ea-8200-30c3463b051f.png">

After:

<img width="732" alt="Screen Shot 2020-08-25 at 12 07 24 AM" src="https://user-images.githubusercontent.com/52152/91143194-fcc45780-e666-11ea-9d63-020a348d1ef3.png">
