### PR TITLE
Fix: Note filtering not reset after new note is created from "no results" sidebar

### DIFF
--- a/lib/note-list/no-notes.tsx
+++ b/lib/note-list/no-notes.tsx
@@ -21,9 +21,10 @@ const NoNotes = () => {
   const getButton = () => {
     return searchQuery.length ? (
       <button
-        onClick={() =>
-          dispatch(actions.ui.createNote({ content: searchQuery }))
-        }
+        onClick={() => {
+          dispatch(actions.ui.createNote({ content: searchQuery }));
+          dispatch(actions.ui.search(searchQuery));
+        }}
       >
         Create a new note titled &quot;{searchQuery}&quot;
       </button>

--- a/lib/note-list/no-notes.tsx
+++ b/lib/note-list/no-notes.tsx
@@ -21,10 +21,9 @@ const NoNotes = () => {
   const getButton = () => {
     return searchQuery.length ? (
       <button
-        onClick={() => {
-          dispatch(actions.ui.createNote({ content: searchQuery }));
-          dispatch(actions.ui.search(searchQuery));
-        }}
+        onClick={() =>
+          dispatch(actions.ui.createNote({ content: searchQuery }))
+        }
       >
         Create a new note titled &quot;{searchQuery}&quot;
       </button>

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -229,8 +229,6 @@ const unsyncedNoteIds: A.Reducer<T.EntityId[]> = (
 
 const searchQuery: A.Reducer<string> = (state = '', action) => {
   switch (action.type) {
-    case 'CREATE_NOTE_WITH_ID':
-      return '';
     case 'SEARCH':
       return action.searchQuery;
     default:


### PR DESCRIPTION
### Fix

Currently the "create a new note titled" callout leaves the search query in a broken state, where the query is removed from the search field, but the filtering is still applied, which makes it appear as though notes are missing. The only way to remove the hidden filtering is by entering a new search query and then clearing it.

This fixes the bug by removing the search query clearing from the dispatch for `CREATE_NOTE_WITH_ID`. As a side effect, the search query will now persist through any creation of a new note, whether created from the sidebar callout or otherwise. It's unclear whether clearing the query when a new note was created was intended behavior but my suspicion is that it was not.

### Test

1. Search for a term with no results
2. Click on "Create a new note titled --"
3. Verify that the search query does not get cleared and you can still view matching notes in the sidebar

### Release

Fixed a bug causing notes to still be filtered after creating a new note from search results