### PR TITLE
Fix: Add multiple checkboxes at once

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -361,7 +361,6 @@ class NoteContentEditor extends Component<Props> {
 
     // try to get any selected text first
     const selection = editor.getSelection();
-    let lineNumber = null;
     if (selection) {
       for (
         let i = selection.startLineNumber;
@@ -375,8 +374,7 @@ class NoteContentEditor extends Component<Props> {
       if (!position) {
         return;
       }
-      lineNumber = position.lineNumber;
-      this.toggleChecklistForLine(editor, lineNumber);
+      this.toggleChecklistForLine(editor, position.lineNumber);
     }
   };
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -359,11 +359,35 @@ class NoteContentEditor extends Component<Props> {
       return;
     }
 
-    const position = editor.getPosition();
-    if (!position) {
+    // try to get any selected text first
+    const selection = editor.getSelection();
+    let lineNumber = null;
+    if (selection) {
+      for (
+        let i = selection.startLineNumber;
+        i <= selection.endLineNumber;
+        i++
+      ) {
+        this.toggleChecklistForLine(editor, i);
+      }
+    } else {
+      const position = editor.getPosition();
+      if (!position) {
+        return;
+      }
+      lineNumber = position.lineNumber;
+      this.toggleChecklistForLine(editor, lineNumber);
+    }
+  };
+
+  toggleChecklistForLine = (
+    editor: Editor.IStandaloneCodeEditor,
+    lineNumber: number
+  ) => {
+    const model = editor.getModel();
+    if (!model) {
       return;
     }
-    const lineNumber = position.lineNumber;
     const thisLine = model.getLineContent(lineNumber);
 
     // "(1)A line without leading space"

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -354,11 +354,6 @@ class NoteContentEditor extends Component<Props> {
 
   insertOrRemoveCheckboxes = (editor: Editor.IStandaloneCodeEditor) => {
     // todo: we're not disabling this if !this.props.keyboardShortcuts, do we want to?
-    const model = editor.getModel();
-    if (!model) {
-      return;
-    }
-
     // try to get any selected text first
     const selection = editor.getSelection();
     if (selection) {


### PR DESCRIPTION
### Fix

This restores the ability to select multiple lines and toggle checkboxes on all of them.

n.b. this runs **toggle checkbox** on all lines of selection, meaning if you select some lines that already have a checkbox, the checkbox will be removed. Is this the desired behavior?

Fixes #2409 

### Test
1. Select multiple lines, Insert Checklist should run the "toggle checkbox" on each of them (inserting or removing depending on if it had one already)
2. Without a selection, Insert Checklist should toggle checkbox on the current line (where the cursor is)

### Release

Restored ability to select multiple lines and add multiple checkboxes at once with Insert Checklist