### PR TITLE
Remove keyboard shortcut from debugging console

### DIFF
--- a/desktop/menus/help-menu.js
+++ b/desktop/menus/help-menu.js
@@ -30,7 +30,7 @@ const buildHelpMenu = (mainWindow, isAuthenticated) => {
       submenu: [
         {
           label: 'Debugging Console',
-          role: 'toggleDevTools',
+          click: (item, focusedWindow) => focusedWindow?.toggleDevTools(),
         },
       ],
     },


### PR DESCRIPTION
### Fix

This conflicts with the New Note shortcut. Fixed in #2490 but I realized it still has the label even though it's now handled by New Note. See also #2436 

### Test

1. Verify that Help -> Advanced shows the option for Debugging Console without the keyboard shortcut
2. Verify it works from clicking on the menu*
3. Verify you can still create a new note with Cmd+Shift+I (or Ctrl+Shift+I)

* In my testing it seems like it doesn't work the first time right after building/starting the app, but that is happening on develop as well, so I don't think it's introduced by this PR