### PR TITLE
Make tags in tag list links until they are being edited

### DIFF
--- a/lib/tag-list/input.tsx
+++ b/lib/tag-list/input.tsx
@@ -39,9 +39,9 @@ export class TagListInput extends Component<Props, OwnState> {
         spellCheck={false}
       />
     ) : (
-      <a className={classes} onClick={onClick}>
+      <button className={classes} onClick={onClick}>
         {value}
-      </a>
+      </button>
     );
   }
 }

--- a/lib/tag-list/input.tsx
+++ b/lib/tag-list/input.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 type OwnProps = {
   editable: boolean;
   isSelected: boolean;
-  onClick: (event: MouseEvent<HTMLInputElement>) => any;
+  onClick: (event: React.MouseEvent) => any;
   onDone: (event: FocusEvent<HTMLInputElement>) => any;
   value: string;
 };
@@ -28,7 +28,7 @@ export class TagListInput extends Component<Props, OwnState> {
       'is-selected': isSelected,
     });
 
-    return (
+    return editable ? (
       <input
         className={classes}
         readOnly={!editable}
@@ -38,6 +38,10 @@ export class TagListInput extends Component<Props, OwnState> {
         onBlur={onDone}
         spellCheck={false}
       />
+    ) : (
+      <a className={classes} onClick={onClick}>
+        {value}
+      </a>
     );
   }
 }

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -95,6 +95,11 @@
   }
 }
 
+button.tag-list-input {
+  overflow-x: hidden;
+  text-align: left;
+}
+
 .tag-list-editing {
   .tag-list-input {
     cursor: text;


### PR DESCRIPTION
### Fix

Closes: https://github.com/Automattic/simplenote-electron/issues/844

In the tag navigation panel, tags are represented as inputs even when not editing.

There are two problems with this:

- It is unsemantic HTML and not good for accessibility.
- An Undo/Redo context menu will be shown on right click, which doesn't make sense for links.

This PR makes them links as they should.

### Test
1. Open chrome dev tools.
2. Inspect tags in the tag list, they should be link tags
3. Ensure that they render correctly
4. Ensure that the selected tag gets rendered correctly
5. Ensure that you can edit a tag
