### PR TITLE
Fix: only focus editor if search field is not focused

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -172,7 +172,9 @@ class NoteContentEditor extends Component<Props> {
         });
       }
     }, SPEED_DELAY);
-    this.focusEditor();
+    if (this.state.searchQuery === '') {
+      this.focusEditor();
+    }
     this.props.storeFocusEditor(this.focusEditor);
     this.props.storeHasFocus(this.hasFocus);
     window.addEventListener('toggleChecklist', this.handleChecklist, true);

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -172,7 +172,7 @@ class NoteContentEditor extends Component<Props> {
         });
       }
     }, SPEED_DELAY);
-    if (this.state.searchQuery === '') {
+    if (document?.activeElement?.id !== 'search-field') {
       this.focusEditor();
     }
     this.props.storeFocusEditor(this.focusEditor);

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -105,7 +105,7 @@ type DispatchProps = {
     direction: 'LTR' | 'RTL'
   ) => any;
   storeNumberOfMatchesInNote: (matches: number) => any;
-  storeSearchSelection: (index: number) => any;
+  storeSearchSelection: (index: number | null) => any;
 };
 
 type Props = OwnProps & StateProps & DispatchProps;
@@ -151,7 +151,7 @@ class NoteContentEditor extends Component<Props> {
     // to avoid, for example, opening a note and having the fourth match selected (or "4 of 1")
     const searchChanged = props.searchQuery !== state.searchQuery;
     if (noteChanged || searchChanged) {
-      props.storeSearchSelection(0);
+      props.storeSearchSelection(null);
     }
 
     return {
@@ -377,9 +377,7 @@ class NoteContentEditor extends Component<Props> {
     if (
       this.editor &&
       this.state.editor === 'full' &&
-      prevProps.selectedSearchMatchIndex !==
-        this.props.selectedSearchMatchIndex &&
-      prevProps.noteId !== this.props.noteId
+      prevProps.selectedSearchMatchIndex !== this.props.selectedSearchMatchIndex
     ) {
       this.setSearchSelection(this.props.selectedSearchMatchIndex);
     }
@@ -1113,6 +1111,7 @@ class NoteContentEditor extends Component<Props> {
     const newIndex = (total + (index ?? -1) + 1) % total;
     this.props.storeSearchSelection(newIndex);
     this.setSearchSelection(newIndex);
+    this.focusEditor();
   };
 
   setPrevSearchSelection = () => {
@@ -1121,16 +1120,16 @@ class NoteContentEditor extends Component<Props> {
     const newIndex = (total + (index ?? total) - 1) % total;
     this.props.storeSearchSelection(newIndex);
     this.setSearchSelection(newIndex);
+    this.focusEditor();
   };
 
   setSearchSelection = (index) => {
-    if (!this.matchesInNote.length) {
+    if (!this.matchesInNote.length || index === null) {
       return;
     }
     const range = this.matchesInNote[index].range;
     this.editor.setSelection(range);
     this.editor.revealLineInCenter(range.startLineNumber);
-    this.focusEditor();
 
     const newDecorations = [];
     this.matchesInNote.forEach((match) => {
@@ -1245,7 +1244,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
   note: state.data.notes.get(state.ui.openedNote),
   notes: state.data.notes,
   searchQuery: state.ui.searchQuery,
-  selectedSearchMatchIndex: state.ui.selectedSearchMatchIndex ?? 0,
+  selectedSearchMatchIndex: state.ui.selectedSearchMatchIndex,
   spellCheckEnabled: state.settings.spellCheckEnabled,
   theme: selectors.getTheme(state),
 });

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -172,9 +172,7 @@ class NoteContentEditor extends Component<Props> {
         });
       }
     }, SPEED_DELAY);
-    if (document?.activeElement?.id !== 'search-field') {
-      this.focusEditor();
-    }
+    this.focusEditor();
     this.props.storeFocusEditor(this.focusEditor);
     this.props.storeHasFocus(this.hasFocus);
     window.addEventListener('toggleChecklist', this.handleChecklist, true);
@@ -379,7 +377,9 @@ class NoteContentEditor extends Component<Props> {
     if (
       this.editor &&
       this.state.editor === 'full' &&
-      prevProps.selectedSearchMatchIndex !== this.props.selectedSearchMatchIndex
+      prevProps.selectedSearchMatchIndex !==
+        this.props.selectedSearchMatchIndex &&
+      prevProps.noteId !== this.props.noteId
     ) {
       this.setSearchSelection(this.props.selectedSearchMatchIndex);
     }
@@ -1245,7 +1245,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
   note: state.data.notes.get(state.ui.openedNote),
   notes: state.data.notes,
   searchQuery: state.ui.searchQuery,
-  selectedSearchMatchIndex: state.ui.selectedSearchMatchIndex,
+  selectedSearchMatchIndex: state.ui.selectedSearchMatchIndex ?? 0,
   spellCheckEnabled: state.settings.spellCheckEnabled,
   theme: selectors.getTheme(state),
 });

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -124,7 +124,7 @@ export type StoreNumberOfMatchesInNote = Action<
 >;
 export type StoreSearchSelection = Action<
   'STORE_SEARCH_SELECTION',
-  { index: number }
+  { index: number | null }
 >;
 export type SystemThemeUpdate = Action<
   'SYSTEM_THEME_UPDATE',

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -308,7 +308,10 @@ const searchQuery: A.Reducer<string> = (state = '', action) => {
   }
 };
 
-const selectedSearchMatchIndex: A.Reducer<number> = (state = null, action) => {
+const selectedSearchMatchIndex: A.Reducer<number | null> = (
+  state = null,
+  action
+) => {
   switch (action.type) {
     case 'STORE_SEARCH_SELECTION':
       return action.index;


### PR DESCRIPTION
### Fix

Fixes #2530

This one is a bit hard to reproduce as it's a race condition, but it happens fairly frequently to me on local dev.

Also Fixes #2613

If you search for a term and toggle through the results and then search again the focus is brought to the editor. 

### Test

1. Load the app and quickly click into the search field and start typing a search
2. You should never end up in the editor window accidentally typing in your note
3. If the editor has focus it should keep focus as you switch notes, create and delete notes, etc.
4. Perform a search
5. Use shortcut keys to toggle through search results (CmdOrCtrl + g)
6. Go back to search again (CmdOrCtrl + f)
7. Type a new search term
8. Focus should stay in the search element

### Release Notes

- Fixed a couple of bugs where the editor would get focus instead of staying with the search field.
