### PR TITLE
[rewrite branch] Logout confirmation dialog: use color studio for all hex colors, fix typo

### DIFF
--- a/lib/dialogs/logout-confirmation/index.tsx
+++ b/lib/dialogs/logout-confirmation/index.tsx
@@ -64,7 +64,7 @@ export class LogoutConfirmation extends Component<Props> {
           )}
           {notes.size > 0 && (
             <button
-              className="export-unsyncronized"
+              className="export-unsynchronized"
               onClick={this.exportUnsyncedNotes}
             >
               Export unsynchronized notes

--- a/lib/dialogs/logout-confirmation/style.scss
+++ b/lib/dialogs/logout-confirmation/style.scss
@@ -30,8 +30,8 @@
   }
 
   .change-list {
-    border-bottom: 1px solid #dcdcde;
-    border-top: 1px solid #dcdcde;
+    border-bottom: 1px solid $studio-gray-5;
+    border-top: 1px solid $studio-gray-5;
 
     ul {
       list-style: none;
@@ -67,8 +67,8 @@
 
     .log-out {
       border-radius: 4px;
-      background-color: #3361cc;
-      color: #ffffff;
+      background-color: $studio-simplenote-blue-50;
+      color: $studio-white;
       font-size: 14px;
       padding: 6px 12px;
       margin: 14px 12px;
@@ -78,7 +78,7 @@
 
 .theme-dark .logoutConfirmation .dialog {
   .change-list {
-    border-color: #2c3338;
+    border-color: $studio-gray-80;
   }
 
   .export-unsyncronized {

--- a/lib/dialogs/logout-confirmation/style.scss
+++ b/lib/dialogs/logout-confirmation/style.scss
@@ -55,7 +55,7 @@
     }
   }
 
-  .export-unsyncronized {
+  .export-unsynchronized {
     color: $studio-simplenote-blue-50;
     padding: 17px;
     text-align: left;
@@ -81,7 +81,7 @@
     border-color: $studio-gray-80;
   }
 
-  .export-unsyncronized {
+  .export-unsynchronized {
     color: $studio-simplenote-blue-30;
   }
 }


### PR DESCRIPTION
### Fix

Cleaning up some stray hex color codes that should be color studio. Fixing a typo "unsyncronized".