### PR TITLE
Fix: Inability to visit external links on Electron

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -137,6 +137,11 @@ module.exports = function main() {
 
     mainWindowState.manage(mainWindow);
 
+    // this TERRIBLE HACK forces vscode to call window.open(url) rather than window.open()
+    // see https://github.com/microsoft/monaco-editor/issues/628
+    mainWindow.webContents.userAgent =
+      mainWindow.webContents.userAgent + '/Edge/WebView/FakeUA';
+
     mainWindow.webContents.on('new-window', function (event, linkUrl) {
       event.preventDefault();
       shell.openExternal(linkUrl);

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -587,38 +587,20 @@ class NoteContentEditor extends Component<Props> {
 
     /* Hack to get external URLs working in Electron */
     if (window.electron) {
-      monaco.languages.registerLinkProvider(
-        { language: 'plaintext', exclusive: true },
-        {
-          provideLinks: (model) => {
-            const matches = model.findMatches(
-              'https?://(www.[-a-zA-Z0-9@:%._+~#=]{1,256}.[a-zA-Z0-9()]{1,6}\b)?([-a-zA-Z0-9()@:%_+.~#?&//=]*)',
-              true, // searchOnlyEditableRange
-              true, // isRegex
-              false, // matchCase
-              null, // wordSeparators
-              false // captureMatches
-            );
-            return {
-              // don't set a URL on these links, because then Monaco skips resolveLink
-              // @cite: https://github.com/Microsoft/vscode/blob/8f89095aa6097f6e0014f2d459ef37820983ae55/src/vs/editor/contrib/links/getLinks.ts#L43:L65
-              links: matches.map(({ range }) => ({
-                range: range,
-                hover: 'test',
-              })),
-            };
-          },
-          resolveLink: (link) => {
-            const href = editor.getModel()?.getValueInRange(link.range) ?? '';
-            // const match = /^simplenote:\/\/note\/(.+)$/.exec(href);
-            // if (!match) {
-            //   return;
-            // }
-            viewExternalUrl(href);
-            return { ...link, url: href }; // tell Monaco to do nothing and not complain about it
-          },
+      editor.onMouseDown((e) => {
+        // Clicked "Follow Link" popup
+        if (
+          e.target.detail === 'editor.contrib.modesContentHoverWidget' &&
+          e.target.element.tagName.toLowerCase() === 'a'
+        ) {
+          viewExternalUrl(e.target.element.getAttribute('data-href'));
         }
-      );
+        // Ctrl or Cmd click on the link
+        else if (e.target.element.classList.contains('detected-link-active')) {
+          // todo: Search back for the previous http://, it could be on the previous line
+          viewExternalUrl(e.target.element.innerText);
+        }
+      });
     }
 
     // remove keybindings; see https://github.com/microsoft/monaco-editor/issues/287

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -589,6 +589,8 @@ class NoteContentEditor extends Component<Props> {
     if (window.electron) {
       editor.onMouseUp((e) => {
         e.event.browserEvent.preventDefault();
+        e.event.browserEvent.stopPropagation();
+        e.event.browserEvent.stopImmediatePropagation();
         // Clicked "Follow Link" popup
         if (
           e.target.detail === 'editor.contrib.modesContentHoverWidget' &&
@@ -596,6 +598,7 @@ class NoteContentEditor extends Component<Props> {
           e.target.element.hasAttribute('data-href')
         ) {
           viewExternalUrl(e.target.element.getAttribute('data-href'));
+          return;
         }
         // Ctrl or Cmd click on the link
         else if (e.target.element?.classList.contains('detected-link-active')) {
@@ -608,6 +611,7 @@ class NoteContentEditor extends Component<Props> {
             links?.forEach((link) => {
               if (link.options.inlineClassName === 'detected-link-active') {
                 viewExternalUrl(editor.getModel()?.getValueInRange(link.range));
+                return;
               }
             });
           }

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -803,9 +803,10 @@ class NoteContentEditor extends Component<Props> {
     );
     editor.onDidDispose(() => completionProviderHandle?.dispose());
     monaco.languages.setLanguageConfiguration('plaintext', {
-      // Allow any non-whitespace character to be part of a "word"
+      // Allow any non-whitespace, non parenthetical character to be part of a "word"
       // This prevents the dictionary suggestions from taking over our autosuggest
-      wordPattern: /[^\s]+/g,
+      // We're allowing parentheses so URLs are detected as "words" in Markdown links
+      wordPattern: /[^\s()]+/g,
     });
 
     document.oncopy = (event) => {

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -22,7 +22,6 @@ import {
   withCheckboxCharacters,
   withCheckboxSyntax,
 } from './utils/task-transform';
-import { viewExternalUrl } from './utils/url-utils';
 import IconButton from './icon-button';
 import ChevronRightIcon from './icons/chevron-right';
 
@@ -584,40 +583,6 @@ class NoteContentEditor extends Component<Props> {
         return { ...link, url: '#' }; // tell Monaco to do nothing and not complain about it
       },
     });
-
-    // Hack to get external URLs working in Electron
-    if (window.electron) {
-      editor.onMouseUp((e) => {
-        e.event.browserEvent.preventDefault();
-        e.event.browserEvent.stopPropagation();
-        e.event.browserEvent.stopImmediatePropagation();
-        // Clicked "Follow Link" popup
-        if (
-          e.target.detail === 'editor.contrib.modesContentHoverWidget' &&
-          e.target.element?.tagName.toLowerCase() === 'a' &&
-          e.target.element.hasAttribute('data-href')
-        ) {
-          viewExternalUrl(e.target.element.getAttribute('data-href'));
-          return;
-        }
-        // Ctrl or Cmd click on the link
-        else if (e.target.element?.classList.contains('detected-link-active')) {
-          // Get the full link, in case the line was wrapped
-          const range = e.target.range;
-          if (range) {
-            const links = editor
-              .getModel()
-              ?.getDecorationsInRange(range, undefined, true);
-            links?.forEach((link) => {
-              if (link.options.inlineClassName === 'detected-link-active') {
-                viewExternalUrl(editor.getModel()?.getValueInRange(link.range));
-                return;
-              }
-            });
-          }
-        }
-      });
-    }
 
     // remove keybindings; see https://github.com/microsoft/monaco-editor/issues/287
     const shortcutsToDisable = [


### PR DESCRIPTION
### Fix

Fix for #2425
This is probably the issue reported upstream here: https://github.com/microsoft/vscode/issues/84265

~First hack: I tried using a custom link provider, but it only works the first time, because Resolve Link is only called once. Also it removed the ability to show a hyperlink in the Follow Link popup (because Monaco didn't know the URL).~

~Plus this would have required defining our own regex for URL detection, boo.~

~Second hack: Add a mouseDown event, check to see if a link was clicked on (or the Follow Link popup), run `viewExternalUrl`. Profit?~

Third hack: JUST SPOOF THE USER-AGENT to fool vscode's platform detection into calling `window.open` with the URL. 😭

### Test
1. Cmd/Ctrl click on links to external sites, verify they open in a browser
2. Use Follow Link popup, ditto
3. Make sure `simplenote://` links still work
4. Verify this still works in the browser as well as Electron build

### Release

Fixed a bug that prevented Follow Link from working within the note editor.