### PR TITLE
Update tag submission from note editor

### DIFF
--- a/lib/tag-input/index.tsx
+++ b/lib/tag-input/index.tsx
@@ -13,6 +13,7 @@ import type * as T from '../types';
 
 const KEY_TAB = 9;
 const KEY_ENTER = 13;
+const KEY_SPACE = 32;
 const KEY_RIGHT = 39;
 const KEY_COMMA = 188;
 
@@ -123,6 +124,7 @@ export class TagInput extends Component<Props> {
       {
         [KEY_ENTER]: this.submitTag,
         [KEY_COMMA]: this.submitTag,
+        [KEY_SPACE]: this.submitTag,
         [KEY_TAB]: this.interceptTabPress,
         [KEY_RIGHT]: this.interceptRightArrow,
       },

--- a/lib/tag-input/index.tsx
+++ b/lib/tag-input/index.tsx
@@ -257,6 +257,7 @@ export class TagInput extends Component<Props> {
           ref={this.storeInput}
           className="tag-input__entry"
           contentEditable="true"
+          onBlur={this.submitTag}
           onCompositionStart={() => this.setState({ isComposing: true })}
           onCompositionEnd={this.onCompositionEnd}
           onKeyDown={this.interceptKeys}


### PR DESCRIPTION
### Fix

When adding tags from the note editor you can add spaces and then when you press enter or a comma tags are submitted and separated on the spaces. This is brought up in #2207.

In addition when entering a tag if you switch to another note, or click out of the tag input area the unfinished tag stays as described in #2589 

This PR will submit the new tag when you enter a space or leave the tag input area.

### Test

1. Open a note.
2. Enter a tag from the tag input at the bottom.
3. Try to type a space character.
4. Notice the tag is added instead of a space character.
5. Enter a tag but don't submit.
6. Click into the note above or to switch to a different note
7. Notice the tag is added to the original note.

### Release

- Fix tag input from the note editor to insert tags when a space is used or when clicking outside of the input area.
