### PR TITLE
Fix: zoom shortcuts on numeric keypad

### DIFF
--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -143,7 +143,7 @@ const buildViewMenu = (settings, isAuthenticated) => {
         role: 'ResetZoom',
       },
 
-      // workarounds for numeric keypad zoom in / zoom out,
+      // backup shortcuts for numeric keypad,
       // see https://github.com/electron/electron/issues/5256#issuecomment-692068367
       {
         label: 'Zoom &In',

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -158,11 +158,10 @@ const buildViewMenu = (settings, isAuthenticated) => {
         accelerator: 'CommandOrControl+numsub',
       },
       {
-        label: '&Actual Size',
+        role: 'ResetZoom',
         visible: false,
         acceleratorWorksWhenHidden: true,
         accelerator: 'CommandOrControl+num0',
-        click: appCommandSender({ action: 'resetFontSize' }),
       },
 
       ...(isAuthenticated ? [{ type: 'separator' }] : []),

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -142,6 +142,31 @@ const buildViewMenu = (settings, isAuthenticated) => {
       {
         role: 'ResetZoom',
       },
+
+      // workarounds for numeric keypad zoom in / zoom out,
+      // see https://github.com/electron/electron/issues/5256#issuecomment-692068367
+      {
+        label: 'Zoom &In',
+        visible: false,
+        acceleratorWorksWhenHidden: true,
+        accelerator: 'CommandOrControl+numadd',
+        click: appCommandSender({ action: 'increaseFontSize' }),
+      },
+      {
+        label: 'Zoom &Out',
+        visible: false,
+        acceleratorWorksWhenHidden: true,
+        accelerator: 'CommandOrControl+numsub',
+        click: appCommandSender({ action: 'decreaseFontSize' }),
+      },
+      {
+        label: '&Actual Size',
+        visible: false,
+        acceleratorWorksWhenHidden: true,
+        accelerator: 'CommandOrControl+num0',
+        click: appCommandSender({ action: 'resetFontSize' }),
+      },
+
       ...(isAuthenticated ? [{ type: 'separator' }] : []),
       {
         label: 'Focus Mode',

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -146,18 +146,16 @@ const buildViewMenu = (settings, isAuthenticated) => {
       // backup shortcuts for numeric keypad,
       // see https://github.com/electron/electron/issues/5256#issuecomment-692068367
       {
-        label: 'Zoom &In',
+        role: 'ZoomIn',
         visible: false,
         acceleratorWorksWhenHidden: true,
         accelerator: 'CommandOrControl+numadd',
-        click: appCommandSender({ action: 'increaseFontSize' }),
       },
       {
-        label: 'Zoom &Out',
+        role: 'ZoomOut',
         visible: false,
         acceleratorWorksWhenHidden: true,
         accelerator: 'CommandOrControl+numsub',
-        click: appCommandSender({ action: 'decreaseFontSize' }),
       },
       {
         label: '&Actual Size',


### PR DESCRIPTION
### Fix

This fixes #2400, a report that these shortcuts only work when triggered from the top keyboard row, and not from the number pad.

In my testing on OSX, the only one that did not work was Zoom In. But based on the report I've also added additional shortcuts to handle Zoom Out (Ctrl + minus) and Default view (Ctrl + zero).

See:

* https://github.com/electron/electron/issues/3332
* https://www.electronjs.org/docs/api/accelerator#available-key-codes

### Test

1. Find a keyboard with a number pad
2. Verify that the numpad keys work to zoom in, out and restore to default zoom
3. Verify that the original keys still work as well

### Release

Fixed a bug preventing zoom level shortcuts from being triggered by keys on the numeric keypad