### PR TITLE
Display first note in trash when going to trash view

### DIFF
--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -7,7 +7,7 @@ export type Action<
 > = { type: T } & Args & {
     meta?: {
       analytics?: [string, T.JSONSerializable | undefined][];
-      nextNoteToOpen?: T.EntityId;
+      nextNoteToOpen?: T.EntityId | null;
       searchResults?: {
         noteIds: T.EntityId[];
         tagHashes: T.TagHash[];

--- a/lib/state/ui/middleware.ts
+++ b/lib/state/ui/middleware.ts
@@ -60,9 +60,11 @@ export const middleware: S.Middleware = (store) => (
     }
 
     case 'SHOW_ALL_NOTES':
+    case 'SELECT_TRASH':
       // this middleware runs after the search middleware which is important
       // because we're reading the new search results which came as a result
-      // of changing the note filter from trash or a tag to "all notes"
+      // of changing the note filter from trash or a tag to "all notes" or
+      // from "all notes to trash"
       return next({
         ...action,
         meta: {

--- a/lib/state/ui/middleware.ts
+++ b/lib/state/ui/middleware.ts
@@ -69,7 +69,7 @@ export const middleware: S.Middleware = (store) => (
         ...action,
         meta: {
           ...action.meta,
-          nextNoteToOpen: action.meta?.searchResults?.noteIds[0],
+          nextNoteToOpen: action.meta?.searchResults?.noteIds[0] ?? null,
         },
       });
 

--- a/lib/state/ui/middleware.ts
+++ b/lib/state/ui/middleware.ts
@@ -64,7 +64,7 @@ export const middleware: S.Middleware = (store) => (
       // this middleware runs after the search middleware which is important
       // because we're reading the new search results which came as a result
       // of changing the note filter from trash or a tag to "all notes" or
-      // from "all notes to trash"
+      // from "all notes" to trash
       return next({
         ...action,
         meta: {


### PR DESCRIPTION
### Fix

Fixes: https://github.com/Automattic/simplenote-electron/issues/2190

When the trash is opened this change causes the first note to be selected. If no notes are selected it makes the note selection null. This ensures that you cannot be viewing a note that is not deleted while you are viewing the trash.

### Test
1. Switch to trash
2. Observe that it selects the first note in the trash
3. If nothing is in the trash it unselects the current note and selects no new note.
