### PR TITLE
Update the tag panel UI

### DIFF
--- a/lib/icons/cross-outline.tsx
+++ b/lib/icons/cross-outline.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
 
-export default function CrossOutlineIcon() {
+type OwnProps = {
+  onClick: (event: React.MouseEvent<SVGSVGElement>) => any;
+};
+
+type Props = OwnProps;
+
+export default function CrossOutlineIcon({ onClick }: Props) {
   return (
     <svg
       className="icon-cross-outline"
+      onClick={onClick}
       xmlns="http://www.w3.org/2000/svg"
       width="22"
       height="22"

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -69,16 +69,21 @@ export class NavigationBar extends Component<Props> {
       <div className="navigation-bar theme-color-bg theme-color-fg theme-color-border">
         <div className="navigation-bar__folders">
           <NavigationBarItem
-            icon={<NotesIcon />}
-            isSelected={this.isSelected({ isTrashRow: false })}
-            label="All Notes"
-            onClick={onShowAllNotes}
+            icon={<SettingsIcon />}
+            label="Settings"
+            onClick={onSettings}
           />
           <NavigationBarItem
             icon={<TrashIcon />}
             isSelected={this.isSelected({ isTrashRow: true })}
             label="Trash"
             onClick={this.onSelectTrash}
+          />
+          <NavigationBarItem
+            icon={<NotesIcon />}
+            isSelected={this.isSelected({ isTrashRow: false })}
+            label="All Notes"
+            onClick={onShowAllNotes}
           />
         </div>
         <div className="navigation-bar__tags theme-color-border">
@@ -88,14 +93,6 @@ export class NavigationBar extends Component<Props> {
           <div className="navigation-bar__server-connection">
             <ConnectionStatus />
           </div>
-        </div>
-
-        <div className="navigation-bar__tools theme-color-border">
-          <NavigationBarItem
-            icon={<SettingsIcon />}
-            label="Settings"
-            onClick={onSettings}
-          />
         </div>
         <div className="navigation-bar__footer">
           <button

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -1,36 +1,40 @@
 .navigation-bar-item {
-  width: 100%;
-  padding: 4px 8px;
+  height: 44px;
+  padding-left: 16px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   text-align: left;
 
+  .button {
+    border-bottom: 1px solid $studio-gray-5;
+    border-radius: 0;
+    font-size: 16px;
+    font-weight: 400;
+    height: 44px;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+  }
+
   .button:active {
-    color: $studio-white;
+    background: none;
+  }
+
+  &.is-selected button {
+    border-bottom: none;
   }
 
   &.is-selected {
-    .button {
-      color: $studio-simplenote-blue-50;
-
-      svg[class^='icon-'] {
-        fill: $studio-simplenote-blue-50;
-      }
-
-      &:active {
-        color: $studio-white;
-        svg[class^='icon-'] {
-          fill: $studio-white;
-        }
-      }
-    }
+    background-color: $studio-blue-5;
   }
 }
 
 .navigation-bar-item__icon {
+  color: $studio-blue-50;
   display: inline-block;
-  margin-right: 0.5em;
+
+  margin-right: 18px;
   vertical-align: middle;
 
   svg {
@@ -38,4 +42,36 @@
     position: relative;
     top: -0.2em;
   }
+}
+
+.theme-dark {
+  .navigation-bar-item {
+    .button {
+      border-bottom: 1px solid $studio-gray-70;
+    }
+
+    &.is-selected button {
+      border-bottom: none;
+    }
+
+    button {
+      color: $studio-white;
+    }
+    svg {
+      fill: $studio-white;
+    }
+  }
+
+  .navigation-bar-item.is-selected {
+    button {
+      color: $studio-simplenote-blue-30;
+    }
+    svg[class^='icon-'] {
+      fill: $studio-simplenote-blue-30;
+    }
+  }
+}
+
+.navigation-bar-item.is-selected + .navigation-bar-item .button {
+  border-bottom: none;
 }

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -33,7 +33,6 @@
 .navigation-bar-item__icon {
   color: $studio-blue-50;
   display: inline-block;
-
   margin-right: 18px;
   vertical-align: middle;
 
@@ -50,8 +49,13 @@
       border-bottom: 1px solid $studio-gray-70;
     }
 
+    &.is-selected svg[class^='icon-'] {
+      fill: $studio-simplenote-blue-30;
+    }
+
     &.is-selected button {
       border-bottom: none;
+      color: $studio-simplenote-blue-30;
     }
 
     button {
@@ -59,15 +63,6 @@
     }
     svg {
       fill: $studio-white;
-    }
-  }
-
-  .navigation-bar-item.is-selected {
-    button {
-      color: $studio-simplenote-blue-30;
-    }
-    svg[class^='icon-'] {
-      fill: $studio-simplenote-blue-30;
     }
   }
 }

--- a/lib/navigation-bar/style.scss
+++ b/lib/navigation-bar/style.scss
@@ -12,6 +12,10 @@
   background: white;
 }
 
+.is-macos .navigation-bar {
+  padding-top: 70px;
+}
+
 .navigation-bar__folders {
   display: flex;
   flex-direction: column-reverse;

--- a/lib/navigation-bar/style.scss
+++ b/lib/navigation-bar/style.scss
@@ -4,6 +4,7 @@
   position: absolute;
   top: 0;
   left: -$navigation-bar-width;
+  padding-top: 55px;
   width: $navigation-bar-width;
   height: 100%;
   overflow: hidden;
@@ -12,8 +13,8 @@
 }
 
 .navigation-bar__folders {
-  flex: none;
-  padding: 10px 0;
+  display: flex;
+  flex-direction: column-reverse;
 }
 
 .navigation-bar__tags {
@@ -24,15 +25,6 @@
   overflow: hidden;
   min-height: 9em;
   padding: 12px 0 0;
-  border-top: 1px solid $studio-gray-5;
-
-  .tag-list-title {
-    padding: 8px 20px 0;
-  }
-
-  .editable-list-item {
-    padding: 0 5px 0 20px;
-  }
 }
 
 .navigation-bar__tools {

--- a/lib/state/data/reducer.ts
+++ b/lib/state/data/reducer.ts
@@ -416,7 +416,7 @@ export const tags: A.Reducer<Map<T.TagHash, T.Tag>> = (
         .forEach(([tagId, tag], index) => {
           next.set(tagId, {
             ...tag,
-            index: index <= action.newIndex ? index : index + 1,
+            index: index < action.newIndex ? index : index + 1,
           });
         });
       next.set(actionTagHash, { ...actionTag, index: action.newIndex });

--- a/lib/state/data/reducer.ts
+++ b/lib/state/data/reducer.ts
@@ -416,7 +416,7 @@ export const tags: A.Reducer<Map<T.TagHash, T.Tag>> = (
         .forEach(([tagId, tag], index) => {
           next.set(tagId, {
             ...tag,
-            index: index < action.newIndex ? index : index + 1,
+            index: index <= action.newIndex ? index : index + 1,
           });
         });
       next.set(actionTagHash, { ...actionTag, index: action.newIndex });

--- a/lib/tag-list/index.tsx
+++ b/lib/tag-list/index.tsx
@@ -10,9 +10,11 @@ import {
 import isEmailTag from '../utils/is-email-tag';
 import PanelTitle from '../components/panel-title';
 import ReorderIcon from '../icons/reorder';
-import TrashIcon from '../icons/trash';
+import CrossOutlineIcon from '../icons/cross-outline';
 import TagListInput from './input';
 import { openTag, toggleTagEditing } from '../state/ui/actions';
+
+import * as selectors from './../state/selectors';
 
 import type * as S from '../state';
 import type * as T from '../types';
@@ -21,6 +23,7 @@ type StateProps = {
   editingTags: boolean;
   openedTag: T.TagHash | null;
   sortTagsAlpha: boolean;
+  theme: 'light' | 'dark';
   tags: Map<T.TagHash, T.Tag>;
 };
 
@@ -43,6 +46,7 @@ const SortableTag = SortableElement(
     isSelected,
     renameTag,
     selectTag,
+    theme,
     trashTag,
     value: [tagHash, tag],
   }: {
@@ -51,11 +55,16 @@ const SortableTag = SortableElement(
     isSelected: boolean;
     renameTag: (oldTagName: T.TagName, newTagName: T.TagName) => any;
     selectTag: (tagName: T.TagName) => any;
+    theme: 'light' | 'dark';
     trashTag: (tagName: T.TagName) => any;
     value: [T.TagHash, T.Tag];
   }) => (
-    <li key={tagHash} className="tag-list-item" data-tag-name={tag.name}>
-      {editingActive && <TrashIcon onClick={() => trashTag(tag.name)} />}
+    <li
+      key={tagHash}
+      className={classNames(`tag-list-item`, `theme-${theme}`)}
+      data-tag-name={tag.name}
+    >
+      {editingActive && <CrossOutlineIcon onClick={() => trashTag(tag.name)} />}
       <TagListInput
         editable={editingActive}
         isSelected={isSelected}
@@ -82,6 +91,7 @@ const SortableTagList = SortableContainer(
     openTag,
     renameTheTag,
     sortTagsAlpha,
+    theme,
     trashTheTag,
   }: {
     editingTags: boolean;
@@ -90,6 +100,7 @@ const SortableTagList = SortableContainer(
     openTag: (tagName: T.TagName) => any;
     renameTheTag: (oldTagName: T.TagName, newTagName: T.TagName) => any;
     sortTagsAlpha: boolean;
+    theme: 'light' | 'dark';
     trashTheTag: (tagName: T.TagName) => any;
   }) => (
     <ul className="tag-list-items">
@@ -102,6 +113,7 @@ const SortableTagList = SortableContainer(
           isSelected={openedTag === value[0]}
           renameTag={renameTheTag}
           selectTag={openTag}
+          theme={theme}
           trashTag={trashTheTag}
           value={value}
         />
@@ -116,7 +128,7 @@ export class TagList extends Component<Props> {
   reorderTag: SortEndHandler = ({ newIndex, nodes, oldIndex }) => {
     const tagName = nodes[oldIndex].node.dataset.tagName;
 
-    this.props.reorderTag(tagName, newIndex);
+    this.props.reorderTag(tagName, newIndex + 1);
   };
 
   render() {
@@ -128,6 +140,7 @@ export class TagList extends Component<Props> {
       renameTag,
       sortTagsAlpha,
       tags,
+      theme,
       trashTag,
     } = this.props;
 
@@ -170,6 +183,7 @@ export class TagList extends Component<Props> {
           items={sortedTags}
           renameTheTag={renameTag}
           sortTagsAlpha={sortTagsAlpha}
+          theme={theme}
           onSortEnd={this.reorderTag}
           useDragHandle={true}
           trashTheTag={trashTag}
@@ -179,16 +193,20 @@ export class TagList extends Component<Props> {
   }
 }
 
-const mapStateToProps: S.MapState<StateProps> = ({
-  data,
-  settings: { sortTagsAlpha },
-  ui: { editingTags, openedTag },
-}) => ({
-  editingTags,
-  sortTagsAlpha,
-  tags: data.tags,
-  openedTag,
-});
+const mapStateToProps: S.MapState<StateProps> = (state) => {
+  const {
+    data,
+    settings: { sortTagsAlpha },
+    ui: { editingTags, openedTag },
+  } = state;
+  return {
+    editingTags,
+    sortTagsAlpha,
+    tags: data.tags,
+    openedTag,
+    theme: selectors.getTheme(state),
+  };
+};
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   onEditTags: toggleTagEditing,

--- a/lib/tag-list/index.tsx
+++ b/lib/tag-list/index.tsx
@@ -127,8 +127,7 @@ export class TagList extends Component<Props> {
 
   reorderTag: SortEndHandler = ({ newIndex, nodes, oldIndex }) => {
     const tagName = nodes[oldIndex].node.dataset.tagName;
-
-    this.props.reorderTag(tagName, newIndex + 1);
+    this.props.reorderTag(tagName, newIndex);
   };
 
   render() {

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -40,11 +40,6 @@
     }
 
     .tag-list-edit-toggle {
-      opacity: 0;
-
-      .touch-enabled & {
-        opacity: 1;
-      }
       &:active {
         color: $studio-white;
       }
@@ -53,10 +48,6 @@
 
   .editable-list-item {
     padding: 0 5px 0 20px;
-  }
-
-  .tag-list-title .tag-list-edit-toggle {
-    opacity: 1;
   }
 }
 

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -1,5 +1,9 @@
 .tag-list-item {
+  color: $studio-gray-80;
+  border-bottom: 1px solid $studio-gray-5;
   display: flex;
+  font-size: 16px;
+  height: 44px;
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
@@ -16,11 +20,23 @@
     flex: none;
     justify-content: space-between;
     align-items: center;
-    line-height: 1.25em;
-    margin-bottom: 0.25em;
+    padding: 5px 17px 2px;
 
     h2 {
+      font-size: 14px;
+      font-weight: 500;
       margin-bottom: 0;
+      text-transform: capitalize;
+    }
+
+    button {
+      font-size: 14px;
+      font-weight: 400;
+      padding: 7px 2px 0;
+    }
+
+    button:active {
+      background: none;
     }
 
     .tag-list-edit-toggle {
@@ -35,48 +51,43 @@
     }
   }
 
-  &:hover,
-  &.tag-list-editing {
-    .tag-list-title .tag-list-edit-toggle {
-      opacity: 1;
-    }
+  .editable-list-item {
+    padding: 0 5px 0 20px;
   }
 
-  &.tag-list-editing .tag-list-items {
-    padding-inline-start: 6px;
+  .tag-list-title .tag-list-edit-toggle {
+    opacity: 1;
   }
 }
 
 .tag-list-items {
   flex: 1 1 auto;
   list-style: none;
-  padding-inline-start: 20px;
-  padding-inline-end: 16px;
+  overflow-y: auto;
+  padding-inline-start: 18px;
+  padding-inline-end: 0;
   padding-top: 0;
   padding-bottom: 0;
-  overflow-y: auto;
   margin: 0;
 
   svg {
     cursor: pointer;
   }
 
-  .icon-trash {
+  .icon-cross-outline {
     margin-right: 5px;
-    &:hover {
-      color: red;
-    }
+    color: $studio-red-50;
   }
 }
 
 .tag-list-input {
-  cursor: pointer;
+  cursor: text;
   flex: 1 1 auto;
   display: block;
   width: 50px;
   height: 2em;
   line-height: 2em;
-  margin: 8px 0;
+  margin: 8px 13px;
   padding: 0;
   border: none;
   text-overflow: ellipsis;
@@ -94,6 +105,7 @@
 }
 
 button.tag-list-input {
+  margin: 8px 0;
   overflow-x: hidden;
   text-align: left;
 }
@@ -102,6 +114,10 @@ button.tag-list-input {
   .tag-list-input {
     cursor: text;
   }
+}
+
+.icon-reorder {
+  margin-right: 25px;
 }
 
 .editable-list {
@@ -220,5 +236,19 @@ button.tag-list-input {
       pointer-events: auto;
       transform: translateX(0);
     }
+  }
+}
+
+.theme-dark {
+  .tag-list .tag-list-input {
+    color: $studio-white;
+  }
+}
+
+.tag-list-item.theme-dark {
+  border-bottom: 1px solid $studio-gray-70;
+
+  svg.icon-reorder {
+    fill: $studio-gray-30;
   }
 }

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -90,7 +90,6 @@ optgroup {
     -webkit-app-region: drag;
   }
 
-  .navigation-bar,
   .note-info {
     padding-top: 10px;
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -14,7 +14,8 @@ $border-radius: 3px;
 $focus-outline: 4px auto $studio-simplenote-blue-5;
 
 // Global Measurements
-$navigation-bar-width: 216px;
+
+$navigation-bar-width: 260px;
 $note-info-width: 320px;
 $max-content-width: 625px;
 $toolbar-height: 56px;

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -268,21 +268,17 @@ span[dir='ltr'] {
     button {
       color: $studio-white;
     }
-    svg {
-      fill: $studio-white;
-    }
-  }
-
-  .navigation-bar-item.is-selected {
-    button {
-      color: $studio-simplenote-blue-30;
-    }
     svg[class^='icon-'] {
       fill: $studio-simplenote-blue-30;
     }
   }
-  .tag-list .tag-list-input.is-selected {
-    color: $studio-simplenote-blue-30;
+
+  .navigation-bar-item.is-selected {
+    background-color: $studio-gray-80;
+
+    button {
+      color: $studio-white;
+    }
   }
 
   .tag-field {
@@ -300,22 +296,6 @@ span[dir='ltr'] {
 
   .settings-group p {
     color: $studio-gray-5;
-  }
-
-  .tab-panels__tab-list {
-    li {
-      color: $studio-gray-50;
-
-      &.is-active {
-        color: $studio-simplenote-blue-30;
-        border-bottom-color: $studio-simplenote-blue-30;
-      }
-    }
-
-    li.button:active {
-      background-color: $studio-simplenote-blue-30;
-      color: $studio-white;
-    }
   }
 
   .note-list-header {


### PR DESCRIPTION
### Fix

This PR updates the tag panel UI to match the new designs. It also fixes a bug where the dragged tag does not know that it should style dark mode.

Designs:

<img width="583" alt="Screen Shot 2020-09-21 at 4 39 11 PM" src="https://user-images.githubusercontent.com/6817400/93818982-15556c80-fc29-11ea-999f-24f0ee774282.png">
<img width="615" alt="Screen Shot 2020-09-21 at 4 39 27 PM" src="https://user-images.githubusercontent.com/6817400/93818984-15ee0300-fc29-11ea-95c7-0bd893f0468b.png">

App:

![image](https://user-images.githubusercontent.com/6817400/93814437-85142900-fc22-11ea-8bac-e5d927a05ce8.png)
![image](https://user-images.githubusercontent.com/6817400/93814447-89d8dd00-fc22-11ea-92f9-7c6619521ff5.png)

### Test
1. Open up tag panel
2. Have a few tags, can you edit, reorder, delete
3. View the panel in light and dark mode
4. View it in several browsers
5. If you have a log of tags does it scroll?

### Release

