### PR TITLE
UI spring cleaning: Some small style fixes

### DIFF
--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -105,7 +105,7 @@
 }
 
 .app-layout__source-column {
-  width: 380px;
+  width: $note-list-width;
   display: flex;
   flex-direction: column;
   flex-shrink: 0;

--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -105,7 +105,7 @@
 }
 
 .app-layout__source-column {
-  width: 328px;
+  width: 380px;
   display: flex;
   flex-direction: column;
   flex-shrink: 0;

--- a/lib/menu-bar/index.tsx
+++ b/lib/menu-bar/index.tsx
@@ -55,7 +55,7 @@ export const MenuBar: FunctionComponent<Props> = ({
         onClick={toggleNavigation}
         title="Menu • Ctrl+Shift+U"
       />
-      {placeholder}
+      <div className="notes-title">{placeholder}</div>
       <IconButton
         disabled={showTrash}
         icon={<NewNoteIcon />}

--- a/lib/menu-bar/style.scss
+++ b/lib/menu-bar/style.scss
@@ -7,6 +7,11 @@
   align-items: center;
   flex: 0 0 auto;
 
+  .notes-title {
+    font-size: 16px;
+    font-weight: 600;
+  }
+
   .icon-button svg.icon-menu {
     width: 24px;
     height: 24px;

--- a/lib/menu-bar/style.scss
+++ b/lib/menu-bar/style.scss
@@ -9,7 +9,7 @@
 
   .notes-title {
     font-size: 16px;
-    font-weight: 600;
+    font-weight: 500;
   }
 
   .icon-button svg.icon-menu {

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -103,7 +103,7 @@
   display: flex;
   padding-left: 8px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  font-family: 'Simplenote Tasks', $sans;
+  font-family: 'Simplenote Tasks', $sans, sans-serif;
   min-height: 64px;
 
   .note-list-item-status {

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -189,7 +189,7 @@
     display: flex;
     justify-content: space-between;
     font-size: 16px;
-    font-weight: 600;
+    font-weight: 500;
 
     & span {
       text-overflow: ellipsis;

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -103,7 +103,7 @@
   display: flex;
   padding-left: 8px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  font-family: 'Simplenote Tasks', sans-serif;
+  font-family: 'Simplenote Tasks', $sans;
   min-height: 64px;
 
   .note-list-item-status {

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -189,6 +189,7 @@
     display: flex;
     justify-content: space-between;
     font-size: 16px;
+    font-weight: 600;
 
     & span {
       text-overflow: ellipsis;

--- a/lib/search-field/style.scss
+++ b/lib/search-field/style.scss
@@ -5,13 +5,14 @@
   width: 100%;
   padding: 6px 5px 5px 20px;
   border-bottom: 1px solid;
+  height: $toolbar-height;
 
   input {
     width: 100%;
     min-width: 0; // Firefox
     border: 0;
-    padding-left: 5px;
     appearance: none;
+    font-size: 16px;
 
     &:focus {
       outline: none;
@@ -20,6 +21,10 @@
 
   .icon-button {
     flex: 0 0 auto;
+  }
+
+  .icon-button:first-child() {
+    text-align: left;
   }
 
   .icon-cross-small {

--- a/lib/sort-order-selector/style.scss
+++ b/lib/sort-order-selector/style.scss
@@ -1,6 +1,6 @@
 .sort-order-selector {
   position: relative;
-  width: 328px;
+  width: $note-list-width;
   height: $toolbar-height;
   line-height: $toolbar-height;
   border-top: 1px solid;

--- a/lib/tag-suggestions/style.scss
+++ b/lib/tag-suggestions/style.scss
@@ -5,15 +5,17 @@
     list-style-type: none;
     padding: 0;
     margin: 0;
-    line-height: 40px;
 
     .tag-suggestion-row {
+      height: 36px;
+      line-height: 36px;
       cursor: pointer;
       position: relative;
       padding: 0;
     }
 
     .tag-suggestion {
+      font-size: 16px;
       margin-left: 30px;
       border-bottom-style: solid;
       border-bottom-width: 1px;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -17,6 +17,7 @@ $focus-outline: 4px auto $studio-simplenote-blue-5;
 
 $navigation-bar-width: 260px;
 $note-info-width: 320px;
+$note-list-width: 380px;
 $max-content-width: 650px;
 $toolbar-height: 44px;
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -277,7 +277,7 @@ span[dir='ltr'] {
 
   .note-list {
     .note-list-item-selected {
-      background: $studio-simplenote-blue-50;
+      background: rgba($studio-simplenote-blue-50, 0.4);
       .note-list-item-excerpt,
       .note-list-item-published-icon,
       .note-list-item-pending-changes {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -84,7 +84,7 @@ span[dir='ltr'] {
 .note-detail-markdown {
   height: 100%;
   width: 100%;
-  font-family: 'Simplenote Tasks', sans-serif;
+  font-family: 'Simplenote Tasks', $sans;
 
   .slider {
     border-radius: 10px;

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -84,7 +84,7 @@ span[dir='ltr'] {
 .note-detail-markdown {
   height: 100%;
   width: 100%;
-  font-family: 'Simplenote Tasks', $sans;
+  font-family: 'Simplenote Tasks', $sans, sans-serif;
 
   .slider {
     border-radius: 10px;


### PR DESCRIPTION
### Fix

As per @SylvesterWilmott:

* In the top toolbar the notes list title eg. All Notes should be 16px with 600 weight
* The text in the search bar should be 16px (including placeholder)
* Can we align the search icon in the search bar with the hamburger icon above?
* Can we add weight: 600 to the note titles in the notes list?
* The entire notes list panel should have a new width of 380px

Also as mentioned [here](https://github.com/Automattic/simplenote-electron/issues/2560#issuecomment-771347658):
* We have updated the selection colour in the notes lost in dark mode [...] from blue50 to blue50 at 40% opacity.

### Screenshots

<img width="1017" alt="Screen Shot 2021-02-04 at 11 48 06 PM" src="https://user-images.githubusercontent.com/52152/107005069-0b4d8980-6744-11eb-8e5d-e649b848d7b3.png">

<img width="1018" alt="Screen Shot 2021-02-04 at 11 48 19 PM" src="https://user-images.githubusercontent.com/52152/107005115-19030f00-6744-11eb-8ccc-4265eca2f4cd.png">

<img width="388" alt="Screen Shot 2021-02-04 at 11 48 35 PM" src="https://user-images.githubusercontent.com/52152/107005143-215b4a00-6744-11eb-9c49-6d8ba2f8db66.png">

At medium width the note list is still 300px wide:

<img width="812" alt="Screen Shot 2021-02-04 at 11 50 08 PM" src="https://user-images.githubusercontent.com/52152/107005357-74cd9800-6744-11eb-9e4f-b5346a9da032.png">

Dark mode:

<img width="992" alt="Screen Shot 2021-02-05 at 12 09 35 AM" src="https://user-images.githubusercontent.com/52152/107007073-e1e22d00-6746-11eb-9dbb-6e96ac1d70cb.png">


### Release

Adjusted note list width and font weights