### PR TITLE
Fixes the css so all pages print

### DIFF
--- a/scss/print.scss
+++ b/scss/print.scss
@@ -26,6 +26,7 @@
   .note-detail-textarea,
   .note-content-editor-shell,
   .note-detail-wrapper {
+    display: block;
     overflow: auto;
     position: relative;
   }

--- a/scss/print.scss
+++ b/scss/print.scss
@@ -26,7 +26,8 @@
   .note-detail-textarea,
   .note-content-editor-shell,
   .note-detail-wrapper {
-    overflow: visible;
+    overflow: auto;
+    position: relative;
   }
 
   [class^='note-detail-'] {


### PR DESCRIPTION
### Fix

There were three issues with printing. The position relative shows more than the first page. The overflow auto allows all the pages to print. I have a note that should bee 22 pages but only 11 were printed without the overflow auto. The last issue is that display flex in Firefox causes only the first page to print. So added display: block to fix that.

Tested in Safari, Chrome, and Firefox

### Test
1. Print in multiple browsers
