### PR TITLE
Change logic to allow for checking checkboxes in preview

### DIFF
--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -44,7 +44,6 @@ export const NotePreview: FunctionComponent<Props> = ({
   showRenderedView,
 }) => {
   const previewNode = useRef<HTMLDivElement>();
-
   useEffect(() => {
     const copyRenderedNote = (event: ClipboardEvent) => {
       if (!isFocused) {
@@ -122,7 +121,6 @@ export const NotePreview: FunctionComponent<Props> = ({
           const content = note.content.replace(
             /(- \[x\]|- \[ \])/g,
             (match) => {
-              debugger;
               return matchCount++ === taskIndex
                 ? match === '- [ ]'
                   ? '- [x]'
@@ -139,7 +137,7 @@ export const NotePreview: FunctionComponent<Props> = ({
     previewNode.current?.addEventListener('click', handleClick, true);
     return () =>
       previewNode.current?.removeEventListener('click', handleClick, true);
-  }, []);
+  }, [note]);
 
   useEffect(() => {
     if (!previewNode.current) {

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -118,12 +118,17 @@ export const NotePreview: FunctionComponent<Props> = ({
           const taskIndex = Array.prototype.indexOf.call(allTasks, node);
 
           let matchCount = 0;
-          const content = note.content.replace(/[\ue000|\ue001]/g, (match) =>
-            matchCount++ === taskIndex
-              ? match === '\ue000'
-                ? '\ue001'
-                : '\ue000'
-              : match
+
+          const content = note.content.replace(
+            /(- \[x\]|- \[ \])/g,
+            (match) => {
+              debugger;
+              return matchCount++ === taskIndex
+                ? match === '- [ ]'
+                  ? '- [x]'
+                  : '- [ ]'
+                : match;
+            }
           );
 
           editNote(noteId, { content });


### PR DESCRIPTION
### Fix

Fixes: https://github.com/Automattic/simplenote-electron/issues/2390

This changes the logic to allow for checkboxes to be checked in preview mode.

- Fixes regex to use `- [ ]` instead of the Unicode characters.
- Adds `note` to the list of the useEffect dependencies so the value will update.

### Test
1. Add some checkboxes to a note
2. Switch to preview mode
3. Check boxes
4. Can you check and uncheck multiple of them?

### Release

Fixed checkboxes so that they can be checked in markdown mode.