### PR TITLE
hide beta bar in print stylesheet

### DIFF
--- a/scss/print.scss
+++ b/scss/print.scss
@@ -45,4 +45,8 @@
       color: $studio-black;
     }
   }
+
+  .beta-bar {
+    display: none;
+  }
 }


### PR DESCRIPTION
### Fix

User reported (3275525-zen) that printing in the browser prints the beta bar, which hides the last row of the text.

### Test
1. Print from browser
2. Verify the beta bar is not printed
