### PR TITLE
Fix: Crash in Safari on search

### DIFF
--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -61,7 +61,7 @@ const getPreview = (content: string, searchQuery?: string) => {
 
       // prettier-ignore
       const regExp = new RegExp(
-        '(?<=\\s|^)[^\n]' + // split at a word boundary (pattern must be preceded by whitespace or beginning of string)
+        '(?:\\s|^)[^\n]' + // split at a word boundary (pattern must be preceded by whitespace or beginning of string)
           '{0,' + leadingChars + '}' + // up to leadingChars of text before the match
           escapeRegExp(firstTerm) +
           '.{0,200}(?=\\s|$)', // up to 200 characters of text after the match, splitting at a word boundary


### PR DESCRIPTION
### Fix

Fixes #2537. Safari does not support "lookbehind" in regex so this PR uses an non-capturing group instead.

### Test

1. Open in Safari
2. Type any search in search field
3. App should not crash

### Release

Fixed a crash on note search in Safari