### PR TITLE
[WIP] Fix for Zoom only working for editor contents

### DIFF
--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -15,7 +15,7 @@ import * as S from '../state';
 import * as T from '../types';
 
 type StateProps = {
-  autoHideMenuBar: boolean;
+  fontSize: number;
   isDialogOpen: boolean;
   openedTag: T.TagEntity | null;
   showNavigation: boolean;
@@ -64,9 +64,12 @@ export class NavigationBar extends Component<Props> {
   };
 
   render() {
-    const { autoHideMenuBar, onAbout, onSettings, onShowAllNotes } = this.props;
+    const { fontSize, onAbout, onSettings, onShowAllNotes } = this.props;
     return (
-      <div className="navigation-bar theme-color-bg theme-color-fg theme-color-border">
+      <div
+        className="navigation-bar theme-color-bg theme-color-fg theme-color-border"
+        style={{ fontSize: `${fontSize}px` }}
+      >
         <div className="navigation-bar__folders">
           <NavigationBarItem
             icon={<NotesIcon />}
@@ -131,7 +134,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
   settings,
   ui: { dialogs, openedTag, showNavigation, showTrash },
 }) => ({
-  autoHideMenuBar: settings.autoHideMenuBar,
+  fontSize: settings.fontSize,
   isDialogOpen: dialogs.length > 0,
   openedTag,
   showNavigation,

--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -12,7 +12,6 @@ type OwnProps = {
 };
 
 type StateProps = {
-  fontSize: number;
   isDialogOpen: boolean;
   keyboardShortcuts: boolean;
   openedNote: T.EntityId | null;
@@ -57,7 +56,6 @@ export class NoteDetail extends Component<Props> {
 }
 
 const mapStateToProps: S.MapState<StateProps> = (state) => ({
-  fontSize: state.settings.fontSize,
   isDialogOpen: state.ui.dialogs.length > 0,
   keyboardShortcuts: state.settings.keyboardShortcuts,
   openedNote: state.ui.openedNote,

--- a/lib/note-info/index.tsx
+++ b/lib/note-info/index.tsx
@@ -16,6 +16,7 @@ import * as S from '../state';
 import * as T from '../types';
 
 type StateProps = {
+  fontSize: number;
   isMarkdown: boolean;
   isPinned: boolean;
   noteId: T.EntityId;
@@ -75,14 +76,17 @@ export class NoteInfo extends Component<Props> {
   };
 
   render() {
-    const { isMarkdown, isPinned, noteId, note } = this.props;
+    const { fontSize, isMarkdown, isPinned, noteId, note } = this.props;
     const formattedDate =
       note.modificationDate && formatTimestamp(note.modificationDate);
     const isPublished = includes(note.systemTags, 'published');
     const publishURL = this.getPublishURL(note.publishURL);
 
     return (
-      <div className="note-info theme-color-bg theme-color-fg theme-color-border">
+      <div
+        className="note-info theme-color-bg theme-color-fg theme-color-border"
+        style={{ fontSize: `${fontSize}px` }}
+      >
         <div className="note-info-panel note-info-stats theme-color-border">
           <div className="note-info-header">
             <PanelTitle headingLevel={2}>Info</PanelTitle>
@@ -250,13 +254,14 @@ function characterCount(content: string) {
   );
 }
 
-const mapStateToProps: S.MapState<StateProps> = ({
+const mapStateToProps: S.MapState<StateProps> = (state) => ({
   data,
   ui: { openedNote },
 }) => {
   const note = data.notes.get(openedNote);
 
   return {
+    fontSize: state.settings.fontSize,
     noteId: openedNote,
     note: note,
     isMarkdown: note?.systemTags.includes('markdown'),

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -19,6 +19,7 @@ import * as T from '../types';
 
 type StateProps = {
   filteredNotes: T.EntityId[];
+  fontSize: number;
   hasLoaded: boolean;
   isSmallScreen: boolean;
   keyboardShortcuts: boolean;
@@ -158,7 +159,12 @@ export class NoteList extends Component<Props> {
       defaultHeight: 21 + 18 + 24 * 4,
       fixedWidth: true,
       keyMapper: (rowIndex) => {
-        const { filteredNotes, searchQuery, tagResultsFound } = this.props;
+        const {
+          filteredNotes,
+          fontSize,
+          searchQuery,
+          tagResultsFound,
+        } = this.props;
 
         if (tagResultsFound === 0 && filteredNotes.length === 0) {
           return 'no-notes';
@@ -267,6 +273,7 @@ export class NoteList extends Component<Props> {
   render() {
     const {
       filteredNotes,
+      fontSize,
       hasLoaded,
       noteDisplay,
       onEmptyTrash,
@@ -303,7 +310,10 @@ export class NoteList extends Component<Props> {
     );
 
     return (
-      <div className={classNames('note-list', { 'is-empty': isEmptyList })}>
+      <div
+        className={classNames('note-list', { 'is-empty': isEmptyList })}
+        style={{ fontSize: `${fontSize}px` }}
+      >
         {isEmptyList ? (
           <span className="note-list-placeholder">
             {hasLoaded ? 'No Notes' : 'Loading Notes'}
@@ -343,6 +353,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => {
     keyboardShortcuts: state.settings.keyboardShortcuts,
     noteDisplay: state.settings.noteDisplay,
     filteredNotes: state.ui.filteredNotes,
+    fontSize: state.settings.fontSize,
     openedNote: state.ui.openedNote,
     openedTag: state.ui.openedTag,
     searchQuery: state.ui.searchQuery,

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -171,7 +171,6 @@
   .note-list-item-title {
     display: flex;
     justify-content: space-between;
-    font-size: 16px;
 
     & span {
       text-overflow: ellipsis;


### PR DESCRIPTION
Notes to self:
* Note info is not re-rendering when font size changes, something with the state is wrong

Things that are not yet resizing:
* Search bar input
* In side tray, All Notes / Trash and Settings / About etc
* Tag chips / tag input
* Text within dialogs

### Fix

This is a regression given comments on https://github.com/Automattic/simplenote-electron/issues/1037
Fix for #2403 

<!-- **_(Required)_** Add a concise description of what you fixed. If this is related to an issue, add a link to it. If applicable, add screenshots, animations, or videos to help illustrate the fix. -->

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1.
2.
3.

### Release

<!-- **_(Required)_** Add a concise statement to `RELEASE-NOTES.md` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.md` was updated with: -->
