### PR TITLE
UI Spring cleaning: Clean up pinner styles

### DIFF
--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -136,14 +136,8 @@
 
   &.note-list-item-selected {
     background: $studio-simplenote-blue-5;
-    &.note-list-item-pinned {
+    &:not(.note-list-item-pinned):hover {
       .note-list-item-pinner {
-        color: $studio-simplenote-blue-50;
-      }
-      &:hover .note-list-item-pinner {
-        color: $studio-simplenote-blue-50;
-      }
-      .note-list-item-pinner:hover {
         color: $studio-gray-50;
       }
     }
@@ -152,15 +146,13 @@
   &:not(.note-list-item-selected) {
     &:hover {
       background: $studio-gray-0;
-    }
-    .note-list-item-pinner:hover {
-      color: $studio-simplenote-blue-50;
+
+      .note-list-item-pinner {
+        color: $studio-gray-50;
+      }
     }
     &.note-list-item-pinned:hover .note-list-item-pinner {
       color: $studio-gray-50;
-      &:hover {
-        color: $studio-simplenote-blue-50;
-      }
     }
   }
 

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -136,23 +136,15 @@
 
   &.note-list-item-selected {
     background: $studio-simplenote-blue-5;
-    &:not(.note-list-item-pinned):hover {
-      .note-list-item-pinner {
-        color: $studio-gray-50;
-      }
-    }
+  }
+
+  &:not(.note-list-item-pinned):hover .note-list-item-pinner {
+    color: $studio-gray-50;
   }
 
   &:not(.note-list-item-selected) {
     &:hover {
       background: $studio-gray-0;
-
-      .note-list-item-pinner {
-        color: $studio-gray-50;
-      }
-    }
-    &.note-list-item-pinned:hover .note-list-item-pinner {
-      color: $studio-gray-50;
     }
   }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -297,18 +297,11 @@ span[dir='ltr'] {
       .note-list-item-pinner {
         color: $studio-simplenote-blue-30;
       }
-      &:hover .note-list-item-pinner {
-        color: $studio-gray-80;
-      }
     }
 
     .note-list-item:not(.note-list-item-selected) {
       &:hover {
         background: $studio-gray-80;
-      }
-
-      &.note-list-item-pinned:hover .note-list-item-pinner {
-        color: $studio-gray-30;
       }
     }
   }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -299,6 +299,12 @@ span[dir='ltr'] {
       }
     }
 
+    .note-list-item:not(.note-list-item-pinned):hover {
+      .note-list-item-pinner {
+        color: rgba(255, 255, 255, 0.4);
+      }
+    }
+
     .note-list-item:not(.note-list-item-selected) {
       &:hover {
         background: $studio-gray-80;

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -158,11 +158,8 @@ span[dir='ltr'] {
     color: $studio-simplenote-blue-50;
   }
 
-  .note-list-item-pinner {
-    &:hover,
-    &.note-list-item-pinned {
-      color: $studio-simplenote-blue-50;
-    }
+  .note-list-item-pinned .note-list-item-pinner {
+    color: $studio-simplenote-blue-50;
   }
 }
 
@@ -279,10 +276,6 @@ span[dir='ltr'] {
   }
 
   .note-list {
-    .note-list-item .note-list-item-pinner:hover {
-      color: $studio-simplenote-blue-30;
-    }
-
     .note-list-item-selected {
       background: $studio-simplenote-blue-50;
       .note-list-item-excerpt,
@@ -295,14 +288,8 @@ span[dir='ltr'] {
           fill: $studio-gray-30;
         }
       }
-      .note-list-item-pinner:hover {
-        color: $studio-white;
-      }
       &.note-list-item-pinned .note-list-item-pinner {
         color: $studio-white;
-        &:hover {
-          color: $studio-simplenote-blue-30;
-        }
       }
     }
 
@@ -322,13 +309,6 @@ span[dir='ltr'] {
 
       &.note-list-item-pinned:hover .note-list-item-pinner {
         color: $studio-gray-30;
-        &:hover {
-          color: $studio-simplenote-blue-30;
-        }
-      }
-
-      .note-list-item-pinner:hover {
-        color: $studio-simplenote-blue-30;
       }
     }
   }


### PR DESCRIPTION
### Fix

Updated design:

![Untitled](https://user-images.githubusercontent.com/52152/106858057-f1de0c00-6675-11eb-8843-25dbe2120a7a.gif)

https://app.zeplin.io/project/5d795a3d8ed5261aa146e057/screen/5fbbc5d768735855a07651d9


### Test

1. Verify note list styles match designs
2. Test both light and dark themes

### Release

Updated pinner styles in the note list