### PR TITLE
Add appID to fix Windows notification management

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -28,7 +28,7 @@ module.exports = function main() {
   let mainWindow = null;
   let isAuthenticated;
 
-  app.setAppUserModelId(process.execPath);
+  app.on('ready', () => app.setAppUserModelId('com.automattic.simplenote'));
 
   app.on('will-finish-launching', function () {
     setTimeout(updater.ping.bind(updater), config.updater.delay);

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -28,8 +28,6 @@ module.exports = function main() {
   let mainWindow = null;
   let isAuthenticated;
 
-  app.on('ready', () => app.setAppUserModelId('com.automattic.simplenote'));
-
   app.on('will-finish-launching', function () {
     setTimeout(updater.ping.bind(updater), config.updater.delay);
     app.on('open-url', function (event, url) {
@@ -249,5 +247,6 @@ module.exports = function main() {
   // This method will be called when Electron has finished
   // initialization and is ready to create browser windows.
   app.on('ready', activateWindow);
+  app.on('ready', () => app.setAppUserModelId('com.automattic.simplenote'));
   app.on('activate', activateWindow);
 };

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -28,6 +28,8 @@ module.exports = function main() {
   let mainWindow = null;
   let isAuthenticated;
 
+  app.setAppUserModelId(process.execPath);
+
   app.on('will-finish-launching', function () {
     setTimeout(updater.ping.bind(updater), config.updater.delay);
     app.on('open-url', function (event, url) {


### PR DESCRIPTION
### Fix

Looks like we missed a step in setting up notifications for Windows. Right now Simplenote doesn't show up in the notifications manager on Windows, and if you opt-out you can't re-enable them.

Fixes #2482 

> On Windows 10, a shortcut to your app with an Application User Model ID must be installed to the Start Menu. This can be overkill during development, so adding node_modules\electron\dist\electron.exe to your Start Menu also does the trick. Navigate to the file in Explorer, right-click and 'Pin to Start Menu'. You will then need to add the line app.setAppUserModelId(process.execPath) to your main process to see notifications.

https://www.electronjs.org/docs/tutorial/notifications#windows

Related: https://github.com/electron/electron/issues/10864 and https://github.com/electron/electron/issues/24330

### Test

1. After receiving at least one notification from Simplenote
2. On Windows, go to Settings>System>Notifications & actions
3. Verify that Simplenote appears under "Get notifications from these senders"
4. Toggle off sounds and verify that only the banner appears, with no sound

### Release

Fixed a bug causing the app to be missing from Windows 10 notification settings.