### PR TITLE
Remove perMachine option from Windows build config to allow non admin…

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -50,7 +50,6 @@
     ]
   },
   "nsis": {
-    "perMachine": true,
     "artifactName": "Simplenote-win-${version}-${arch}.${ext}",
     "deleteAppDataOnUninstall": true
   },


### PR DESCRIPTION
Remove perMachine option from Windows build config to allow non admin installations

### Fix

When installing on Windows it currently requires administrator privileges to complete the installation. 

Resolve issue in #1181. 

The issue above looks like this is caused by the build option [perMachine](https://www.electron.build/configuration/nsis) being set to true. This forces to install for everyone on the machine which requires admin privileges. The default value for this option is false so I've removed the option and using this PR to build the Windows install so I can test the installation process.

### Current install from exe Screenshots

Installing as Admin user
<img width="455" alt="Installing as Admin user" src="https://user-images.githubusercontent.com/1326294/104735900-907ee900-5718-11eb-9ada-cd3f55ea8c5b.png">

Installing as Standard user
<img width="566" alt="Installing as Standard user" src="https://user-images.githubusercontent.com/1326294/104735962-a68ca980-5718-11eb-8793-e4ae988b8a27.png">

### Test

1. Download the Windows exe install file generated from this PR
2. Go through the installation as both an Administrator user and Standard Windows user
3. See if it can be installed for current user without requiring admin privileges. 

### Todo

- Add release notes

### Release

<!-- **_(Required)_** Add a concise statement to `RELEASE-NOTES.md` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.md` was updated with: -->
