### PR TITLE
Electron: Use native zoom

### DIFF
--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -127,21 +127,26 @@ const buildViewMenu = (settings, isAuthenticated) => {
       ...(isAuthenticated ? [{ type: 'separator' }] : []),
       {
         label: 'Zoom &In',
+        role: 'ZoomIn',
         visible: isAuthenticated,
         accelerator: 'CommandOrControl+=',
-        click: appCommandSender({ action: 'increaseFontSize' }),
+      },
+      {
+        label: 'Zoom &In',
+        role: 'ZoomIn',
+        visible: false,
+        acceleratorWorksWhenHidden: true,
+        accelerator: 'CommandOrControl+Plus',
       },
       {
         label: 'Zoom &Out',
+        role: 'ZoomOut',
         visible: isAuthenticated,
-        accelerator: 'CommandOrControl+-',
-        click: appCommandSender({ action: 'decreaseFontSize' }),
       },
       {
         label: '&Actual Size',
         visible: isAuthenticated,
-        accelerator: 'CommandOrControl+0',
-        click: appCommandSender({ action: 'resetFontSize' }),
+        role: 'ResetZoom',
       },
       ...(isAuthenticated ? [{ type: 'separator' }] : []),
       {

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -134,7 +134,7 @@ const buildViewMenu = (settings, isAuthenticated) => {
       {
         label: 'Zoom &In',
         role: 'ZoomIn',
-        visible: false,
+        visible: false, // enable shortcut to work both with and without Shift
         acceleratorWorksWhenHidden: true,
         accelerator: 'CommandOrControl+Plus',
       },
@@ -145,8 +145,8 @@ const buildViewMenu = (settings, isAuthenticated) => {
       },
       {
         label: '&Actual Size',
-        visible: isAuthenticated,
         role: 'ResetZoom',
+        visible: isAuthenticated,
       },
       ...(isAuthenticated ? [{ type: 'separator' }] : []),
       {

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -129,10 +129,12 @@ const buildViewMenu = (settings, isAuthenticated) => {
         role: 'ZoomIn',
       },
       {
+        // enable ZoomIn shortcut to work both with and without Shift
+        // the default accelerator added by Electron is CommandOrControl+Shift+=
         role: 'ZoomIn',
-        visible: false, // enable ZoomIn shortcut to work both with and without Shift on OSX
+        visible: false,
         acceleratorWorksWhenHidden: true,
-        accelerator: platform.isOSX() ? 'CommandOrControl+=' : '',
+        accelerator: 'CommandOrControl+=',
       },
       {
         role: 'ZoomOut',

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -126,27 +126,19 @@ const buildViewMenu = (settings, isAuthenticated) => {
       },
       ...(isAuthenticated ? [{ type: 'separator' }] : []),
       {
-        label: 'Zoom &In',
         role: 'ZoomIn',
-        visible: isAuthenticated,
-        accelerator: 'CommandOrControl+=',
       },
       {
-        label: 'Zoom &In',
         role: 'ZoomIn',
-        visible: false, // enable shortcut to work both with and without Shift
+        visible: false, // enable ZoomIn shortcut to work both with and without Shift on OSX
         acceleratorWorksWhenHidden: true,
-        accelerator: 'CommandOrControl+Plus',
+        accelerator: platform.isOSX() ? 'CommandOrControl+=' : '',
       },
       {
-        label: 'Zoom &Out',
         role: 'ZoomOut',
-        visible: isAuthenticated,
       },
       {
-        label: '&Actual Size',
         role: 'ResetZoom',
-        visible: isAuthenticated,
       },
       ...(isAuthenticated ? [{ type: 'separator' }] : []),
       {

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -16,7 +16,6 @@ type OwnProps = {
 };
 
 type StateProps = {
-  fontSize: number;
   isFocused: boolean;
   note: T.Note | null;
   noteId: T.EntityId | null;
@@ -34,7 +33,6 @@ type Props = OwnProps & StateProps & DispatchProps;
 
 export const NotePreview: FunctionComponent<Props> = ({
   editNote,
-  fontSize,
   isFocused,
   note,
   noteId,
@@ -157,7 +155,6 @@ export const NotePreview: FunctionComponent<Props> = ({
           ref={previewNode}
           className="note-detail-markdown theme-color-bg theme-color-fg"
           data-markdown-root
-          style={{ fontSize: `${fontSize}px` }}
         >
           <div style={{ whiteSpace: 'pre' }}>
             {!showRenderedView && withCheckboxCharacters(note?.content ?? '')}
@@ -173,7 +170,6 @@ const mapStateToProps: S.MapState<StateProps, OwnProps> = (state, props) => {
   const note = props.note ?? state.data.notes.get(noteId);
 
   return {
-    fontSize: state.settings.fontSize,
     isFocused: state.ui.dialogs.length === 0 && !state.ui.showNoteInfo,
     note,
     noteId,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -57,7 +57,6 @@ type OwnProps = {
 
 type StateProps = {
   editorSelection: [number, number, 'RTL' | 'LTR'];
-  fontSize: number;
   isFocusMode: boolean;
   keyboardShortcuts: boolean;
   lineLength: T.LineLength;
@@ -903,7 +902,7 @@ class NoteContentEditor extends Component<Props> {
   };
 
   render() {
-    const { fontSize, lineLength, noteId, searchQuery, theme } = this.props;
+    const { lineLength, noteId, searchQuery, theme } = this.props;
     const { content, editor, overTodo, selectedSearchMatchIndex } = this.state;
     const searchMatches = searchQuery ? this.searchMatches() : [];
 
@@ -944,10 +943,11 @@ class NoteContentEditor extends Component<Props> {
               folding: false,
               fontFamily:
                 '"Simplenote Tasks", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
-              fontSize,
               hideCursorInOverviewRuler: true,
               lineDecorationsWidth: editorPadding,
-              lineHeight: fontSize > 20 ? 42 : 24,
+              fontSize: 16,
+              lineHeight: 24,
+              // lineHeight: fontSize > 20 ? 42 : 24,
               lineNumbers: 'off',
               links: true,
               matchBrackets: 'never',
@@ -1007,7 +1007,6 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
     0,
     'LTR',
   ],
-  fontSize: state.settings.fontSize,
   isFocusMode: state.settings.focusModeEnabled,
   keyboardShortcuts: state.settings.keyboardShortcuts,
   lineLength: state.settings.lineLength,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -947,7 +947,6 @@ class NoteContentEditor extends Component<Props> {
               lineDecorationsWidth: editorPadding,
               fontSize: 16,
               lineHeight: 24,
-              // lineHeight: fontSize > 20 ? 42 : 24,
               lineNumbers: 'off',
               links: true,
               matchBrackets: 'never',

--- a/lib/note-detail/index.tsx
+++ b/lib/note-detail/index.tsx
@@ -12,7 +12,6 @@ type OwnProps = {
 };
 
 type StateProps = {
-  fontSize: number;
   isDialogOpen: boolean;
   keyboardShortcuts: boolean;
   openedNote: T.EntityId | null;
@@ -57,7 +56,6 @@ export class NoteDetail extends Component<Props> {
 }
 
 const mapStateToProps: S.MapState<StateProps> = (state) => ({
-  fontSize: state.settings.fontSize,
   isDialogOpen: state.ui.dialogs.length > 0,
   keyboardShortcuts: state.settings.keyboardShortcuts,
   openedNote: state.ui.openedNote,

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -62,7 +62,6 @@ export type CreateNoteWithId = Action<
   'CREATE_NOTE_WITH_ID',
   { noteId: T.EntityId; note?: Partial<T.Note> }
 >;
-export type DecreaseFontSize = Action<'DECREASE_FONT_SIZE'>;
 export type DeleteOpenNoteForever = Action<'DELETE_OPEN_NOTE_FOREVER'>;
 export type ExportNotes = Action<'EXPORT_NOTES'>;
 export type FilterNotes = Action<
@@ -70,7 +69,6 @@ export type FilterNotes = Action<
   { noteIds: T.EntityId[]; tagHashes: T.TagHash[] }
 >;
 export type FocusSearchField = Action<'FOCUS_SEARCH_FIELD'>;
-export type IncreaseFontSize = Action<'INCREASE_FONT_SIZE'>;
 export type Logout = Action<'LOGOUT'>;
 export type OpenNote = Action<'OPEN_NOTE', { noteId?: T.EntityId }>;
 export type OpenRevision = Action<
@@ -88,7 +86,6 @@ export type RequestNotifications = Action<
   'REQUEST_NOTIFICATIONS',
   { sendNotifications: boolean }
 >;
-export type ResetFontSize = Action<'RESET_FONT_SIZE'>;
 export type RestoreOpenNote = Action<'RESTORE_OPEN_NOTE'>;
 export type Search = Action<'SEARCH', { searchQuery: string }>;
 export type SelectNote = Action<'SELECT_NOTE', { noteId: T.EntityId }>;
@@ -315,7 +312,6 @@ export type ActionType =
   | CloseWindow
   | CreateNote
   | CreateNoteWithId
-  | DecreaseFontSize
   | DeleteOpenNoteForever
   | DeleteNoteForever
   | EditNote
@@ -328,7 +324,6 @@ export type ActionType =
   | GhostSetEntity
   | ImportNote
   | ImportNoteWithId
-  | IncreaseFontSize
   | InsertTask
   | InsertTaskIntoNote
   | LoadRevisions
@@ -356,7 +351,6 @@ export type ActionType =
   | RenameTag
   | ReorderTag
   | RequestNotifications
-  | ResetFontSize
   | RestoreOpenNote
   | RestoreNote
   | RestoreNoteRevision

--- a/lib/state/electron/middleware.ts
+++ b/lib/state/electron/middleware.ts
@@ -49,18 +49,6 @@ export const middleware: S.Middleware = ({ dispatch, getState }) => {
         dispatch(actions.ui.createNote());
         return;
 
-      case 'increaseFontSize':
-        dispatch(actions.settings.increaseFontSize());
-        return;
-
-      case 'decreaseFontSize':
-        dispatch(actions.settings.decreaseFontSize());
-        return;
-
-      case 'resetFontSize':
-        dispatch(actions.settings.resetFontSize());
-        return;
-
       case 'setLineLength':
         dispatch(actions.settings.setLineLength(command.lineLength));
         return;

--- a/lib/state/settings/actions.ts
+++ b/lib/state/settings/actions.ts
@@ -1,18 +1,6 @@
 import * as A from '../action-types';
 import * as T from '../../types';
 
-export const increaseFontSize: A.ActionCreator<A.IncreaseFontSize> = () => ({
-  type: 'INCREASE_FONT_SIZE',
-});
-
-export const decreaseFontSize: A.ActionCreator<A.DecreaseFontSize> = () => ({
-  type: 'DECREASE_FONT_SIZE',
-});
-
-export const resetFontSize: A.ActionCreator<A.ResetFontSize> = () => ({
-  type: 'RESET_FONT_SIZE',
-});
-
 export const activateTheme: A.ActionCreator<A.SetTheme> = (theme: T.Theme) => ({
   type: 'setTheme',
   theme,

--- a/lib/state/settings/reducer.ts
+++ b/lib/state/settings/reducer.ts
@@ -34,22 +34,6 @@ const focusModeEnabled: A.Reducer<boolean> = (state = false, action) => {
   }
 };
 
-const fontSizes = [10, 14, 16, 20, 24, 34];
-const fontSize: A.Reducer<number> = (state = 16, action) => {
-  switch (action.type) {
-    case 'DECREASE_FONT_SIZE':
-      return fontSizes[Math.max(0, fontSizes.indexOf(state) - 1)];
-    case 'INCREASE_FONT_SIZE':
-      return fontSizes[
-        Math.min(fontSizes.length - 1, fontSizes.indexOf(state) + 1)
-      ];
-    case 'RESET_FONT_SIZE':
-      return 16;
-    default:
-      return state;
-  }
-};
-
 const keyboardShortcuts: A.Reducer<boolean> = (state = true, action) => {
   switch (action.type) {
     case 'KEYBOARD_SHORTCUTS_TOGGLE':
@@ -159,7 +143,6 @@ export default combineReducers({
   accountName,
   autoHideMenuBar,
   focusModeEnabled,
-  fontSize,
   keyboardShortcuts,
   lineLength,
   markdownEnabled,


### PR DESCRIPTION
### Fix

Electron's menuItems support native Zoom functionality using defined [roles](https://www.electronjs.org/docs/api/menu-item#roles). What we're doing now, for reasons unknown to me (maybe it wasn't previously supported?) is using a hidden `fontSize` setting, which currently has the effect that only the editor content zooms in/out. (#2403)

It works fine in the browser, which uses native zooming.

I explored adjusting the font sizes and styles throughout the app in #2405, which got sticky because we have to set the font size **everywhere**, and still have the accessibility issue where all parts of the app (icons, etc) are not  always zooming.

This is a problem we previously had and fixed (#1037), which makes me think it's a regression introduced by the rewrite, or somewhere else along the line. I haven't tested on older app versions.

Anyhow this PR removes the hidden `fontSize` option and allows Electron to add menu items for the native Zoom functionality, which should work better cross-platform. We pass a fixed font-size and line-height to Monaco (16/24) which matches the current default size, and is also adjusted as the app zooms in and out. 

Needs testing on Windows build.

WIll fix #2403 // supersedes #2405 

### Test
1. On Electron build, zoom in and out using shortcut keys or menu, make sure everything looks good
2. On web, zoom in and out using native browser functionality

### Release

Fixed a bug causing zoom in / zoom out to only apply to the editor contents.