### PR TITLE
Fix loading of the analytics preference so it will send events if user has opted in

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 
+- Fixed loading of the analytics preference so it will send events if user has opted in [#2605](https://github.com/Automattic/simplenote-electron/pull/2605)
 - Added a missing aria-label to the revision slider (props to @tbourrely) [#2583](https://github.com/Automattic/simplenote-electron/pull/2583)
 
 ### Other Changes

--- a/lib/state/simperium/functions/preferences-bucket.ts
+++ b/lib/state/simperium/functions/preferences-bucket.ts
@@ -14,7 +14,7 @@ export class PreferencesBucket implements BucketStore<T.Preferences> {
     this.store = store;
   }
 
-  get(id: T.EntityId, callback: EntityCallback<BucketObject<T.Note>>) {
+  get(id: T.EntityId, callback: EntityCallback<BucketObject<T.Preferences>>) {
     const data = this.store.getState().data.preferences.get(id);
 
     callback(null, { id, data });

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -223,10 +223,11 @@ export const initSimperium = (
       });
     }
   });
-  preferencesBucket.channel.once('ready', () => {
+  preferencesBucket.channel.once('ready', async () => {
+    const preferences = await preferencesBucket.get('preferences-key');
     dispatch({
       type: 'REMOTE_ANALYTICS_UPDATE',
-      allowAnalytics: getState().data.analyticsAllowed,
+      allowAnalytics: !!preferences?.data?.analytics_enabled,
     });
   });
 

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -60,6 +60,7 @@ export const initSimperium = (
     ghostStoreProvider: (bucket) => {
       switch (bucket.name) {
         case 'account':
+        case 'preferences':
           return new InMemoryGhost();
 
         default:
@@ -209,19 +210,14 @@ export const initSimperium = (
   });
 
   const preferencesBucket = client.bucket('preferences');
-  preferencesBucket.channel.on('update', (entityId, updatedEntity) => {
+  preferencesBucket.on('update', (entityId, updatedEntity) => {
     if ('preferences-key' !== entityId) {
       return;
     }
-
-    if (
-      !!updatedEntity.analytics_enabled !== getState().data.analyticsAllowed
-    ) {
-      dispatch({
-        type: 'REMOTE_ANALYTICS_UPDATE',
-        allowAnalytics: !!updatedEntity.analytics_enabled,
-      });
-    }
+    dispatch({
+      type: 'REMOTE_ANALYTICS_UPDATE',
+      allowAnalytics: updatedEntity.analytics_enabled,
+    });
   });
 
   if (createWelcomeNote) {

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -213,6 +213,7 @@ export const initSimperium = (
     if ('preferences-key' !== entityId) {
       return;
     }
+
     if (
       !!updatedEntity.analytics_enabled !== getState().data.analyticsAllowed
     ) {


### PR DESCRIPTION
### Fix

Ensure that we set the analyticsAllowed value on window when page loads and the preferences bucket is ready.

### Test
1. Sign in
2. Have analytics enabled
3. Ensure window.analyticsEnabled is set
4. Refresh
5. Ensure window.analyticsEnabled is set
