### PR TITLE
Fix: Add selected tag to new notes by default

### DIFF
--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -368,7 +368,14 @@ export const middleware: S.Middleware = (store) => {
       }
 
       case 'CREATE_NOTE_WITH_ID':
-        searchState.collection = { type: 'all' };
+        if (action.note?.tags && action.note?.tags.length > 0) {
+          searchState.collection = {
+            type: 'tag',
+            tagName: action.note.tags[0],
+          };
+        } else {
+          searchState.collection = { type: 'all' };
+        }
         searchState.notes.set(action.noteId, toSearchNote(action.note ?? {}));
         indexNote(action.noteId);
         queueSearch();

--- a/lib/state/data/middleware.ts
+++ b/lib/state/data/middleware.ts
@@ -2,6 +2,7 @@ import { v4 as uuid } from 'uuid';
 
 import { tagHashOf } from '../../utils/tag-hash';
 import exportZipArchive from '../../utils/export';
+import { tagHashOf as t, withTag } from '../../utils/tag-hash';
 
 import type * as A from '../action-types';
 import type * as S from '../';
@@ -30,10 +31,18 @@ export const middleware: S.Middleware = (store) => (
         systemTags.splice(markdownInNote, 1);
       }
 
+      // apply selected tag by default
+      const selectedTag = state.ui.openedTag;
+      let tags = action.note?.tags ?? [];
+      if (selectedTag) {
+        tags = withTag(tags, selectedTag);
+        // tags.push(t(selectedTag));
+      }
+
       return next({
         type: 'CREATE_NOTE_WITH_ID',
         noteId,
-        note: { ...action.note, systemTags },
+        note: { ...action.note, systemTags, tags },
         meta: {
           nextNoteToOpen: noteId,
         },

--- a/lib/state/data/middleware.ts
+++ b/lib/state/data/middleware.ts
@@ -2,12 +2,12 @@ import { v4 as uuid } from 'uuid';
 
 import { tagHashOf } from '../../utils/tag-hash';
 import exportZipArchive from '../../utils/export';
-import { tagNameOf, withTag } from '../../utils/tag-hash';
+import { withTag } from '../../utils/tag-hash';
 
 import type * as A from '../action-types';
 import type * as S from '../';
 import type * as T from '../../types';
-import { numberOfNonEmailTags } from '../selectors';
+import { numberOfNonEmailTags, openedTag } from '../selectors';
 
 export const middleware: S.Middleware = (store) => (
   next: (action: A.ActionType) => A.ActionType
@@ -32,11 +32,9 @@ export const middleware: S.Middleware = (store) => (
       }
 
       // apply selected tag by default
-      const openedTag = state.ui.openedTag
-        ? tagNameOf(state.ui.openedTag)
-        : null;
+      const selectedTag = openedTag(state);
       const givenTags = action.note?.tags ?? [];
-      const tags = openedTag ? withTag(givenTags, openedTag) : givenTags;
+      const tags = selectedTag ? withTag(givenTags, selectedTag) : givenTags;
 
       return next({
         type: 'CREATE_NOTE_WITH_ID',

--- a/lib/state/data/middleware.ts
+++ b/lib/state/data/middleware.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from 'uuid';
 
 import { tagHashOf } from '../../utils/tag-hash';
 import exportZipArchive from '../../utils/export';
-import { tagHashOf as t, withTag } from '../../utils/tag-hash';
+import { tagNameOf, withTag } from '../../utils/tag-hash';
 
 import type * as A from '../action-types';
 import type * as S from '../';
@@ -32,12 +32,11 @@ export const middleware: S.Middleware = (store) => (
       }
 
       // apply selected tag by default
-      const selectedTag = state.ui.openedTag;
-      let tags = action.note?.tags ?? [];
-      if (selectedTag) {
-        tags = withTag(tags, selectedTag);
-        // tags.push(t(selectedTag));
-      }
+      const openedTag = state.ui.openedTag
+        ? tagNameOf(state.ui.openedTag)
+        : null;
+      const givenTags = action.note?.tags ?? [];
+      const tags = openedTag ? withTag(givenTags, openedTag) : givenTags;
 
       return next({
         type: 'CREATE_NOTE_WITH_ID',

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -108,6 +108,8 @@ const collection: A.Reducer<T.Collection> = (
     case 'CREATE_NOTE_WITH_ID': {
       if (state.type === 'trash') {
         return { type: 'all' };
+      } else if (state.type === 'tag') {
+        return { type: 'tag', tagName: state.tagName };
       }
       return state;
     }


### PR DESCRIPTION
### Fix

Fixes #2423

If you are on a selected tag and choose to add a new note, the new note will now automatically get that tag added to it.

### Test

1. Click a tag in the sidebar to select it
2. Create a new note
3. Verify that the new note has the selected tag
4. Create a new note with no tag selected
5. Verify that no tags are added to that note

### Release

Fix: Apply selected tag to a new note by default