### PR TITLE
Update tag input styling

### DIFF
--- a/lib/components/tag-chip/__snapshots__/test.tsx.snap
+++ b/lib/components/tag-chip/__snapshots__/test.tsx.snap
@@ -6,5 +6,20 @@ exports[`TagChip should not introduce visual regressions 1`] = `
   data-tag-name="spline"
 >
   spline
+  <span
+    className="remove-tag-icon"
+  >
+    <svg
+      className="icon-cross-small"
+      height="22"
+      viewBox="0 0 22 22"
+      width="22"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M16.707 6.707l-1.414-1.414L11 9.586 6.707 5.293 5.293 6.707 9.586 11l-4.293 4.293 1.414 1.414L11 12.414l4.293 4.293 1.414-1.414L12.414 11z"
+      />
+    </svg>
+  </span>
 </div>
 `;

--- a/lib/components/tag-chip/index.tsx
+++ b/lib/components/tag-chip/index.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+import SmallCrossIcon from '../../icons/cross-small';
 import classNames from 'classnames';
 
 import type * as T from '../../types';
@@ -20,6 +21,9 @@ const TagChip: FunctionComponent<OwnProps> = ({
     onClick={onSelect}
   >
     {tagName}
+    <span className="remove-tag-icon">
+      <SmallCrossIcon />
+    </span>
   </div>
 );
 

--- a/lib/components/tag-chip/style.scss
+++ b/lib/components/tag-chip/style.scss
@@ -3,29 +3,50 @@
   flex: none;
   margin: 2px 8px 6px 0;
   padding: 1px 14px 3px;
-  border-radius: 14px;
+  border-radius: 16px;
   line-height: 1.25em;
   white-space: nowrap;
   background: $studio-gray-5;
   text-decoration: none;
   font-size: 14px;
+  position: relative;
   -webkit-tap-highlight-color: transparent;
 
   &.selected,
   &:hover {
-    background: $studio-simplenote-blue-5;
+    .remove-tag-icon {
+      display: inline-block;
+    }
+  }
+
+  .remove-tag-icon {
+    display: none;
+    position: absolute;
+    background-color: $studio-gray-50;
+    color: $studio-white;
+    border-radius: 50%;
+    top: -8px;
+    width: 16px;
+    height: 16px;
+    line-height: 14px;
+    font-size: 14px;
+    text-align: center;
+
+    .icon-cross-small {
+      height: 14px;
+      width: 14px;
+    }
   }
 }
 
 .theme-dark {
   .tag-chip {
     background: $studio-gray-70;
-    color: $studio-gray-20;
+    color: $studio-white;
+  }
 
-    &.selected,
-    &:hover {
-      background: $studio-gray-70;
-      color: $studio-white;
-    }
+  .remove-tag-icon {
+    background-color: $studio-gray-30;
+    color: $studio-black;
   }
 }

--- a/lib/tag-field/index.tsx
+++ b/lib/tag-field/index.tsx
@@ -129,12 +129,12 @@ export class TagField extends Component<Props, OwnState> {
 
   interceptKeys: React.KeyboardEventHandler = (e) => {
     if (KEY_BACKSPACE === e.which) {
-      if (this.hasSelection()) {
-        this.deleteSelection();
-      }
-
       if ('' !== this.state.tagInput) {
         return;
+      }
+
+      if (this.hasSelection()) {
+        this.deleteSelection();
       }
 
       this.selectLastTag();
@@ -149,6 +149,9 @@ export class TagField extends Component<Props, OwnState> {
     if (KEY_TAB === e.which && this.hasSelection()) {
       this.unselect(e);
       return;
+    }
+    if (this.hasSelection()) {
+      this.unselect(e);
     }
   };
 
@@ -218,7 +221,10 @@ export class TagField extends Component<Props, OwnState> {
       return;
     }
 
-    if (this.hiddenTag?.current !== event.relatedTarget) {
+    if (
+      this.hiddenTag?.current !== event.relatedTarget ||
+      this.hiddenTag?.current === undefined
+    ) {
       this.setState({ selectedTag: '' as T.TagName });
     }
   };

--- a/lib/tag-input/index.tsx
+++ b/lib/tag-input/index.tsx
@@ -249,11 +249,11 @@ export class TagInput extends Component<Props> {
             aria-hidden
             className="tag-input__placeholder theme-color-fg-dim"
           >
-            Add a tag…
+            Add tag…
           </span>
         )}
         <div
-          aria-label="Add a tag…"
+          aria-label="Add tag…"
           ref={this.storeInput}
           className="tag-input__entry"
           contentEditable="true"

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -256,11 +256,6 @@ span[dir='ltr'] {
     }
   }
 
-  .tag-field {
-    height: 56px;
-    padding: 7px;
-  }
-
   .tag-field input {
     background: transparent;
 


### PR DESCRIPTION
### Fix

This PR resolves #2564.

Addresses the following changes:
- Updates placeholder text to be "Add tag...".
- Updates colors for both light and dark mode.
- Adds a cross icon indicator when you hover over an added tag to better show this will delete the tag from the note.

![Screen Shot 2021-02-01 at 11 14 15 AM](https://user-images.githubusercontent.com/1326294/106477559-ab728c80-647e-11eb-8126-3b3694025426.png)

![Screen Shot 2021-02-01 at 11 03 02 AM](https://user-images.githubusercontent.com/1326294/106476616-a06b2c80-647d-11eb-87d5-b18f5fdd324e.png)


### Test

1. Open a note.
2. Add at least one tag.
3. Hover over tag.
4. Notice (x) indicator appears.
5. Ensure clicking removes tag from note.
6. Verify colors are correct in both dark and light mode.

### Release

- Added delete tag indicator when hovering over tags in note editor and updated styles.
