### PR TITLE
Search bar: Make it into its own component in order to fix layout bugs

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -22,7 +22,6 @@ import {
   withCheckboxCharacters,
   withCheckboxSyntax,
 } from './utils/task-transform';
-import SearchResultsBar from './search-results-bar';
 
 import * as S from './state';
 import * as T from './types';
@@ -1168,7 +1167,6 @@ class NoteContentEditor extends Component<Props> {
             value={content}
           />
         )}
-        {searchQuery.length > 0 && searchMatches && <SearchResultsBar />}
       </div>
     );
   }

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -145,15 +145,11 @@ class NoteContentEditor extends Component<Props> {
 
     const editor = noteChanged ? (goFast ? 'fast' : 'full') : state.editor;
 
-    // @todo what was this doing and now what should it do instead?
-    // const searchChanged = props.searchQuery !== state.searchQuery;
-    // const selectedSearchMatchIndex =
-    //   noteChanged || searchChanged ? null : props.selectedSearchMatchIndex;
-
-    // maybe something like this to invalidate the pre-existing selection?
-    // if(noteChanged || searchChanged) {
-    // props.storeSearchSelection(null);
-    // }
+    // reset search selection if the search or note has changed
+    const searchChanged = props.searchQuery !== state.searchQuery;
+    if (noteChanged || searchChanged) {
+      props.storeSearchSelection(0);
+    }
 
     return {
       content,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -145,7 +145,8 @@ class NoteContentEditor extends Component<Props> {
 
     const editor = noteChanged ? (goFast ? 'fast' : 'full') : state.editor;
 
-    // reset search selection if the search or note has changed
+    // reset search selection when either the note or the search changes
+    // to avoid, for example, opening a note and having the fourth match selected (or "4 of 1")
     const searchChanged = props.searchQuery !== state.searchQuery;
     if (noteChanged || searchChanged) {
       props.storeSearchSelection(0);

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -346,6 +346,7 @@ class NoteContentEditor extends Component<Props> {
       this.state.editor === 'full' &&
       prevProps.searchQuery !== this.props.searchQuery
     ) {
+      this.editor?.layout();
       this.setDecorators();
     }
 

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import SearchResultsBar from '../search-results-bar';
 import TagField from '../tag-field';
 import NoteDetail from '../note-detail';
 import NotePreview from '../components/note-preview';
@@ -16,6 +17,8 @@ type StateProps = {
   isEditorActive: boolean;
   isSearchActive: boolean;
   isSmallScreen: boolean;
+  hasSearchMatchesInNote: boolean;
+  hasSearchQuery: boolean;
   keyboardShortcuts: boolean;
   noteId: T.EntityId;
   note: T.Note;
@@ -111,7 +114,13 @@ export class NoteEditor extends Component<Props> {
   };
 
   render() {
-    const { editMode, note, noteId } = this.props;
+    const {
+      editMode,
+      hasSearchQuery,
+      hasSearchMatchesInNote,
+      note,
+      noteId,
+    } = this.props;
 
     if (!note) {
       return (
@@ -139,6 +148,7 @@ export class NoteEditor extends Component<Props> {
             storeHasFocus={this.storeTagFieldHasFocus}
           />
         )}
+        {hasSearchQuery && hasSearchMatchesInNote && <SearchResultsBar />}
       </div>
     );
   }
@@ -152,6 +162,9 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
   noteId: state.ui.openedNote,
   note: state.data.notes.get(state.ui.openedNote),
   revision: state.ui.selectedRevision,
+  hasSearchQuery: state.ui.searchQuery !== '',
+  hasSearchMatchesInNote:
+    !!state.ui.numberOfMatchesInNote && state.ui.numberOfMatchesInNote > 0,
   isSearchActive: !!state.ui.searchQuery.length,
   isSmallScreen: selectors.isSmallScreen(state),
 });

--- a/lib/search-results-bar/index.tsx
+++ b/lib/search-results-bar/index.tsx
@@ -28,44 +28,34 @@ const SearchResultsBar: FunctionComponent<Props> = ({
   numberOfMatchesInNote: total,
   setSearchSelection,
 }) => {
-  const nextButtonRef = useRef<HTMLButtonElement>();
-  const prevButtonRef = useRef<HTMLButtonElement>();
+  const setPrev = (event: MouseEvent) => {
+    const newIndex = (total + (index ?? -1) - 1) % total;
+    setSearchSelection(newIndex);
+  };
 
-  useEffect(() => {
-    const setPrev = (event: MouseEvent) => {
-      const newIndex = (total + (index ?? -1) - 1) % total;
-      setSearchSelection(newIndex);
-    };
-
-    const setNext = (event: MouseEvent) => {
-      const newIndex = (total + (index ?? -1) + 1) % total;
-      setSearchSelection(newIndex);
-    };
-    prevButtonRef.current?.addEventListener('click', setPrev, true);
-    nextButtonRef.current?.addEventListener('click', setNext, true);
-
-    return () => {
-      prevButtonRef.current?.removeEventListener('click', setPrev, true);
-      nextButtonRef.current?.removeEventListener('click', setNext, true);
-    };
-  }, [index, total]);
+  const setNext = (event: MouseEvent) => {
+    const newIndex = (total + (index ?? -1) + 1) % total;
+    setSearchSelection(newIndex);
+  };
 
   return (
     <div className="search-results">
       <div>
         {index === null ? `${total} Results` : `${index + 1} of ${total}`}
       </div>
-      <span className="search-results-next" ref={nextButtonRef}>
+      <span className="search-results-next">
         <IconButton
           disabled={total <= 1}
           icon={<ChevronRightIcon />}
+          onClick={setNext}
           title="Next"
         />
       </span>
-      <span className="search-results-prev" ref={prevButtonRef}>
+      <span className="search-results-prev">
         <IconButton
           disabled={total <= 1}
           icon={<ChevronRightIcon />}
+          onClick={setPrev}
           title="Prev"
         />
       </span>

--- a/lib/search-results-bar/index.tsx
+++ b/lib/search-results-bar/index.tsx
@@ -33,7 +33,7 @@ const SearchResultsBar: FunctionComponent<Props> = ({
 
   useEffect(() => {
     const setPrev = (event: MouseEvent) => {
-      const newIndex = (total + (index ?? -1) + 1) % total;
+      const newIndex = (total + (index ?? -1) - 1) % total;
       setSearchSelection(newIndex);
     };
 

--- a/lib/search-results-bar/index.tsx
+++ b/lib/search-results-bar/index.tsx
@@ -71,9 +71,11 @@ const mapStateToProps: S.MapState<StateProps> = ({
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({
-  setSearchSelection: (index: number) => {
-    dispatch({ type: 'STORE_SEARCH_SELECTION', index: index });
-  },
+  setSearchSelection: (index: number) =>
+    dispatch({
+      type: 'STORE_SEARCH_SELECTION',
+      index,
+    }),
 });
 
 SearchResultsBar.displayName = 'SearchResultsBar';

--- a/lib/search-results-bar/index.tsx
+++ b/lib/search-results-bar/index.tsx
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent, useEffect, useRef } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import IconButton from '../icon-button';
+import ChevronRightIcon from '../icons/chevron-right';
+
+import * as S from '../state';
+
+type StateProps = {
+  selectedSearchMatchIndex: number | null;
+  numberOfMatchesInNote: number;
+};
+
+type DispatchProps = {
+  setSearchSelection: (index: number) => any;
+};
+
+type Props = StateProps & DispatchProps;
+
+const SearchResultsBar: FunctionComponent<Props> = ({
+  selectedSearchMatchIndex: index,
+  numberOfMatchesInNote: total,
+  setSearchSelection,
+}) => {
+  const nextButtonRef = useRef<HTMLButtonElement>();
+  const prevButtonRef = useRef<HTMLButtonElement>();
+
+  useEffect(() => {
+    const setPrev = (event: MouseEvent) => {
+      const newIndex = (total + (index ?? -1) + 1) % total;
+      setSearchSelection(newIndex);
+    };
+
+    const setNext = (event: MouseEvent) => {
+      const newIndex = (total + (index ?? -1) + 1) % total;
+      setSearchSelection(newIndex);
+    };
+    prevButtonRef.current?.addEventListener('click', setPrev, true);
+    nextButtonRef.current?.addEventListener('click', setNext, true);
+
+    return () => {
+      prevButtonRef.current?.removeEventListener('click', setPrev, true);
+      nextButtonRef.current?.removeEventListener('click', setNext, true);
+    };
+  }, [index, total]);
+
+  return (
+    <div className="search-results">
+      <div>
+        {index === null ? `${total} Results` : `${index + 1} of ${total}`}
+      </div>
+      <span className="search-results-next" ref={nextButtonRef}>
+        <IconButton
+          disabled={total <= 1}
+          icon={<ChevronRightIcon />}
+          title="Next"
+        />
+      </span>
+      <span className="search-results-prev" ref={prevButtonRef}>
+        <IconButton
+          disabled={total <= 1}
+          icon={<ChevronRightIcon />}
+          title="Prev"
+        />
+      </span>
+    </div>
+  );
+};
+
+const mapStateToProps: S.MapState<StateProps> = ({
+  ui: { selectedSearchMatchIndex, numberOfMatchesInNote },
+}) => ({
+  selectedSearchMatchIndex,
+  numberOfMatchesInNote,
+});
+
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({
+  setSearchSelection: (index: number) => {
+    dispatch({ type: 'STORE_SEARCH_SELECTION', index: index });
+  },
+});
+
+SearchResultsBar.displayName = 'SearchResultsBar';
+
+export default connect(mapStateToProps, mapDispatchToProps)(SearchResultsBar);

--- a/lib/search-results-bar/style.scss
+++ b/lib/search-results-bar/style.scss
@@ -1,0 +1,39 @@
+.search-results {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 45px;
+  line-height: 45px;
+  z-index: 100;
+  border-top: 1px solid $studio-gray-5;
+  background-color: $studio-white;
+  text-align: center;
+  user-select: none;
+
+  div {
+    display: inline-block;
+  }
+
+  .search-results-next,
+  .search-results-prev {
+    float: right;
+    padding: 0 6px;
+    width: 42px;
+    height: 100%;
+
+    svg {
+      fill: $studio-simplenote-blue-50;
+    }
+  }
+  .search-results-next {
+    margin-right: 6px;
+  }
+  .search-results-prev svg {
+    transform: scaleX(-1);
+  }
+
+  @media only screen and (max-width: $single-column) {
+    left: 0;
+  }
+}

--- a/lib/search-results-bar/style.scss
+++ b/lib/search-results-bar/style.scss
@@ -1,10 +1,6 @@
 .search-results {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 45px;
-  line-height: 45px;
+  height: 56px;
+  line-height: 56px;
   z-index: 100;
   border-top: 1px solid $studio-gray-5;
   background-color: $studio-white;

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -103,6 +103,14 @@ export type StoreEditorSelection = Action<
   'STORE_EDITOR_SELECTION',
   { noteId: T.EntityId; start: number; end: number; direction: 'RTL' | 'LTR' }
 >;
+export type StoreNumberOfMatchesInNote = Action<
+  'STORE_NUMBER_OF_MATCHES_IN_NOTE',
+  { matches: number }
+>;
+export type StoreSearchSelection = Action<
+  'STORE_SEARCH_SELECTION',
+  { index: number }
+>;
 export type SystemThemeUpdate = Action<
   'SYSTEM_THEME_UPDATE',
   { prefers: 'light' | 'dark' }
@@ -376,6 +384,8 @@ export type ActionType =
   | ShowAllNotes
   | ShowDialog
   | StoreEditorSelection
+  | StoreNumberOfMatchesInNote
+  | StoreSearchSelection
   | SubmitPendingChange
   | SystemThemeUpdate
   | TagBucketRemove

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -148,6 +148,15 @@ const hasLoadedNotes: A.Reducer<boolean> = (state = false, action) => {
   }
 };
 
+const numberOfMatchesInNote: A.Reducer<number> = (state = null, action) => {
+  switch (action.type) {
+    case 'STORE_NUMBER_OF_MATCHES_IN_NOTE':
+      return action.matches;
+    default:
+      return state;
+  }
+};
+
 const openedNote: A.Reducer<T.EntityId | null> = (state = null, action) => {
   switch (action.type) {
     case 'CLOSE_NOTE':
@@ -224,6 +233,15 @@ const searchQuery: A.Reducer<string> = (state = '', action) => {
       return '';
     case 'SEARCH':
       return action.searchQuery;
+    default:
+      return state;
+  }
+};
+
+const selectedSearchMatchIndex: A.Reducer<number> = (state = null, action) => {
+  switch (action.type) {
+    case 'STORE_SEARCH_SELECTION':
+      return action.index;
     default:
       return state;
   }
@@ -314,10 +332,12 @@ export default combineReducers({
   editingTags,
   filteredNotes,
   hasLoadedNotes,
+  numberOfMatchesInNote,
   openedNote,
   openedRevision,
   openedTag,
   searchQuery,
+  selectedSearchMatchIndex,
   showNavigation,
   showNoteInfo,
   showNoteList,

--- a/scss/_components.scss
+++ b/scss/_components.scss
@@ -35,6 +35,7 @@
 @import 'revision-selector/style';
 @import 'search-bar/style';
 @import 'search-field/style';
+@import 'search-results-bar/style';
 @import 'tag-email-tooltip/style';
 @import 'tag-field/style';
 @import 'tag-input/style';

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -120,46 +120,6 @@ span[dir='ltr'] {
   width: 100%;
 }
 
-.search-results {
-  position: fixed;
-  left: 330px;
-  right: 0;
-  bottom: 0;
-  height: 56px;
-  line-height: 56px;
-  z-index: 100;
-  border-top: 1px solid $studio-gray-5;
-  background-color: $studio-white;
-  text-align: center;
-  user-select: none;
-
-  div {
-    display: inline-block;
-  }
-
-  .search-results-next,
-  .search-results-prev {
-    float: right;
-    padding: 0 6px;
-    width: 42px;
-    height: 100%;
-
-    svg {
-      fill: $studio-simplenote-blue-50;
-    }
-  }
-  .search-results-next {
-    margin-right: 6px;
-  }
-  .search-results-prev svg {
-    transform: scaleX(-1);
-  }
-
-  @media only screen and (max-width: $single-column) {
-    left: 0;
-  }
-}
-
 .note-detail-textarea .note-content-editor-shell.cursor-pointer div {
   cursor: pointer;
 }


### PR DESCRIPTION
### Fix

Fixes #2544 and the issue where the tag bar is overlapped.

### Test
1. Do some searches with matches in long notes
2. Scroll to the bottom of the note and verify that the tags and last lines of the note are still visible
3. Switch notes, change the search, verify that the selected result properly resets to the first.

### Screenshots

<img width="1114" alt="Screen Shot 2021-01-04 at 11 29 23 PM" src="https://user-images.githubusercontent.com/52152/103618541-fda6a900-4ee4-11eb-99e8-02f0ba96e2ad.png">

### Release

Fixed layout bugs causing the search results bar to overlap note contents and tag input field