### PR TITLE
Fix: Safari navigation list styles

### DIFF
--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -1,5 +1,5 @@
 .navigation-bar-item {
-  height: 44px;
+  min-height: 44px;
   padding-left: 16px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -28,6 +28,10 @@
   &.is-selected {
     background-color: $studio-simplenote-blue-5;
   }
+}
+
+.navigation-bar-item:first-child .button {
+  border-bottom: none;
 }
 
 .navigation-bar-item__icon {

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -1,5 +1,5 @@
 .navigation-bar-item {
-  min-height: 44px;
+  height: 44px;
   padding-left: 16px;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/lib/navigation-bar/style.scss
+++ b/lib/navigation-bar/style.scss
@@ -18,6 +18,7 @@
 
 .navigation-bar__folders {
   display: flex;
+  flex: none;
   flex-direction: column-reverse;
   border-bottom: 1px solid $studio-gray-5;
 }

--- a/lib/navigation-bar/style.scss
+++ b/lib/navigation-bar/style.scss
@@ -19,6 +19,7 @@
 .navigation-bar__folders {
   display: flex;
   flex-direction: column-reverse;
+  border-bottom: 1px solid $studio-gray-5;
 }
 
 .navigation-bar__tags {


### PR DESCRIPTION
### Fix

Fixes #2541. Also cleaned up the bottom border under the top navigation section.

Before:

<img width="584" alt="Screen Shot 2021-01-07 at 3 08 32 PM" src="https://user-images.githubusercontent.com/52152/103955122-7fbbeb00-50fa-11eb-824d-974f04306754.png">

After:

<img width="695" alt="Screen Shot 2021-01-07 at 3 08 01 PM" src="https://user-images.githubusercontent.com/52152/103955131-85b1cc00-50fa-11eb-9987-abb88b0594b2.png">


### Release

Fixed navigation list styles on Safari