### PR TITLE
Note list: prevent scrollbar slider from being very small with many notes

### DIFF
--- a/scss/_scrollbar.scss
+++ b/scss/_scrollbar.scss
@@ -12,6 +12,7 @@
   background: $studio-gray-10;
   border-radius: 100px;
   border: 4px solid $studio-white;
+  min-height: 24px;
 }
 // hover effect for scrollbar 'thumb'
 ::-webkit-scrollbar-thumb:hover {


### PR DESCRIPTION
### Fix

This sets a minimum height on the scrollbar slider so that it is more usable with a lot of notes.

Will fix #2417 

This appears to affect Electron builds and Webkit browsers only, from my testing Firefox already has a minimum slider size that makes sense.

### Screenshots

**Before:**

<img width="327" alt="Screen Shot 2020-10-23 at 12 40 52 PM" src="https://user-images.githubusercontent.com/52152/97047476-e3883c00-152d-11eb-9cdd-11dc7d572c12.png">

**After:**

<img width="331" alt="Screen Shot 2020-10-23 at 12 41 36 PM" src="https://user-images.githubusercontent.com/52152/97047484-e7b45980-152d-11eb-8524-1a8b61485bd9.png">

### Release

Prevent the scrollbar slider from becoming tiny when there are many notes in the note list