### PR TITLE
Icon tooltip: Fix console error with a wrapper span

### DIFF
--- a/lib/icon-button/index.tsx
+++ b/lib/icon-button/index.tsx
@@ -10,12 +10,12 @@ type OwnProps = {
 type Props = OwnProps;
 
 export const IconButton = ({ icon, title, ...props }: Props) => (
-  <span>
-    <Tooltip
-      classes={{ tooltip: 'icon-button__tooltip' }}
-      enterDelay={200}
-      title={title}
-    >
+  <Tooltip
+    classes={{ tooltip: 'icon-button__tooltip' }}
+    enterDelay={200}
+    title={title}
+  >
+    <span>
       <button
         className="icon-button"
         type="button"
@@ -24,8 +24,8 @@ export const IconButton = ({ icon, title, ...props }: Props) => (
       >
         {icon}
       </button>
-    </Tooltip>
-  </span>
+    </span>
+  </Tooltip>
 );
 
 export default IconButton;


### PR DESCRIPTION
### Fix

Follow-up to #2322 . Move the `span` inside the `Tooltip`. Icon button elements need to be wrapped in their own span in order to make sure tooltips stay aligned (because the tooltip is spawned as a sibling of the `button`).

See https://github.com/Automattic/simplenote-electron/pull/2322#pullrequestreview-482202141