### PR TITLE
Adds Internal link references

### DIFF
--- a/lib/note-info/index.tsx
+++ b/lib/note-info/index.tsx
@@ -10,6 +10,7 @@ import PanelTitle from '../components/panel-title';
 import ToggleControl from '../controls/toggle';
 import CrossIcon from '../icons/cross';
 import getNoteTitleAndPreview from '../utils/note-utils';
+import References from './references';
 
 import actions from '../state/actions';
 
@@ -163,6 +164,7 @@ export class NoteInfo extends Component<Props> {
             </span>
           </div>
         )}
+        <References></References>
       </div>
     );
   }

--- a/lib/note-info/index.tsx
+++ b/lib/note-info/index.tsx
@@ -142,15 +142,6 @@ export class NoteInfo extends Component<Props> {
             </span>
           </label>
         </div>
-        <div className="note-info-panel note-info-internal-link theme-color-border">
-          <span className="note-info-item-text">
-            <span className="note-info-name">Internal link</span>
-            <div className="note-info-copy">
-              <p className="note-info-detail note-info-link-text">{`simplenote://note/${noteId}`}</p>
-              <ClipboardButton text={noteLink} />
-            </div>
-          </span>
-        </div>
         {isPublished && (
           <div className="note-info-panel note-info-public-link theme-color-border">
             <span className="note-info-item-text">
@@ -164,6 +155,15 @@ export class NoteInfo extends Component<Props> {
             </span>
           </div>
         )}
+        <div className="note-info-panel note-info-internal-link theme-color-border">
+          <span className="note-info-item-text">
+            <span className="note-info-name">Internal link</span>
+            <div className="note-info-copy">
+              <p className="note-info-detail note-info-link-text">{`simplenote://note/${noteId}`}</p>
+              <ClipboardButton text={noteLink} />
+            </div>
+          </span>
+        </div>
         <References></References>
       </div>
     );

--- a/lib/note-info/reference.tsx
+++ b/lib/note-info/reference.tsx
@@ -46,7 +46,8 @@ export const Reference: FunctionComponent<Props> = ({
     <button className="reference-link" onClick={openNote}>
       <span className="reference-title note-info-name">{reference.title}</span>
       <span>
-        {reference.count} References, Last modified {formattedDate}
+        {reference.count} Reference{reference.count > 1 ? 's' : ''}, Last
+        modified {formattedDate}
       </span>
     </button>
   );
@@ -63,10 +64,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (
   dispatch,
   { noteId }
 ) => ({
-  openNote: () => {
-    dispatch(actions.ui.toggleNoteInfo());
-    dispatch(actions.ui.selectNote(noteId));
-  },
+  openNote: () => dispatch(actions.ui.selectNote(noteId)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Reference);

--- a/lib/note-info/reference.tsx
+++ b/lib/note-info/reference.tsx
@@ -46,7 +46,7 @@ export const Reference: FunctionComponent<Props> = ({
     <button className="reference-link" onClick={openNote}>
       <span className="reference-title note-info-name">{reference.title}</span>
       <span>
-        {reference.count} Reference{reference.count > 1 ? 's' : ''}, Last
+        {reference.count} Reference{reference.count > 1 ? 's' : ''}, last
         modified {formattedDate}
       </span>
     </button>

--- a/lib/note-info/reference.tsx
+++ b/lib/note-info/reference.tsx
@@ -1,0 +1,72 @@
+import React, { Fragment, FunctionComponent } from 'react';
+import { connect } from 'react-redux';
+import format from 'date-fns/format';
+
+import actions from '../state/actions';
+import { getNoteReference } from '../utils/get-note-references';
+
+import type * as S from '../state';
+import type * as T from '../types';
+
+type OwnProps = {
+  noteId: T.EntityId;
+};
+
+type StateProps = {
+  reference:
+    | {
+        count: number;
+        noteId: T.EntityId;
+        modificationDate: T.SecondsEpoch;
+        title: string;
+      }
+    | undefined;
+};
+
+type DispatchProps = {
+  openNote: () => any;
+};
+
+type Props = StateProps & DispatchProps;
+
+function formatTimestamp(unixTime: number) {
+  return format(unixTime * 1000, 'MM/dd/yyyy');
+}
+
+export const Reference: FunctionComponent<Props> = ({
+  openNote,
+  reference,
+}) => {
+  if (!reference) {
+    return null;
+  }
+  const formattedDate =
+    reference.modificationDate && formatTimestamp(reference.modificationDate);
+  return (
+    <button className="reference-link" onClick={openNote}>
+      <span className="reference-title note-info-name">{reference.title}</span>
+      <span>
+        {reference.count} References, Last modified {formattedDate}
+      </span>
+    </button>
+  );
+};
+
+const mapStateToProps: S.MapState<StateProps, OwnProps> = (
+  state,
+  { noteId }
+) => ({
+  reference: getNoteReference(state, noteId),
+});
+
+const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (
+  dispatch,
+  { noteId }
+) => ({
+  openNote: () => {
+    dispatch(actions.ui.toggleNoteInfo());
+    dispatch(actions.ui.selectNote(noteId));
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Reference);

--- a/lib/note-info/references.tsx
+++ b/lib/note-info/references.tsx
@@ -1,0 +1,38 @@
+import React, { FunctionComponent } from 'react';
+import { connect } from 'react-redux';
+
+import { getNoteReferences } from '../utils/get-note-references';
+
+import Reference from './reference';
+
+import type * as S from '../state';
+import type * as T from '../types';
+
+type StateProps = {
+  references: T.EntityId[];
+};
+
+type Props = StateProps;
+
+export const References: FunctionComponent<Props> = ({ references }) => {
+  if (!references.length) {
+    return null;
+  }
+
+  return (
+    <div className="note-info-panel note-info-internal-link theme-color-border">
+      <span className="note-info-item-text">
+        <span className="note-info-name">References</span>
+        {references.map((noteId) => (
+          <Reference noteId={noteId} key={noteId} />
+        ))}
+      </span>
+    </div>
+  );
+};
+
+const mapStateToProps: S.MapState<StateProps, OwnProps> = (state) => ({
+  references: getNoteReferences(state),
+});
+
+export default connect(mapStateToProps)(References);

--- a/lib/note-info/style.scss
+++ b/lib/note-info/style.scss
@@ -77,4 +77,33 @@
       flex: 1 0 auto;
     }
   }
+
+  .reference-link {
+    display: block;
+    padding: 5px;
+    text-align: left;
+    text-decoration: none;
+
+    span {
+      color: $studio-gray-50;
+      display: block;
+      margin: 0;
+    }
+
+    .reference-title {
+      color: $studio-gray-80;
+      font-style: italic;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+}
+
+.theme-dark {
+  .reference-link {
+    .reference-title {
+      color: $studio-white;
+    }
+  }
 }

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -240,6 +240,7 @@ const showNoteInfo: A.Reducer<boolean> = (state = false, action) => {
       return !state;
 
     case 'NAVIGATION_TOGGLE':
+    case 'SELECT_NOTE':
       return false;
 
     default:

--- a/lib/utils/get-note-references.ts
+++ b/lib/utils/get-note-references.ts
@@ -1,0 +1,49 @@
+import { number } from 'prop-types';
+import type * as S from '../state';
+import type * as T from '../types';
+
+import getNoteTitleAndPreview from './note-utils';
+
+const getNoteLink = (id: T.EntityId): string => `simplenote://note/${id}`;
+
+export const getNoteReferences = (state: S.State): T.EntityId[] => {
+  const matches = new Set<T.EntityId>();
+  if (!state.ui.openedNote) {
+    return [];
+  }
+  const noteLink = getNoteLink(state.ui.openedNote);
+  state.data.notes.forEach((note, key) => {
+    if (note.content.includes(noteLink)) {
+      matches.add(key);
+    }
+  });
+  return [...matches.values()];
+};
+
+type noteReference =
+  | {
+      count: number;
+      noteId: T.EntityId;
+      modificationDate: T.SecondsEpoch;
+      title: string;
+    }
+  | undefined;
+
+export const getNoteReference = (
+  state: S.State,
+  noteId: T.EntityId
+): noteReference => {
+  const note = state.data.notes.get(noteId);
+  if (!note || !state.ui.openedNote) {
+    return;
+  }
+  const regExp = new RegExp(getNoteLink(state.ui.openedNote), 'gi');
+  const count = note?.content.match(regExp)?.length || 0;
+  const { title } = getNoteTitleAndPreview(note);
+  return {
+    count,
+    noteId,
+    modificationDate: note?.modificationDate,
+    title,
+  };
+};

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -15,7 +15,7 @@ $focus-outline: 4px auto $studio-simplenote-blue-5;
 
 // Global Measurements
 $navigation-bar-width: 216px;
-$note-info-width: 315px;
+$note-info-width: 320px;
 $max-content-width: 625px;
 $toolbar-height: 56px;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -15,7 +15,7 @@ $focus-outline: 4px auto $studio-simplenote-blue-5;
 
 // Global Measurements
 $navigation-bar-width: 216px;
-$note-info-width: 268px;
+$note-info-width: 315px;
 $max-content-width: 625px;
 $toolbar-height: 56px;
 


### PR DESCRIPTION
### Change

This PR adds internal link references to the note info panel. When a user opens the note info panel we display a list of notes that contain internal link references to that note. Those references are also clickable allowing the user to navigate to the notes.

<img width="327" alt="Screen Shot 2020-10-22 at 12 23 02 PM" src="https://user-images.githubusercontent.com/6817400/96904228-cfc4d300-1464-11eb-915e-d5fd2e5b9587.png">
<img width="336" alt="Screen Shot 2020-10-22 at 12 22 44 PM" src="https://user-images.githubusercontent.com/6817400/96904229-d05d6980-1464-11eb-8304-d58bb336873f.png">


### Test
1. Add internal links to a bunch of notes
2. Open the note info panel to view the references to that note
3. Ensure that link count and modification date are correct
4. Ensure references are clickable
5. Ensure light and dark mode look good

### Release

Added internal link references to the note info panel
