### PR TITLE
Internal links: use a Monaco link provider

### DIFF
--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -20,6 +20,7 @@ type StateProps = {
   isFocused: boolean;
   note: T.Note | null;
   noteId: T.EntityId | null;
+  notes: Map<T.EntityId, T.Note>;
   searchQuery: string;
   showRenderedView: boolean;
 };
@@ -37,6 +38,7 @@ export const NotePreview: FunctionComponent<Props> = ({
   isFocused,
   note,
   noteId,
+  notes,
   openNote,
   searchQuery,
   showRenderedView,
@@ -89,7 +91,12 @@ export const NotePreview: FunctionComponent<Props> = ({
             }
 
             const [fullMatch, linkedNoteId] = match;
-            openNote(linkedNoteId as T.EntityId);
+            // if we try to open a note that doesn't exist in local state,
+            // then we annoyingly close the open note without opening anything else
+            // implicit else: links that aren't openable will just do nothing
+            if (notes.has(linkedNoteId as T.EntityId)) {
+              openNote(linkedNoteId as T.EntityId);
+            }
             return;
           }
 
@@ -170,6 +177,7 @@ const mapStateToProps: S.MapState<StateProps, OwnProps> = (state, props) => {
     isFocused: state.ui.dialogs.length === 0 && !state.ui.showNoteInfo,
     note,
     noteId,
+    notes: state.data.notes,
     searchQuery: state.ui.searchQuery,
     showRenderedView:
       !!note?.systemTags.includes('markdown') && !state.ui.editMode,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -429,7 +429,7 @@ class NoteContentEditor extends Component<Props> {
     monaco.languages.registerLinkProvider('plaintext', {
       provideLinks: (model) => {
         const matches = model.findMatches(
-          'simplenote://note/[a-zA-Z0-9-]*',
+          'simplenote://note/[a-zA-Z0-9-]+',
           true, // searchOnlyEditableRange
           true, // isRegex
           false, // matchCase

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -444,10 +444,7 @@ class NoteContentEditor extends Component<Props> {
         };
       },
       resolveLink: (link) => {
-        const href = editor.getModel()?.getValueInRange(link.range);
-        if (!href) {
-          return;
-        }
+        const href = editor.getModel()?.getValueInRange(link.range) ?? '';
         const match = /^simplenote:\/\/note\/(.+)$/.exec(href);
         if (!match) {
           return;

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -450,13 +450,13 @@ class NoteContentEditor extends Component<Props> {
           return;
         }
 
-        const [fullMatch, linkedNoteId] = match;
+        const [fullMatch, linkedNoteId] = match as [string, T.EntityId];
 
         // if we try to open a note that doesn't exist in local state,
         // then we annoyingly close the open note without opening anything else
         // implicit else: links that aren't openable will just do nothing
-        if (this.props.notes.has(linkedNoteId as T.EntityId)) {
-          this.props.openNote(linkedNoteId as T.EntityId);
+        if (this.props.notes.has(linkedNoteId)) {
+          this.props.openNote(linkedNoteId);
         }
         return { ...link, url: '#' }; // tell Monaco to do nothing and not complain about it
       },

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -436,16 +436,10 @@ class NoteContentEditor extends Component<Props> {
           null, // wordSeparators
           false // captureMatches
         );
-        const links = [];
-        matches.forEach(function (match) {
-          links.push({
-            range: match.range,
-            // don't set URL here because then Monaco skips resolveLink
-            // @cite: https://github.com/Microsoft/vscode/blob/8f89095aa6097f6e0014f2d459ef37820983ae55/src/vs/editor/contrib/links/getLinks.ts#L43:L65
-          });
-        });
         return {
-          links: links,
+          // don't set a URL on these links, because then Monaco skips resolveLink
+          // @cite: https://github.com/Microsoft/vscode/blob/8f89095aa6097f6e0014f2d459ef37820983ae55/src/vs/editor/contrib/links/getLinks.ts#L43:L65
+          links: matches.map(({ range }) => ({ range })),
         };
       },
       resolveLink: (link) => {
@@ -460,10 +454,10 @@ class NoteContentEditor extends Component<Props> {
 
         const [fullMatch, linkedNoteId] = match;
         this.props.openNote(linkedNoteId as T.EntityId);
-        link.url = '#'; // tell Monaco to do nothing and not complain about it
-        return link;
+        return { ...link, url: '#' }; // tell Monaco to do nothing and not complain about it
       },
     });
+
     // remove keybindings; see https://github.com/microsoft/monaco-editor/issues/287
     const shortcutsToDisable = [
       'cancelSelection', // escape; we need to allow this to bubble up to clear search

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -458,7 +458,7 @@ class NoteContentEditor extends Component<Props> {
         if (this.props.notes.has(linkedNoteId as T.EntityId)) {
           this.props.openNote(linkedNoteId as T.EntityId);
         }
-        // if it's not a valid note ID, silently fail
+        // implicit else: if it's not a valid note ID, silently fail
         return { ...link, url: '#' }; // tell Monaco to do nothing and not complain about it
       },
     });

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -444,7 +444,7 @@ class NoteContentEditor extends Component<Props> {
           links.push({
             range: match.range,
             href: match.matches[0],
-            // don't set URL because then Monaco skips resolveLink
+            // don't set URL here because then Monaco skips resolveLink
           });
         });
         return {
@@ -455,19 +455,16 @@ class NoteContentEditor extends Component<Props> {
         link: monaco.languages.ILink,
         token: monaco.CancellationToken
       ): monaco.languages.ProviderResult<monaco.languages.ILink> => {
-        if (link.href.startsWith('simplenote://note/')) {
-          const match = /^simplenote:\/\/note\/(.+)$/.exec(link.href);
-          if (!match) {
-            return;
-          }
-
-          const [fullMatch, linkedNoteId] = match;
-          this.props.openNote(linkedNoteId as T.EntityId);
+        const match = /^simplenote:\/\/note\/(.+)$/.exec(link.href);
+        if (!match) {
           return;
         }
 
-        return;
-        // return { target: 'https://www.google.com' };
+        const [fullMatch, linkedNoteId] = match;
+        this.props.openNote(linkedNoteId as T.EntityId);
+        return {
+          url: '#', // tell Monaco to do nothing and not complain about it
+        };
       },
     });
     // remove keybindings; see https://github.com/microsoft/monaco-editor/issues/287

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -431,14 +431,13 @@ class NoteContentEditor extends Component<Props> {
         model: monaco.editor.ITextModel,
         token: monaco.CancellationToken
       ): monaco.languages.ProviderResult<monaco.languages.ILinksList> => {
-        // https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.itextmodel.html#findmatches
         const matches = model.findMatches(
-          'simplenote://note/[^)]*',
-          '',
-          true,
-          false,
-          null,
-          true
+          'simplenote://note/[a-zA-Z0-9-]*',
+          true, // searchOnlyEditableRange
+          true, // isRegex
+          false, // matchCase
+          null, // wordSeparators
+          true // captureMatches
         );
         const links = [];
         matches.forEach(function (match) {

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -455,10 +455,12 @@ class NoteContentEditor extends Component<Props> {
 
         const [fullMatch, linkedNoteId] = match;
 
+        // if we try to open a note that doesn't exist in local state,
+        // then we annoyingly close the open note without opening anything else
+        // implicit else: links that aren't openable will just do nothing
         if (this.props.notes.has(linkedNoteId as T.EntityId)) {
           this.props.openNote(linkedNoteId as T.EntityId);
         }
-        // implicit else: if it's not a valid note ID, silently fail
         return { ...link, url: '#' }; // tell Monaco to do nothing and not complain about it
       },
     });

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -62,6 +62,7 @@ type StateProps = {
   lineLength: T.LineLength;
   noteId: T.EntityId;
   note: T.Note;
+  notes: Map<T.EntityId, T.Note>;
   searchQuery: string;
   spellCheckEnabled: boolean;
   theme: T.Theme;
@@ -453,7 +454,11 @@ class NoteContentEditor extends Component<Props> {
         }
 
         const [fullMatch, linkedNoteId] = match;
-        this.props.openNote(linkedNoteId as T.EntityId);
+
+        if (this.props.notes.has(linkedNoteId as T.EntityId)) {
+          this.props.openNote(linkedNoteId as T.EntityId);
+        }
+        // if it's not a valid note ID, silently fail
         return { ...link, url: '#' }; // tell Monaco to do nothing and not complain about it
       },
     });
@@ -1002,6 +1007,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
   lineLength: state.settings.lineLength,
   noteId: state.ui.openedNote,
   note: state.data.notes.get(state.ui.openedNote),
+  notes: state.data.notes,
   searchQuery: state.ui.searchQuery,
   spellCheckEnabled: state.settings.spellCheckEnabled,
   theme: selectors.getTheme(state),


### PR DESCRIPTION
This PR adds a custom `LinkProvider` that searches the note for `simplenote://` links and linkifies them, then handles the click event by opening the linked note in the editor.

If the note ID does not refer to a note we can open, it will silently fail. I'm not sure what else it can or should do in that case.

Also adds a check to the preview component to skip links that can't be opened (i.e. the noteId isn't in our notes list), as otherwise it closes the selected note in favor of.. nothing.

<img width="606" alt="Screen Shot 2020-09-30 at 12 46 06 AM" src="https://user-images.githubusercontent.com/52152/94667521-c613d980-02c3-11eb-9f0e-836865471bc4.png">
