### PR TITLE
Fix: guard against passing an empty array to replaceToArray

### DIFF
--- a/lib/note-list/decorators.tsx
+++ b/lib/note-list/decorators.tsx
@@ -14,6 +14,9 @@ export const decorateWith = (decorators, text) =>
               ? new RegExp(escapeRegExp(searchText), 'gi')
               : filter;
 
+          if (output?.length === 0) {
+            return [];
+          }
           return replaceToArray(output, pattern, replacer);
         }, text)
         .map((chunk, key) =>

--- a/lib/note-list/decorators.tsx
+++ b/lib/note-list/decorators.tsx
@@ -5,7 +5,7 @@ import replaceToArray from 'string-replace-to-array';
 import { withoutTags } from '../utils/filter-notes';
 
 export const decorateWith = (decorators, text) =>
-  decorators.length > 0
+  decorators.length > 0 && text.length > 0
     ? decorators
         .reduce((output, { filter, replacer }) => {
           const searchText = 'string' === typeof filter && withoutTags(filter);
@@ -14,9 +14,6 @@ export const decorateWith = (decorators, text) =>
               ? new RegExp(escapeRegExp(searchText), 'gi')
               : filter;
 
-          if (output?.length === 0) {
-            return [];
-          }
           return replaceToArray(output, pattern, replacer);
         }, text)
         .map((chunk, key) =>


### PR DESCRIPTION
### Fix

Fixes the crash in #2514 

### Test
1. Set display to expanded mode
2. Enter a search term with a space and start to type a second word
3. It should not crash

### Release

Fix a crash when entering a multi-word search term in Expanded display mode.