### PR TITLE
Note List: Add contextual excerpts for search results

### DIFF
--- a/lib/note-list/note-cell.tsx
+++ b/lib/note-list/note-cell.tsx
@@ -85,7 +85,7 @@ export class NoteCell extends Component<Props> {
       return <div>{"Couldn't find note"}</div>;
     }
 
-    const { title, preview } = noteTitleAndPreview(note);
+    const { title, preview } = noteTitleAndPreview(note, searchQuery);
     const isPinned = note.systemTags.includes('pinned');
     const isPublished = !!note.publishURL;
     const recentlyUpdated =

--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -12,6 +12,8 @@ export interface TitleAndPreview {
 export const maxTitleChars = 64;
 export const maxPreviewChars = 200;
 
+const isLowSurrogate = (c: number) => 0xdc00 <= c && c <= 0xdfff;
+
 /**
  * Returns a string with markdown stripped
  *
@@ -69,7 +71,6 @@ const getPreview = (content: string, searchQuery?: string) => {
       preview = matches[0];
 
       // don't return half of a surrogate pair
-      const isLowSurrogate = (c: number) => 0xdc00 <= c && c <= 0xdfff;
       return isLowSurrogate(preview.charCodeAt(0)) ? preview.slice(1) : preview;
     }
   }

--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -56,7 +56,7 @@ const getPreview = (content: string, searchQuery: string) => {
       const matches = regExp.exec(content);
       if (matches && matches.length > 0) {
         preview = matches[0];
-        preview = preview.replace(/ +/g, ' ').replaceAll('\n', '').trim();
+        preview = preview.replace(/ +/g, ' ').replace(/\n/g, '').trim();
 
         // @todo: add '...' before/after to indication truncation
         return preview;

--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -56,16 +56,13 @@ const getPreview = (content: string, searchQuery?: string) => {
     const firstTerm = terms[0].toLocaleLowerCase();
     const leadingChars = 30 - firstTerm.length;
 
+    // prettier-ignore
     const regExp = new RegExp(
-      /* eslint-disable */
       '(?<=\\s|^)[^\n]' + // split at a word boundary (pattern must be preceded by whitespace or beginning of string)
-      '{0,' +
-      leadingChars +
-      '}' + // up to leadingChars of text before the match
+        '{0,' + leadingChars + '}' + // up to leadingChars of text before the match
         escapeRegExp(firstTerm) +
         '.{0,200}(?=\\s|$)', // up to 200 characters of text after the match, splitting at a word boundary
       'ims'
-      /* eslint-enable */
     );
     const matches = regExp.exec(content);
     if (matches && matches.length > 0) {

--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -74,7 +74,7 @@ const getPreview = (content: string, searchQuery?: string) => {
     }
   }
 
-  // implicit else: if the query didn't match, fall back to first N lines
+  // implicit else: if the query didn't match, fall back to first four lines
   let index = content.indexOf('\n');
 
   if (index === -1) {

--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -42,7 +42,7 @@ export const getTitle = (content) => {
  *
  * @param content
  */
-const getPreview = (content: string, searchQuery: string) => {
+const getPreview = (content: string, searchQuery?: string) => {
   let preview = '';
   let lines = 0;
 
@@ -58,7 +58,7 @@ const getPreview = (content: string, searchQuery: string) => {
         preview = matches[0];
         preview = preview.replace(/ +/g, ' ').replace(/\n/g, '').trim();
 
-        // @todo: add '...' before/after to indication truncation
+        // @todo: add '...' before/after to indicate truncation
         return preview;
       }
     }
@@ -92,7 +92,7 @@ const getPreview = (content: string, searchQuery: string) => {
 const formatPreview = (stripMarkdown: boolean, s: string): string =>
   stripMarkdown ? removeMarkdownWithFix(s) || s : s;
 
-const previewCache = new Map<string, [boolean, TitleAndPreview]>();
+const previewCache = new Map<string, [TitleAndPreview, boolean, string?]>();
 
 /**
  * Returns the title and excerpt for a given note
@@ -102,16 +102,16 @@ const previewCache = new Map<string, [boolean, TitleAndPreview]>();
  */
 export const noteTitleAndPreview = (
   note: T.Note,
-  searchQuery?: String
+  searchQuery?: string
 ): TitleAndPreview => {
   const stripMarkdown = isMarkdown(note);
-  // const cached = previewCache.get(note.content);
-  // if (cached) {
-  //   const [wasMarkdown, value] = cached;
-  //   if (wasMarkdown === stripMarkdown) {
-  //     return value;
-  //   }
-  // }
+  const cached = previewCache.get(note.content);
+  if (cached) {
+    const [value, wasMarkdown, savedQuery] = cached;
+    if (wasMarkdown === stripMarkdown && savedQuery === searchQuery) {
+      return value;
+    }
+  }
 
   const content = note.content || '';
   const title = formatPreview(stripMarkdown, getTitle(content));
@@ -121,7 +121,7 @@ export const noteTitleAndPreview = (
   );
   const result = { title, preview };
 
-  previewCache.set(note.content, [stripMarkdown, result]);
+  previewCache.set(note.content, [result, stripMarkdown, searchQuery]);
 
   return result;
 };

--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -57,12 +57,15 @@ const getPreview = (content: string, searchQuery?: string) => {
     const leadingChars = 30 - firstTerm.length;
 
     const regExp = new RegExp(
-      '(?<=\\s|^)[^\n]{0,' +
-        leadingChars +
-        '}' +
+      /* eslint-disable */
+      '(?<=\\s|^)[^\n]' + // split at a word boundary (pattern must be preceded by whitespace or beginning of string)
+      '{0,' +
+      leadingChars +
+      '}' + // up to leadingChars of text before the match
         escapeRegExp(firstTerm) +
-        '.{0,200}(?=\\s|$)',
+        '.{0,200}(?=\\s|$)', // up to 200 characters of text after the match, splitting at a word boundary
       'ims'
+      /* eslint-enable */
     );
     const matches = regExp.exec(content);
     if (matches && matches.length > 0) {

--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -1,4 +1,6 @@
 import removeMarkdown from 'remove-markdown';
+import { escapeRegExp } from 'lodash';
+import { getTerms } from './filter-notes';
 
 import * as T from '../types';
 
@@ -47,12 +49,18 @@ const getPreview = (content: string, searchQuery?: string) => {
   let lines = 0;
 
   // contextual note previews
-  if (searchQuery && searchQuery.trim()) {
-    // use only the first word of a multiword query
-    const firstTerm = searchQuery.trim().split(' ')[0];
-    const searchRegex = new RegExp(firstTerm, 'ims');
+  if (searchQuery?.trim()) {
+    const terms = getTerms(searchQuery);
+
+    // use only the first term of a multi-term query
+    const firstTerm = terms[0].toLocaleLowerCase();
+
+    const searchRegex = new RegExp(escapeRegExp(firstTerm), 'ims');
     if (searchRegex.test(content)) {
-      const regExp = new RegExp('.{0,10}' + firstTerm + '.{0,200}', 'ims');
+      const regExp = new RegExp(
+        '.{0,10}' + escapeRegExp(firstTerm) + '.{0,200}',
+        'ims'
+      );
       const matches = regExp.exec(content);
       if (matches && matches.length > 0) {
         preview = matches[0];
@@ -64,7 +72,6 @@ const getPreview = (content: string, searchQuery?: string) => {
     }
   }
   // implicit else: if the query didn't match, fall back to first N lines
-
   let index = content.indexOf('\n');
 
   if (index === -1) {

--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -54,23 +54,23 @@ const getPreview = (content: string, searchQuery?: string) => {
 
     // use only the first term of a multi-term query
     const firstTerm = terms[0].toLocaleLowerCase();
+    const leadingChars = 30 - firstTerm.length;
 
-    const searchRegex = new RegExp(escapeRegExp(firstTerm), 'ims');
-    if (searchRegex.test(content)) {
-      const regExp = new RegExp(
-        '.{0,10}' + escapeRegExp(firstTerm) + '.{0,200}',
-        'ims'
-      );
-      const matches = regExp.exec(content);
-      if (matches && matches.length > 0) {
-        preview = matches[0];
-        preview = preview.replace(/ +/g, ' ').replace(/\n/g, '').trim();
-
-        // @todo: add '...' before/after to indicate truncation
-        return preview;
-      }
+    const regExp = new RegExp(
+      '(?<=\\s|^)[^\n]{0,' +
+        leadingChars +
+        '}' +
+        escapeRegExp(firstTerm) +
+        '.{0,200}(?=\\s|$)',
+      'ims'
+    );
+    const matches = regExp.exec(content);
+    if (matches && matches.length > 0) {
+      preview = matches[0];
+      return preview;
     }
   }
+
   // implicit else: if the query didn't match, fall back to first N lines
   let index = content.indexOf('\n');
 

--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -70,7 +70,10 @@ const getPreview = (content: string, searchQuery?: string) => {
     const matches = regExp.exec(content);
     if (matches && matches.length > 0) {
       preview = matches[0];
-      return preview;
+
+      // don't return half of a surrogate pair
+      const isLowSurrogate = (c: number) => 0xdc00 <= c && c <= 0xdfff;
+      return isLowSurrogate(preview.charCodeAt(0)) ? preview.slice(1) : preview;
     }
   }
 


### PR DESCRIPTION
This PR adds search query context to the note list previews.

### Screenshots

<img width="330" alt="Screen Shot 2020-12-10 at 10 22 31 PM" src="https://user-images.githubusercontent.com/52152/101870349-45c8ea80-3b36-11eb-836d-dfe8a40163a4.png">

<img width="327" alt="Screen Shot 2020-12-10 at 10 22 20 PM" src="https://user-images.githubusercontent.com/52152/101870360-4b263500-3b36-11eb-86d7-a3cb4b8b46d7.png">

### Test
Use various search strings in both Comfy and Expanded display mode.

### Release
Added search context to the note list