### PR TITLE
Fix: re-layout editor after focus mode change

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -58,6 +58,7 @@ type OwnProps = {
 type StateProps = {
   editorSelection: [number, number, 'RTL' | 'LTR'];
   fontSize: number;
+  isFocusMode: boolean;
   keyboardShortcuts: boolean;
   lineLength: T.LineLength;
   noteId: T.EntityId;
@@ -220,7 +221,10 @@ class NoteContentEditor extends Component<Props> {
       this.editor?.setSelection(new this.monaco.Range(0, 0, 0, 0));
     }
 
-    if (this.props.lineLength !== prevProps.lineLength) {
+    if (
+      this.props.lineLength !== prevProps.lineLength ||
+      this.props.isFocusMode !== prevProps.isFocusMode
+    ) {
       // @TODO: This timeout is necessary for no apparent reason
       //        Figure out why and take it out!
       setTimeout(() => {
@@ -965,6 +969,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
     'LTR',
   ],
   fontSize: state.settings.fontSize,
+  isFocusMode: state.settings.focusModeEnabled,
   keyboardShortcuts: state.settings.keyboardShortcuts,
   lineLength: state.settings.lineLength,
   noteId: state.ui.openedNote,


### PR DESCRIPTION
### Fix

This fixes an issue where the width doesn't get properly adjusted when going to/from focus mode:

<img width="1160" alt="Screen Shot 2020-09-29 at 9 24 23 PM" src="https://user-images.githubusercontent.com/52152/94643522-dd3ed100-029b-11eb-82a6-5844813995a0.png">


### Test
1. Toggle focus mode on and off
2. Verify that the width gets adjusted accordingly