### PR TITLE
Terminology: Change "Inter-note link" to "Internal link"

### DIFF
--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -81,7 +81,7 @@ export const NotePreview: FunctionComponent<Props> = ({
 
           const tag = node as HTMLAnchorElement;
 
-          // Intercept inter-note links
+          // Intercept internal links
           if (tag.href.startsWith('simplenote://note/')) {
             const match = /^simplenote:\/\/note\/(.+)$/.exec(tag.href);
             if (!match) {

--- a/lib/note-info/index.tsx
+++ b/lib/note-info/index.tsx
@@ -171,7 +171,7 @@ export class NoteInfo extends Component<Props> {
         </div>
         <div className="note-info-panel note-info-internal-link theme-color-border">
           <span className="note-info-item-text">
-            <span className="note-info-name">Inter-Note link</span>
+            <span className="note-info-name">Internal link</span>
             <div className="note-info-form">
               <input
                 className="note-info-detail note-info-link-text"


### PR DESCRIPTION
For conformity with other platforms and as per @SylvesterWilmott 

<img width="276" alt="Screen Shot 2020-09-24 at 1 24 03 PM" src="https://user-images.githubusercontent.com/52152/94196456-3ad0b900-fe69-11ea-8e2b-ac10b946e0af.png">
