### PR TITLE
Right align rtl languages

### DIFF
--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -88,6 +88,9 @@
   display: none !important;
 }
 
+/* Monaco adds the dir='ltr' attribute to rtl languages.
+   This does the opposite of what you think it should do.
+*/
 span[dir='ltr'] {
   float: right;
 }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -88,6 +88,10 @@
   display: none !important;
 }
 
+span[dir='ltr'] {
+  float: right;
+}
+
 /* Safari requires that it be displayed absolute so that it takes the full height
 */
 .note-content-editor-shell {


### PR DESCRIPTION
### Fix

When a line is a rtl language such as Arabic it should be aligned to the right. This PR floats it to the right.

### Test
1. Add some Arabic text to a note.
2. It should float to the right
