### PR TITLE
Chore: add arguments to addDynamicKeybinding

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -610,7 +610,11 @@ class NoteContentEditor extends Component<Props> {
       shortcutsToDisable.push('undo', 'redo', 'editor.action.selectAll');
     }
     shortcutsToDisable.forEach(function (action) {
-      editor._standaloneKeybindingService.addDynamicKeybinding('-' + action);
+      editor._standaloneKeybindingService.addDynamicKeybinding(
+        '-' + action,
+        undefined,
+        () => {}
+      );
     });
 
     // disable editor keybindings for Electron since it is handled by editorCommand


### PR DESCRIPTION
### Fix

In upcoming Monaco versions we will need to add these arguments to avoid a crash. We can't update Monaco yet but we can update this so it won't break whenever we do.

It looks like this will become an issue starting in monaco-editor 0.21.0.

See https://github.com/microsoft/monaco-editor/issues/2157#issuecomment-723343819

### Test

1. Test keybindings in browser and Electron
2. Verify they still work as expected and none of the default Monaco behaviors are still present

### Release

Future-proof a function call to the keybinding service