### PR TITLE
[WIP] Only load revisions when history is opened

### DIFF
--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -27,7 +27,6 @@ const NotePreview = React.lazy(() =>
 );
 
 type StateProps = {
-  hasRevisions: boolean;
   isFocusMode: boolean;
   isNavigationOpen: boolean;
   isNoteInfoOpen: boolean;
@@ -84,7 +83,6 @@ export class AppLayout extends Component<Props> {
   render = () => {
     const {
       showNoteList,
-      hasRevisions,
       isFocusMode = false,
       isNavigationOpen,
       isNoteInfoOpen,
@@ -122,7 +120,7 @@ export class AppLayout extends Component<Props> {
           </div>
           {editorVisible && (
             <div className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border">
-              {hasRevisions && <RevisionSelector />}
+              {showRevisions && <RevisionSelector />}
               <NoteToolbar />
               {showRevisions ? (
                 <NotePreview noteId={openedNote} note={openedRevision} />
@@ -138,8 +136,6 @@ export class AppLayout extends Component<Props> {
 }
 
 const mapStateToProps: S.MapState<StateProps> = (state) => ({
-  hasRevisions:
-    state.ui.showRevisions && state.data.noteRevisions.has(state.ui.openedNote),
   keyboardShortcutsAreOpen: state.ui.dialogs.includes('KEYBINDINGS'),
   keyboardShortcuts: state.settings.keyboardShortcuts,
   isFocusMode: state.settings.focusModeEnabled,

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -20,7 +20,6 @@ import * as T from '../types';
 
 type StateProps = {
   editMode: boolean;
-  hasRevisions: boolean;
   isOffline: boolean;
   markdownEnabled: boolean;
   note: T.Note | null;
@@ -57,7 +56,6 @@ export class NoteToolbar extends Component<Props> {
     const {
       editMode,
       newNote,
-      hasRevisions,
       isOffline,
       markdownEnabled,
       note,
@@ -111,10 +109,9 @@ export class NoteToolbar extends Component<Props> {
           )}
           <div className="note-toolbar__button">
             <IconButton
-              disabled={!hasRevisions}
               icon={<RevisionsIcon />}
               onClick={this.props.toggleRevisions}
-              title={hasRevisions ? 'History' : 'History (unavailable)'}
+              title="History"
             />
           </div>
           <div className="note-toolbar__button">
@@ -190,7 +187,6 @@ const mapStateToProps: S.MapState<StateProps> = ({
 
   return {
     editMode,
-    hasRevisions: !!data.noteRevisions.get(openedNote)?.size,
     isOffline: connectionStatus === 'offline',
     markdownEnabled: note?.systemTags.includes('markdown') || false,
     note,


### PR DESCRIPTION
### Fix

@belcherj started this PR, I think it needs a loading state for the history slider (it also needs a rebase)

Fix for #2464 

To consider: This probably changes offline behavior of revisions (history would no longer be accessible if the note was simply opened)

### Test
 TBD

### Release
