### PR TITLE
Disable Ctrl+G "Goto Line"

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -476,6 +476,7 @@ class NoteContentEditor extends Component<Props> {
       'editor.action.transposeLetters', // ctrl+T
       'editor.action.triggerSuggest', // ctrl+space
       'expandLineSelection', // meta+L
+      'editor.action.gotoLine', // ctrl+G
       // search shortcuts
       'actions.find',
       'actions.findWithSelection',


### PR DESCRIPTION
### Fix

Fixes #2399 - Ctrl+G opening a "go to line" menu on Windows

### Test

1. With a search, use Ctrl+G and make sure it goes to the next search result
2. Without a search, make sure Ctrl+G does nothing
