### PR TITLE
Electron: Handle all keyboard shortcuts that are in the menu, from the menu

### DIFF
--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -66,7 +66,7 @@ const buildEditMenu = (settings, isAuthenticated, editMode) => {
       {
         label: '&Find in Note',
         visible: isAuthenticated,
-        click: editorCommandSender({ action: 'find' }),
+        click: appCommandSender({ action: 'focusSearchField' }),
         accelerator: 'CommandOrControl+F',
       },
       {

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -92,6 +92,27 @@ class AppComponent extends Component<Props> {
       return false;
     }
 
+    if (('Escape' === key || 'Esc' === key) && this.props.isSearchActive) {
+      this.props.clearSearch();
+    }
+
+    if (!window.electron) {
+      this.handleBrowserShortcut(event);
+    }
+
+    return true;
+  };
+
+  // handle all keyboard shortcuts that are duplicated in the Electron menus
+  // this listener is only called in browsers, as otherwise the
+  // menu will trigger them via the provided Accelerator, so we don't need a listener
+  handleBrowserShortcut = (event: KeyboardEvent) => {
+    const { ctrlKey, metaKey, shiftKey } = event;
+    const key = event.key.toLowerCase();
+
+    // Is either cmd or ctrl pressed? (But not both)
+    const cmdOrCtrl = (ctrlKey || metaKey) && ctrlKey !== metaKey;
+
     if (
       (cmdOrCtrl && shiftKey && 's' === key) ||
       (cmdOrCtrl && !shiftKey && 'f' === key)
@@ -101,10 +122,6 @@ class AppComponent extends Component<Props> {
       event.stopPropagation();
       event.preventDefault();
       return false;
-    }
-
-    if (('Escape' === key || 'Esc' === key) && this.props.isSearchActive) {
-      this.props.clearSearch();
     }
 
     if (cmdOrCtrl && shiftKey && 'f' === key) {
@@ -128,8 +145,6 @@ class AppComponent extends Component<Props> {
       event.stopPropagation();
       event.preventDefault();
     }
-
-    return true;
   };
 
   toggleShortcuts = (doEnable: boolean) => {

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -145,7 +145,11 @@ class NoteContentEditor extends Component<Props> {
     }, SPEED_DELAY);
     this.props.storeFocusEditor(this.focusEditor);
     this.props.storeHasFocus(this.hasFocus);
-    this.toggleShortcuts(true);
+
+    // let Electron trigger these from the menus
+    if (!window.electron) {
+      this.toggleShortcuts(true);
+    }
   }
 
   componentWillUnmount() {
@@ -154,7 +158,9 @@ class NoteContentEditor extends Component<Props> {
     }
     window.electron?.removeListener('editorCommand');
     window.removeEventListener('input', this.handleUndoRedo, true);
-    this.toggleShortcuts(false);
+    if (!window.electron) {
+      this.toggleShortcuts(false);
+    }
   }
 
   toggleShortcuts = (doEnable: boolean) => {

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -146,10 +146,7 @@ class NoteContentEditor extends Component<Props> {
     this.props.storeFocusEditor(this.focusEditor);
     this.props.storeHasFocus(this.hasFocus);
 
-    // let Electron trigger these from the menus
-    if (!window.electron) {
-      this.toggleShortcuts(true);
-    }
+    this.toggleShortcuts(true);
   }
 
   componentWillUnmount() {
@@ -158,9 +155,7 @@ class NoteContentEditor extends Component<Props> {
     }
     window.electron?.removeListener('editorCommand');
     window.removeEventListener('input', this.handleUndoRedo, true);
-    if (!window.electron) {
-      this.toggleShortcuts(false);
-    }
+    this.toggleShortcuts(false);
   }
 
   toggleShortcuts = (doEnable: boolean) => {
@@ -183,7 +178,8 @@ class NoteContentEditor extends Component<Props> {
       return false;
     }
 
-    if (cmdOrCtrl && !shiftKey && key === 'g') {
+    // Electron can trigger this from the menu
+    if (!window.electron && cmdOrCtrl && !shiftKey && key === 'g') {
       this.setNextSearchSelection();
       event.stopPropagation();
       event.preventDefault();

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -145,7 +145,6 @@ class NoteContentEditor extends Component<Props> {
     }, SPEED_DELAY);
     this.props.storeFocusEditor(this.focusEditor);
     this.props.storeHasFocus(this.hasFocus);
-
     this.toggleShortcuts(true);
   }
 


### PR DESCRIPTION
### Fix

When we add menu items in Electron we're passing a keyboard shortcut, but we were clobbering those with our keyboard event listeners in the app. This causes them to fire and be handled without the Electron menu flashing, which makes things feel kind of janky and breaks the illusion of a native app.

This also fixes the missing handler for Find Note, although it does the exact same thing as Search in Notes, so it's kind of odd to have them both in the menu?

### Test

1. Go through the keyboard shortcuts and make sure they all work
2. For the ones that are in the menu, verify that:
a) they can be triggered by clicking in the menu
b) triggering them by keyboard shortcut causes the menu to flash
3. Make sure keyboard shortcuts also work in the browser

