### PR TITLE
Update behavior and view when adding new note from trash

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -37,6 +37,7 @@ type StateProps = {
   showEmailVerification: boolean;
   showNavigation: boolean;
   showNoteInfo: boolean;
+  showTrash: boolean;
   theme: 'light' | 'dark';
 };
 
@@ -219,6 +220,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
   showEmailVerification: selectors.shouldShowEmailVerification(state),
   showNavigation: state.ui.showNavigation,
   showNoteInfo: state.ui.showNoteInfo,
+  showTrash: state.ui.showTrash,
   theme: selectors.getTheme(state),
 });
 

--- a/lib/icons/tag.tsx
+++ b/lib/icons/tag.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function TagIcon() {
+  return (
+    <svg
+      className="icon-tag"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+    >
+      <rect x="0" fill="none" width="24" height="24" />
+      <path d="M18.29 5.71v5.17l-7 7L6.12 12.71l7-7h5.17m2-2h-8L4 12a1 1 0 0 0 0 1.41L10.59 20A1 1 0 0 0 12 20l8.29-8.29v-8Zm-4.5 5.5a1 1 0 1 0-1-1A1 1 0 0 0 15.79 9.21Z" />
+    </svg>
+  );
+}

--- a/lib/menu-bar/index.tsx
+++ b/lib/menu-bar/index.tsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
  */
 import { CmdOrCtrl } from '../utils/platform';
 import IconButton from '../icon-button';
+import { isMac } from '../utils/platform';
 import NewNoteIcon from '../icons/new-note';
 import MenuIcon from '../icons/menu';
 import { withoutTags } from '../utils/filter-notes';
@@ -48,6 +49,8 @@ export const MenuBar: FunctionComponent<Props> = ({
     : openedTag
     ? 'Notes With Selected Tag'
     : 'All Notes';
+
+  const CmdOrCtrl = isMac ? 'Cmd' : 'Ctrl';
 
   return (
     <div className="menu-bar theme-color-border">

--- a/lib/menu-bar/style.scss
+++ b/lib/menu-bar/style.scss
@@ -22,4 +22,10 @@
     width: 32px;
     height: 32px;
   }
+
+  .icon-button:disabled {
+    svg {
+      cursor: default;
+    }
+  }
 }

--- a/lib/note-list/no-notes.tsx
+++ b/lib/note-list/no-notes.tsx
@@ -1,22 +1,26 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+
+import NotesIcon from '../icons/notes';
+import TagIcon from '../icons/tag';
+import TrashIcon from '../icons/trash';
 
 import actions from '../state/actions';
 
 import * as S from '../state';
 
+type EmptyNoteListPlaceholder = {
+  message: String;
+  icon: JSX.Element | null;
+  button: JSX.Element | null;
+};
+
 const NoNotes = () => {
   const hasLoaded = useSelector((state: S.State) => state.ui.hasLoadedNotes);
   const searchQuery = useSelector((state: S.State) => state.ui.searchQuery);
+  const showTrash = useSelector((state: S.State) => state.ui.showTrash);
+  const openedTag = useSelector((state: S.State) => state.ui.openedTag);
   const dispatch = useDispatch();
-
-  const getMessage = () => {
-    return hasLoaded
-      ? searchQuery.length
-        ? 'No Results'
-        : 'No Notes'
-      : 'Loading Notes';
-  };
 
   const getButton = () => {
     return searchQuery.length ? (
@@ -29,15 +33,54 @@ const NoNotes = () => {
       </button>
     ) : (
       <button onClick={() => dispatch(actions.ui.createNote())}>
-        Create a new note
+        Create your first note
       </button>
     );
   };
 
+  const placeholderInfo = ({
+    searchQuery,
+    openedTag,
+    showTrash,
+  }): EmptyNoteListPlaceholder => {
+    if (searchQuery.length > 0) {
+      return { message: 'No Results', icon: null, button: getButton() };
+    }
+
+    if (openedTag !== null) {
+      return {
+        message: `No notes tagged "${openedTag}"`,
+        icon: <TagIcon />,
+        button: null,
+      };
+    }
+
+    if (showTrash) {
+      return {
+        message: 'Your trash is empty',
+        icon: <TrashIcon />,
+        button: null,
+      };
+    }
+
+    return {
+      message: '',
+      icon: <NotesIcon />,
+      button: getButton(),
+    };
+  };
+
+  const { message, icon, button } = placeholderInfo({
+    searchQuery,
+    openedTag,
+    showTrash,
+  });
+
   return (
     <div className="note-list-placeholder theme-color-fg">
-      {getMessage()}
-      {hasLoaded && getButton()}
+      <div className="no-notes-icon">{icon}</div>
+      <div className="no-notes-message">{message}</div>
+      <div className="no-notes-button">{hasLoaded && button}</div>
     </div>
   );
 };

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -58,16 +58,37 @@
   font-size: 1.5em;
   text-align: center;
 
+  .no-notes-icon svg {
+    width: 48px;
+    height: 48px;
+    margin-bottom: 8px;
+    color: $studio-gray-10;
+  }
+
+  .no-notes-message {
+    font-size: 16px;
+    color: $studio-gray-50;
+  }
+
   button {
     color: $studio-simplenote-blue-50;
     display: block;
     font-size: 14px;
-    margin-top: 7px;
+    margin-top: 8px;
   }
 }
 
-.theme-dark .note-list-placeholder button {
-  color: $studio-simplenote-blue-30;
+.theme-dark {
+  .note-list-placeholder {
+    .no-notes-icon,
+    .no-notes-message {
+      color: $studio-gray-30;
+    }
+
+    button {
+      color: $studio-simplenote-blue-30;
+    }
+  }
 }
 
 .note-list-items {

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -364,6 +364,11 @@ export const middleware: S.Middleware = (store) => {
       }
 
       case 'CREATE_NOTE_WITH_ID':
+        searchState.showTrash = false;
+        searchState.notes.set(action.noteId, toSearchNote(action.note ?? {}));
+        indexNote(action.noteId);
+        queueSearch();
+        return next(action);
       case 'IMPORT_NOTE_WITH_ID':
       case 'REMOTE_NOTE_UPDATE':
       case 'RESTORE_NOTE_REVISION':


### PR DESCRIPTION
### Fix

Currently when you are viewing the trash adding a new note is confusing.
This PR resolves #2612 by updating the view to all notes when adding a note from trash.

It also resolves #2627 by updating the views which appear when there are no notes in a list.

![no-tags](https://user-images.githubusercontent.com/1326294/106928497-9d747400-66e9-11eb-86a4-d5791f8aa9cc.png)
![no-search-results](https://user-images.githubusercontent.com/1326294/106928500-9e0d0a80-66e9-11eb-9e05-7320899ec7c1.png)
![empty-trash](https://user-images.githubusercontent.com/1326294/106928502-9e0d0a80-66e9-11eb-8221-7a92a20c4286.png)
![empty-note-list](https://user-images.githubusercontent.com/1326294/106928504-9ea5a100-66e9-11eb-84b8-efcc3805b6b9.png)

### Test

1. Visit trash screen.
2. Notice New Note icon appears disabled.
3. Clicking New Note icon does not create new note.
4.  Pressing keyboard shortcut `Cmd or Ctrl + Shift + i` does create a new note
5. After note is created you have the all notes view.
6. Remove all notes from trash.
7. Notice there is no link to create a new note.

Additional testing

1. Visit All Notes
2. Trash all notes
3. Notice updated empty note list view
4. Search for a non existent term
5. Notice updated empty note list view
6. Visit a tag which have no notes
7. Notice updated empty note list view

### Release

- Update the messaging and view when no notes show in a specific list.
- Fixes the view when adding a new note when viewing the trash.