### PR TITLE
Dont find highlights if no search

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -199,6 +199,9 @@ class NoteContentEditor extends Component<Props> {
   };
 
   searchMatches = () => {
+    if (!this.editor || !this.props.searchQuery) {
+      return;
+    }
     const model = this.editor.getModel();
     const terms = getTerms(this.props.searchQuery)
       .map((term) => term.normalize().toLowerCase())


### PR DESCRIPTION
### Fix

Return early if there are no highlights to find. If there is no searchQuery there cannot be any highlights.

### Test
1. Test a search
2. Test text editing with no search