### PR TITLE
Fix: List continuations in notes created on Windows

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -948,7 +948,8 @@ class NoteContentEditor extends Component<Props> {
       }
 
       const change = event.changes.find(
-        ({ text }) => text[0] === '\n' && text.trim() === ''
+        ({ text }) =>
+          (text[0] === '\r' || text[0] === '\n') && text.trim() === ''
       );
 
       if (!change) {


### PR DESCRIPTION
### Fix

Finally! The fix for the issue reported in #2379!

Turns out this was bailing early in the case of Windows EOL characters, as it was only testing for `\n`. Monaco [determines the line ending from the default](https://microsoft.github.io/monaco-editor/api/enums/monaco.editor.endoflinepreference.html) and/or what is currently in the note, so any note originally created on Windows would be buggy forevermore.

Props to @nsakaimbo for figuring out how to reproduce this!

### Test

1. Create a note on Windows (Electron or in browser, it doesn't matter)
2. Insert a checklist item
3. Press enter and confirm that the next line automatically begins with a checklist as well
4. Ditto for bulleted lists
5. Repeat testing steps in a note created on a non-Windows platform

### Release

Fixed a bug preventing checklists and bulleted lists from automatically continuing when a note was created on Windows