### PR TITLE
Allow window close when logged out

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -159,7 +159,6 @@ module.exports = function main() {
     // When we receive a close event prevent the window from closing and
     // tell the app to check for unsynchronized notes.
     mainWindow.on('close', (event) => {
-      console.log(isAuthenticated);
       if (isAuthenticated) {
         event.preventDefault();
         mainWindow.webContents.send('appCommand', { action: 'closeWindow' });

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -26,6 +26,7 @@ module.exports = function main() {
   // Keep a global reference of the window object, if you don't, the window will
   // be closed automatically when the JavaScript object is GCed.
   let mainWindow = null;
+  let isAuthenticated;
 
   app.on('will-finish-launching', function () {
     setTimeout(updater.ping.bind(updater), config.updater.delay);
@@ -92,6 +93,8 @@ module.exports = function main() {
     Menu.setApplicationMenu(appMenu);
 
     ipcMain.on('appStateUpdate', function (event, args) {
+      const settings = args['settings'] || {};
+      isAuthenticated = settings && 'accountName' in settings;
       Menu.setApplicationMenu(
         Menu.buildFromTemplate(createMenuTemplate(args), mainWindow)
       );
@@ -156,8 +159,11 @@ module.exports = function main() {
     // When we receive a close event prevent the window from closing and
     // tell the app to check for unsynchronized notes.
     mainWindow.on('close', (event) => {
-      event.preventDefault();
-      mainWindow.webContents.send('appCommand', { action: 'closeWindow' });
+      console.log(isAuthenticated);
+      if (isAuthenticated) {
+        event.preventDefault();
+        mainWindow.webContents.send('appCommand', { action: 'closeWindow' });
+      }
     });
 
     // Once the app has dealt with unsynchronized notes close the window.


### PR DESCRIPTION
### Fix

We display a dialog when a user has unsynchronized changes and they try to close the window. This logic kept the window from closing. When a user is logged out this kept them from closing the window. This change only prevents window closes when the user is logged in.

### Test
1. Be logged out
2. Close electron window, does it close?
3. Be logged in
4. Close electron window, does it close?
5. Be logged in and have an unsynchronized change
6. Close electron window, does it display dialog?

### Release

Allow for window to be closed when the user is logged out.
