### PR TITLE
Fix: Icon and pinner styles in navigation and notes list

### DIFF
--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -16,70 +16,59 @@
     padding: 0;
     text-align: left;
     width: 100%;
+
+    &:active {
+      background: none;
+    }
   }
 
-  &:hover {
+  &:hover:not(.is-selected) {
     background: $studio-gray-0;
-
-    button svg[class^='icon-'] {
-      fill: $studio-gray-50 !important;
-    }
-  }
-
-  .button:active {
-    background: none;
-  }
-
-  &.is-selected button {
-    border-bottom: none;
-
-    svg[class^='icon-'] {
-      fill: $studio-simplenote-blue-50;
-    }
   }
 
   &.is-selected {
     background-color: $studio-simplenote-blue-5;
+
+    button {
+      border-bottom: none;
+
+      svg[class^='icon-'] {
+        fill: $studio-simplenote-blue-50;
+      }
+    }
+  }
+
+  .navigation-bar-item__icon {
+    color: $studio-gray-50;
+    display: inline-block;
+    margin-right: 18px;
+    vertical-align: middle;
+
+    svg {
+      vertical-align: middle;
+      position: relative;
+      top: -0.2em;
+    }
   }
 }
 
+/* this is the last child (Settings) and prevents a double border on the bottom */
 .navigation-bar-item:first-child .button {
   border-bottom: none !important;
 }
 
-.navigation-bar-item__icon {
-  color: $studio-gray-50;
-  display: inline-block;
-  margin-right: 18px;
-  vertical-align: middle;
-
-  svg {
-    vertical-align: middle;
-    position: relative;
-    top: -0.2em;
-  }
+.navigation-bar-item.is-selected + .navigation-bar-item .button {
+  border-bottom: none;
 }
 
 .theme-dark {
   .navigation-bar-item {
-    &.is-selected svg[class^='icon-'] {
-      fill: $studio-simplenote-blue-30;
-    }
-
     &.is-selected button {
-      color: $studio-simplenote-blue-30;
-    }
-
-    &:hover {
-      background: $studio-gray-80;
-    }
-
-    button {
       color: $studio-white;
     }
-  }
-}
 
-.navigation-bar-item.is-selected + .navigation-bar-item .button {
-  border-bottom: none;
+    &:hover:not(.is-selected) {
+      background: $studio-gray-80;
+    }
+  }
 }

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -30,15 +30,16 @@
     white-space: nowrap;
   }
 
-  .condensed .note-list-item {
-    min-height: 43px;
-  }
-  .condensed .note-list-item-text {
-    padding-bottom: 0;
-  }
-
-  .condensed .note-list-item-excerpt {
-    display: none;
+  .condensed {
+    .note-list-item {
+      min-height: 43px;
+    }
+    .note-list-item-text {
+      padding-bottom: 0;
+    }
+    .note-list-item-excerpt {
+      display: none;
+    }
   }
 
   .expanded .note-list-item-excerpt {
@@ -82,7 +83,7 @@
 .note-list-empty-trash {
   flex: none;
   padding: 10px 20px;
-  border-top: 1px solid $studio-gray-5;
+  border-top: 1px solid;
   text-align: center;
 }
 
@@ -115,11 +116,6 @@
     width: 16px;
   }
 
-  .note-list-item-pinner:hover,
-  .note-list-item-pinner.note-list-item-pinned {
-    color: $studio-simplenote-blue-50;
-  }
-
   .note-list-item-text {
     flex: 1 1 auto;
     overflow: hidden;
@@ -138,13 +134,23 @@
     overflow: hidden;
   }
 
-  &.note-list-item-selected,
-  &.note-list-item-selected:hover {
+  &.note-list-item-selected {
     background: $studio-simplenote-blue-5;
   }
 
-  &:hover {
-    background: $studio-gray-0;
+  &.note-list-item-pinned:not(.note-list-item-selected) {
+    .note-list-item-pinner {
+      color: $studio-gray-50;
+    }
+    .note-list-item-pinner:hover {
+      color: $studio-simplenote-blue-50;
+    }
+  }
+
+  &:not(.note-list-item-selected) {
+    &:hover {
+      background: $studio-gray-0;
+    }
   }
 
   &.note-recently-updated {
@@ -155,15 +161,15 @@
   .note-list-item-status-right {
     display: flex;
     padding: 9px 6px 0 0; // we want 10px total to the right side, but the icon has 4px padding already
-    border-bottom: 1px solid $studio-gray-5;
+    border-bottom: 1px solid;
   }
 
   .note-list-item-pending-changes,
   .note-list-item-published-icon {
     padding: 0 4px;
+    color: $studio-gray-50;
 
     & svg {
-      fill: $studio-gray-50;
       height: 16px;
       width: 16px;
     }
@@ -193,9 +199,5 @@
       text-overflow: ellipsis;
       overflow: hidden;
     }
-  }
-
-  .note-list-item-excerpt {
-    color: $studio-gray-80;
   }
 }

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -136,20 +136,31 @@
 
   &.note-list-item-selected {
     background: $studio-simplenote-blue-5;
-  }
-
-  &.note-list-item-pinned:not(.note-list-item-selected) {
-    .note-list-item-pinner {
-      color: $studio-gray-50;
-    }
-    .note-list-item-pinner:hover {
-      color: $studio-simplenote-blue-50;
+    &.note-list-item-pinned {
+      .note-list-item-pinner {
+        color: $studio-simplenote-blue-50;
+      }
+      &:hover .note-list-item-pinner {
+        color: $studio-simplenote-blue-50;
+      }
+      .note-list-item-pinner:hover {
+        color: $studio-gray-50;
+      }
     }
   }
 
   &:not(.note-list-item-selected) {
     &:hover {
       background: $studio-gray-0;
+    }
+    .note-list-item-pinner:hover {
+      color: $studio-simplenote-blue-50;
+    }
+    &.note-list-item-pinned:hover .note-list-item-pinner {
+      color: $studio-gray-50;
+      &:hover {
+        color: $studio-simplenote-blue-50;
+      }
     }
   }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -306,8 +306,11 @@ span[dir='ltr'] {
       }
     }
 
-    &.note-list-item-pinned:not(.note-list-item-selected) {
+    .note-list-item-pinned:not(.note-list-item-selected) {
       .note-list-item-pinner {
+        color: $studio-simplenote-blue-30;
+      }
+      &:hover .note-list-item-pinner {
         color: $studio-gray-80;
       }
     }
@@ -315,6 +318,17 @@ span[dir='ltr'] {
     .note-list-item:not(.note-list-item-selected) {
       &:hover {
         background: $studio-gray-80;
+      }
+
+      &.note-list-item-pinned:hover .note-list-item-pinner {
+        color: $studio-gray-30;
+        &:hover {
+          color: $studio-simplenote-blue-30;
+        }
+      }
+
+      .note-list-item-pinner:hover {
+        color: $studio-simplenote-blue-30;
       }
     }
   }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -157,6 +157,13 @@ span[dir='ltr'] {
   .button-borderless {
     color: $studio-simplenote-blue-50;
   }
+
+  .note-list-item-pinner {
+    &:hover,
+    &.note-list-item-pinned {
+      color: $studio-simplenote-blue-50;
+    }
+  }
 }
 
 .theme-dark {
@@ -271,43 +278,44 @@ span[dir='ltr'] {
     background-color: rgba(50, 52, 54, 0.5);
   }
 
-  .note-list-item {
-    &.note-list-item-selected,
-    &.note-list-item-selected:hover {
-      background: $studio-simplenote-blue-50;
+  .note-list {
+    .note-list-item .note-list-item-pinner:hover {
+      color: $studio-simplenote-blue-30;
+    }
 
-      .note-list-item-excerpt {
+    .note-list-item-selected {
+      background: $studio-simplenote-blue-50;
+      .note-list-item-excerpt,
+      .note-list-item-published-icon,
+      .note-list-item-pending-changes {
         color: $studio-white;
       }
-      svg[class^='icon-'] {
-        fill: $studio-white;
+      .note-list-item-pending-changes {
+        &.is-offline svg {
+          fill: $studio-gray-30;
+        }
+      }
+      .note-list-item-pinner:hover {
+        color: $studio-white;
+      }
+      &.note-list-item-pinned .note-list-item-pinner {
+        color: $studio-white;
+        &:hover {
+          color: $studio-simplenote-blue-30;
+        }
       }
     }
 
-    &.note-list-item-pinned.note-list-item-selected:hover {
-      svg[class^='icon-'] {
-        fill: $studio-white;
+    &.note-list-item-pinned:not(.note-list-item-selected) {
+      .note-list-item-pinner {
+        color: $studio-gray-80;
       }
     }
 
-    &:hover {
-      background: $studio-gray-80;
-    }
-
-    &.note-list-item-pinned:hover {
-      svg[class^='icon-'] {
-        fill: $studio-gray-30;
+    .note-list-item:not(.note-list-item-selected) {
+      &:hover {
+        background: $studio-gray-80;
       }
-    }
-  }
-
-  .note-list-item-pinner.note-list-item-pinned {
-    color: $studio-simplenote-blue-30;
-  }
-
-  .note-list-item-pinner:hover {
-    svg[class^='icon-'] {
-      fill: $studio-simplenote-blue-30 !important;
     }
   }
 


### PR DESCRIPTION
### Fix

This fixes some incorrect icon colors and makes some progress in untangling these component styles generally. Follow-up to #2580.

Designs:
* https://app.zeplin.io/project/5d795a3d8ed5261aa146e057/screen/5fbbc5e81bc37159baf42a47
* https://app.zeplin.io/project/5d795a3d8ed5261aa146e057/screen/5fbbc5347608905ee4ae2dd3
* https://app.zeplin.io/project/5d795a3d8ed5261aa146e057/screen/5fbbc5d768735855a07651d9
* https://app.zeplin.io/project/5d795a3d8ed5261aa146e057/screen/5fbbc5944b88d656997f593a

### Test

1. In both light and dark themes:
1. Verify that the navigation list has the right icon colors that don't change when hovered over
2. Verify the notes list has the right backgrounds and hovers for selected / pinned / hovered notes
3. Verify the pin icon in the notes list:
3a. Only is shown on pinned notes (unless hovered)
3b. Is visible when a pinned note is selected
3c. Is not shown when a non-pinned note is selected (unless hovered)
3d. Changes color in all of the above states, when hovered over, to indicate it can be clicked
4. Make sure published icon is legible for all note states (selected, hover)
5. Make sure syncing and offline/unsynced icon is legible for all note states

### Screenshots

<img width="262" alt="Screen Shot 2021-01-23 at 9 42 13 PM" src="https://user-images.githubusercontent.com/52152/105622199-2cb58980-5dc4-11eb-9666-b04896c09e55.png">

<img width="333" alt="Screen Shot 2021-01-23 at 9 42 10 PM" src="https://user-images.githubusercontent.com/52152/105622201-30e1a700-5dc4-11eb-8f3c-0e16fc0fb4bb.png">

<img width="263" alt="Screen Shot 2021-01-23 at 9 42 47 PM" src="https://user-images.githubusercontent.com/52152/105622223-6f776180-5dc4-11eb-9802-70193b04d6e5.png">
  
<img width="330" alt="Screen Shot 2021-01-23 at 9 42 32 PM" src="https://user-images.githubusercontent.com/52152/105622219-64243600-5dc4-11eb-9a46-4266f3e92d4f.png">

<img width="333" alt="Screen Shot 2021-01-23 at 9 42 52 PM" src="https://user-images.githubusercontent.com/52152/105622222-6ab2ad80-5dc4-11eb-968a-e9e9ce0d4b28.png">



### Release

Fixed icon and pinner styles in the navigation and notes list