### PR TITLE
Add support for importing .md files

### DIFF
--- a/lib/dialogs/import/source-importer/executor/index.tsx
+++ b/lib/dialogs/import/source-importer/executor/index.tsx
@@ -11,7 +11,7 @@ import ImportProgress from '../progress';
 import type * as S from '../../../../state/';
 import type * as T from '../../../../types';
 
-type ImporterSource = 'evernote' | 'plaintext' | 'simplenote';
+type ImporterSource = 'evernote' | 'plaintext' | 'markdown' | 'simplenote';
 
 const getImporter = (importer: ImporterSource): Promise<object> => {
   switch (importer) {
@@ -19,7 +19,7 @@ const getImporter = (importer: ImporterSource): Promise<object> => {
       return import(
         /* webpackChunkName: 'utils-import-evernote' */ '../../../../utils/import/evernote'
       );
-
+    case 'markdown':
     case 'plaintext':
       return import(
         /* webpackChunkName: 'utils-import-text-files' */ '../../../../utils/import/text-files'

--- a/lib/dialogs/import/source-importer/executor/index.tsx
+++ b/lib/dialogs/import/source-importer/executor/index.tsx
@@ -19,6 +19,7 @@ const getImporter = (importer: ImporterSource): Promise<object> => {
       return import(
         /* webpackChunkName: 'utils-import-evernote' */ '../../../../utils/import/evernote'
       );
+
     case 'plaintext':
       return import(
         /* webpackChunkName: 'utils-import-text-files' */ '../../../../utils/import/text-files'

--- a/lib/dialogs/import/source-importer/executor/index.tsx
+++ b/lib/dialogs/import/source-importer/executor/index.tsx
@@ -11,7 +11,7 @@ import ImportProgress from '../progress';
 import type * as S from '../../../../state/';
 import type * as T from '../../../../types';
 
-type ImporterSource = 'evernote' | 'plaintext' | 'markdown' | 'simplenote';
+type ImporterSource = 'evernote' | 'plaintext' | 'simplenote';
 
 const getImporter = (importer: ImporterSource): Promise<object> => {
   switch (importer) {
@@ -19,7 +19,6 @@ const getImporter = (importer: ImporterSource): Promise<object> => {
       return import(
         /* webpackChunkName: 'utils-import-evernote' */ '../../../../utils/import/evernote'
       );
-    case 'markdown':
     case 'plaintext':
       return import(
         /* webpackChunkName: 'utils-import-text-files' */ '../../../../utils/import/text-files'

--- a/lib/dialogs/import/sources.ts
+++ b/lib/dialogs/import/sources.ts
@@ -20,7 +20,7 @@ const sources = [
     name: 'Plain text files',
     slug: 'plaintext',
     acceptedTypes: '.txt,.md',
-    instructions: 'Choose one or more plain text files (.txt, .md)',
+    instructions: 'Choose one or more text files (.txt, .md)',
     multiple: true,
   },
 ];

--- a/lib/dialogs/import/sources.ts
+++ b/lib/dialogs/import/sources.ts
@@ -19,15 +19,8 @@ const sources = [
   {
     name: 'Plain text files',
     slug: 'plaintext',
-    acceptedTypes: '.txt',
-    instructions: 'Choose one or more plain text files (.txt)',
-    multiple: true,
-  },
-  {
-    name: 'Markdown files',
-    slug: 'markdown',
-    acceptedTypes: '.md',
-    instructions: 'Choose one or more mardown files (.md)',
+    acceptedTypes: '.txt,.md',
+    instructions: 'Choose one or more plain text files (.txt, .md)',
     multiple: true,
   },
 ];

--- a/lib/dialogs/import/sources.ts
+++ b/lib/dialogs/import/sources.ts
@@ -23,6 +23,13 @@ const sources = [
     instructions: 'Choose one or more plain text files (.txt)',
     multiple: true,
   },
+  {
+    name: 'Markdown files',
+    slug: 'markdown',
+    acceptedTypes: '.md',
+    instructions: 'Choose one or more mardown files (.md)',
+    multiple: true,
+  },
 ];
 
 export default sources;

--- a/lib/utils/import/text-files/index.ts
+++ b/lib/utils/import/text-files/index.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import CoreImporter from '../';
-import { endsWith, startsWith } from 'lodash';
+import { startsWith } from 'lodash';
 
 import * as T from '../../../types';
 
@@ -22,13 +22,10 @@ class TextFileImporter extends EventEmitter {
     }
 
     const importTextFile = (file) => {
-      if (
-        !file ||
-        !(
-          endsWith(file.name.toLowerCase(), '.txt') ||
-          endsWith(file.name.toLowerCase(), '.md')
-        )
-      ) {
+      const hasAllowableName = /\.(txt|md)$/.test(
+        file?.name.toLowerCase() ?? ''
+      );
+      if (!hasAllowableName) {
         return;
       }
 

--- a/lib/utils/import/text-files/index.ts
+++ b/lib/utils/import/text-files/index.ts
@@ -17,12 +17,18 @@ class TextFileImporter extends EventEmitter {
     let lastFileName = '';
 
     if (!filesArray) {
-      this.emit('status', 'error', 'No text files to import.');
+      this.emit('status', 'error', 'No files to import.');
       return;
     }
 
     const importTextFile = (file) => {
-      if (!file || !endsWith(file.name.toLowerCase(), '.txt')) {
+      if (
+        !file ||
+        !(
+          endsWith(file.name.toLowerCase(), '.txt') ||
+          endsWith(file.name.toLowerCase(), '.md')
+        )
+      ) {
         return;
       }
 


### PR DESCRIPTION
### Fix

Fixes: https://github.com/Automattic/simplenote-electron/issues/2155

Adds support for .md files. Since they are basically plaintext files we can import them using the plaintext editor.

<img width="355" alt="Screen Shot 2020-09-22 at 3 24 20 PM" src="https://user-images.githubusercontent.com/6817400/93928055-bc004280-fce7-11ea-872c-375d2047663b.png">

### Test
1. Test importing markdown files
2. Test importing plain text files.

