### PR TITLE
[staging] Fix editor container padding

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -37,7 +37,10 @@ const getEditorPadding = (lineLength: T.LineLength, width?: number) => {
     return 25;
   }
 
-  if (width <= 1400) {
+  // magic number alert: 328px is the width of the sidebar :/
+  // this logic matches "@media only screen and (max-width: 1400px)" in the CSS
+  // 1400 is the viewport width; width is the width of the container element
+  if (width <= 1400 - 328) {
     // should be 10% up to 1400px wide
     return width * 0.1;
   } else {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -27,12 +27,14 @@
   unicode-range: U+E000-E001;
 }
 
-.note-detail-preview {
+.note-detail-preview,
+.note-content-plaintext.visible {
   padding: 0 calc((100% - 768px) / 2);
 }
 
 @media only screen and (max-width: 1400px) {
-  .note-detail-preview {
+  .note-detail-preview,
+  .note-content-plaintext.visible {
     padding: 0 10%;
   }
 }
@@ -54,7 +56,8 @@
 }
 
 .is-line-length-full {
-  .note-detail-preview {
+  .note-detail-preview,
+  .note-content-plaintext.visible {
     padding: 0 25px;
   }
 }
@@ -163,13 +166,8 @@ span[dir='ltr'] {
   font-size: 16px;
   white-space: pre-wrap;
 
-  &::first-line {
-    font-size: 18px;
-  }
-
   &.visible {
     display: inherit;
-    padding: 0 10px;
   }
 }
 


### PR DESCRIPTION
### Fix
* This (mostly) fixes a flicker when switching to long notes, by fixing the padding on the plaintext div
* Also removes the larger title size since we removed that in #2298 
* I additionally found a bug with the width calculation within the Monaco container; we want the style to change at a viewport width of 1400px, not a container width, so we need to add the sidebar width to the container width before checking. Yay, more magic numbers!

n.b. There's still a slight flicker when switching to a long note that I haven't tracked down. It's not the font, font size, letter spacing, line height, or anything else I can think of.

### Test
1. Switch between long notes and verify that the note padding stays the same while the note is loading
2. Try it with line lengths of narrow and full
3. Try it with various window widths
