### PR TITLE
Fix: Weird cursor behavior with lists

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -993,10 +993,15 @@ class NoteContentEditor extends Component<Props> {
           lineNumber: lineNumber + 1,
         });
 
-        // const range = new this.monaco.Range(lineNumber, 0, lineNumber + 1, 0);
-        // const identifier = { major: 1, minor: 1 };
-        // const op = { identifier, range, text: null, forceMoveMarkers: true };
-        // this.editor.executeEdits('autolist', [op]);
+        const range = new this.monaco.Range(
+          lineNumber,
+          0,
+          lineNumber + 1,
+          thisLine.length + 1
+        );
+        const identifier = { major: 1, minor: 1 };
+        const op = { identifier, range, text: null, forceMoveMarkers: true };
+        this.editor.executeEdits('autolist', [op]);
 
         Promise.resolve().then(() =>
           this.editor.setPosition({

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -993,14 +993,21 @@ class NoteContentEditor extends Component<Props> {
           lineNumber: lineNumber + 1,
         });
 
-        const range = new this.monaco.Range(lineNumber, 0, lineNumber + 1, 0);
-        const identifier = { major: 1, minor: 1 };
-        const op = { identifier, range, text: '', forceMoveMarkers: true };
-        this.editor.executeEdits('autolist', [op]);
+        // const range = new this.monaco.Range(lineNumber, 0, lineNumber + 1, 0);
+        // const identifier = { major: 1, minor: 1 };
+        // const op = { identifier, range, text: null, forceMoveMarkers: true };
+        // this.editor.executeEdits('autolist', [op]);
+
+        Promise.resolve().then(() =>
+          this.editor.setPosition({
+            column: 0,
+            lineNumber: lineNumber,
+          })
+        );
 
         return (
-          value.slice(0, Math.max(0, prevLineStart - 1)) +
-          value.slice(thisLineStart)
+          value.slice(0, Math.max(0, prevLineStart)) +
+          value.slice(thisLineStart + thisLine.length) // thisLine.length will also remove any indentation
         );
       }
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1001,19 +1001,16 @@ class NoteContentEditor extends Component<Props> {
         );
         const identifier = { major: 1, minor: 1 };
         const op = { identifier, range, text: null, forceMoveMarkers: true };
-        this.editor.executeEdits('autolist', [op]);
 
-        Promise.resolve().then(() =>
+        Promise.resolve().then(() => {
+          this.editor.executeEdits('autolist', [op]);
           this.editor.setPosition({
             column: 0,
             lineNumber: lineNumber,
-          })
-        );
+          });
+        });
 
-        return (
-          value.slice(0, Math.max(0, prevLineStart)) +
-          value.slice(thisLineStart + thisLine.length) // thisLine.length will also remove any indentation
-        );
+        return;
       }
 
       const lineStart = model.getOffsetAt({


### PR DESCRIPTION
### Fix

This fixes the buggy behavior when pressing enter on an empty list item ("lonely bullets").

Fixes #2336

### Test
1. Start a list
2. Hit enter to create a new list item
3. (optional) change the indentation
4. Hit enter without adding text
5. The bullet should be removed and the cursor should end up on the same line
6. Undo should behave sensically

### Release

Fix buggy cursor when hitting enter on an empty list item