### PR TITLE
Fix the isMac variable so it is accurate on web and electron

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -177,7 +177,7 @@ class AppComponent extends Component<Props> {
       'note-info-open': showNoteInfo,
       'navigation-open': showNavigation,
       'is-electron': isElectron,
-      'is-macos': isMac,
+      'is-macos': isElectron && isMac,
     });
 
     return (

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -70,7 +70,7 @@ export class Auth extends Component<Props> {
 
     return (
       <div className={mainClasses}>
-        {isMac && <div className="login__draggable-area" />}
+        {isElectron && isMac && <div className="login__draggable-area" />}
         <SimplenoteLogo />
         <form className="login__form" onSubmit={this.onSubmit}>
           <h1>{buttonLabel}</h1>

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -143,7 +143,7 @@ export class AboutDialog extends Component<DispatchProps> {
                   </li>
                 )}
                 <li>
-                  <Keys keys={[CmdOrCtrl, 'Shift', 'P']}>
+                  <Keys keys={['Ctrl', 'Shift', 'P']}>
                     Toggle Markdown preview
                   </Keys>
                 </li>

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import Dialog from '../../dialog';
 import { closeDialog } from '../../state/ui/actions';
-import { isElectron, isMac } from '../../utils/platform';
+import { CmdOrCtrl, isElectron } from '../../utils/platform';
 
 import * as S from '../../state';
 
@@ -40,7 +40,6 @@ const Keys = ({
 export class AboutDialog extends Component<DispatchProps> {
   render() {
     const { closeDialog } = this.props;
-    const CmdOrCtrl = isMac ? 'Cmd' : 'Ctrl';
 
     return (
       <div className="keybindings">
@@ -143,7 +142,7 @@ export class AboutDialog extends Component<DispatchProps> {
                   </li>
                 )}
                 <li>
-                  <Keys keys={['Ctrl', 'Shift', 'P']}>
+                  <Keys keys={[CmdOrCtrl, 'Shift', 'P']}>
                     Toggle Markdown preview
                   </Keys>
                 </li>

--- a/lib/menu-bar/index.tsx
+++ b/lib/menu-bar/index.tsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { CmdOrCtrl } from '../utils/platform';
 import IconButton from '../icon-button';
 import NewNoteIcon from '../icons/new-note';
 import MenuIcon from '../icons/menu';
@@ -53,14 +54,14 @@ export const MenuBar: FunctionComponent<Props> = ({
       <IconButton
         icon={<MenuIcon />}
         onClick={toggleNavigation}
-        title="Menu • Ctrl+Shift+U"
+        title={`Menu • ${CmdOrCtrl}+Shift+U`}
       />
       {placeholder}
       <IconButton
         disabled={showTrash}
         icon={<NewNoteIcon />}
         onClick={() => onNewNote(withoutTags(searchQuery))}
-        title="New Note • Ctrl+Shift+I"
+        title={`New Note • ${CmdOrCtrl}+Shift+I`}
       />
     </div>
   );

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -738,6 +738,7 @@ class NoteContentEditor extends Component<Props> {
       label: 'Insert Checklist',
       keybindings: [
         monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KEY_C,
+        monaco.KeyMod.WinCtrl | monaco.KeyMod.Shift | monaco.KeyCode.KEY_C,
       ],
       keybindingContext: 'allowBrowserKeybinding',
       contextMenuGroupId: '10_checklist',

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { isMac } from '../utils/platform';
+import { CmdOrCtrl } from '../utils/platform';
 
 import BackIcon from '../icons/back';
 import ChecklistIcon from '../icons/check-list';
@@ -63,7 +63,7 @@ export class NoteToolbar extends Component<Props> {
       note,
       toggleNoteInfo,
     } = this.props;
-    const CmdOrCtrl = isMac ? 'Cmd' : 'Ctrl';
+
     return !note ? (
       <div className="note-toolbar-placeholder theme-color-border" />
     ) : (
@@ -73,7 +73,7 @@ export class NoteToolbar extends Component<Props> {
             <IconButton
               icon={<NewNoteIcon />}
               onClick={() => newNote()}
-              title="New Note • Ctrl+Shift+I"
+              title={`New Note • ${CmdOrCtrl}+Shift+I`}
             />
           </div>
           <div className="note-toolbar__button note-toolbar__button-sidebar">
@@ -87,7 +87,7 @@ export class NoteToolbar extends Component<Props> {
             <IconButton
               icon={<BackIcon />}
               onClick={this.props.toggleNoteList}
-              title="Back • Ctrl+Shift+L"
+              title={`Back • ${CmdOrCtrl}+Shift+L`}
             />
           </div>
         </div>
@@ -105,7 +105,7 @@ export class NoteToolbar extends Component<Props> {
               <IconButton
                 icon={!editMode ? <PreviewStopIcon /> : <PreviewIcon />}
                 onClick={this.props.toggleEditMode}
-                title="Preview • Ctrl+Shift+P"
+                title={`Preview • ${CmdOrCtrl}+Shift+P`}
               />
             </div>
           )}
@@ -152,7 +152,7 @@ export class NoteToolbar extends Component<Props> {
           <IconButton
             icon={<BackIcon />}
             onClick={this.props.toggleNoteList}
-            title="Back • Ctrl+Shift+L"
+            title={`Back • ${CmdOrCtrl}+Shift+L`}
           />
         </div>
         {isOffline && <div className="offline-badge">OFFLINE</div>}

--- a/lib/utils/platform.ts
+++ b/lib/utils/platform.ts
@@ -5,6 +5,8 @@ export const isMac = isElectron
   ? window?.electron?.isMac
   : navigator.appVersion.indexOf('Mac') !== -1;
 
+export const CmdOrCtrl = isElectron && isMac ? 'Cmd' : 'Ctrl';
+
 export const isSafari = /^((?!chrome|android).)*safari/i.test(
   window.navigator.userAgent
 );

--- a/lib/utils/platform.ts
+++ b/lib/utils/platform.ts
@@ -1,7 +1,9 @@
 // https://github.com/atom/electron/issues/22
 export const isElectron = !!window?.electron;
 
-export const isMac = window?.electron?.isMac;
+export const isMac = isElectron
+  ? window?.electron?.isMac
+  : navigator.appVersion.indexOf('Mac') !== -1;
 
 export const isSafari = /^((?!chrome|android).)*safari/i.test(
   window.navigator.userAgent


### PR DESCRIPTION
### Fix

We were using the variable isMac to determine if we should use show Ctrl or Cmd for keyboard shortcuts and a couple other places. But isMac was only defined on Electron. It The keyboard shortcut display worked, but was a side effect.

- This fixes the isMac variable so it reliably will tell us if a system is Mac. 
- Updates places where isMac was used but meant for only Mac & Electron to check both isMac and isElectron.
- Fixes the Insert checklist keyboard shortcut so it works with both Ctrl and Cmd on Mac Browsers
- Introduces a new variable CmdOrCtrl which allows us to display keyboard shortcuts appropriately.
- Updates icon tool tips to use this variable so they wills how the right keyboard shortcut.

### Test

1. Open keyboard shortcuts with either `Ctrl + /` or `Cmd + /` keyboard shortcut or by going to the menu and clicking the keyboard shortcut link
2. Ensure on Mac Electron the keyboard shortcuts are showing as Cmd
3. Ensure on Windows and Linux they are showing as Ctrl
4. Ensure top navigation bar is the correct height on Mac Electron
5. Ensure top navigation bar is the correct height in browsers.
6. Ensure the insert checklist keyboard shortcut works with either `Ctrl+Shift+C` or `Cmd+Shift+C` in Mac Browsers

### Release

- Update keyboard shortcut keys to reflect correctly based on platform
