### PR TITLE
Add created date to the note info panel

### DIFF
--- a/lib/note-info/index.tsx
+++ b/lib/note-info/index.tsx
@@ -92,7 +92,7 @@ export class NoteInfo extends Component<Props> {
             <span className="note-info-item-text">
               <span className="note-info-name">Created</span>
               <br />
-              <span className="note-info-detail">
+              <span className="note-info-detail theme-color-fg-dim">
                 <time dateTime={new Date(creationDate).toISOString()}>
                   {new Date(creationDate).toLocaleString([], {
                     year: 'numeric',

--- a/lib/note-info/index.tsx
+++ b/lib/note-info/index.tsx
@@ -49,6 +49,7 @@ export class NoteInfo extends Component<Props> {
   render() {
     const { isMarkdown, isPinned, noteId, note } = this.props;
     const isPublished = includes(note.systemTags, 'published');
+    const creationDate = note.creationDate * 1000;
     const modificationDate = note.modificationDate
       ? note.modificationDate * 1000
       : null;
@@ -68,6 +69,23 @@ export class NoteInfo extends Component<Props> {
               <CrossIcon />
             </button>
           </div>
+          <p className="note-info-item">
+            <span className="note-info-item-text">
+              <span className="note-info-name">Created</span>
+              <br />
+              <span className="note-info-detail">
+                <time dateTime={new Date(creationDate).toISOString()}>
+                  {new Date(creationDate).toLocaleString([], {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: 'numeric',
+                  })}
+                </time>
+              </span>
+            </span>
+          </p>
           {modificationDate && (
             <p className="note-info-item">
               <span className="note-info-item-text">

--- a/lib/note-info/index.tsx
+++ b/lib/note-info/index.tsx
@@ -69,23 +69,6 @@ export class NoteInfo extends Component<Props> {
               <CrossIcon />
             </button>
           </div>
-          <p className="note-info-item">
-            <span className="note-info-item-text">
-              <span className="note-info-name">Created</span>
-              <br />
-              <span className="note-info-detail">
-                <time dateTime={new Date(creationDate).toISOString()}>
-                  {new Date(creationDate).toLocaleString([], {
-                    year: 'numeric',
-                    month: 'short',
-                    day: 'numeric',
-                    hour: 'numeric',
-                    minute: 'numeric',
-                  })}
-                </time>
-              </span>
-            </span>
-          </p>
           {modificationDate && (
             <p className="note-info-item">
               <span className="note-info-item-text">
@@ -105,6 +88,23 @@ export class NoteInfo extends Component<Props> {
               </span>
             </p>
           )}
+          <p className="note-info-item">
+            <span className="note-info-item-text">
+              <span className="note-info-name">Created</span>
+              <br />
+              <span className="note-info-detail">
+                <time dateTime={new Date(creationDate).toISOString()}>
+                  {new Date(creationDate).toLocaleString([], {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: 'numeric',
+                  })}
+                </time>
+              </span>
+            </span>
+          </p>
           <p className="note-info-item">
             <span className="note-info-item-text">
               <span className="note-info-name">Last sync</span>


### PR DESCRIPTION
### Fix

The note info panel didn't display the created date for a note as mentioned in #2506 as well as in our feature request tracker.

This pull request adds the created date below the last modified date in the note info panel.

### Test

1. Open a note
2. Click the info panel
3. See the created date at the top

### Screenshot

![Screen Shot 2021-01-21 at 8 59 22 AM](https://user-images.githubusercontent.com/1326294/105354481-01198000-5bc7-11eb-9b20-dfc5e56978bf.png)


### Release

- Added created date to note info panel