### PR TITLE
Email verification: lowercase username from verification token

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,6 +13,7 @@
 
 - Fixed loading of the analytics preference so it will send events if user has opted in [#2605](https://github.com/Automattic/simplenote-electron/pull/2605)
 - Added a missing aria-label to the revision slider (props to @tbourrely) [#2583](https://github.com/Automattic/simplenote-electron/pull/2583)
+- Updated email verification logic to handle a mixed-case email address [#2619](https://github.com/Automattic/simplenote-electron/pull/2619)
 
 ### Other Changes
 

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -178,7 +178,8 @@ export const initSimperium = (
     const { token, sent_to } = entity;
 
     const parsedToken = parseVerificationToken(token);
-    const hasValidToken = parsedToken && parsedToken.username === username;
+    const hasValidToken =
+      parsedToken && parsedToken.username.toLowerCase() === username;
     const hasPendingEmail = sent_to === username;
 
     const state = hasValidToken


### PR DESCRIPTION
**2.6.0 Hotfix**

### Fix

This prevents email verification from erroneously thinking an account is not verified if we receive a mixed-case username from Simperium.

n.b. We are already forcing usernames to lowercase on login, so we only need to apply this transform to the username from the Simperium token. https://github.com/Automattic/simplenote-electron/blob/e805fd665efbcb34576e8a66d78cc80d4e7e9730/lib/boot-without-auth.tsx#L63

### Test

I'm not sure how to get a mixed-case email address in the system, possibly by creating an account in iOS? But either way...

1. Log in with an unverified account and make sure it still prompts for verification
2. Verify, or log in with a verified account, and make sure the verification dialog is not shown

### Release

Updated email verification logic to handle a mixed-case email address.