### PR TITLE
Fixes safari height and Chrome editor width

### DIFF
--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -91,8 +91,12 @@
 
 /* Safari requires that it be displayed absolute so that it takes the full height
 */
-.react-monaco-editor-container {
+.note-content-editor-shell {
+  height: 100%;
+  left: 0;
   position: absolute;
+  top: 0;
+  width: 100%;
 }
 
 .note-detail-textarea .note-content-editor-shell.cursor-pointer div {


### PR DESCRIPTION
### Fix

This is a followup from https://github.com/Automattic/simplenote-electron/pull/2320

This fixes Safari and does not cause Chrome to break. The previous fix caused the editor to be wider than it should which made the right side of the editor cut off.

### Test
1. Test safari, firefox, and chrome
2. Does the editor appear correct?