### PR TITLE
Updates styling for rtl lanaguage lines

### DIFF
--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -39,6 +39,26 @@
   }
 }
 
+/* Monaco adds the dir='ltr' attribute to rtl languages.
+   This does the opposite of what you think it should do.
+*/
+span[dir='ltr'] {
+  float: right;
+  margin-right: calc(100% - 768px);
+}
+
+.is-line-length-full {
+  span[dir='ltr'] {
+    margin-right: 20px;
+  }
+}
+
+@media only screen and (max-width: 1400px) {
+  span[dir='ltr'] {
+    margin-right: 14%;
+  }
+}
+
 .react-monaco-editor-container {
   .scrollbar.vertical {
     width: 10px !important;
@@ -98,13 +118,6 @@
 */
 .monaco-editor .suggest-widget {
   display: none !important;
-}
-
-/* Monaco adds the dir='ltr' attribute to rtl languages.
-   This does the opposite of what you think it should do.
-*/
-span[dir='ltr'] {
-  float: right;
 }
 
 /* Safari requires that it be displayed absolute so that it takes the full height


### PR DESCRIPTION
### Fix

Adds correct spacing to the right side of the editor for RTL languages. 

After:

![image](https://user-images.githubusercontent.com/6817400/93612852-0c049f80-f99e-11ea-89b1-2be49538c523.png)
![image](https://user-images.githubusercontent.com/6817400/93612888-1e7ed900-f99e-11ea-8fd5-91c6fe9950ea.png)

Before:

![image](https://user-images.githubusercontent.com/6817400/93614853-acf45a00-f9a0-11ea-8628-5890eaedd783.png)

### Test
1. Have rtl text
2. Test in narrow and wide editor modes
3. Test various screen widths

