### PR TITLE
Added ARM architectures to the Linux build

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -71,7 +71,7 @@
       },
       {
         "target": "tar.gz",
-        "arch": ["x64", "ia32"]
+        "arch": ["x64", "ia32", "arm64", "armv7l"]
       }
     ],
     "synopsis": "The simplest way to keep notes",

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -59,15 +59,15 @@
     "target": [
       {
         "target": "AppImage",
-        "arch": ["x64", "ia32"]
+        "arch": ["x64", "ia32", "arm64", "armv7l"]
       },
       {
         "target": "deb",
-        "arch": ["x64", "ia32"]
+        "arch": ["x64", "ia32", "armv7l"]
       },
       {
         "target": "rpm",
-        "arch": ["x64", "ia32"]
+        "arch": ["x64", "ia32", "armv7l"]
       },
       {
         "target": "tar.gz",


### PR DESCRIPTION
It is possible to package the app using the `electron-builder` app on the ARM architectures (tested on ARM64: Raspberry Pi 4B, Manjaro ARM 20.10).

### Fix

<!-- **_(Required)_** Add a concise description of what you fixed. If this is related to an issue, add a link to it. If applicable, add screenshots, animations, or videos to help illustrate the fix. -->
Allows to build the app as an `tar.gz` archive with the `electron-builder` tool.

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1. Clone this repository and `cd` to it.
2. Use the `npm install` to get it's all dependencies.
3. Install `electron-builder` globally on your machine and package this repo with it for ARM64 and ARMv7 architectures:
```sh
electron-builder -l tar.gz --arm64 --armv7l
```
### Release

<!-- **_(Required)_** Add a concise statement to `RELEASE-NOTES.md` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.md` was updated with: -->
In my opinion this change could be included in [`RELEASE-NOTES.md`](../blob/develop/RELEASE-NOTES.md) – however I haven't done this yet, as I would wait with that for the next release.