### PR TITLE
feat(slider): aria-label

### DIFF
--- a/lib/components/slider/index.tsx
+++ b/lib/components/slider/index.tsx
@@ -16,6 +16,7 @@ export const Slider: FunctionComponent<Props> = ({
   onChange,
 }) => (
   <input
+    aria-label="Select revision"
     className="slider"
     disabled={disabled}
     type="range"


### PR DESCRIPTION
### Fix

Adding an Aria label to the revision slider input to be more accessible specifically for screen readers.
Addresses Issue #1396 

### Test

1. View the history of a note
2. Inspect the slider element
3. See the label is now showing.

### Release

- Add label to note revision slider to make more accessible.
