### PR TITLE
Fix: Use tab to indent list items from anywhere within the line

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -745,6 +745,23 @@ class NoteContentEditor extends Component<Props> {
       },
     });
 
+    // Tab to indent lists and tasks
+    editor.addCommand(monaco.KeyCode.Tab, () => {
+      const lineNumber = editor.getPosition()?.lineNumber;
+      if (!lineNumber) {
+        return;
+      }
+      const thisLine = editor.getModel()?.getLineContent(lineNumber);
+      if (!thisLine) {
+        return;
+      }
+
+      const isList = /^(\s*)([-+*\u2022\ue000\ue001])(\s+)/.test(thisLine);
+      if (isList) {
+        editor.trigger('commands', 'editor.action.indentLines', null);
+      }
+    });
+
     window.electron?.receive('editorCommand', (command) => {
       switch (command.action) {
         case 'findAgain':


### PR DESCRIPTION
### Fix

This fixes #2468 by adding an action that triggers `editor.action.indentLines` on Tab if the current line is a list or task.

Interestingly, `editor.action.outdentLines` is already being triggered by Shift+Tab. I guess this is because sometimes Tab is expected to insert spacing wherever the cursor is currently located.

### Test

1. Make some lists or checklists
2. Use Tab to indent and shift+tab to outdent
3. Verify that you can still insert normal tab spacing with the Tab key outside of a list item

### Release

Use the Tab key to indent nested list items from anywhere within the line.