### PR TITLE
Fix: getTerms dropping terms when search query is a mix of literal and non-literals

### DIFF
--- a/lib/utils/filter-notes.ts
+++ b/lib/utils/filter-notes.ts
@@ -25,10 +25,12 @@ export const getTerms = (filterText: string): string[] => {
     withoutLiterals += filter.slice(storedLastIndex, match.index);
 
     // lastIndex is the end of the current match
-    // (i.e., where in the string to start scanning for the next match)
+    // -- where in the string to start scanning for the next match on the next loop iteration
     storedLastIndex = literalsPattern.lastIndex;
   }
 
+  // save any search terms that occur after the last matched literal
+  // i.e. between our last saved index and the end of the string
   if (
     (storedLastIndex > 0 || literals.length === 0) &&
     storedLastIndex < filter.length


### PR DESCRIPTION
### Fix

Fixes #2481.

There were two issues here:
1. Greedy regex matching meant that a search query such as `"foo" "bar"` would be interpreted as one long literal rather than two small ones. Adding a `?` to the regex turns this into a "lazy" match which halts at the first matching `"`.
2. The regex pattern `.lastIndex` refers to the last index of the _current match_, in other words, the place to start scanning the string for the next match. We were treating it as if it was the last index of the previous match. Instead we need to store it in a variable and use it on the next iteration of the loop.

### Test

1. Search for terms with a mix of quoted literal strings and non-quoted and ensure they are all matched

### Release

Fixed a bug where some search terms could be dropped when searching for quoted strings