### PR TITLE
Focus editor when note editor pane is clicked

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -917,6 +917,7 @@ class NoteContentEditor extends Component<Props> {
         className={`note-content-editor-shell${
           overTodo ? ' cursor-pointer' : ''
         }`}
+        onClick={this.focusEditor}
       >
         <div
           className={`note-content-plaintext${


### PR DESCRIPTION
### Fix

When in narrow mode if you click on the margins of the editor pane it does not focus the editor. This change focuses the editor when you click into that area.

In this screenshot notice the large area to the left of the text. This PR makes that area clickable.

<img width="967" alt="Screen Shot 2020-10-29 at 11 18 19 AM" src="https://user-images.githubusercontent.com/6817400/97594002-9ba76000-19d8-11eb-8ab0-5db753ff6469.png">


### Test
1. In the settings set the line length to narrow.
2. Click into the margin
3. Is the editor focused?
4. Make a selection
5. Click into the margin
6. Selection should not change

### Release

Fix: Made margin in editor clickable to focus editor
