### PR TITLE
Catch errors when parsing invalid JSON

### DIFF
--- a/lib/dialogs/import/source-importer/progress/index.tsx
+++ b/lib/dialogs/import/source-importer/progress/index.tsx
@@ -1,10 +1,19 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { FunctionComponent } from 'react';
 
 import ImportProgressBar from './bar';
 import ImportProgressText from './text';
 
-const ImportProgress = ({ currentValue, endValue, isDone }) => {
+type OwnProps = {
+  currentValue?: number;
+  endValue?: number;
+  isDone: boolean;
+};
+
+const ImportProgress: FunctionComponent<OwnProps> = ({
+  currentValue = 0,
+  endValue = 0,
+  isDone,
+}) => {
   return (
     <section>
       <ImportProgressBar
@@ -15,12 +24,6 @@ const ImportProgress = ({ currentValue, endValue, isDone }) => {
       <ImportProgressText currentValue={currentValue} isDone={isDone} />
     </section>
   );
-};
-
-ImportProgress.propTypes = {
-  currentValue: PropTypes.number.isRequired,
-  endValue: PropTypes.number,
-  isDone: PropTypes.bool.isRequired,
 };
 
 export default ImportProgress;

--- a/lib/utils/import/simplenote/index.ts
+++ b/lib/utils/import/simplenote/index.ts
@@ -42,7 +42,14 @@ class SimplenoteImporter extends EventEmitter {
         return;
       }
 
-      const dataObj = JSON.parse(fileContent);
+      let dataObj;
+      try {
+        dataObj = JSON.parse(fileContent);
+      } catch (error) {
+        this.emit('status', 'error', 'Invalid json file.');
+        return;
+      }
+
       const noteCount =
         dataObj.activeNotes.length + dataObj.trashedNotes.length;
       const processedNotes = {


### PR DESCRIPTION
### Fix

Fixes: https://github.com/Automattic/simplenote-electron/issues/1105

If you import an invalid JSON file it would fail silently. This ensures that we catch errors when JSON is invalid. I added the typing and default values because when there is an error we are passing undefined to `<ImportProgress>`.

### Test
1. Have a text file, add a json extension
2. Try and import it
3. See it fail and give you an error message

### Release

Fix: Show error message when trying to import invalid JSON.
