### PR TITLE
Fix: Load configured `app_id` when connecting to Simperium

### DIFF
--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -2,6 +2,7 @@ import { default as createClient } from 'simperium';
 
 import debugFactory from 'debug';
 import actions from '../actions';
+import getConfig from '../../../get-config';
 import { BucketQueue } from './functions/bucket-queue';
 import { NoteBucket } from './functions/note-bucket';
 // import { NoteDoctor } from './functions/note-doctor';
@@ -36,7 +37,7 @@ export const initSimperium = (
 ): S.Middleware => (store) => {
   const { dispatch, getState } = store;
 
-  const client = createClient<Buckets>('chalk-bump-f49', token, {
+  const client = createClient<Buckets>(getConfig().app_id, token, {
     objectStoreProvider: (bucket) => {
       switch (bucket.name) {
         case 'note':


### PR DESCRIPTION
Resolves #2396 

In the big rewrite I accidentally instructed the Simperium middleware to always connect
to the production Simperium application and overlook what might be configured in the
`config.json` or `config-local.json` files. This led to people being unable to sign in
to test accounts on the test backend: the successful authorizatio would lead to the app
immediately signing out due to an `Token Invalid` over the WebSocket.

With this fix we're using the configured app name, reading it from the configs, so that
when the repo is cloned and ran it properly connects to `history-analyst-dad` (or any
value set in its place). This fix restores one's ability to sign in.

Props to @tbourrely for valuable diagnosis of this issue in #2396 