### PR TITLE
Only request revisions when the revisions panel is opened

### DIFF
--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -274,9 +274,8 @@ export const initSimperium = (
       }
 
       case 'REVISIONS_TOGGLE': {
-        const state = nextState;
-        const showRevisions = state.ui.showRevisions;
-        const noteId = state.ui.openedNote;
+        const showRevisions = nextState.ui.showRevisions;
+        const noteId = nextState.ui.openedNote;
 
         if (noteId && showRevisions) {
           noteBucket.getRevisions(noteId).then((revisions) => {

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -274,7 +274,7 @@ export const initSimperium = (
       }
 
       case 'REVISIONS_TOGGLE': {
-        const state = getState();
+        const state = nextState;
         const showRevisions = state.ui.showRevisions;
         const noteId = state.ui.openedNote;
 

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -255,15 +255,20 @@ export const initSimperium = (
         //  Preload the revisions when opening a note but only do it if no revisions are in memory
         if (noteId && !state.data.noteRevisions.get(noteId)?.size) {
           setTimeout(() => {
-            noteBucket.getRevisions(noteId).then((revisions) => {
-              dispatch({
-                type: 'LOAD_REVISIONS',
-                noteId: noteId,
-                revisions: revisions
-                  .map(({ data, version }): [number, T.Note] => [version, data])
-                  .sort((a, b) => a[0] - b[0]),
+            if (getState().ui.openedNote === noteId) {
+              noteBucket.getRevisions(noteId).then((revisions) => {
+                dispatch({
+                  type: 'LOAD_REVISIONS',
+                  noteId: noteId,
+                  revisions: revisions
+                    .map(({ data, version }): [number, T.Note] => [
+                      version,
+                      data,
+                    ])
+                    .sort((a, b) => a[0] - b[0]),
+                });
               });
-            });
+            }
           }, 250);
         }
         return result;

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -243,30 +243,22 @@ export const initSimperium = (
         queueNoteUpdate(action.noteId);
         return result;
 
-      case 'FILTER_NOTES':
-      case 'OPEN_NOTE':
-      case 'SELECT_NOTE': {
-        const noteId =
-          action.noteId ??
-          action.meta?.nextNoteToOpen ??
-          getState().ui.openedNote;
+      case 'REVISIONS_TOGGLE': {
+        const state = getState();
+        const showRevisions = state.ui.showRevisions;
+        const noteId = state.ui.openedNote;
 
-        if (noteId) {
+        if (noteId && showRevisions) {
           setTimeout(() => {
-            if (getState().ui.openedNote === noteId) {
-              noteBucket.getRevisions(noteId).then((revisions) => {
-                dispatch({
-                  type: 'LOAD_REVISIONS',
-                  noteId: noteId,
-                  revisions: revisions
-                    .map(({ data, version }): [number, T.Note] => [
-                      version,
-                      data,
-                    ])
-                    .sort((a, b) => a[0] - b[0]),
-                });
+            noteBucket.getRevisions(noteId).then((revisions) => {
+              dispatch({
+                type: 'LOAD_REVISIONS',
+                noteId: noteId,
+                revisions: revisions
+                  .map(({ data, version }): [number, T.Note] => [version, data])
+                  .sort((a, b) => a[0] - b[0]),
               });
-            }
+            });
           }, 250);
         }
 

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -187,6 +187,8 @@ export const initSimperium = (
   const queueNoteUpdate = (noteId: T.EntityId, delay = 2000) =>
     noteQueue.add(noteId, Date.now() + delay);
 
+  const hasRequestedRevisions = new Set<T.EntityId>();
+
   const tagQueue = new BucketQueue(tagBucket);
   const queueTagUpdate = (tagHash: T.TagHash, delay = 20) =>
     tagQueue.add(tagHash, Date.now() + delay);
@@ -252,7 +254,12 @@ export const initSimperium = (
           getState().ui.openedNote;
 
         //  Preload the revisions when opening a note but only do it if no revisions are in memory
-        if (noteId && !nextState.data.noteRevisions.get(noteId)?.size) {
+        if (
+          noteId &&
+          !nextState.data.noteRevisions.get(noteId)?.size &&
+          !hasRequestedRevisions.has(noteId)
+        ) {
+          hasRequestedRevisions.add(noteId);
           setTimeout(() => {
             if (getState().ui.openedNote === noteId) {
               noteBucket.getRevisions(noteId).then((revisions) => {

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -279,17 +279,15 @@ export const initSimperium = (
         const noteId = state.ui.openedNote;
 
         if (noteId && showRevisions) {
-          setTimeout(() => {
-            noteBucket.getRevisions(noteId).then((revisions) => {
-              dispatch({
-                type: 'LOAD_REVISIONS',
-                noteId: noteId,
-                revisions: revisions
-                  .map(({ data, version }): [number, T.Note] => [version, data])
-                  .sort((a, b) => a[0] - b[0]),
-              });
+          noteBucket.getRevisions(noteId).then((revisions) => {
+            dispatch({
+              type: 'LOAD_REVISIONS',
+              noteId: noteId,
+              revisions: revisions
+                .map(({ data, version }): [number, T.Note] => [version, data])
+                .sort((a, b) => a[0] - b[0]),
             });
-          }, 250);
+          });
         }
 
         return result;

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -246,14 +246,13 @@ export const initSimperium = (
       case 'FILTER_NOTES':
       case 'OPEN_NOTE':
       case 'SELECT_NOTE': {
-        const state = getState();
         const noteId =
           action.noteId ??
           action.meta?.nextNoteToOpen ??
           getState().ui.openedNote;
 
         //  Preload the revisions when opening a note but only do it if no revisions are in memory
-        if (noteId && !state.data.noteRevisions.get(noteId)?.size) {
+        if (noteId && !nextState.data.noteRevisions.get(noteId)?.size) {
           setTimeout(() => {
             if (getState().ui.openedNote === noteId) {
               noteBucket.getRevisions(noteId).then((revisions) => {


### PR DESCRIPTION
### Fix

Only request revisions when the revisions panel is opened. We are making a lot of Simperium requests when they are unneeded.

### Test
1. Test revisions panel

