### PR TITLE
Open Note list when using search

### DIFF
--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -202,7 +202,7 @@ const showNoteList: A.Reducer<boolean> = (state = true, action) => {
     case 'NOTE_LIST_TOGGLE':
       return !state;
 
-    case 'SEARCH':
+    case 'FOCUS_SEARCH_FIELD':
       return true;
 
     case 'OPEN_NOTE':

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -202,6 +202,9 @@ const showNoteList: A.Reducer<boolean> = (state = true, action) => {
     case 'NOTE_LIST_TOGGLE':
       return !state;
 
+    case 'SEARCH':
+      return true;
+
     case 'OPEN_NOTE':
       return false;
 


### PR DESCRIPTION
### Fix

Fixes: https://github.com/Automattic/simplenote-electron/issues/728

When in a narrow mode if you use the search hotkey it does not open the note list. I am not sure what the UI should be.

What do you think @SylvesterWilmott ?

Existing Functionality:
![existing](https://user-images.githubusercontent.com/6817400/93835079-1946b600-fc4c-11ea-892f-1e106f73a079.gif)

This PR:
![thispr](https://user-images.githubusercontent.com/6817400/93835087-1e0b6a00-fc4c-11ea-967a-3cdc22da2a05.gif)

### Test
1. Have a narrow browser
2. Have a note open
3. Use the hotkey CMD + F
