### PR TITLE
Fixes the editor height in Safari

### DIFF
--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -89,6 +89,12 @@
   display: none !important;
 }
 
+/* Safari requires that it be displayed absolute so that it takes the full height
+*/
+.react-monaco-editor-container {
+  position: absolute;
+}
+
 .note-detail-textarea .note-content-editor-shell.cursor-pointer div {
   cursor: pointer;
 }


### PR DESCRIPTION
### Fix

Fixes the height of the editor in Safari, without this the editor is only a couple pixels high.

### Test
1. Open app in safari.
2. Does the editor look correct?
