### PR TITLE
Fix keyboard shortcuts on Windows/Linux

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,6 +12,7 @@
 - Fixed Ctrl+Alt+Up/Down arrow selection shortcuts on Win/Linux [#2428](https://github.com/Automattic/simplenote-electron/pull/2428)
 - Fixed a bug that prevented Follow Link / cmd+click from working on external links within the note editor [#2470](https://github.com/Automattic/simplenote-electron/pull/2470)
 - Fixed inconsistent datetime formatting in the note info panel [#2473](https://github.com/Automattic/simplenote-electron/pull/2473)
+- Fixed keyboard shortcuts sometimes not working on Win/Linux [#2490](https://github.com/Automattic/simplenote-electron/pull/2490)
 
 ### Other Changes
 

--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -5,7 +5,6 @@ const buildEditMenu = (settings, isAuthenticated, editMode) => {
   isAuthenticated = isAuthenticated || false;
   editMode = editMode || false;
 
-  // menu items with roles don't respect visibility, so we have to do this the hard way
   let undo = {
     label: '&Undo',
     click: editorCommandSender({ action: 'undo' }),
@@ -23,9 +22,9 @@ const buildEditMenu = (settings, isAuthenticated, editMode) => {
     click: editorCommandSender({ action: 'selectAll' }),
     accelerator: 'CommandOrControl+A',
   };
+
+  // menu items with roles don't respect visibility, so we have to do this the hard way
   if (!editMode) {
-    undo['role'] = 'undo';
-    redo['role'] = 'redo';
     selectAll['role'] = 'selectAll';
   }
 

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -96,7 +96,7 @@ class AppComponent extends Component<Props> {
       this.props.clearSearch();
     }
 
-    if (!window.electron) {
+    if (!window.electron || !isMac) {
       this.handleBrowserShortcut(event);
     }
 
@@ -106,6 +106,7 @@ class AppComponent extends Component<Props> {
   // handle all keyboard shortcuts that are duplicated in the Electron menus
   // this listener is only called in browsers, as otherwise the
   // menu will trigger them via the provided Accelerator, so we don't need a listener
+  // n.b. we're also running this on Win/Linux builds as they seem to be broken otherwise
   handleBrowserShortcut = (event: KeyboardEvent) => {
     const { ctrlKey, metaKey, shiftKey } = event;
     const key = event.key.toLowerCase();

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -17,7 +17,7 @@ import actions from './state/actions';
 import * as selectors from './state/selectors';
 import { getTerms } from './utils/filter-notes';
 import { noteTitleAndPreview } from './utils/note-utils';
-import { isSafari } from './utils/platform';
+import { isMac, isSafari } from './utils/platform';
 import {
   withCheckboxCharacters,
   withCheckboxSyntax,
@@ -604,8 +604,9 @@ class NoteContentEditor extends Component<Props> {
       'editor.action.nextMatchFindAction',
       'editor.action.selectHighlights',
     ];
-    // let Electron menus trigger these
-    if (window.electron) {
+    // let Electron menus trigger these on the Mac
+    // this breaks the shortcuts on Win/Linux -- not sure why
+    if (window.electron && isMac) {
       shortcutsToDisable.push('undo', 'redo', 'editor.action.selectAll');
     }
     shortcutsToDisable.forEach(function (action) {


### PR DESCRIPTION
## Fix

This fixes sporadically broken shortcut keys on Windows and Linux, including Select All, Undo/Redo, and New Note. Annoyingly I spent awhile debugging this but wasn't able to figure out why some shortcuts are working and others seem to be failing to trigger the Electron accelerators (only on Win/Linux, they all work as expected on the Mac). It doesn't seem related to `editMode`, `roles`, whether the handler is `appCommand` vs `editorCommand`, or anything else I could think of. It might be an obscure Electron bug or an obscure Monaco bug, or a combination of the two.

Anyhow I want to get this fix in, and having redundant handlers for certain functions isn't the worst thing that ever happened, so this is ready for review and I can debug it further later on.

Fixes #2426, #2432, #2436

## Test

On the Windows and Linux app builds, verify that keyboard shortcuts consistently work, especially New Note, Select All, and Undo/Redo. Verify that the context (right-click) menu and clicking on the menu options (e.g. File -> New Note, Edit -> Select All) continue to behave themselves as well.

## Release Notes

Added: Fixed keyboard shortcuts sometimes not working on Win/Linux