### PR TITLE
[rewrite branch] Enable Monaco find widget

### DIFF
--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -56,6 +56,12 @@ const buildEditMenu = (settings, isAuthenticated) => {
         click: editorCommandSender({ action: 'find' }),
         accelerator: 'CommandOrControl+F',
       },
+      {
+        label: 'Find Again',
+        visible: isAuthenticated,
+        click: editorCommandSender({ action: 'findAgain' }),
+        accelerator: 'CommandOrControl+G',
+      },
       { type: 'separator' },
       {
         label: 'C&heck Spelling',

--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -50,6 +50,12 @@ const buildEditMenu = (settings, isAuthenticated) => {
         click: appCommandSender({ action: 'focusSearchField' }),
         accelerator: 'CommandOrControl+Shift+S',
       },
+      {
+        label: 'Find in Note',
+        visible: isAuthenticated,
+        click: editorCommandSender({ action: 'find' }),
+        accelerator: 'CommandOrControl+F',
+      },
       { type: 'separator' },
       {
         label: 'C&heck Spelling',

--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -51,13 +51,13 @@ const buildEditMenu = (settings, isAuthenticated) => {
         accelerator: 'CommandOrControl+Shift+S',
       },
       {
-        label: 'Find in Note',
+        label: '&Find in Note',
         visible: isAuthenticated,
         click: editorCommandSender({ action: 'find' }),
         accelerator: 'CommandOrControl+F',
       },
       {
-        label: 'Find Again',
+        label: 'Find A&gain',
         visible: isAuthenticated,
         click: editorCommandSender({ action: 'findAgain' }),
         accelerator: 'CommandOrControl+G',

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -84,10 +84,7 @@ class AppComponent extends Component<Props> {
       return false;
     }
 
-    if (
-      (cmdOrCtrl && shiftKey && 'KeyS' === code) ||
-      (isElectron && cmdOrCtrl && !shiftKey && 'KeyF' === code)
-    ) {
+    if (cmdOrCtrl && shiftKey && 'KeyS' === code) {
       this.props.focusSearchField();
 
       event.stopPropagation();
@@ -114,7 +111,7 @@ class AppComponent extends Component<Props> {
     // prevent default browser behavior for search and find
     // do NOT stopPropagation because note-detail still needs to catch it!
     // @todo it would be great if this could focus the note and send an editor command to Monaco
-    if (cmdOrCtrl && ('KeyG' === code || 'KeyF' === code)) {
+    if (!isElectron && cmdOrCtrl && ('KeyG' === code || 'KeyF' === code)) {
       event.preventDefault();
     }
 

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -111,10 +111,10 @@ class AppComponent extends Component<Props> {
       return false;
     }
 
-    // prevent default browser behavior for search
-    // will bubble up from note-detail
-    if (cmdOrCtrl && 'KeyG' === code) {
-      event.stopPropagation();
+    // prevent default browser behavior for search and find
+    // do NOT stopPropagation because note-detail still needs to catch it!
+    // @todo it would be great if this could focus the note and send an editor command to Monaco
+    if (cmdOrCtrl && ('KeyG' === code || 'KeyF' === code)) {
       event.preventDefault();
     }
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -363,7 +363,12 @@ class NoteContentEditor extends Component<Props> {
 
     // let Electron menus trigger these
     if (window.electron) {
-      shortcutsToDisable.push('undo', 'redo', 'editor.action.selectAll');
+      shortcutsToDisable.push(
+        'actions.find',
+        'undo',
+        'redo',
+        'editor.action.selectAll'
+      );
     }
     shortcutsToDisable.forEach(function (action) {
       editor._standaloneKeybindingService.addDynamicKeybinding('-' + action);
@@ -476,6 +481,9 @@ class NoteContentEditor extends Component<Props> {
 
     window.electron?.receive('editorCommand', (command) => {
       switch (command.action) {
+        case 'find':
+          editor.trigger('editorCommand', 'actions.find', null);
+          return;
         case 'insertChecklist':
           editor.trigger('editorCommand', 'insertChecklist', null);
           return;

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -351,18 +351,16 @@ class NoteContentEditor extends Component<Props> {
 
     // remove keybindings; see https://github.com/microsoft/monaco-editor/issues/287
     const shortcutsToDisable = [
+      'actions.findWithSelection', // meta+E
       'cursorUndo', // meta+U
+      'editor.action.addSelectionToNextFindMatch', // meta+D
       'editor.action.commentLine', // meta+/
       'editor.action.jumpToBracket', // shift+meta+\
       'editor.action.transposeLetters', // ctrl+T
       'editor.action.triggerSuggest', // ctrl+space
       'expandLineSelection', // meta+L
-      // search shortcuts
-      'actions.findWithSelection',
-      'editor.action.addSelectionToNextFindMatch',
-      'editor.action.nextMatchFindAction',
-      'editor.action.selectHighlights',
     ];
+
     // let Electron menus trigger these
     if (window.electron) {
       shortcutsToDisable.push('undo', 'redo', 'editor.action.selectAll');
@@ -376,12 +374,6 @@ class NoteContentEditor extends Component<Props> {
     editor.createContextKey(
       'allowBrowserKeybinding',
       window.electron ? false : true
-    );
-
-    // map Meta+G to next match
-    editor._standaloneKeybindingService.addDynamicKeybinding(
-      'editor.action.nextMatchFindAction',
-      [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_G]
     );
 
     editor.addAction({

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -249,7 +249,7 @@ class NoteContentEditor extends Component<Props> {
 
   focusEditor = () => this.editor?.focus();
 
-  hasFocus = () => this.editor?.hasTextFocus();
+  hasFocus = () => this.editor?.hasWidgetFocus();
 
   handleUndoRedo = (event: InputEvent) => {
     switch (event.inputType) {
@@ -466,6 +466,7 @@ class NoteContentEditor extends Component<Props> {
       run: () => {
         editor.setSelection(editor.getModel().getFullModelRange());
       },
+      precondition: '!findWidgetVisible',
     });
 
     editor.addAction({
@@ -478,6 +479,7 @@ class NoteContentEditor extends Component<Props> {
       contextMenuGroupId: '10_checklist',
       contextMenuOrder: 1,
       run: this.insertOrRemoveCheckboxes,
+      precondition: '!findWidgetVisible',
     });
 
     window.electron?.receive('editorCommand', (command) => {

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -484,6 +484,13 @@ class NoteContentEditor extends Component<Props> {
         case 'find':
           editor.trigger('editorCommand', 'actions.find', null);
           return;
+        case 'findAgain':
+          editor.trigger(
+            'editorCommand',
+            'editor.action.nextMatchFindAction',
+            null
+          );
+          return;
         case 'insertChecklist':
           editor.trigger('editorCommand', 'insertChecklist', null);
           return;

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -374,6 +374,12 @@ class NoteContentEditor extends Component<Props> {
       window.electron ? false : true
     );
 
+    // map Meta+G to next match
+    editor._standaloneKeybindingService.addDynamicKeybinding(
+      'editor.action.nextMatchFindAction',
+      [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_G]
+    );
+
     editor.addAction({
       id: 'context_undo',
       label: 'Undo',

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -319,6 +319,8 @@ class NoteContentEditor extends Component<Props> {
         'editor.foreground': '#2c3338', // $studio-gray-80 AKA theme-color-fg
         'editor.background': '#ffffff',
         'editor.selectionBackground': '#ced9f2', // $studio-simplenote-blue-5
+        'editor.findMatchBackground': '#ced9f2', // $studio-simplenote-blue-5
+        'editor.findMatchHighlightBackground': '#abc1f5', // $studio-simplenote-blue-10
         'scrollbarSlider.activeBackground': '#8c8f94', // $studio-gray-30
         'scrollbarSlider.background': '#c3c4c7', // $studio-gray-10
         'scrollbarSlider.hoverBackground': '#a7aaad', // $studio-gray-20
@@ -333,6 +335,8 @@ class NoteContentEditor extends Component<Props> {
         'editor.foreground': '#ffffff',
         'editor.background': '#1d2327', // $studio-gray-90
         'editor.selectionBackground': '#50575e', // $studio-gray-60
+        'editor.findMatchBackground': '#50575e', // $studio-gray-60
+        'editor.findMatchHighlightBackground': '#3c434a', // $studio-gray-70
         'scrollbarSlider.activeBackground': '#646970', // $studio-gray-50
         'scrollbarSlider.background': '#2c3338', // $studio-gray-80
         'scrollbarSlider.hoverBackground': '#1d2327', // $studio-gray-90

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -365,9 +365,10 @@ class NoteContentEditor extends Component<Props> {
     if (window.electron) {
       shortcutsToDisable.push(
         'actions.find',
-        'undo',
+        'editor.action.nextMatchFindAction',
+        'editor.action.selectAll',
         'redo',
-        'editor.action.selectAll'
+        'undo'
       );
     }
     shortcutsToDisable.forEach(function (action) {

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -354,7 +354,6 @@ class NoteContentEditor extends Component<Props> {
       'editor.action.triggerSuggest', // ctrl+space
       'expandLineSelection', // meta+L
       // search shortcuts
-      'actions.find',
       'actions.findWithSelection',
       'editor.action.addSelectionToNextFindMatch',
       'editor.action.nextMatchFindAction',


### PR DESCRIPTION
### Fix

This PR uses Monaco's Find widget to provide search within note (find in page) functionality.

### Todo // Known Issues & Questions
* The title of the note gets bumped down when the widget is shown
* Scrollbar highlight color is wrong
* If text focus is within the find widget, the combo to toggle between tag/editor focus erroneously toggles to the editor text, and leaves the find widget visible
* In the browser only, if the editor is not focused, Find and Find Next get eaten. We disable the browser behavior but it would be ideal if we could focus the editor and trigger the editor action. (This works in Electron because we don't override the default behavior, since it doesn't have one.)
* Search prefills with whatever word you're next to, or if you're next to punctuation, were previously closest to, which is kind of confusing. Probably this isn't customizable. Are we okay with it?
* Not sure about the word highlight colors (different for current match / all matches in page) -- check w/Sly
* Should this interact better with our existing / global search functionality? Right now they are totally separate which is somewhat odd. IF we do want that maybe we should use different highlight colors?