### PR TITLE
[Rewrite Branch] Adds the new search interface

### DIFF
--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -50,6 +50,18 @@ const buildEditMenu = (settings, isAuthenticated) => {
         click: appCommandSender({ action: 'focusSearchField' }),
         accelerator: 'CommandOrControl+Shift+S',
       },
+      {
+        label: '&Find in Note',
+        visible: isAuthenticated,
+        click: editorCommandSender({ action: 'find' }),
+        accelerator: 'CommandOrControl+F',
+      },
+      {
+        label: 'Find A&gain',
+        visible: isAuthenticated,
+        click: editorCommandSender({ action: 'findAgain' }),
+        accelerator: 'CommandOrControl+G',
+      },
       { type: 'separator' },
       {
         label: 'C&heck Spelling',

--- a/lib/icons/chevron-right.tsx
+++ b/lib/icons/chevron-right.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function ChevronRightIcon() {
+  return (
+    <svg
+      className="icon-chevron-right"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24px"
+      height="24px"
+      viewBox="0 0 24 24"
+    >
+      <rect x="0" fill="none" width="24" height="24" />
+      <g>
+        <polygon points="10.11 21.19 8.7 19.78 16.48 12 8.7 4.22 10.11 2.81 19.3 12 10.11 21.19" />
+      </g>
+    </svg>
+  );
+}

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -93,11 +93,13 @@ class NoteContentEditor extends Component<Props> {
     const noteChanged = props.noteId !== state.noteId;
     const needsNewContent = contentChanged || noteChanged;
 
-    const content = needsNewContent
+    const content = noteChanged
       ? goFast
         ? props.note.content.slice(0, props.editorSelection[1] + 5000)
         : withCheckboxCharacters(props.note.content)
-      : state.content;
+      : contentChanged
+      ? withCheckboxCharacters(props.note.content)
+      : null;
 
     const editor = noteChanged ? (goFast ? 'fast' : 'full') : state.editor;
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -91,15 +91,12 @@ class NoteContentEditor extends Component<Props> {
     const goFast = props.note.content.length > 5000;
     const contentChanged = props.note.content !== state.content;
     const noteChanged = props.noteId !== state.noteId;
-    const needsNewContent = contentChanged || noteChanged;
 
-    const content = noteChanged
-      ? goFast
+    const content = contentChanged
+      ? noteChanged && goFast
         ? props.note.content.slice(0, props.editorSelection[1] + 5000)
         : withCheckboxCharacters(props.note.content)
-      : contentChanged
-      ? withCheckboxCharacters(props.note.content)
-      : null;
+      : state.content;
 
     const editor = noteChanged ? (goFast ? 'fast' : 'full') : state.editor;
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -15,6 +15,8 @@ import {
   withCheckboxCharacters,
   withCheckboxSyntax,
 } from './utils/task-transform';
+import IconButton from './icon-button';
+import ChevronRightIcon from './icons/chevron-right';
 
 import * as S from './state';
 import * as T from './types';
@@ -65,6 +67,8 @@ type OwnState = {
   editor: 'fast' | 'full';
   noteId: T.EntityId | null;
   overTodo: boolean;
+  searchQuery: string;
+  selectedSearchMatchIndex: number | null;
 };
 
 class NoteContentEditor extends Component<Props> {
@@ -72,33 +76,42 @@ class NoteContentEditor extends Component<Props> {
   editor: Editor.IStandaloneCodeEditor | null = null;
   monaco: Monaco | null = null;
   decorations: string[] = [];
+  matchesInNote: [] = [];
 
   state: OwnState = {
     content: '',
     editor: 'fast',
     noteId: null,
     overTodo: false,
+    searchQuery: '',
+    selectedSearchMatchIndex: null,
   };
 
   static getDerivedStateFromProps(props: Props, state: OwnState) {
-    const {
-      note: { content },
-    } = props;
-    const goFast = content.length > 5000;
+    const goFast = props.note.content.length > 5000;
+    const contentChanged = props.note.content !== state.content;
+    const noteChanged = props.noteId !== state.noteId;
+    const needsNewContent = contentChanged || noteChanged;
 
-    if (props.noteId !== state.noteId) {
-      return {
-        content: goFast
-          ? content.slice(0, props.editorSelection[1] + 5000)
-          : withCheckboxCharacters(content),
-        editor: goFast ? 'fast' : 'full',
-        noteId: props.noteId,
-      };
-    }
+    const content = needsNewContent
+      ? goFast
+        ? props.note.content.slice(0, props.editorSelection[1] + 5000)
+        : withCheckboxCharacters(props.note.content)
+      : state.content;
 
-    return content !== state.content
-      ? { content: withCheckboxCharacters(content) }
-      : null;
+    const editor = noteChanged ? (goFast ? 'fast' : 'full') : state.editor;
+
+    const searchChanged = props.searchQuery !== state.searchQuery;
+    const selectedSearchMatchIndex =
+      noteChanged || searchChanged ? null : state.selectedSearchMatchIndex;
+
+    return {
+      content,
+      editor,
+      noteId: props.noteId,
+      searchQuery: props.searchQuery,
+      selectedSearchMatchIndex,
+    };
   }
 
   componentDidMount() {
@@ -113,6 +126,7 @@ class NoteContentEditor extends Component<Props> {
     }, SPEED_DELAY);
     this.props.storeFocusEditor(this.focusEditor);
     this.props.storeHasFocus(this.hasFocus);
+    this.toggleShortcuts(true);
   }
 
   componentWillUnmount() {
@@ -121,7 +135,35 @@ class NoteContentEditor extends Component<Props> {
     }
     window.electron?.removeListener('editorCommand');
     window.removeEventListener('input', this.handleUndoRedo, true);
+    this.toggleShortcuts(false);
   }
+
+  toggleShortcuts = (doEnable: boolean) => {
+    if (doEnable) {
+      window.addEventListener('keydown', this.handleShortcut, true);
+    } else {
+      window.removeEventListener('keydown', this.handleShortcut, true);
+    }
+  };
+
+  handleShortcut = (event: KeyboardEvent) => {
+    const { ctrlKey, code, metaKey, shiftKey } = event;
+
+    const cmdOrCtrl = ctrlKey || metaKey;
+    if (cmdOrCtrl && shiftKey && code === 'KeyG') {
+      this.setPrevSearchSelection();
+      event.stopPropagation();
+      event.preventDefault();
+      return false;
+    }
+
+    if (cmdOrCtrl && !shiftKey && code === 'KeyG') {
+      this.setNextSearchSelection();
+      event.stopPropagation();
+      event.preventDefault();
+      return false;
+    }
+  };
 
   componentDidUpdate(prevProps: Props) {
     const {
@@ -174,11 +216,11 @@ class NoteContentEditor extends Component<Props> {
   }
 
   setDecorators = () => {
-    const searchMatches = this.searchMatches() ?? [];
+    this.matchesInNote = this.searchMatches() ?? [];
     const titleDecoration = this.getTitleDecoration() ?? [];
 
     this.decorations = this.editor.deltaDecorations(this.decorations, [
-      ...searchMatches,
+      ...this.matchesInNote,
       ...titleDecoration,
     ]);
   };
@@ -232,7 +274,10 @@ class NoteContentEditor extends Component<Props> {
           matches.push({
             options: {
               inlineClassName: 'search-decoration',
-              overviewRuler: { color: '#3361cc' },
+              overviewRuler: {
+                color: '#3361cc',
+                position: Editor.OverviewRulerLane.Full,
+              },
             },
             range: {
               startLineNumber: start.lineNumber,
@@ -321,7 +366,9 @@ class NoteContentEditor extends Component<Props> {
       colors: {
         'editor.foreground': '#2c3338', // $studio-gray-80 AKA theme-color-fg
         'editor.background': '#ffffff',
-        'editor.selectionBackground': '#ced9f2', // $studio-simplenote-blue-5
+        'editor.inactiveSelectionBackground': '#4678eb', // $studio-simplenote-blue-50
+        'editor.selectionBackground': '#4678eb', // $studio-simplenote-blue-40
+        'editor.selectionHighlightBackground': '#135564',
         'scrollbarSlider.activeBackground': '#8c8f94', // $studio-gray-30
         'scrollbarSlider.background': '#c3c4c7', // $studio-gray-10
         'scrollbarSlider.hoverBackground': '#a7aaad', // $studio-gray-20
@@ -335,7 +382,8 @@ class NoteContentEditor extends Component<Props> {
       colors: {
         'editor.foreground': '#ffffff',
         'editor.background': '#1d2327', // $studio-gray-90
-        'editor.selectionBackground': '#50575e', // $studio-gray-60
+        'editor.inactiveSelectionBackground': '#3361cc', // $studio-simplenote-blue-50
+        'editor.selectionBackground': '#3361cc', // $studio-simplenote-blue-50
         'scrollbarSlider.activeBackground': '#646970', // $studio-gray-50
         'scrollbarSlider.background': '#2c3338', // $studio-gray-80
         'scrollbarSlider.hoverBackground': '#1d2327', // $studio-gray-90
@@ -476,6 +524,9 @@ class NoteContentEditor extends Component<Props> {
 
     window.electron?.receive('editorCommand', (command) => {
       switch (command.action) {
+        case 'findAgain':
+          this.setNextSearchSelection();
+          return;
         case 'insertChecklist':
           editor.trigger('editorCommand', 'insertChecklist', null);
           return;
@@ -509,6 +560,8 @@ class NoteContentEditor extends Component<Props> {
     }
 
     this.setDecorators();
+    // make component rerender after the decorators are set.
+    this.setState({});
     editor.onDidChangeModelContent(() => this.setDecorators());
 
     document.oncopy = (event) => {
@@ -733,10 +786,35 @@ class NoteContentEditor extends Component<Props> {
     editNote(noteId, { content: withCheckboxSyntax(content) });
   };
 
-  render() {
-    const { fontSize, noteId, theme } = this.props;
-    const { content, editor, overTodo } = this.state;
+  setNextSearchSelection = () => {
+    const { selectedSearchMatchIndex: index } = this.state;
+    const total = this.matchesInNote.length;
+    const newIndex = (total + (index ?? -1) + 1) % total;
+    this.setSearchSelection(newIndex);
+  };
 
+  setPrevSearchSelection = () => {
+    const { selectedSearchMatchIndex: index } = this.state;
+    const total = this.matchesInNote.length;
+    const newIndex = (total + (index ?? total) - 1) % total;
+    this.setSearchSelection(newIndex);
+  };
+
+  setSearchSelection = (index) => {
+    if (!this.matchesInNote.length) {
+      return;
+    }
+    const range = this.matchesInNote[index].range;
+    this.setState({ selectedSearchMatchIndex: index });
+    this.editor.setSelection(range);
+    this.editor.revealLineInCenter(range.startLineNumber);
+    this.focusEditor();
+  };
+
+  render() {
+    const { fontSize, noteId, searchQuery, theme } = this.props;
+    const { content, editor, overTodo, selectedSearchMatchIndex } = this.state;
+    const searchMatches = searchQuery ? this.searchMatches() : [];
     return (
       <div
         className={`note-content-editor-shell${
@@ -789,6 +867,31 @@ class NoteContentEditor extends Component<Props> {
             }}
             value={content}
           />
+        )}
+        {searchQuery.length > 0 && searchMatches && (
+          <div className="search-results">
+            <div>
+              {selectedSearchMatchIndex === null
+                ? `${searchMatches.length} Results`
+                : `${selectedSearchMatchIndex + 1} of ${searchMatches.length}`}
+            </div>
+            <span className="search-results-next">
+              <IconButton
+                disabled={searchMatches.length <= 1}
+                icon={<ChevronRightIcon />}
+                onClick={this.setNextSearchSelection}
+                title="Next"
+              />
+            </span>
+            <span className="search-results-prev">
+              <IconButton
+                disabled={searchMatches.length <= 1}
+                icon={<ChevronRightIcon />}
+                onClick={this.setPrevSearchSelection}
+                title="Prev"
+              />
+            </span>
+          </div>
         )}
       </div>
     );

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -368,9 +368,7 @@ class NoteContentEditor extends Component<Props> {
       colors: {
         'editor.foreground': '#2c3338', // $studio-gray-80 AKA theme-color-fg
         'editor.background': '#ffffff',
-        'editor.inactiveSelectionBackground': '#4678eb', // $studio-simplenote-blue-50
-        'editor.selectionBackground': '#4678eb', // $studio-simplenote-blue-40
-        'editor.selectionHighlightBackground': '#135564',
+        'editor.selectionBackground': '#ced9f2', // $studio-simplenote-blue-5
         'scrollbarSlider.activeBackground': '#8c8f94', // $studio-gray-30
         'scrollbarSlider.background': '#c3c4c7', // $studio-gray-10
         'scrollbarSlider.hoverBackground': '#a7aaad', // $studio-gray-20
@@ -384,8 +382,7 @@ class NoteContentEditor extends Component<Props> {
       colors: {
         'editor.foreground': '#ffffff',
         'editor.background': '#1d2327', // $studio-gray-90
-        'editor.inactiveSelectionBackground': '#3361cc', // $studio-simplenote-blue-50
-        'editor.selectionBackground': '#3361cc', // $studio-simplenote-blue-50
+        'editor.selectionBackground': '#50575e', // $studio-gray-60
         'scrollbarSlider.activeBackground': '#646970', // $studio-gray-50
         'scrollbarSlider.background': '#2c3338', // $studio-gray-80
         'scrollbarSlider.hoverBackground': '#1d2327', // $studio-gray-90

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -14,6 +14,7 @@ type StateProps = {
   allTags: Map<T.TagHash, T.Tag>;
   editMode: boolean;
   isEditorActive: boolean;
+  isSearchActive: boolean;
   isSmallScreen: boolean;
   keyboardShortcuts: boolean;
   lastUpdated: number;
@@ -73,7 +74,7 @@ export class NoteEditor extends Component<Props> {
     // toggle between tag editor and note editor
     if (shiftKey && cmdOrCtrl && 'KeyY' === code && this.props.isEditorActive) {
       // prefer focusing the edit field first
-      if (!this.editFieldHasFocus()) {
+      if (!this.editFieldHasFocus() || this.props.isSearchActive) {
         this.focusNoteEditor?.();
 
         event.stopPropagation();
@@ -159,6 +160,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
   noteId: state.ui.openedNote,
   note: state.data.notes.get(state.ui.openedNote),
   revision: state.ui.selectedRevision,
+  isSearchActive: !!state.ui.searchQuery.length,
   isSmallScreen: selectors.isSmallScreen(state),
 });
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -61,9 +61,8 @@
     border-radius: 10px;
     border: 3px solid gray;
   }
-
   .search-decoration {
-    background-color: $studio-simplenote-blue-50 !important;
+    background-color: rgba($studio-simplenote-blue-40, 0.6);
   }
 }
 
@@ -99,13 +98,58 @@
   width: 100%;
 }
 
+.search-results {
+  position: fixed;
+  left: 330px;
+  right: 0;
+  bottom: 0;
+  height: 56px;
+  line-height: 56px;
+  z-index: 100;
+  border-top: 1px solid $studio-gray-5;
+  background-color: $studio-white;
+  text-align: center;
+  user-select: none;
+
+  div {
+    display: inline-block;
+  }
+
+  .search-results-next,
+  .search-results-prev {
+    float: right;
+    padding: 0px 6px;
+    width: 42px;
+    height: 100%;
+
+    svg {
+      fill: $studio-simplenote-blue-50;
+    }
+  }
+  .search-results-next {
+    margin-right: 6px;
+  }
+  .search-results-prev svg {
+    transform: scaleX(-1);
+  }
+
+  @media only screen and (max-width: $single-column) {
+    left: 0;
+  }
+}
+
 .note-detail-textarea .note-content-editor-shell.cursor-pointer div {
   cursor: pointer;
 }
 
 .note-content-plaintext {
   display: none;
+  font-size: 16px;
   white-space: pre-wrap;
+
+  &::first-line {
+    font-size: 18px;
+  }
 
   &.visible {
     display: inherit;
@@ -134,10 +178,6 @@
   }
   .search-field {
     border-color: $studio-gray-10;
-  }
-
-  .search-decoration {
-    color: $studio-white;
   }
 }
 
@@ -228,6 +268,11 @@
     color: $studio-simplenote-blue-30;
   }
 
+  .tag-field {
+    height: 56px;
+    padding: 7px;
+  }
+
   .tag-field input {
     background: transparent;
 
@@ -299,6 +344,16 @@
       tr:nth-child(2n) {
         background-color: $studio-gray-80;
       }
+    }
+  }
+
+  .search-results {
+    color: $studio-gray-10;
+    border-color: $studio-gray-80;
+    background-color: $studio-gray-90;
+
+    button svg {
+      fill: $studio-simplenote-blue-30;
     }
   }
 }


### PR DESCRIPTION
### Fix

Implements the new search interface. This PR captures the browser "finds" (cmd+f) and displays a search UI that allows users to navigate through results. This also enables the user to use the (cmd+g) and (cdm+shift+g)

<img width="743" alt="Screen Shot 2020-09-02 at 7 49 26 PM" src="https://user-images.githubusercontent.com/6817400/92048334-73dba900-ed55-11ea-80f3-2e54a46d09d6.png">

### Test
1. Use the cmd+F, cmd+shift+g, and cmd+g to navigate search results
2. Use the search on a note that doesn't have the result
3. Use the search bottom bar to navigate results

