### PR TITLE
Add Checklist icon to note toolbar

### DIFF
--- a/lib/icons/check-list.tsx
+++ b/lib/icons/check-list.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function ChecklistIcon() {
+  return (
+    <svg
+      className="icon-checklist"
+      xmlns="http://www.w3.org/2000/svg"
+      width="22"
+      height="22"
+      viewBox="0 0 22 22"
+    >
+      <path d="M21 11H11v2h10V11zM21 6H11v2h10V6zM21 16H11v2h10V16zM5.43 9.03L3 6.72l1.38-1.45 1.03 0.98L7.69 4 9.1 5.43 5.43 9.03zM5.43 14.51L3 12.21l1.38-1.45 1.03 0.97 2.28-2.24 1.41 1.42L5.43 14.51zM5.43 20L3 17.69l1.38-1.45 1.03 0.98 2.28-2.25L9.1 16.4 5.43 20z" />
+    </svg>
+  );
+}

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -173,6 +173,7 @@ class NoteContentEditor extends Component<Props> {
     this.focusEditor();
     this.props.storeFocusEditor(this.focusEditor);
     this.props.storeHasFocus(this.hasFocus);
+    window.addEventListener('toggleChecklist', this.handleChecklist, true);
     this.toggleShortcuts(true);
   }
 
@@ -182,6 +183,7 @@ class NoteContentEditor extends Component<Props> {
     }
     window.electron?.removeListener('editorCommand');
     window.removeEventListener('input', this.handleUndoRedo, true);
+    window.removeEventListener('toggleChecklist', this.handleChecklist, true);
     this.toggleShortcuts(false);
   }
 
@@ -440,6 +442,10 @@ class NoteContentEditor extends Component<Props> {
   focusEditor = () => this.editor?.focus();
 
   hasFocus = () => this.editor?.hasTextFocus();
+
+  handleChecklist = (event: InputEvent) => {
+    this.editor?.trigger('editorCommand', 'insertChecklist', null);
+  };
 
   handleUndoRedo = (event: InputEvent) => {
     switch (event.inputType) {

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -1,15 +1,17 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { isMac } from '../utils/platform';
 
-import IconButton from '../icon-button';
 import BackIcon from '../icons/back';
+import ChecklistIcon from '../icons/check-list';
+import IconButton from '../icon-button';
 import InfoIcon from '../icons/info';
 import PreviewIcon from '../icons/preview';
 import PreviewStopIcon from '../icons/preview-stop';
 import RevisionsIcon from '../icons/revisions';
-import TrashIcon from '../icons/trash';
 import ShareIcon from '../icons/share';
 import SidebarIcon from '../icons/sidebar';
+import TrashIcon from '../icons/trash';
 import actions from '../state/actions';
 
 import * as S from '../state';
@@ -59,6 +61,7 @@ export class NoteToolbar extends Component<Props> {
       note,
       toggleNoteInfo,
     } = this.props;
+    const CmdOrCtrl = isMac ? 'Cmd' : 'Ctrl';
     return !note ? (
       <div className="note-toolbar-placeholder theme-color-border" />
     ) : (
@@ -81,6 +84,12 @@ export class NoteToolbar extends Component<Props> {
         </div>
         {isOffline && <div className="offline-badge">OFFLINE</div>}
         <div className="note-toolbar__column-right">
+          <div className="note-toolbar__button">
+            <IconButton
+              icon={<ChecklistIcon />}
+              title={`Insert Checklist • ${CmdOrCtrl}+Shift+C`}
+            />
+          </div>
           {markdownEnabled && (
             <div className="note-toolbar__button">
               <IconButton

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -87,6 +87,7 @@ export class NoteToolbar extends Component<Props> {
           <div className="note-toolbar__button">
             <IconButton
               icon={<ChecklistIcon />}
+              onClick={() => window.dispatchEvent(new Event('toggleChecklist'))}
               title={`Insert Checklist • ${CmdOrCtrl}+Shift+C`}
             />
           </div>


### PR DESCRIPTION
### Fix

This addresses part of #2563 and adds a checklist icon to the left of the note toolbar. This allows clicking the icon to start a checklist instead of relying on keyboard shortcuts or electron menu items.

A big part of this is thanks to @codebykat for coming up with a way to communicate with the editor instance from outside its component.

![Screen Shot 2021-01-27 at 1 14 00 PM](https://user-images.githubusercontent.com/1326294/106027716-8dcdad80-60a1-11eb-9059-bd3bdb91ca10.png)
![Screen Shot 2021-01-27 at 1 13 44 PM](https://user-images.githubusercontent.com/1326294/106027733-90300780-60a1-11eb-85c7-fa8da5462ac1.png)


### Test

1. In a note click into the note where you want to start a checklist
2. Click the checklist icon in the top note toolbar.
3. Notice a checklist is started.
4. Highlight a few lines in a note.
5. Click the checklist icon again.
6. Notice all selected lines are turned in checklist items.

### Release

- Add checklist icon to note toolbar to allow easily starting checklists.
