### PR TITLE
Sidebar icons: studio-blue should be studio-simplenote-blue

### DIFF
--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -26,12 +26,12 @@
   }
 
   &.is-selected {
-    background-color: $studio-blue-5;
+    background-color: $studio-simplenote-blue-5;
   }
 }
 
 .navigation-bar-item__icon {
-  color: $studio-blue-50;
+  color: $studio-simplenote-blue-50;
   display: inline-block;
   margin-right: 18px;
   vertical-align: middle;


### PR DESCRIPTION
### Fix

In #2302 we erroneously used a couple of `studio-blue-50` that should have been `studio-simplenote-blue-50`.

Thanks @SylvesterWilmott for catching this!

Before:

<img width="149" alt="Screen Shot 2020-12-09 at 11 20 41 AM" src="https://user-images.githubusercontent.com/52152/101676854-980feb80-3a10-11eb-95bd-c11fb87bb7e4.png">

After:

<img width="158" alt="Screen Shot 2020-12-09 at 11 20 34 AM" src="https://user-images.githubusercontent.com/52152/101676858-9c3c0900-3a10-11eb-827c-3579bca68b7f.png">
