### PR TITLE
Updating revision slider position and styling

### DIFF
--- a/lib/components/slider/index.tsx
+++ b/lib/components/slider/index.tsx
@@ -14,7 +14,6 @@ export const Slider: FunctionComponent<Props> = ({
   min,
   max,
   value,
-  list,
   onChange,
 }) => (
   <input
@@ -25,7 +24,6 @@ export const Slider: FunctionComponent<Props> = ({
     min={min}
     max={max}
     value={value}
-    list={list}
     onChange={onChange}
   />
 );

--- a/lib/components/slider/index.tsx
+++ b/lib/components/slider/index.tsx
@@ -6,7 +6,6 @@ type Props = {
   min: number;
   max: number;
   value: number;
-  list: string;
 };
 
 export const Slider: FunctionComponent<Props> = ({

--- a/lib/components/slider/index.tsx
+++ b/lib/components/slider/index.tsx
@@ -6,6 +6,7 @@ type Props = {
   min: number;
   max: number;
   value: number;
+  list: string;
 };
 
 export const Slider: FunctionComponent<Props> = ({
@@ -13,6 +14,7 @@ export const Slider: FunctionComponent<Props> = ({
   min,
   max,
   value,
+  list,
   onChange,
 }) => (
   <input

--- a/lib/components/slider/index.tsx
+++ b/lib/components/slider/index.tsx
@@ -25,6 +25,7 @@ export const Slider: FunctionComponent<Props> = ({
     min={min}
     max={max}
     value={value}
+    list={list}
     onChange={onChange}
   />
 );

--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -12,17 +12,17 @@
     display: flex;
     align-items: center;
     height: 2px;
-    background: $studio-white;
+    background: $studio-gray-30;
     border-radius: 5px;
   }
   &::-moz-range-track {
     height: 2px;
-    background: $studio-white;
+    background: $studio-gray-30;
     border-radius: 5px;
   }
   &::-ms-track {
     height: 2px;
-    border-color: $studio-simplenote-blue-50;
+    border-color: $studio-gray-30;
     border-width: 7px 0;
     color: transparent;
   }
@@ -38,7 +38,7 @@
     width: 14px;
     height: 14px;
     border-radius: 50%;
-    border: 2px solid $studio-simplenote-blue-50;
+    border: 2px solid $studio-gray-30;
     appearance: none;
     background: $studio-white;
     transition: 0.15s ease-in-out;
@@ -49,7 +49,7 @@
   }
   &::-moz-range-thumb {
     border-radius: 50%;
-    border: 2px solid $studio-simplenote-blue-50;
+    border: 2px solid $studio-gray-30;
     appearance: none;
     background: $studio-white;
     transition: 0.15s ease-in-out;
@@ -62,7 +62,7 @@
     width: 16px;
     height: 16px;
     border-radius: 50%;
-    border: 2px solid $studio-simplenote-blue-50;
+    border: 2px solid $studio-gray-30;
     appearance: none;
     background: $studio-white;
     transition: 0.15s ease-in-out;

--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -11,36 +11,26 @@
   &::-webkit-slider-runnable-track {
     display: flex;
     align-items: center;
-    height: 2px;
-    background: $studio-gray-30;
-    border-radius: 5px;
+    height: 3px;
+    border-radius: 2px;
   }
   &::-moz-range-track {
-    height: 2px;
-    background: $studio-gray-30;
-    border-radius: 5px;
+    height: 3px;
+    border-radius: 2px;
   }
   &::-ms-track {
-    height: 2px;
-    border-color: $studio-gray-30;
+    height: 3px;
     border-width: 7px 0;
     color: transparent;
-  }
-  &::-ms-fill-lower {
-    background: $studio-white;
-  }
-  &::-ms-fill-upper {
-    background: $studio-white;
   }
 
   // Thumb
   &::-webkit-slider-thumb {
-    width: 14px;
-    height: 14px;
+    width: 15px;
+    height: 15px;
     border-radius: 50%;
-    border: 2px solid $studio-gray-30;
+    border: 2px solid;
     appearance: none;
-    background: $studio-white;
     transition: 0.15s ease-in-out;
 
     &:active {
@@ -51,9 +41,8 @@
     height: 15px;
     width: 15px;
     border-radius: 50%;
-    border: 1px solid $studio-gray-30;
+    border: 1px solid;
     appearance: none;
-    background: $studio-white;
     transition: 0.15s ease-in-out;
 
     &:active {
@@ -61,12 +50,11 @@
     }
   }
   &::-ms-thumb {
-    width: 16px;
-    height: 16px;
+    width: 15px;
+    height: 15px;
     border-radius: 50%;
-    border: 2px solid $studio-gray-30;
+    border: 2px solid;
     appearance: none;
-    background: $studio-white;
     transition: 0.15s ease-in-out;
 
     &:active {
@@ -76,5 +64,81 @@
 
   &::-ms-tooltip {
     display: none;
+  }
+}
+
+.theme-dark {
+  .slider {
+    // Track
+    &::-webkit-slider-runnable-track {
+      background: $studio-gray-50;
+    }
+    &::-moz-range-track {
+      background: $studio-gray-50;
+    }
+    &::-ms-track {
+      border-color: $studio-gray-50;
+    }
+    &::-ms-fill-lower {
+      background: $studio-white;
+    }
+    &::-ms-fill-upper {
+      background: $studio-white;
+    }
+
+    // Thumb
+    &::-webkit-slider-thumb {
+      border-color: $studio-gray-5;
+      background: $studio-white;
+      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
+    }
+    &::-moz-range-thumb {
+      background: $studio-white;
+      border-color: $studio-gray-5;
+      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
+    }
+    &::-ms-thumb {
+      border-color: $studio-gray-5;
+      background: $studio-white;
+      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
+    }
+  }
+}
+
+.theme-light {
+  .slider {
+    // Track
+    &::-webkit-slider-runnable-track {
+      background: $studio-gray-5;
+    }
+    &::-moz-range-track {
+      background: $studio-gray-5;
+    }
+    &::-ms-track {
+      border-color: $studio-gray-5;
+    }
+    &::-ms-fill-lower {
+      background: $studio-white;
+    }
+    &::-ms-fill-upper {
+      background: $studio-white;
+    }
+
+    // Thumb
+    &::-webkit-slider-thumb {
+      border-color: $studio-gray-5;
+      background: $studio-white;
+      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
+    }
+    &::-moz-range-thumb {
+      background: $studio-white;
+      border-color: $studio-gray-5;
+      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
+    }
+    &::-ms-thumb {
+      border-color: $studio-gray-5;
+      background: $studio-white;
+      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
+    }
   }
 }

--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -48,8 +48,10 @@
     }
   }
   &::-moz-range-thumb {
+    height: 15px;
+    width: 15px;
     border-radius: 50%;
-    border: 2px solid $studio-gray-30;
+    border: 1px solid $studio-gray-30;
     appearance: none;
     background: $studio-white;
     transition: 0.15s ease-in-out;

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -73,12 +73,15 @@ export class RevisionSelector extends Component<Props> {
       (openedRevision
         ? revisions.get(openedRevision).modificationDate
         : note.modificationDate) * 1000,
-      'MMM d, yyyy'
+      'MMM d, yyyy h:mm a'
     );
 
-    const mainClasses = classNames('revision-selector', {
-      'is-visible': isViewingRevisions,
-    });
+    const mainClasses = classNames(
+      'revision-selector theme-color-border theme-color-fg',
+      {
+        'is-visible': isViewingRevisions,
+      }
+    );
 
     return (
       <div className={mainClasses}>

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -104,7 +104,6 @@ export class RevisionSelector extends Component<Props> {
               }
               max={revisions?.size - 1}
               value={selectedIndex > -1 ? selectedIndex : revisions?.size - 1}
-              list="revisionpoints"
               onChange={this.onSelectRevision}
             />
           </div>

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -69,6 +69,12 @@ export class RevisionSelector extends Component<Props> {
       !openedRevision ||
       (openedRevision && selectedIndex === revisions?.size - 1);
 
+    const leftPos = Number(
+      (((selectedIndex === -1 ? revisions?.size : selectedIndex) - 1) * 100) /
+        (revisions?.size - 2)
+    );
+    const datePos = `calc(${leftPos}% + (${8 - leftPos * 0.15}px))`;
+
     const revisionDate = format(
       (openedRevision
         ? revisions.get(openedRevision).modificationDate
@@ -85,34 +91,38 @@ export class RevisionSelector extends Component<Props> {
 
     return (
       <div className={mainClasses}>
-        <div className="revision-slider-title">History</div>
-        <div className="revision-date">{revisionDate}</div>
-        <div className="revision-slider">
-          <Slider
-            disabled={!revisions || revisions.size === 0}
-            min={
-              1 /* don't allow reverting to the very first version because that's a blank note */
-            }
-            max={revisions?.size - 1}
-            value={selectedIndex > -1 ? selectedIndex : revisions?.size - 1}
-            list="revisionpoints"
-            onChange={this.onSelectRevision}
-          />
-        </div>
-        <div className="revision-buttons">
-          <button
-            className="button button-secondary button-compact"
-            onClick={this.onCancelRevision}
-          >
-            Cancel
-          </button>
-          <button
-            disabled={isNewest}
-            className="button button-primary button-compact"
-            onClick={this.onAcceptRevision}
-          >
-            Restore Note
-          </button>
+        <div className="revision-selector-inner">
+          <div className="revision-slider-title">History</div>
+          <div className="revision-date" style={{ left: datePos }}>
+            {revisionDate}
+          </div>
+          <div className="revision-slider">
+            <Slider
+              disabled={!revisions || revisions.size === 0}
+              min={
+                1 /* don't allow reverting to the very first version because that's a blank note */
+              }
+              max={revisions?.size - 1}
+              value={selectedIndex > -1 ? selectedIndex : revisions?.size - 1}
+              list="revisionpoints"
+              onChange={this.onSelectRevision}
+            />
+          </div>
+          <div className="revision-buttons">
+            <button
+              className="button button-secondary button-compact"
+              onClick={this.onCancelRevision}
+            >
+              Cancel
+            </button>
+            <button
+              disabled={isNewest}
+              className="button button-primary button-compact"
+              onClick={this.onAcceptRevision}
+            >
+              Restore Note
+            </button>
+          </div>
         </div>
       </div>
     );

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -73,7 +73,7 @@ export class RevisionSelector extends Component<Props> {
       (openedRevision
         ? revisions.get(openedRevision).modificationDate
         : note.modificationDate) * 1000,
-      'MMM d, yyyy h:mm a'
+      'MMM d, yyyy'
     );
 
     const mainClasses = classNames('revision-selector', {
@@ -82,7 +82,8 @@ export class RevisionSelector extends Component<Props> {
 
     return (
       <div className={mainClasses}>
-        <div className="revision-date">{`Originally created: ${revisionDate}`}</div>
+        <div className="revision-slider-title">History</div>
+        <div className="revision-date">{revisionDate}</div>
         <div className="revision-slider">
           <Slider
             disabled={!revisions || revisions.size === 0}
@@ -91,6 +92,7 @@ export class RevisionSelector extends Component<Props> {
             }
             max={revisions?.size - 1}
             value={selectedIndex > -1 ? selectedIndex : revisions?.size - 1}
+            list="revisionpoints"
             onChange={this.onSelectRevision}
           />
         </div>

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -70,6 +70,7 @@ export class RevisionSelector extends Component<Props> {
       (openedRevision && selectedIndex === revisions?.size - 1);
 
     const leftPos = Number(
+      // Based on ((selected - min) * 100) / (max - min);
       (((selectedIndex === -1 ? revisions?.size : selectedIndex) - 1) * 100) /
         (revisions?.size - 2)
     );

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -119,7 +119,7 @@ export class RevisionSelector extends Component<Props> {
               className="button button-primary button-compact"
               onClick={this.onAcceptRevision}
             >
-              Restore Note
+              Restore
             </button>
           </div>
         </div>

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -83,7 +83,7 @@ export class RevisionSelector extends Component<Props> {
     );
 
     const mainClasses = classNames(
-      'revision-selector theme-color-border theme-color-fg',
+      'revision-selector theme-color-border theme-color-fg theme-color-bg',
       {
         'is-visible': isViewingRevisions,
       }

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -1,9 +1,7 @@
 .revision-selector {
-  background: $studio-white;
-  border-top: 1px solid $studio-gray-30;
-  color: $studio-gray-80;
-  height: 144px;
-  padding: 10px 20px 20px;
+  border-top: 1px solid;
+  height: 178px;
+  padding: 19px 20px 20px;
   position: absolute;
   transition: all 0.3s ease-in-out;
   width: 100%;
@@ -20,19 +18,17 @@
   .revision-buttons {
     display: flex;
     justify-content: flex-end;
-    max-width: 625px;
+    max-width: $max-content-width;
     margin: 0 auto;
 
     button {
       @extend %smart-focus-outline;
       font-weight: 400;
+      border: 0;
     }
   }
 
   .button-primary {
-    background: $studio-simplenote-blue-50;
-    color: $studio-white;
-
     &:active {
       background: $studio-simplenote-blue-5;
       border-color: $studio-simplenote-blue-5;
@@ -40,10 +36,9 @@
   }
 
   .button-secondary {
-    background: $studio-gray-30;
+    background: $studio-gray-50;
     color: $studio-white;
     margin-right: 10px;
-    border: 0;
 
     &:active {
       background: $studio-white;
@@ -59,22 +54,22 @@
 
   .revision-date {
     width: 100%;
-    color: $studio-gray-80;
     text-align: center;
-    margin-bottom: 10px;
+    margin-bottom: 8px;
+    font-size: 12px;
   }
 
   .revision-slider-title {
-    margin: 0 auto;
-    max-width: 625px;
-    font-weight: 700;
+    margin: 0 auto 26px auto;
+    max-width: $max-content-width;
+    font-weight: 600;
+    font-size: 16px;
   }
 }
 
 .theme-dark {
   .revision-selector {
     background-color: $studio-gray-80;
-    color: $studio-white;
   }
 
   .revision-date {

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -15,10 +15,16 @@
     width: 100%;
   }
 
+  .revision-selector-inner {
+    max-width: $max-content-width;
+    width: 85%;
+    position: relative;
+    margin: 0 auto;
+  }
+
   .revision-buttons {
     display: flex;
     justify-content: flex-end;
-    max-width: $max-content-width;
     margin: 0 auto;
 
     button {
@@ -54,15 +60,16 @@
   }
 
   .revision-date {
-    width: 100%;
     text-align: center;
-    margin-bottom: 8px;
     font-size: 12px;
+    position: absolute;
+    top: 28px;
+    transform: translateX(-50%);
+    white-space: nowrap;
   }
 
   .revision-slider-title {
     margin: 0 auto 26px auto;
-    max-width: $max-content-width;
     font-weight: 600;
     font-size: 16px;
   }
@@ -70,7 +77,8 @@
 
 .theme-dark {
   .revision-selector {
-    background-color: $studio-gray-80;
+    //background-color: $studio-gray-80;
+    background-color: #323436;
   }
 
   .revision-date {

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -1,13 +1,16 @@
 .revision-selector {
-  background: $studio-simplenote-blue-50;
+  background: $studio-white;
+  border-top: 1px solid $studio-gray-30;
+  color: $studio-gray-80;
+  height: 144px;
   padding: 10px 20px 20px;
-  color: $studio-white;
-  z-index: 1000;
-  height: 114px;
+  position: absolute;
   transition: all 0.3s ease-in-out;
+  width: 100%;
+  z-index: 1000;
 
   &.is-visible {
-    top: 0;
+    bottom: 0;
   }
 
   @media only screen and (max-width: $single-column) {
@@ -16,17 +19,19 @@
 
   .revision-buttons {
     display: flex;
-    justify-content: center;
+    justify-content: flex-end;
+    max-width: 625px;
+    margin: 0 auto;
 
     button {
       @extend %smart-focus-outline;
+      font-weight: 400;
     }
   }
 
   .button-primary {
-    background: $studio-white;
-    color: $studio-simplenote-blue-50;
-    border-color: $studio-white;
+    background: $studio-simplenote-blue-50;
+    color: $studio-white;
 
     &:active {
       background: $studio-simplenote-blue-5;
@@ -35,9 +40,10 @@
   }
 
   .button-secondary {
-    border-color: $studio-white;
+    background: $studio-gray-30;
     color: $studio-white;
     margin-right: 10px;
+    border: 0;
 
     &:active {
       background: $studio-white;
@@ -53,9 +59,26 @@
 
   .revision-date {
     width: 100%;
-    color: $studio-white;
+    color: $studio-gray-80;
     text-align: center;
     margin-bottom: 10px;
+  }
+
+  .revision-slider-title {
+    margin: 0 auto;
+    max-width: 625px;
+    font-weight: 700;
+  }
+}
+
+.theme-dark {
+  .revision-selector {
+    background-color: $studio-gray-80;
+    color: $studio-white;
+  }
+
+  .revision-date {
+    color: $studio-white;
   }
 }
 

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -75,12 +75,6 @@
   }
 }
 
-.theme-dark {
-  .revision-selector.theme-color-bg {
-    background-color: #323436;
-  }
-}
-
 .is-focus-mode .revision-selector {
   width: 100%;
 }

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -76,13 +76,8 @@
 }
 
 .theme-dark {
-  .revision-selector {
-    //background-color: $studio-gray-80;
+  .revision-selector.theme-color-bg {
     background-color: #323436;
-  }
-
-  .revision-date {
-    color: $studio-white;
   }
 }
 

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -23,6 +23,7 @@
 
     button {
       @extend %smart-focus-outline;
+
       font-weight: 400;
       border: 0;
     }

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -63,13 +63,13 @@
     text-align: center;
     font-size: 12px;
     position: absolute;
-    top: 28px;
+    top: 35px;
     transform: translateX(-50%);
     white-space: nowrap;
   }
 
   .revision-slider-title {
-    margin: 0 auto 26px auto;
+    margin: 0 auto 38px auto;
     font-weight: 600;
     font-size: 16px;
   }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -17,7 +17,7 @@ $focus-outline: 4px auto $studio-simplenote-blue-5;
 
 $navigation-bar-width: 260px;
 $note-info-width: 320px;
-$max-content-width: 625px;
+$max-content-width: 650px;
 $toolbar-height: 44px;
 
 // Viewport widths for media queries


### PR DESCRIPTION
### Fix

Part of our UI Spring Cleaning and resolves #2565.
This moves the Slider to the bottom of the note instead of the top and starts to adjust the styles.
This includes updated colors and has the revision date follow the current slider position

<img width="1022" alt="Screen Shot 2021-01-25 at 11 24 16 AM" src="https://user-images.githubusercontent.com/1326294/105725923-e2392780-5eff-11eb-9705-31a8b12f6a79.png">
<img width="1021" alt="Screen Shot 2021-01-25 at 11 38 36 AM" src="https://user-images.githubusercontent.com/1326294/105727899-ed8d5280-5f01-11eb-950d-f55f52e4a47e.png">


### Items not yet addressed

- Part of the new design is to have tick marks below the slider one for each revision available. This will be looked at in a different PR later.
- In Chrome the slider handle is down below the slider track, but that seems to be the case in the current live version as well. Does not happen in Electron.
- The design calls to show just the date for revisions and not the time. This makes it awkward for multiple revisions on the same date so for now I've left the time in as well.
- Some colors are still being set in the component and not in the theme.scss file.

### Test

1. Open history for a note
2. Notice the revision slider is now at the bottom
3. Move slider ensure revision date follows current slider position
4. Ensure styling looks correct.
5. Repeat for both dark mode and light mode. 

### Release

- Move note revision slider to the bottom of note and update styles.
