### PR TITLE
Unsynchronized notes warning: Make wording less confusing

### DIFF
--- a/lib/dialogs/close-window-confirmation/index.tsx
+++ b/lib/dialogs/close-window-confirmation/index.tsx
@@ -15,8 +15,8 @@ type Props = DispatchProps;
 const CloseWindowConfirmation = ({ reallyCloseWindow }: Props) => (
   <UnsynchronizedConfirmation
     description="Closing the app with unsynchronized notes could cause data loss."
-    unsafeAction="Close window"
-    safeAction="Safely close window"
+    unsafeAction="Close anyway"
+    safeAction="Safely close app"
     action={reallyCloseWindow}
   />
 );


### PR DESCRIPTION
### Fix

This changes the wording on the unsynchronized notes dialog to read "Close anyway" rather than "Close window". The safe close option reads "Safely close app" rather than "Safely close window", to match the "Closing the app.." wording above.

Fixes #2590

### Release

Clarified the wording of the unsynchronized notes warning