### PR TITLE
Refactor tag-list/input components to allow better control of renaming tags

### DIFF
--- a/lib/state/data/actions.ts
+++ b/lib/state/data/actions.ts
@@ -64,6 +64,15 @@ export const removeCollaborator: A.ActionCreator<A.RemoveCollaborator> = (
   collaboratorAccount,
 });
 
+export const renameTag: A.ActionCreator<A.RenameTag> = (
+  oldTagName: T.TagName,
+  newTagName: T.TagName
+) => ({
+  type: 'RENAME_TAG',
+  oldTagName,
+  newTagName,
+});
+
 export const toggleAnalytics: A.ActionCreator<A.ToggleAnalytics> = () => ({
   type: 'TOGGLE_ANALYTICS',
 });

--- a/lib/tag-input/index.tsx
+++ b/lib/tag-input/index.tsx
@@ -13,7 +13,6 @@ import type * as T from '../types';
 
 const KEY_TAB = 9;
 const KEY_ENTER = 13;
-const KEY_SPACE = 32;
 const KEY_RIGHT = 39;
 const KEY_COMMA = 188;
 
@@ -124,7 +123,6 @@ export class TagInput extends Component<Props> {
       {
         [KEY_ENTER]: this.submitTag,
         [KEY_COMMA]: this.submitTag,
-        [KEY_SPACE]: this.submitTag,
         [KEY_TAB]: this.interceptTabPress,
         [KEY_RIGHT]: this.interceptRightArrow,
       },

--- a/lib/tag-list/index.tsx
+++ b/lib/tag-list/index.tsx
@@ -30,7 +30,6 @@ type StateProps = {
 type DispatchProps = {
   onEditTags: () => any;
   openTag: (tagName: T.TagName) => any;
-  renameTag: (oldTagName: T.TagName, newTagName: T.TagName) => any;
   reorderTag: (tagName: T.TagName, newIndex: number) => any;
   trashTag: (tagName: T.TagName) => any;
 };
@@ -44,7 +43,6 @@ const SortableTag = SortableElement(
     allowReordering,
     editingActive,
     isSelected,
-    renameTag,
     selectTag,
     theme,
     trashTag,
@@ -53,7 +51,6 @@ const SortableTag = SortableElement(
     allowReordering: boolean;
     editingActive: boolean;
     isSelected: boolean;
-    renameTag: (oldTagName: T.TagName, newTagName: T.TagName) => any;
     selectTag: (tagName: T.TagName) => any;
     theme: 'light' | 'dark';
     trashTag: (tagName: T.TagName) => any;
@@ -69,14 +66,7 @@ const SortableTag = SortableElement(
         editable={editingActive}
         isSelected={isSelected}
         onClick={() => !editingActive && selectTag(tag.name)}
-        onDone={(event) => {
-          const newTagName = event.target?.value as T.TagName;
-
-          if (newTagName && newTagName !== tag.name) {
-            renameTag(tag.name, newTagName);
-          }
-        }}
-        value={tag.name}
+        tagName={tag.name}
       />
       {editingActive && allowReordering && <TagHandle />}
     </li>
@@ -89,7 +79,6 @@ const SortableTagList = SortableContainer(
     items,
     openedTag,
     openTag,
-    renameTheTag,
     sortTagsAlpha,
     theme,
     trashTheTag,
@@ -98,7 +87,6 @@ const SortableTagList = SortableContainer(
     items: [T.TagHash, T.Tag][];
     openedTag: T.TagHash | null;
     openTag: (tagName: T.TagName) => any;
-    renameTheTag: (oldTagName: T.TagName, newTagName: T.TagName) => any;
     sortTagsAlpha: boolean;
     theme: 'light' | 'dark';
     trashTheTag: (tagName: T.TagName) => any;
@@ -111,7 +99,6 @@ const SortableTagList = SortableContainer(
           editingActive={editingTags}
           index={index}
           isSelected={openedTag === value[0]}
-          renameTag={renameTheTag}
           selectTag={openTag}
           theme={theme}
           trashTag={trashTheTag}
@@ -136,7 +123,6 @@ export class TagList extends Component<Props> {
       onEditTags,
       openTag,
       openedTag,
-      renameTag,
       sortTagsAlpha,
       tags,
       theme,
@@ -180,7 +166,6 @@ export class TagList extends Component<Props> {
           openedTag={openedTag}
           openTag={openTag}
           items={sortedTags}
-          renameTheTag={renameTag}
           sortTagsAlpha={sortTagsAlpha}
           theme={theme}
           onSortEnd={this.reorderTag}
@@ -210,11 +195,6 @@ const mapStateToProps: S.MapState<StateProps> = (state) => {
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   onEditTags: toggleTagEditing,
   openTag: openTag,
-  renameTag: (oldTagName, newTagName) => ({
-    type: 'RENAME_TAG',
-    oldTagName,
-    newTagName,
-  }),
   reorderTag: (tagName, newIndex) => ({
     type: 'REORDER_TAG',
     tagName,

--- a/lib/tag-list/input.tsx
+++ b/lib/tag-list/input.tsx
@@ -38,7 +38,7 @@ export const TagListInput: FunctionComponent<Props> = ({
 }) => {
   const [value, setValue] = useState(tagName);
   const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setValue(event.target.value.replace(/\s/g, ''));
+    setValue(event.target.value.replace(/[\s,]/g, ''));
   };
   const onDone = (event: FocusEvent<HTMLInputElement>) => {
     const newTagName = event.target?.value.trim() as T.TagName;

--- a/lib/tag-list/input.tsx
+++ b/lib/tag-list/input.tsx
@@ -1,9 +1,4 @@
-import React, {
-  ChangeEvent,
-  FocusEvent,
-  FunctionComponent,
-  useState,
-} from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 
@@ -20,7 +15,7 @@ type OwnProps = {
 };
 
 type OwnState = {
-  value: string;
+  enteredTagName: string;
 };
 
 type DispatchProps = {
@@ -36,17 +31,17 @@ export const TagListInput: FunctionComponent<Props> = ({
   renameTag,
   tagName,
 }) => {
-  const [value, setValue] = useState(tagName);
-  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setValue(event.target.value.replace(/[\s,]/g, ''));
+  const [enteredTagName, setTagName] = useState(tagName);
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setTagName(event.target.value.replace(/[\s,]/g, ''));
   };
-  const onDone = (event: FocusEvent<HTMLInputElement>) => {
+  const onDone = (event: React.FocusEvent<HTMLInputElement>) => {
     const newTagName = event.target?.value.trim() as T.TagName;
 
     if (newTagName && newTagName !== tagName) {
       renameTag(tagName, newTagName);
     } else {
-      setValue(tagName);
+      setTagName(tagName);
     }
   };
   const classes = classNames('tag-list-input', 'theme-color-fg', {
@@ -58,21 +53,20 @@ export const TagListInput: FunctionComponent<Props> = ({
       className={classes}
       readOnly={!editable}
       onClick={onClick}
-      value={value}
+      value={enteredTagName}
       onChange={onChange}
       onBlur={onDone}
       spellCheck={false}
     />
   ) : (
     <button className={classes} onClick={onClick}>
-      {value}
+      {enteredTagName}
     </button>
   );
 };
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
-  renameTag: (oldTagName, newTagName) =>
-    actions.data.renameTag(oldTagName, newTagName),
+  renameTag: actions.data.renameTag,
 };
 
 export default connect(null, mapDispatchToProps)(TagListInput);

--- a/lib/tag-list/input.tsx
+++ b/lib/tag-list/input.tsx
@@ -1,49 +1,78 @@
-import React, { Component, FocusEvent, MouseEvent } from 'react';
+import React, {
+  ChangeEvent,
+  FocusEvent,
+  FunctionComponent,
+  useState,
+} from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
+
+import actions from '../state/actions';
+
+import type * as S from '../state';
+import type * as T from '../types';
 
 type OwnProps = {
   editable: boolean;
   isSelected: boolean;
   onClick: (event: React.MouseEvent) => any;
-  onDone: (event: FocusEvent<HTMLInputElement>) => any;
-  value: string;
+  tagName: T.TagName;
 };
 
 type OwnState = {
   value: string;
 };
 
-type Props = OwnProps;
+type DispatchProps = {
+  renameTag: (oldTagName: T.TagName, newTagName: T.TagName) => any;
+};
 
-export class TagListInput extends Component<Props, OwnState> {
-  constructor(props: Props) {
-    super(props);
-    this.state = { value: props.value };
-  }
+type Props = OwnProps & DispatchProps;
 
-  render() {
-    const { editable, isSelected, onClick, onDone } = this.props;
-    const { value } = this.state;
-    const classes = classNames('tag-list-input', 'theme-color-fg', {
-      'is-selected': isSelected,
-    });
+export const TagListInput: FunctionComponent<Props> = ({
+  editable,
+  isSelected,
+  onClick,
+  renameTag,
+  tagName,
+}) => {
+  const [value, setValue] = useState(tagName);
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value.replace(/\s/g, ''));
+  };
+  const onDone = (event: FocusEvent<HTMLInputElement>) => {
+    const newTagName = event.target?.value.trim() as T.TagName;
 
-    return editable ? (
-      <input
-        className={classes}
-        readOnly={!editable}
-        onClick={onClick}
-        value={value}
-        onChange={(e) => this.setState({ value: e.target.value })}
-        onBlur={onDone}
-        spellCheck={false}
-      />
-    ) : (
-      <button className={classes} onClick={onClick}>
-        {value}
-      </button>
-    );
-  }
-}
+    if (newTagName && newTagName !== tagName) {
+      renameTag(tagName, newTagName);
+    } else {
+      setValue(tagName);
+    }
+  };
+  const classes = classNames('tag-list-input', 'theme-color-fg', {
+    'is-selected': isSelected,
+  });
 
-export default TagListInput;
+  return editable ? (
+    <input
+      className={classes}
+      readOnly={!editable}
+      onClick={onClick}
+      value={value}
+      onChange={onChange}
+      onBlur={onDone}
+      spellCheck={false}
+    />
+  ) : (
+    <button className={classes} onClick={onClick}>
+      {value}
+    </button>
+  );
+};
+
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
+  renameTag: (oldTagName, newTagName) =>
+    actions.data.renameTag(oldTagName, newTagName),
+};
+
+export default connect(null, mapDispatchToProps)(TagListInput);


### PR DESCRIPTION
### Fix

Started pairing with @belcherj to look at issues in #2207 
We ended up refactoring the TagList and TagListInput components. We moved the `onDone` function from the TagList to TagListInput instead. We also converted the TagListInput to be a function component instead of a class.

This allowed us to address:
- You can no longer rename a tag to be blank.
- You can no longer rename a tag to be only whitespace.
- You can [no longer use spaces](https://github.com/Automattic/Simplenote-United/blob/trunk/docs/tags.md) in a tag.
- You can no longer use commas in a tag.

### Test

1. Open tag list.
2. Choose to edit tags.
3. Try to remove all characters from the tag. Ensure the tag resets to the original name if you do.
4. Try to rename a tag to only have whitespace. Ensure the tag resets to the original name if you do.
5. Try to add spaces to a tag. Ensure no space can be added.
6. Try to add a comma to a tag. Ensure no comma can be added. 

### Release

- Update renaming tag functionality to be more consistent in the app and across platforms.
