### PR TITLE
[staging] Fix keyboard shortcuts on Edge and non-English layouts

### DIFF
--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -65,11 +65,12 @@ export class AppLayout extends Component<Props> {
       keyboardShortcutsAreOpen,
       showKeyboardShortcuts,
     } = this.props;
-    const { ctrlKey, code, metaKey } = event;
+    const { ctrlKey, metaKey } = event;
+    const key = event.key.toLowerCase();
 
     const cmdOrCtrl = ctrlKey || metaKey;
 
-    if (cmdOrCtrl && code === 'Slash') {
+    if (cmdOrCtrl && key === '/') {
       keyboardShortcutsAreOpen
         ? hideKeyboardShortcuts()
         : showKeyboardShortcuts();

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -77,7 +77,8 @@ class AppComponent extends Component<Props> {
     if (!hotkeysEnabled) {
       return;
     }
-    const { key, ctrlKey, metaKey, shiftKey } = event;
+    const { ctrlKey, metaKey, shiftKey } = event;
+    const key = event.key.toLowerCase();
 
     // Is either cmd or ctrl pressed? (But not both)
     const cmdOrCtrl = (ctrlKey || metaKey) && ctrlKey !== metaKey;

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -77,13 +77,13 @@ class AppComponent extends Component<Props> {
     if (!hotkeysEnabled) {
       return;
     }
-    const { code, ctrlKey, metaKey, shiftKey } = event;
+    const { key, ctrlKey, metaKey, shiftKey } = event;
 
     // Is either cmd or ctrl pressed? (But not both)
     const cmdOrCtrl = (ctrlKey || metaKey) && ctrlKey !== metaKey;
 
     // open tag list
-    if (cmdOrCtrl && shiftKey && 'KeyU' === code) {
+    if (cmdOrCtrl && shiftKey && 'u' === key) {
       this.props.toggleTagList();
 
       event.stopPropagation();
@@ -92,8 +92,8 @@ class AppComponent extends Component<Props> {
     }
 
     if (
-      (cmdOrCtrl && shiftKey && 'KeyS' === code) ||
-      (cmdOrCtrl && !shiftKey && 'KeyF' === code)
+      (cmdOrCtrl && shiftKey && 's' === key) ||
+      (cmdOrCtrl && !shiftKey && 'f' === key)
     ) {
       this.props.focusSearchField();
 
@@ -102,11 +102,11 @@ class AppComponent extends Component<Props> {
       return false;
     }
 
-    if (('Escape' === code || 'Esc' === code) && this.props.isSearchActive) {
+    if (('Escape' === key || 'Esc' === key) && this.props.isSearchActive) {
       this.props.clearSearch();
     }
 
-    if (cmdOrCtrl && shiftKey && 'KeyF' === code) {
+    if (cmdOrCtrl && shiftKey && 'f' === key) {
       this.props.toggleFocusMode();
 
       event.stopPropagation();
@@ -114,7 +114,7 @@ class AppComponent extends Component<Props> {
       return false;
     }
 
-    if (cmdOrCtrl && shiftKey && 'KeyI' === code) {
+    if (cmdOrCtrl && shiftKey && 'i' === key) {
       this.props.createNote();
 
       event.stopPropagation();
@@ -123,7 +123,7 @@ class AppComponent extends Component<Props> {
     }
 
     // prevent default browser behavior for search and find
-    if (cmdOrCtrl && ('KeyG' === code || 'KeyF' === code)) {
+    if (cmdOrCtrl && ('g' === key || 'f' === key)) {
       event.stopPropagation();
       event.preventDefault();
     }

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -161,17 +161,18 @@ class NoteContentEditor extends Component<Props> {
   };
 
   handleShortcut = (event: KeyboardEvent) => {
-    const { ctrlKey, code, metaKey, shiftKey } = event;
+    const { ctrlKey, metaKey, shiftKey } = event;
+    const key = event.key.toLowerCase();
 
     const cmdOrCtrl = ctrlKey || metaKey;
-    if (cmdOrCtrl && shiftKey && code === 'KeyG') {
+    if (cmdOrCtrl && shiftKey && key === 'g') {
       this.setPrevSearchSelection();
       event.stopPropagation();
       event.preventDefault();
       return false;
     }
 
-    if (cmdOrCtrl && !shiftKey && code === 'KeyG') {
+    if (cmdOrCtrl && !shiftKey && key === 'g') {
       this.setNextSearchSelection();
       event.stopPropagation();
       event.preventDefault();

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -49,7 +49,9 @@ export class NoteEditor extends Component<Props> {
     if (!this.props.keyboardShortcuts) {
       return;
     }
-    const { key, ctrlKey, metaKey, shiftKey } = event;
+
+    const { ctrlKey, metaKey, shiftKey } = event;
+    const key = event.key.toLowerCase();
     const { note, noteId, toggleMarkdown } = this.props;
 
     const cmdOrCtrl = ctrlKey || metaKey;

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -49,13 +49,13 @@ export class NoteEditor extends Component<Props> {
     if (!this.props.keyboardShortcuts) {
       return;
     }
-    const { code, ctrlKey, metaKey, shiftKey } = event;
+    const { key, ctrlKey, metaKey, shiftKey } = event;
     const { note, noteId, toggleMarkdown } = this.props;
 
     const cmdOrCtrl = ctrlKey || metaKey;
 
     // toggle Markdown enabled
-    if (note && cmdOrCtrl && shiftKey && 'KeyM' === code) {
+    if (note && cmdOrCtrl && shiftKey && 'm' === key) {
       console.log('toggling markdown');
       toggleMarkdown(noteId, !this.markdownEnabled());
       event.stopPropagation();
@@ -64,7 +64,7 @@ export class NoteEditor extends Component<Props> {
     }
 
     // toggle editor mode
-    if (cmdOrCtrl && shiftKey && 'KeyP' === code && this.markdownEnabled()) {
+    if (cmdOrCtrl && shiftKey && 'p' === key && this.markdownEnabled()) {
       this.props.toggleEditMode();
       event.stopPropagation();
       event.preventDefault();
@@ -72,7 +72,7 @@ export class NoteEditor extends Component<Props> {
     }
 
     // toggle between tag editor and note editor
-    if (shiftKey && cmdOrCtrl && 'KeyY' === code && this.props.isEditorActive) {
+    if (shiftKey && cmdOrCtrl && 'y' === key && this.props.isEditorActive) {
       // prefer focusing the edit field first
       if (!this.editFieldHasFocus() || this.props.isSearchActive) {
         this.focusNoteEditor?.();

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -216,7 +216,8 @@ export class NoteList extends Component<Props> {
     if (!this.props.keyboardShortcuts) {
       return;
     }
-    const { ctrlKey, key, metaKey, shiftKey } = event;
+    const { ctrlKey, metaKey, shiftKey } = event;
+    const key = event.key.toLowerCase();
     const { isSmallScreen, showNoteList } = this.props;
 
     const cmdOrCtrl = ctrlKey || metaKey;

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -216,11 +216,11 @@ export class NoteList extends Component<Props> {
     if (!this.props.keyboardShortcuts) {
       return;
     }
-    const { ctrlKey, code, metaKey, shiftKey } = event;
+    const { ctrlKey, key, metaKey, shiftKey } = event;
     const { isSmallScreen, showNoteList } = this.props;
 
     const cmdOrCtrl = ctrlKey || metaKey;
-    if (cmdOrCtrl && shiftKey && code === 'KeyK') {
+    if (cmdOrCtrl && shiftKey && key === 'k') {
       this.props.selectNoteAbove();
 
       event.stopPropagation();
@@ -228,7 +228,7 @@ export class NoteList extends Component<Props> {
       return false;
     }
 
-    if (cmdOrCtrl && shiftKey && code === 'KeyJ') {
+    if (cmdOrCtrl && shiftKey && key === 'j') {
       this.props.selectNoteBelow();
 
       event.stopPropagation();
@@ -236,7 +236,7 @@ export class NoteList extends Component<Props> {
       return false;
     }
 
-    if (isSmallScreen && cmdOrCtrl && shiftKey && code === 'KeyL') {
+    if (isSmallScreen && cmdOrCtrl && shiftKey && key === 'l') {
       this.props.toggleNoteList();
 
       event.stopPropagation();
@@ -244,7 +244,7 @@ export class NoteList extends Component<Props> {
       return false;
     }
 
-    if (isSmallScreen && showNoteList && code === 'Enter') {
+    if (isSmallScreen && showNoteList && key === 'Enter') {
       this.props.openNote();
 
       event.stopPropagation();

--- a/lib/tag-field/index.tsx
+++ b/lib/tag-field/index.tsx
@@ -163,7 +163,7 @@ export class TagField extends Component<Props, OwnState> {
     }
     const cmdOrCtrl = ctrlKey || metaKey;
 
-    if (cmdOrCtrl && shiftKey && 'y' === key) {
+    if (cmdOrCtrl && shiftKey && 'y' === key.toLowerCase()) {
       this.setState({ selectedTag: '' as T.TagName });
     }
 

--- a/lib/tag-field/index.tsx
+++ b/lib/tag-field/index.tsx
@@ -154,7 +154,7 @@ export class TagField extends Component<Props, OwnState> {
 
   preventStealingFocus = ({
     ctrlKey,
-    code,
+    key,
     metaKey,
     shiftKey,
   }: KeyboardEvent) => {
@@ -163,7 +163,7 @@ export class TagField extends Component<Props, OwnState> {
     }
     const cmdOrCtrl = ctrlKey || metaKey;
 
-    if (cmdOrCtrl && shiftKey && 'KeyY' === code) {
+    if (cmdOrCtrl && shiftKey && 'y' === key) {
       this.setState({ selectedTag: '' as T.TagName });
     }
 


### PR DESCRIPTION
### Fix

Keyboard shortcuts are currently not working on legacy Edge, because it does not include a `code` value.

The docs recommend using `key` instead of `code`, anyhow:

>  Be aware, however, that you can't use the value reported by KeyboardEvent.code to determine the character generated by the keystroke, because the keycode's name may not match the actual character that's printed on the key or that's generated by the computer when the key is pressed.

> For example, the code returned is "KeyQ" for the Q key on a QWERTY layout keyboard, but the same code value also represents the ' key on Dvorak keyboards and the A key on AZERTY keyboards. That makes it impossible to use the value of code to determine what the name of the key is to users if they're not using an anticipated keyboard layout.

> To determine what character corresponds with the key event, use the KeyboardEvent.key property instead.

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code

**I have NOT YET tested this very heavily so more testing would be appreciated!**

### Test

1. Test all keyboard shortcuts on multiple browsers

