### PR TITLE
Fix: Dropped filename character when importing .md files

### DIFF
--- a/lib/utils/import/text-files/index.ts
+++ b/lib/utils/import/text-files/index.ts
@@ -38,8 +38,8 @@ class TextFileImporter extends EventEmitter {
       fileReader.onload = (event) => {
         let noteContent = event.target.result;
 
-        // Trim the .txt extension from the file name
-        const fileTitle = file.name.slice(0, -4);
+        // Trim the extension from the file name
+        const fileTitle = file.name.substring(0, file.name.lastIndexOf('.'));
         if (!startsWith(noteContent, fileTitle)) {
           // Add the file title to the top of the note content
           noteContent = fileTitle + '\n\n' + noteContent;


### PR DESCRIPTION
### Fix

We enabled .md import in #2351 but missed a line of code that assumes the file extension is always 4 characters long when it strips it out. This PR is a tiny bit smarter.

Fixes #2398 

### Test
1. Import a .md file
2. Verify that the note title isn't missing a character
3. Verify that .txt files also work properly

### Release

Fixed a bug where a character of the filename was dropped when importing a .md file