### PR TITLE
Hide the scrollbars in edge on print in markdown preview

### DIFF
--- a/scss/print.scss
+++ b/scss/print.scss
@@ -1,4 +1,8 @@
 @media print {
+  html {
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+  }
+
   .theme-dark .theme-color-bg {
     background-color: #ffffff;
   }


### PR DESCRIPTION
### Fix

When you print on Legacy Edge the scroll bars have the potential to appear. I don't see it every time and on every note. It appears to occur when you have a long line with no spaces for the horizontal bar. I cannot replicate vertical every time so I am not sure what is causing that.

This hides the scroll bars so that they don't appear.

![Screen Shot 2020-09-22 at 9 40 18 AM](https://user-images.githubusercontent.com/6817400/93889810-a4a96100-fcb7-11ea-810a-e4898a01b5e6.png)

### Test
1. Have a really long note or a really long line with no spaces
2. Be in markdown mode
3. Print in Legacy Edge
