### PR TITLE
Fix: Contextual excerpt crash on tag search

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,6 +13,7 @@
 - Show error message when trying to import invalid JSON [#2446](https://github.com/Automattic/simplenote-electron/pull/2446)
 - Fixed buggy cursor when hitting enter on an empty list item [#2519](https://github.com/Automattic/simplenote-electron/pull/2519)
 - Made sidebar icons the correct shade of blue [#2513](https://github.com/Automattic/simplenote-electron/pull/2513)
+- Fixed a crash when clicking on a tag suggestion from search [#2529](https://github.com/Automattic/simplenote-electron/pull/2529)
 
 ### Other Changes
 

--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -55,23 +55,27 @@ const getPreview = (content: string, searchQuery?: string) => {
     const terms = getTerms(searchQuery);
 
     // use only the first term of a multi-term query
-    const firstTerm = terms[0].toLocaleLowerCase();
-    const leadingChars = 30 - firstTerm.length;
+    if (terms.length > 0) {
+      const firstTerm = terms[0].toLocaleLowerCase();
+      const leadingChars = 30 - firstTerm.length;
 
-    // prettier-ignore
-    const regExp = new RegExp(
-      '(?<=\\s|^)[^\n]' + // split at a word boundary (pattern must be preceded by whitespace or beginning of string)
-        '{0,' + leadingChars + '}' + // up to leadingChars of text before the match
-        escapeRegExp(firstTerm) +
-        '.{0,200}(?=\\s|$)', // up to 200 characters of text after the match, splitting at a word boundary
-      'ims'
-    );
-    const matches = regExp.exec(content);
-    if (matches && matches.length > 0) {
-      preview = matches[0];
+      // prettier-ignore
+      const regExp = new RegExp(
+        '(?<=\\s|^)[^\n]' + // split at a word boundary (pattern must be preceded by whitespace or beginning of string)
+          '{0,' + leadingChars + '}' + // up to leadingChars of text before the match
+          escapeRegExp(firstTerm) +
+          '.{0,200}(?=\\s|$)', // up to 200 characters of text after the match, splitting at a word boundary
+        'ims'
+      );
+      const matches = regExp.exec(content);
+      if (matches && matches.length > 0) {
+        preview = matches[0];
 
-      // don't return half of a surrogate pair
-      return isLowSurrogate(preview.charCodeAt(0)) ? preview.slice(1) : preview;
+        // don't return half of a surrogate pair
+        return isLowSurrogate(preview.charCodeAt(0))
+          ? preview.slice(1)
+          : preview;
+      }
     }
   }
 


### PR DESCRIPTION
### Fix

We need to guard against `getTerms` returning an empty array, which it does if the only search terms are tags (e.g. `tag:testing`).

### Test
1. Search for text that will bring up tag suggestions
2. Click on a suggested tag
3. The app should not crash

### Release

Updated: Fixed a crash when clicking on a tag suggestion from search