### PR TITLE
Queue note updates after tag deletion

### DIFF
--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -352,6 +352,11 @@ export const initSimperium = (
 
       case 'TRASH_TAG': {
         tagBucket.remove(t(action.tagName));
+        nextState.data.notes.forEach((note, noteId) => {
+          if (prevState.data.notes.get(noteId) !== note) {
+            queueNoteUpdate(noteId);
+          }
+        });
         return result;
       }
 


### PR DESCRIPTION
### Fix

When a tag is deleted we loop through all the notes and delete the tag. We were not however telling node-simperium to queue a change for that note.

This change queues a note update for all the notes that need to have the tag removed.

### Test
1. Have a tag that is added to several notes
2. Deleted tag
3. Have another device open, does the tag get removed from notes?

### Release

Fixed issue where deleting a tag did not immediately update the note. 
