### PR TITLE
[rewrite branch] Fix various CSS issues (scrollbars, icons, font sizes)

### DIFF
--- a/lib/dialogs/keybindings/style.scss
+++ b/lib/dialogs/keybindings/style.scss
@@ -56,7 +56,7 @@
 .keybindings__sections {
   position: relative;
   max-height: 480px;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   section {
     margin-right: 2em;

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -68,6 +68,7 @@
 }
 
 .note-detail-textarea {
+  overflow-x: hidden;
   min-height: 100%;
   cursor: text;
 

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -80,10 +80,6 @@
   .checkbox {
     cursor: pointer;
   }
-
-  &::first-line {
-    font-size: 120%;
-  }
 }
 
 .note-detail-markdown {

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -60,8 +60,7 @@
 
 .note-list-items {
   flex: 1 1 auto;
-  overflow: auto;
-  overflow-x: hidden;
+  overflow: hidden;
   -webkit-overflow-scrolling: touch;
 
   div:focus {

--- a/lib/search-bar/style.scss
+++ b/lib/search-bar/style.scss
@@ -7,6 +7,11 @@
   align-items: center;
   flex: 0 0 auto;
 
+  .icon-button svg.icon-menu {
+    width: 24px;
+    height: 24px;
+  }
+
   .button {
     padding: 0;
     width: 32px;

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -54,7 +54,7 @@
   padding-inline-end: 16px;
   padding-top: 0;
   padding-bottom: 0;
-  overflow-y: scroll;
+  overflow-y: auto;
   margin: 0;
   padding-top: 0;
   padding-bottom: 0;

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -51,7 +51,7 @@
   font-family: 'Simplenote Tasks', sans-serif;
 
   .note-title {
-    font-size: 20px;
+    font-size: 120%;
   }
 
   .slider {


### PR DESCRIPTION
### Fix
* Scrollbars should be hidden on tag list when there are few tags (Win/Edge and Win/Firefox)
* Note list should hide scrollbar when short, allow correct scrolling when long (Win/Edge and Win/Firefox)
* Menu icon should be 24px size (Win/Edge)
* Note body should never show a horizontal scroll, in editor or preview (various)
* First line of note should continue to be larger than the text while zoomed in/out (currently broken on all platforms)

Tested on Windows 10 (Parallels), Firefox (79.0) and Edge (pre-Chromium, 44.18362.449.0)

### Screenshots
Before:
<img width="396" alt="Screen Shot 2020-08-26 at 11 55 14 PM" src="https://user-images.githubusercontent.com/52152/91408029-05986300-e7f8-11ea-92fa-3a6a8ddf1efc.png">

<img width="218" alt="Screen Shot 2020-08-26 at 11 36 49 PM" src="https://user-images.githubusercontent.com/52152/91408057-12b55200-e7f8-11ea-8b8e-c285c2095b87.png">

<img width="334" alt="Screen Shot 2020-08-27 at 12 18 10 AM" src="https://user-images.githubusercontent.com/52152/91409949-07aff100-e7fb-11ea-8bd4-fa2aad770605.png">


After:
<img width="337" alt="Screen Shot 2020-08-26 at 11 54 54 PM" src="https://user-images.githubusercontent.com/52152/91408040-0af5ad80-e7f8-11ea-9b1d-f13e86277b11.png">

<img width="214" alt="Screen Shot 2020-08-26 at 11 35 15 PM" src="https://user-images.githubusercontent.com/52152/91408080-18ab3300-e7f8-11ea-9b01-e983dbc95bea.png">

<img width="329" alt="Screen Shot 2020-08-27 at 12 18 33 AM" src="https://user-images.githubusercontent.com/52152/91409968-0c74a500-e7fb-11ea-9188-fb7206e8d66c.png">
