### PR TITLE
Fix updater dialog to properly resolve

### DIFF
--- a/desktop/app-quit/index.js
+++ b/desktop/app-quit/index.js
@@ -10,12 +10,12 @@ function AppQuit() {
 }
 
 AppQuit.prototype.shouldQuitToBackground = function () {
-  if (this.canQuit === false) {
-    return true;
+  if (this.canQuit) {
+    this.canQuit = false;
+    return false;
   }
 
-  this.canQuit = false;
-  return false;
+  return true;
 };
 
 AppQuit.prototype.allowQuit = function () {

--- a/desktop/updater/lib/Updater.js
+++ b/desktop/updater/lib/Updater.js
@@ -74,6 +74,9 @@ class Updater extends EventEmitter {
       if (button === 0) {
         // Confirm
         this.onConfirm();
+      } else if (button === 2) {
+        // Open changelog
+        this.onChangelog();
       } else {
         this.onCancel();
       }


### PR DESCRIPTION
### Fix

Fixes the updater. The dialog actions were broken because of a deprecated API that was failing silently.

This uses the new async flow to ensure that updates work as expected.

### Test
1. Download the exe from this PR: https://github.com/Automattic/simplenote-electron/pull/2438
2. Install, run app
3. Observe that the update dialog opens
4. Tell it to install

### Release

Fixed the Windows updater
