### PR TITLE
Display cannonical lexical tag name

### DIFF
--- a/lib/components/tag-chip/index.tsx
+++ b/lib/components/tag-chip/index.tsx
@@ -1,10 +1,12 @@
 import React, { FunctionComponent } from 'react';
 import classNames from 'classnames';
 
+import type * as T from '../../types';
+
 type OwnProps = {
   onSelect?: (event: React.MouseEvent<HTMLDivElement>) => any;
   selected: boolean;
-  tagName: string;
+  tagName: T.TagName | undefined;
 };
 
 const TagChip: FunctionComponent<OwnProps> = ({

--- a/lib/state/data/reducer.ts
+++ b/lib/state/data/reducer.ts
@@ -198,8 +198,10 @@ export const notes: A.Reducer<Map<T.EntityId, T.Note>> = (
     case 'RENAME_TAG': {
       const oldHash = t(action.oldTagName);
       const newHash = t(action.newTagName);
-
       const next = new Map(state);
+      if (oldHash === newHash) {
+        return next;
+      }
       next.forEach((note, noteId) => {
         const newTags: T.TagName[] = [];
         const hashes = new Set<T.TagHash>();

--- a/lib/tag-field/index.tsx
+++ b/lib/tag-field/index.tsx
@@ -223,6 +223,10 @@ export class TagField extends Component<Props, OwnState> {
     }
   };
 
+  getTagName = (tag: T.TagName) => {
+    return this.props.allTags.get(tagHashOf(tag))?.name;
+  };
+
   render() {
     const { note } = this.props;
     const { selectedTag, showEmailTooltip, tagInput } = this.state;
@@ -244,7 +248,7 @@ export class TagField extends Component<Props, OwnState> {
           {note?.tags.filter(negate(isEmailTag)).map((tag) => (
             <TagChip
               key={tag}
-              tagName={tag}
+              tagName={this.getTagName(tag)}
               selected={tag === selectedTag}
               onSelect={this.selectTag}
             />


### PR DESCRIPTION
### Fix

When displaying tags on a note this PR uses the canonical lexical version on the Tag entity and not the lexical tag name on the note. Additionally, this PR makes it so during a rename we no longer change the tags on a note if it is just a lexical change.

### Test
1. Have a tag `A`
2. Add tag `a` to a note
3. After adding the tag it should be displayed as `A`
4. Rename tag to `a` in the tag list.
5. Tag should now display as `a` on the note
6. Rename tag `a` to `b`
7. Tag should now display everywhere as `b`

### Release

Display the canonical lexical version ensuring one capitalization or lexical version of a tag is displayed.
