### PR TITLE
Remove ?from=react from Settings URL

### DIFF
--- a/lib/dialogs/settings/panels/account.tsx
+++ b/lib/dialogs/settings/panels/account.tsx
@@ -28,7 +28,7 @@ const AccountPanel: FunctionComponent<Props> = ({
   toggleAnalytics,
 }) => {
   const onEditAccount = () => {
-    viewExternalUrl(`https://app.simplenote.com/settings/?from=react`);
+    viewExternalUrl(`https://app.simplenote.com/settings/`);
   };
 
   return (


### PR DESCRIPTION
### Fix

We can deploy this once the associated PR is deployed on App Engine. (It won't break or anything but this parameter is no longer required.)


### Test
1. Go to Settings
2. Ensure you see the abbreviated Settings screen (without the display settings for the old web app)
3. Click on Back to Notes and ensure you are directed back to the new app

### Release

Updated the external Settings URL