### PR TITLE
Fix unsynchronized notes log out action

### DIFF
--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -56,7 +56,7 @@ export const openTag: A.ActionCreator<A.OpenTag> = (tagName: T.TagName) => ({
 });
 
 export const reallyLogOut: A.ActionCreator<A.ReallyLogOut> = () => ({
-  type: 'REALLY_LOG_OUT',
+  type: 'REALLY_LOGOUT',
 });
 
 export const restoreOpenNote: A.ActionCreator<A.RestoreOpenNote> = () => ({


### PR DESCRIPTION
### Fix

There is a typo in the logout action. This bug occurs when you have unsynchronized notes and you click the logout button in the dialog.

### Test
1. Turn off wifi
2. Make a change to a note
3. Log out
4. Can you log out?

### Release

- Fixed log out button when there are unsynchronized changes
