### PR TITLE
Merge release 2.5.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [v2.5.0]
+
+### Fixes
+
+- Fixed a bug that sometimes prevented checklists and bulleted lists from automatically continuing on the next line [#2548](https://github.com/Automattic/simplenote-electron/pull/2548)
+- Fixed layout bugs causing the search results bar to overlap note contents and tag input field [#2545](https://github.com/Automattic/simplenote-electron/pull/2545)
+- Fixed a bug where some search terms could be dropped when searching for quoted strings [#2550](https://github.com/Automattic/simplenote-electron/pull/2550)
+- Fixed navigation list styles on Safari [#2552](https://github.com/Automattic/simplenote-electron/pull/2552)
+- Fixed a bug causing notes to still be filtered after creating a new note from search results [#2557](https://github.com/Automattic/simplenote-electron/pull/2557)
+- Load the correct configuration file in local development [#2536](https://github.com/Automattic/simplenote-electron/pull/2536)
+- Fixed a crash on note search in Safari [#2538](https://github.com/Automattic/simplenote-electron/pull/2538)
+
+### Other Changes
+
+- Updated dependencies [#2547](https://github.com/Automattic/simplenote-electron/pull/2547)
+- Updated arguments to addDynamicKeybinding function [#2546](https://github.com/Automattic/simplenote-electron/pull/2546)
+- Prevent adding undefined as a className when no value provided (props to @ubaidisaev) [#2551](https://github.com/Automattic/simplenote-electron/pull/2551)
+
 ## [v2.4.0]
 
 ### Enhancements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplenote",
-  "version": "2.4.0",
+  "version": "2.5.0-beta1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplenote",
-  "version": "2.5.0-beta1",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "support@simplenote.com"
   },
   "productName": "Simplenote",
-  "version": "2.4.0",
+  "version": "2.5.0-beta1",
   "main": "desktop/index.js",
   "license": "GPL-2.0",
   "homepage": "https://simplenote.com",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "support@simplenote.com"
   },
   "productName": "Simplenote",
-  "version": "2.5.0-beta1",
+  "version": "2.5.0",
   "main": "desktop/index.js",
   "license": "GPL-2.0",
   "homepage": "https://simplenote.com",


### PR DESCRIPTION
The conflicts were only in the `version` key of the `package*.json` file.

---

I got confused for a few seconds from the discrepancies between the commit log and the diff. Then I realized that's due to the "Squash and merge" policy: because https://github.com/Automattic/simplenote-electron/pull/2559 was squashed, Git can't tell that two of the commits in this branch are already on `develop`. The diff not showing them is correct, too: those changes are already in the base branch so there's no diff.