### PR TITLE
Make Electron menus aware of editMode

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -91,9 +91,9 @@ module.exports = function main() {
     const appMenu = Menu.buildFromTemplate(menuTemplate, mainWindow);
     Menu.setApplicationMenu(appMenu);
 
-    ipcMain.on('settingsUpdate', function (event, settings) {
+    ipcMain.on('settingsUpdate', function (event, args) {
       Menu.setApplicationMenu(
-        Menu.buildFromTemplate(createMenuTemplate(settings), mainWindow)
+        Menu.buildFromTemplate(createMenuTemplate(args), mainWindow)
       );
     });
 

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -91,7 +91,7 @@ module.exports = function main() {
     const appMenu = Menu.buildFromTemplate(menuTemplate, mainWindow);
     Menu.setApplicationMenu(appMenu);
 
-    ipcMain.on('settingsUpdate', function (event, args) {
+    ipcMain.on('appStateUpdate', function (event, args) {
       Menu.setApplicationMenu(
         Menu.buildFromTemplate(createMenuTemplate(args), mainWindow)
       );

--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -1,22 +1,39 @@
 const { appCommandSender, editorCommandSender } = require('./utils');
 
-const buildEditMenu = (settings, isAuthenticated) => {
+const buildEditMenu = (settings, isAuthenticated, editMode) => {
   settings = settings || {};
   isAuthenticated = isAuthenticated || false;
+  editMode = editMode || false;
+
+  // menu items with roles don't respect visibility, so we have to do this the hard way
+  let undo = {
+    label: '&Undo',
+    click: editorCommandSender({ action: 'undo' }),
+    accelerator: 'CommandOrControl+Z',
+    visible: editMode,
+  };
+  let redo = {
+    label: '&Redo',
+    click: editorCommandSender({ action: 'redo' }),
+    accelerator: 'CommandOrControl+Shift+Z',
+    visible: editMode,
+  };
+  let selectAll = {
+    label: '&Select All',
+    click: editorCommandSender({ action: 'selectAll' }),
+    accelerator: 'CommandOrControl+A',
+  };
+  if (!editMode) {
+    undo['role'] = 'undo';
+    redo['role'] = 'redo';
+    selectAll['role'] = 'selectAll';
+  }
 
   return {
     label: '&Edit',
     submenu: [
-      {
-        label: '&Undo',
-        click: editorCommandSender({ action: 'undo' }),
-        accelerator: 'CommandOrControl+Z',
-      },
-      {
-        label: '&Redo',
-        click: editorCommandSender({ action: 'redo' }),
-        accelerator: 'CommandOrControl+Shift+Z',
-      },
+      undo,
+      redo,
       {
         type: 'separator',
       },
@@ -32,11 +49,7 @@ const buildEditMenu = (settings, isAuthenticated) => {
         label: '&Paste',
         role: 'paste',
       },
-      {
-        label: '&Select All',
-        click: editorCommandSender({ action: 'selectAll' }),
-        accelerator: 'CommandOrControl+A',
-      },
+      selectAll,
       { type: 'separator' },
       {
         label: '&Trash Note',

--- a/desktop/menus/format-menu.js
+++ b/desktop/menus/format-menu.js
@@ -1,12 +1,14 @@
 const { editorCommandSender } = require('./utils');
 
-const buildFormatMenu = (isAuthenticated) => {
+const buildFormatMenu = (isAuthenticated, editMode) => {
   isAuthenticated = isAuthenticated || false;
+  editMode = editMode || false;
   const submenu = [
     {
       label: 'Insert &Checklist',
       accelerator: 'CommandOrControl+Shift+C',
       click: editorCommandSender({ action: 'insertChecklist' }),
+      enabled: editMode,
     },
   ];
 

--- a/desktop/menus/index.js
+++ b/desktop/menus/index.js
@@ -7,8 +7,11 @@ const buildViewMenu = require('./view-menu');
 const buildFormatMenu = require('./format-menu');
 const buildHelpMenu = require('./help-menu');
 
-function createMenuTemplate(settings, mainWindow) {
+function createMenuTemplate(args, mainWindow) {
+  args = args || {};
+  const settings = args['settings'] || {};
   const isAuthenticated = settings && 'accountName' in settings;
+  const editMode = args['editMode'] || false;
   const windowMenu = {
     role: 'window',
     submenu: [
@@ -22,9 +25,9 @@ function createMenuTemplate(settings, mainWindow) {
   return [
     platform.isOSX() ? buildMacAppMenu(isAuthenticated) : null,
     buildFileMenu(isAuthenticated),
-    buildEditMenu(settings, isAuthenticated),
+    buildEditMenu(settings, isAuthenticated, editMode),
     buildViewMenu(settings, isAuthenticated),
-    buildFormatMenu(isAuthenticated),
+    buildFormatMenu(isAuthenticated, editMode),
     platform.isOSX() ? windowMenu : null,
     buildHelpMenu(mainWindow, isAuthenticated),
   ].filter((menu) => menu !== null);

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -2,12 +2,12 @@ const { contextBridge, ipcRenderer, remote } = require('electron');
 
 const validChannels = [
   'appCommand',
+  'appStateUpdate',
   'clearCookies',
   'editorCommand',
   'importNotes',
   'noteImportChannel',
   'setAutoHideMenuBar',
-  'settingsUpdate',
   'wpLogin',
 ];
 

--- a/lib/boot-with-auth.tsx
+++ b/lib/boot-with-auth.tsx
@@ -42,7 +42,10 @@ export const bootWithToken = (
       },
     });
 
-    window.electron?.send('settingsUpdate', store.getState().settings);
+    window.electron?.send('settingsUpdate', {
+      settings: store.getState().settings,
+      editMode: store.getState().ui.editMode,
+    });
 
     render(
       <Provider store={store}>

--- a/lib/boot-with-auth.tsx
+++ b/lib/boot-with-auth.tsx
@@ -42,7 +42,7 @@ export const bootWithToken = (
       },
     });
 
-    window.electron?.send('settingsUpdate', {
+    window.electron?.send('appStateUpdate', {
       settings: store.getState().settings,
       editMode: store.getState().ui.editMode,
     });

--- a/lib/boot.ts
+++ b/lib/boot.ts
@@ -19,7 +19,7 @@ const clearStorage = (): Promise<void> =>
     localStorage.removeItem('localQueue:preferences');
     localStorage.removeItem('localQueue:tag');
     localStorage.removeItem('stored_user');
-    window.electron?.send('settingsUpdate', {});
+    window.electron?.send('appStateUpdate', {});
 
     const settings = localStorage.getItem('simpleNote');
     if (settings) {

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -130,6 +130,17 @@ export const NotePreview: FunctionComponent<Props> = ({
   }, []);
 
   useEffect(() => {
+    window.electron?.receive('editorCommand', (command) => {
+      switch (command.action) {
+        case 'selectAll':
+          document.execCommand('selectAll');
+          return;
+      }
+    });
+    return () => window.electron?.removeListener('editorCommand');
+  }, []);
+
+  useEffect(() => {
     if (!previewNode.current) {
       return;
     }

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -132,8 +132,14 @@ export const NotePreview: FunctionComponent<Props> = ({
   useEffect(() => {
     window.electron?.receive('editorCommand', (command) => {
       switch (command.action) {
+        case 'redo':
+          document.execCommand('redo');
+          return;
         case 'selectAll':
           document.execCommand('selectAll');
+          return;
+        case 'undo':
+          document.execCommand('undo');
           return;
       }
     });

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -130,23 +130,6 @@ export const NotePreview: FunctionComponent<Props> = ({
   }, []);
 
   useEffect(() => {
-    window.electron?.receive('editorCommand', (command) => {
-      switch (command.action) {
-        case 'redo':
-          document.execCommand('redo');
-          return;
-        case 'selectAll':
-          document.execCommand('selectAll');
-          return;
-        case 'undo':
-          document.execCommand('undo');
-          return;
-      }
-    });
-    return () => window.electron?.removeListener('editorCommand');
-  }, []);
-
-  useEffect(() => {
     if (!previewNode.current) {
       return;
     }

--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -18,7 +18,13 @@ declare global {
       send(command: 'clearCookies'): void;
       send(command: 'importNotes', filePath: string);
       send(command: 'setAutoHideMenuBar', newValue: boolean);
-      send(command: 'settingsUpdate', settings: S.State['settings']);
+      send(
+        command: 'settingsUpdate',
+        args: {
+          settings: S.State['settings'];
+          editMode: boolean;
+        }
+      );
       send(command: 'wpLogin', url: string);
     };
     location: Location;

--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -15,16 +15,16 @@ declare global {
       receive(command: 'noteImportChannel', callback: (event: any) => any);
       receive(command: 'wpLogin', callback: (event: any) => any);
       removeListener(command: 'noteImportChannel');
-      send(command: 'clearCookies'): void;
-      send(command: 'importNotes', filePath: string);
-      send(command: 'setAutoHideMenuBar', newValue: boolean);
       send(
-        command: 'settingsUpdate',
+        command: 'appStateUpdate',
         args: {
           settings: S.State['settings'];
           editMode: boolean;
         }
       );
+      send(command: 'clearCookies'): void;
+      send(command: 'importNotes', filePath: string);
+      send(command: 'setAutoHideMenuBar', newValue: boolean);
       send(command: 'wpLogin', url: string);
     };
     location: Location;

--- a/lib/state/electron/middleware.ts
+++ b/lib/state/electron/middleware.ts
@@ -90,7 +90,10 @@ export const middleware: S.Middleware = ({ dispatch, getState }) => {
     }
   });
 
-  window.electron.send('settingsUpdate', getState().settings);
+  window.electron.send('settingsUpdate', {
+    settings: getState().settings,
+    editMode: getState().ui.editMode,
+  });
 
   return (next) => (action) => {
     const prevState = getState();
@@ -98,7 +101,16 @@ export const middleware: S.Middleware = ({ dispatch, getState }) => {
     const nextState = getState();
 
     if (prevState.settings !== nextState.settings) {
-      window.electron.send('settingsUpdate', nextState.settings);
+      window.electron.send('settingsUpdate', {
+        settings: nextState.settings,
+        editMode: nextState.ui.editMode,
+      });
+    }
+    if (prevState.ui.editMode !== nextState.ui.editMode) {
+      window.electron.send('settingsUpdate', {
+        settings: nextState.settings,
+        editMode: nextState.ui.editMode,
+      });
     }
 
     return result;

--- a/lib/state/electron/middleware.ts
+++ b/lib/state/electron/middleware.ts
@@ -90,7 +90,7 @@ export const middleware: S.Middleware = ({ dispatch, getState }) => {
     }
   });
 
-  window.electron.send('settingsUpdate', {
+  window.electron.send('appStateUpdate', {
     settings: getState().settings,
     editMode: getState().ui.editMode,
   });
@@ -101,13 +101,13 @@ export const middleware: S.Middleware = ({ dispatch, getState }) => {
     const nextState = getState();
 
     if (prevState.settings !== nextState.settings) {
-      window.electron.send('settingsUpdate', {
+      window.electron.send('appStateUpdate', {
         settings: nextState.settings,
         editMode: nextState.ui.editMode,
       });
     }
     if (prevState.ui.editMode !== nextState.ui.editMode) {
-      window.electron.send('settingsUpdate', {
+      window.electron.send('appStateUpdate', {
         settings: nextState.settings,
         editMode: nextState.ui.editMode,
       });


### PR DESCRIPTION
### Fix

This PR fixes the ability to select all, undo and redo in the non-editor textareas while preview mode is active.

It also makes Electron aware of the editor state and allows it to disable menu options accordingly (though the only one this affects is Insert Checklist).

Follow-up to #2293 

### Test

1. In Electron, go into a Markdown note
2. Type in the tag field and verify that select all, undo and redo affect that field (not the editor)
3. Repeat for the search field
4. Go into preview mode
5. Type in the tag field and verify that it is still possible to select all, undo and redo using the menu or keyboard commands
6. Repeat for the search field

### Review

In the first iteration of this PR, I simply added the Electron listeners to the preview component, but that felt icky. So I went down the rabbithole of figuring out how to make Electron aware of the current edit mode and ended up adding an argument to the existing `settingsUpdate` channel.

The docs claimed more than one argument was supported, but in practice arguments after the second were undefined, so I ended up passing a dictionary.

### Todo

There is still some weirdness here that may or may not need a follow-up.

* SelectAll in edit mode when the editor doesn't have focus doesn't do anything. IMO it would be better to check if the tag or search field have focus and if not, select the text within the note, but I'm not sure this is possible in React.
* If you enter text in the search and/or tag boxes, go into preview mode, then click back on the note preview, selectAll selects all input text: editor text, tag box text AND search box text. It's... odd.