### PR TITLE
Remove code that is causing continuous indexing events

### DIFF
--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -161,9 +161,9 @@ export const initSimperium = (
     });
   });
 
-  preferencesBucket.channel.on('ready', () =>
-    preferencesBucket.channel.sendIndexRequest()
-  );
+  // preferencesBucket.channel.on('ready', () =>
+  //   preferencesBucket.channel.sendIndexRequest()
+  // );
 
   if (createWelcomeNote) {
     import(


### PR DESCRIPTION
### Fix

The 'ready' event appears to be firing continuously which is not expected. This causes the index request to be sent over and over.

### Test
1. Take a look at the web socket.
