### PR TITLE
UI Spring Cleaning: Navigation bar blue should match note list blue

### DIFF
--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -249,7 +249,7 @@ span[dir='ltr'] {
   }
 
   .navigation-bar-item.is-selected {
-    background-color: $studio-simplenote-blue-50;
+    background-color: rgba($studio-simplenote-blue-50, 0.4);
 
     svg[class^='icon-'] {
       fill: $studio-white;


### PR DESCRIPTION
### Fix

As per @SylvesterWilmott the selected item in the navigation bar / tag list in dark mode should be the same as in the note list, `$studio-simplenote-blue-50` at 40% opacity.
    
<img width="638" alt="Screen Shot 2021-02-08 at 9 28 42 PM" src="https://user-images.githubusercontent.com/52152/107320071-d51a4d80-6a54-11eb-9e25-b53713a8a6fa.png">

