### PR TITLE
Icon tooltip: Fix console error with a wrapper span

### DIFF
--- a/lib/icon-button/index.tsx
+++ b/lib/icon-button/index.tsx
@@ -10,15 +10,22 @@ type OwnProps = {
 type Props = OwnProps;
 
 export const IconButton = ({ icon, title, ...props }: Props) => (
-  <Tooltip
-    classes={{ tooltip: 'icon-button__tooltip' }}
-    enterDelay={200}
-    title={title}
-  >
-    <button className="icon-button" type="button" data-title={title} {...props}>
-      {icon}
-    </button>
-  </Tooltip>
+  <span>
+    <Tooltip
+      classes={{ tooltip: 'icon-button__tooltip' }}
+      enterDelay={200}
+      title={title}
+    >
+      <button
+        className="icon-button"
+        type="button"
+        data-title={title}
+        {...props}
+      >
+        {icon}
+      </button>
+    </Tooltip>
+  </span>
 );
 
 export default IconButton;


### PR DESCRIPTION
### Fix

This PR fixes the following error, which has been around for awhile:

<img width="594" alt="Screen Shot 2020-09-03 at 1 25 58 PM" src="https://user-images.githubusercontent.com/52152/92165503-0595f580-edec-11ea-9c6c-e7a0c08bb4af.png">

We need to add a wrapping `<span>` to the button which allows the tooltip to still be displayed without an error, whether or not the button is disabled.

See https://material-ui.com/components/tooltips/#disabled-elements

### Test
1. Verify you can still mouseover buttons and get pop-up tooltips
2. Verify this warning is gone from console