### PR TITLE
Disable insert cursor shortcuts

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -519,24 +519,22 @@ class NoteContentEditor extends Component<Props> {
 
     editor.addAction({
       id: 'insertCursorAboveNoMulticursor',
-      label: 'Add Cursor Above',
-      precondition: 'editorHasSelection',
+      label: 'Select Up',
       keybindings: [
         monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.UpArrow,
       ],
       run: () => {
-        editor.trigger('shortcuts', 'editor.action.insertCursorAbove', null);
+        editor.trigger('shortcuts', 'cursorUpSelect', null);
       },
     });
     editor.addAction({
       id: 'insertCursorBelowNoMulticursor',
-      label: 'Add Cursor Below',
-      precondition: 'editorHasSelection',
+      label: 'Select Down',
       keybindings: [
         monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.DownArrow,
       ],
       run: () => {
-        editor.trigger('shortcuts', 'editor.action.insertCursorBelow', null);
+        editor.trigger('shortcuts', 'cursorDownSelect', null);
       },
     });
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -623,7 +623,7 @@ class NoteContentEditor extends Component<Props> {
     });
 
     editor.addAction({
-      id: 'insertCursorAboveNoMulticursor',
+      id: 'selectUpWithoutMulticursor',
       label: 'Select Up',
       keybindings: [
         monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.UpArrow,
@@ -633,7 +633,7 @@ class NoteContentEditor extends Component<Props> {
       },
     });
     editor.addAction({
-      id: 'insertCursorBelowNoMulticursor',
+      id: 'selectDownWithoutMulticursor',
       label: 'Select Down',
       keybindings: [
         monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.DownArrow,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -518,6 +518,31 @@ class NoteContentEditor extends Component<Props> {
     );
 
     editor.addAction({
+      id: 'insertCursorAboveNoMulticursor',
+      label: 'Add Cursor Above',
+      keybindings: [
+        monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.UpArrow,
+      ],
+      run: () => {
+        if (!editor.getSelection()?.isEmpty()) {
+          editor.trigger('shortcuts', 'editor.action.insertCursorAbove', null);
+        }
+      },
+    });
+    editor.addAction({
+      id: 'insertCursorBelowNoMulticursor',
+      label: 'Add Cursor Below',
+      keybindings: [
+        monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.DownArrow,
+      ],
+      run: () => {
+        if (!editor.getSelection()?.isEmpty()) {
+          editor.trigger('shortcuts', 'editor.action.insertCursorBelow', null);
+        }
+      },
+    });
+
+    editor.addAction({
       id: 'context_undo',
       label: 'Undo',
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_Z],

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -493,6 +493,8 @@ class NoteContentEditor extends Component<Props> {
       'editor.action.triggerSuggest', // ctrl+space
       'expandLineSelection', // meta+L
       'editor.action.gotoLine', // ctrl+G
+      'editor.action.insertCursorAbove', // alt+meta+UpArrow
+      'editor.action.insertCursorBelow', // alt+meta+DownArrow
       // search shortcuts
       'actions.find',
       'actions.findWithSelection',

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -493,8 +493,10 @@ class NoteContentEditor extends Component<Props> {
       'editor.action.triggerSuggest', // ctrl+space
       'expandLineSelection', // meta+L
       'editor.action.gotoLine', // ctrl+G
+      // multicursor shortcuts
       'editor.action.insertCursorAbove', // alt+meta+UpArrow
       'editor.action.insertCursorBelow', // alt+meta+DownArrow
+      'editor.action.insertCursorAtEndOfEachLineSelected', // shift+alt+I
       // search shortcuts
       'actions.find',
       'actions.findWithSelection',
@@ -516,27 +518,6 @@ class NoteContentEditor extends Component<Props> {
       'allowBrowserKeybinding',
       window.electron ? false : true
     );
-
-    editor.addAction({
-      id: 'insertCursorAboveNoMulticursor',
-      label: 'Select Up',
-      keybindings: [
-        monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.UpArrow,
-      ],
-      run: () => {
-        editor.trigger('shortcuts', 'cursorUpSelect', null);
-      },
-    });
-    editor.addAction({
-      id: 'insertCursorBelowNoMulticursor',
-      label: 'Select Down',
-      keybindings: [
-        monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.DownArrow,
-      ],
-      run: () => {
-        editor.trigger('shortcuts', 'cursorDownSelect', null);
-      },
-    });
 
     editor.addAction({
       id: 'context_undo',
@@ -639,6 +620,27 @@ class NoteContentEditor extends Component<Props> {
       contextMenuGroupId: '10_checklist',
       contextMenuOrder: 1,
       run: this.insertOrRemoveCheckboxes,
+    });
+
+    editor.addAction({
+      id: 'insertCursorAboveNoMulticursor',
+      label: 'Select Up',
+      keybindings: [
+        monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.UpArrow,
+      ],
+      run: () => {
+        editor.trigger('shortcuts', 'cursorUpSelect', null);
+      },
+    });
+    editor.addAction({
+      id: 'insertCursorBelowNoMulticursor',
+      label: 'Select Down',
+      keybindings: [
+        monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.DownArrow,
+      ],
+      run: () => {
+        editor.trigger('shortcuts', 'cursorDownSelect', null);
+      },
     });
 
     window.electron?.receive('editorCommand', (command) => {

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -520,25 +520,23 @@ class NoteContentEditor extends Component<Props> {
     editor.addAction({
       id: 'insertCursorAboveNoMulticursor',
       label: 'Add Cursor Above',
+      precondition: 'editorHasSelection',
       keybindings: [
         monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.UpArrow,
       ],
       run: () => {
-        if (!editor.getSelection()?.isEmpty()) {
-          editor.trigger('shortcuts', 'editor.action.insertCursorAbove', null);
-        }
+        editor.trigger('shortcuts', 'editor.action.insertCursorAbove', null);
       },
     });
     editor.addAction({
       id: 'insertCursorBelowNoMulticursor',
       label: 'Add Cursor Below',
+      precondition: 'editorHasSelection',
       keybindings: [
         monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.DownArrow,
       ],
       run: () => {
-        if (!editor.getSelection()?.isEmpty()) {
-          editor.trigger('shortcuts', 'editor.action.insertCursorBelow', null);
-        }
+        editor.trigger('shortcuts', 'editor.action.insertCursorBelow', null);
       },
     });
 


### PR DESCRIPTION
### Fix

On Ubuntu it's possible to add multiple cursors with `ctrl+alt+UpArrow` and `ctrl+alt+DownArrow`. This PR disables those.

However simply disabling these key combos did not restore the default selection behavior on Ubuntu. As a hack, I added handlers mapped to CmdCtrl + Shift + up/down ... this does have the side effect of subtly changing the behavior on ~other platforms~ OSX but I think unifying the selection behavior is arguably a good thing.

Fixes #2427 

On Windows this **retains the existing behavior of this key combo**.
On Linux this **restores the missing behavior that should be associated with this key combo**.
On OSX this **changes the existing behavior from select-to-beginning/end-of-document to select-up/select-down**.

### Test

See #2427
