### PR TITLE
[Rewrite Branch] Remove unnecessary divs

### DIFF
--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -23,8 +23,6 @@ type Props = OwnProps & StateProps;
 export class NoteDetail extends Component<Props> {
   static displayName = 'NoteDetail';
 
-  noteDetail = createRef<HTMLDivElement>();
-
   componentDidMount() {
     this.props.storeFocusEditor(this.focusEditor);
     this.props.storeHasFocus(this.hasFocus);
@@ -47,18 +45,11 @@ export class NoteDetail extends Component<Props> {
             <SimplenoteCompactLogo />
           </div>
         ) : (
-          <div ref={this.noteDetail} className="note-detail">
-            <div
-              className="note-detail-textarea theme-color-bg theme-color-fg"
-              style={{ fontSize: `${fontSize}px`, overflowY: 'hidden' }}
-            >
-              <NoteContentEditor
-                key={openedNote}
-                storeFocusEditor={this.storeFocusContentEditor}
-                storeHasFocus={this.storeEditorHasFocus}
-              />
-            </div>
-          </div>
+          <NoteContentEditor
+            key={openedNote}
+            storeFocusEditor={this.storeFocusContentEditor}
+            storeHasFocus={this.storeEditorHasFocus}
+          />
         )}
       </div>
     );

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -27,18 +27,21 @@
   unicode-range: U+E000-E001;
 }
 
-.note-detail {
+.note-detail,
+.note-content-editor-shell {
   padding: 0 calc((100% - 768px) / 2);
 }
 
 @media only screen and (max-width: 1400px) {
-  .note-detail {
+  .note-detail,
+  .note-content-editor-shell {
     padding: 0 10%;
   }
 }
 
 .is-line-length-full {
-  .note-detail {
+  .note-detail,
+  .note-content-editor-shell {
     padding: 0 25px;
   }
 }


### PR DESCRIPTION
### Fix

There are two unnecessary divs that wrap the Monaco editor. These are no longer needed. This is a prerequisite for adding the new search interface: https://github.com/Automattic/simplenote-electron/pull/2313

### Test
1. Test editor and preview when it is in both narrow and full line length
2. Test editor and preview width on small screens and large
