### PR TITLE
Change tag autocomplete logic to make it work

### DIFF
--- a/lib/tag-input/index.tsx
+++ b/lib/tag-input/index.tsx
@@ -132,11 +132,18 @@ export class TagInput extends Component<Props> {
 
   interceptRightArrow = (event: KeyboardEvent) => {
     const { value } = this.props;
-
+    if (!window.getSelection) {
+      return;
+    }
     // if we aren't already at the right-most extreme
     // then don't complete the suggestion; we could
     // be moving the cursor around inside the input
-    const caretPosition = window.getSelection().getRangeAt(0).endOffset;
+    const origionalRange = window.getSelection().getRangeAt(0);
+    const range = origionalRange.cloneRange();
+    range.selectNodeContents(event.currentTarget);
+    range.setEnd(origionalRange.endContainer, origionalRange.endOffset);
+    const caretPosition = range.toString().length;
+
     if (caretPosition !== value.length) {
       return;
     }

--- a/lib/tag-input/index.tsx
+++ b/lib/tag-input/index.tsx
@@ -138,10 +138,10 @@ export class TagInput extends Component<Props> {
     // if we aren't already at the right-most extreme
     // then don't complete the suggestion; we could
     // be moving the cursor around inside the input
-    const origionalRange = window.getSelection().getRangeAt(0);
-    const range = origionalRange.cloneRange();
+    const originalRange = window.getSelection().getRangeAt(0);
+    const range = originalRange.cloneRange();
     range.selectNodeContents(event.currentTarget);
-    range.setEnd(origionalRange.endContainer, origionalRange.endOffset);
+    range.setEnd(originalRange.endContainer, originalRange.endOffset);
     const caretPosition = range.toString().length;
 
     if (caretPosition !== value.length) {


### PR DESCRIPTION
### Fix

Fixes: https://github.com/Automattic/simplenote-electron/issues/1854

This updates the logic to get the correct caret (cursor) position inside the contentEditable. The previous logic did not provide the current cursor position.

endOffset is not what you would expect, it does not give you the cursor position. The selection starts and ends at the same place. You have to get the contents of the element and determine where you are within that element.

This PR additionally returns early if window.getSelection does not exist.

### Test
1. Have a tag "blahblah"
2. Go to a not that does not have that tag
3. Start typing "bla"
4. Use the right arrow to autocomplete
5. Does it work?
