### PR TITLE
Allow RTL formatting in markdown mode

### DIFF
--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -87,6 +87,7 @@
 
   p {
     margin: 0 0 1.5em;
+    unicode-bidi: plaintext;
   }
 
   ul p {


### PR DESCRIPTION
### Fix

Fixes: https://github.com/Automattic/simplenote-electron/issues/562

Allow RTL languages to be right aligned in markdown preview mode.

Before:

<img width="491" alt="Screen Shot 2020-09-21 at 8 22 57 PM" src="https://user-images.githubusercontent.com/6817400/93834008-6b85d800-fc48-11ea-9a22-1e8804e067b8.png">

After:

<img width="483" alt="Screen Shot 2020-09-21 at 8 22 42 PM" src="https://user-images.githubusercontent.com/6817400/93834020-717bb900-fc48-11ea-91a3-78ae6b1b7c69.png">

### Test
1. Have several notes with markdown
2. Does markdown look properly in preview mode

