### PR TITLE
Hides the search results banner on print

### DIFF
--- a/scss/print.scss
+++ b/scss/print.scss
@@ -11,7 +11,8 @@
   .app-layout__source-column,
   .tag-field,
   .note-toolbar-wrapper,
-  .react-monaco-editor-container {
+  .react-monaco-editor-container,
+  .search-results {
     display: none;
   }
 


### PR DESCRIPTION
### Fix

If you have an active search while printing it will show the search result banner which is not correct. This PR hides the search results banner on print.

<img width="633" alt="Screen Shot 2020-09-22 at 9 56 48 AM" src="https://user-images.githubusercontent.com/6817400/93892015-0f5b9c00-fcba-11ea-890a-9bf3e997a56e.png">


### Test
1. Have an active search
2. Print
3. You should not see the search results bar in the print
