### PR TITLE
Add new note icon to top toolbar when in focus mode

### DIFF
--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -17,7 +17,6 @@ import ShareIcon from '../icons/share';
 import SidebarIcon from '../icons/sidebar';
 import TrashIcon from '../icons/trash';
 import actions from '../state/actions';
-import { createNote } from '../state/ui/actions';
 
 import * as S from '../state';
 import * as T from '../types';
@@ -204,7 +203,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   deleteNoteForever: actions.ui.deleteOpenNoteForever,
-  newNote: createNote,
+  newNote: actions.ui.createNote,
   restoreNote: actions.ui.restoreOpenNote,
   shareNote: () => actions.ui.showDialog('SHARE'),
   toggleEditMode: actions.ui.toggleEditMode,

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -22,7 +22,6 @@ import * as S from '../state';
 import * as T from '../types';
 
 type StateProps = {
-  newNote: Function;
   editMode: boolean;
   hasRevisions: boolean;
   isOffline: boolean;

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -3,10 +3,7 @@ import { connect } from 'react-redux';
 import { isMac } from '../utils/platform';
 
 import BackIcon from '../icons/back';
-<<<<<<< HEAD
 import ChecklistIcon from '../icons/check-list';
-=======
->>>>>>> Add new note icon to top toolbar when in focus mode
 import IconButton from '../icon-button';
 import InfoIcon from '../icons/info';
 import NewNoteIcon from '../icons/new-note';

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -3,9 +3,13 @@ import { connect } from 'react-redux';
 import { isMac } from '../utils/platform';
 
 import BackIcon from '../icons/back';
+<<<<<<< HEAD
 import ChecklistIcon from '../icons/check-list';
+=======
+>>>>>>> Add new note icon to top toolbar when in focus mode
 import IconButton from '../icon-button';
 import InfoIcon from '../icons/info';
+import NewNoteIcon from '../icons/new-note';
 import PreviewIcon from '../icons/preview';
 import PreviewStopIcon from '../icons/preview-stop';
 import RevisionsIcon from '../icons/revisions';
@@ -13,11 +17,13 @@ import ShareIcon from '../icons/share';
 import SidebarIcon from '../icons/sidebar';
 import TrashIcon from '../icons/trash';
 import actions from '../state/actions';
+import { createNote } from '../state/ui/actions';
 
 import * as S from '../state';
 import * as T from '../types';
 
 type StateProps = {
+  onNewNote: Function;
   editMode: boolean;
   hasRevisions: boolean;
   isOffline: boolean;
@@ -27,6 +33,7 @@ type StateProps = {
 
 type DispatchProps = {
   deleteNoteForever: () => any;
+  onNewNote: () => any;
   restoreNote: () => any;
   shareNote: () => any;
   toggleEditMode: () => any;
@@ -44,7 +51,6 @@ export class NoteToolbar extends Component<Props> {
 
   render() {
     const { note } = this.props;
-
     return (
       <div className="note-toolbar-wrapper theme-color-border">
         {note?.deleted ? this.renderTrashed() : this.renderNormal()}
@@ -55,6 +61,7 @@ export class NoteToolbar extends Component<Props> {
   renderNormal = () => {
     const {
       editMode,
+      onNewNote,
       hasRevisions,
       isOffline,
       markdownEnabled,
@@ -67,6 +74,13 @@ export class NoteToolbar extends Component<Props> {
     ) : (
       <div className="note-toolbar">
         <div className="note-toolbar__column-left">
+          <div className="note-toolbar__button new-note-toolbar__button-sidebar theme-color-border">
+            <IconButton
+              icon={<NewNoteIcon />}
+              onClick={() => onNewNote()}
+              title="New Note • Ctrl+Shift+I"
+            />
+          </div>
           <div className="note-toolbar__button note-toolbar__button-sidebar">
             <IconButton
               icon={<SidebarIcon />}
@@ -190,6 +204,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   deleteNoteForever: actions.ui.deleteOpenNoteForever,
+  onNewNote: () => createNote(),
   restoreNote: actions.ui.restoreOpenNote,
   shareNote: () => actions.ui.showDialog('SHARE'),
   toggleEditMode: actions.ui.toggleEditMode,

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -23,7 +23,7 @@ import * as S from '../state';
 import * as T from '../types';
 
 type StateProps = {
-  onNewNote: Function;
+  newNote: Function;
   editMode: boolean;
   hasRevisions: boolean;
   isOffline: boolean;
@@ -33,7 +33,7 @@ type StateProps = {
 
 type DispatchProps = {
   deleteNoteForever: () => any;
-  onNewNote: () => any;
+  newNote: () => any;
   restoreNote: () => any;
   shareNote: () => any;
   toggleEditMode: () => any;
@@ -61,7 +61,7 @@ export class NoteToolbar extends Component<Props> {
   renderNormal = () => {
     const {
       editMode,
-      onNewNote,
+      newNote,
       hasRevisions,
       isOffline,
       markdownEnabled,
@@ -77,7 +77,7 @@ export class NoteToolbar extends Component<Props> {
           <div className="note-toolbar__button new-note-toolbar__button-sidebar theme-color-border">
             <IconButton
               icon={<NewNoteIcon />}
-              onClick={() => onNewNote()}
+              onClick={() => newNote()}
               title="New Note • Ctrl+Shift+I"
             />
           </div>
@@ -204,7 +204,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   deleteNoteForever: actions.ui.deleteOpenNoteForever,
-  onNewNote: () => createNote(),
+  newNote: createNote,
   restoreNote: actions.ui.restoreOpenNote,
   shareNote: () => actions.ui.showDialog('SHARE'),
   toggleEditMode: actions.ui.toggleEditMode,

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -106,17 +106,17 @@
 }
 
 .note-toolbar-placeholder {
+  border-bottom: 1px solid $studio-gray-5;
   display: block;
   height: $toolbar-height;
-  border-bottom: 1px solid $studio-gray-5;
 }
 
 .new-note-toolbar__button-sidebar {
   border-right: 1px solid;
-  padding-right: 13px;
   display: none;
-  height: 100%;
-  padding-top: 5px;
+  height: $toolbar-height;
+  line-height: $toolbar-height;
+  padding-right: 13px;
 }
 
 .is-focus-mode .new-note-toolbar__button-sidebar {

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -110,3 +110,15 @@
   height: $toolbar-height;
   border-bottom: 1px solid $studio-gray-5;
 }
+
+.new-note-toolbar__button-sidebar {
+  border-right: 1px solid;
+  padding-right: 13px;
+  display: none;
+  height: 100%;
+  padding-top: 5px;
+}
+
+.is-focus-mode .new-note-toolbar__button-sidebar {
+  display: block;
+}

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -79,6 +79,11 @@ optgroup {
     padding: 40px 0 30px;
   }
 
+  .new-note-toolbar__button-sidebar {
+    height: 70px;
+    line-height: 70px;
+  }
+
   .menu-bar {
     padding: 40px 15px 30px;
     box-sizing: border-box;


### PR DESCRIPTION
### Fix

Adding the new note icon to the note toolbar when we are in focus mode.
This addresses part of the issue #2563 as part of the UI Spring Cleaning.

![Screen Shot 2021-01-25 at 3 01 04 PM](https://user-images.githubusercontent.com/1326294/105753400-035d4080-5f1f-11eb-984a-6b27b092a7dd.png)
![Screen Shot 2021-01-25 at 3 01 26 PM](https://user-images.githubusercontent.com/1326294/105753408-06583100-5f1f-11eb-808a-c191539f6a17.png)


### Test

1. Enter focus mode by toggling the left sidebar so it is hidden 
2. Click the new note icon in the upper left
3. Ensure the new note is created
4. Try this in both light and dark mode to ensure styles appear correct. 

### Release

- Add the new note icon to the toolbar when in focus mode.
