### PR TITLE
Fix: Should be able to insert tabs using tab key when not in a list

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -752,13 +752,12 @@ class NoteContentEditor extends Component<Props> {
         return;
       }
       const thisLine = editor.getModel()?.getLineContent(lineNumber);
-      if (!thisLine) {
-        return;
-      }
-
-      const isList = /^(\s*)([-+*\u2022\ue000\ue001])(\s+)/.test(thisLine);
-      if (isList) {
+      const isList = /^(\s*)([-+*\u2022\ue000\ue001])(\s+)/;
+      if (thisLine && isList.test(thisLine)) {
         editor.trigger('commands', 'editor.action.indentLines', null);
+      } else {
+        // default tab key behavior
+        editor.trigger('commands', 'tab', null);
       }
     });
 


### PR DESCRIPTION
### Fix

In adding tabbing for lists in #2515 I accidentally disabled Tab key to insert tabs when not in a list. This PR restores the default behavior.

### Test
1. Use Tab key within normal text; does it insert spaces at the cursor?
2. Use Tab key on empty line; does it insert spaces at the cursor?
3. Use Tab key inside a list item; does it change the nesting level of the entire line?

### Release

N/A (update to #2515)