### PR TITLE
Update the navigation bar and taglist styles

### DIFF
--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -30,9 +30,25 @@
   &.is-navigation-open {
     pointer-events: none;
 
+    &:before {
+      content: '';
+      background-color: rgba($studio-black, 0.2);
+      display: block;
+      height: 100%;
+      left: 0;
+      position: absolute;
+      top: 0;
+      width: 100%;
+      z-index: 1;
+    }
+
     @media only screen and (max-width: $single-column) {
       .app-layout__note-column {
         opacity: 0;
+      }
+
+      &:before {
+        display: none;
       }
     }
   }

--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -30,7 +30,7 @@
   &.is-navigation-open {
     pointer-events: none;
 
-    &:before {
+    &::before {
       content: '';
       background-color: rgba($studio-black, 0.2);
       display: block;
@@ -47,7 +47,7 @@
         opacity: 0;
       }
 
-      &:before {
+      &::before {
         display: none;
       }
     }

--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -28,8 +28,6 @@
   }
 
   &.is-navigation-open {
-    opacity: $fade-alpha;
-    transition: $anim;
     pointer-events: none;
 
     @media only screen and (max-width: $single-column) {

--- a/lib/navigation-bar/style.scss
+++ b/lib/navigation-bar/style.scss
@@ -3,12 +3,14 @@
   flex-direction: column;
   position: absolute;
   top: 0;
-  left: -$navigation-bar-width;
+  left: 0;
   padding-top: $toolbar-height;
   width: $navigation-bar-width;
   height: 100%;
   overflow: hidden;
   border-right: 1px solid;
+  z-index: 2;
+  transition: transform 200ms ease-in-out;
 }
 
 .is-macos .navigation-bar {

--- a/lib/tag-list/index.tsx
+++ b/lib/tag-list/index.tsx
@@ -61,7 +61,10 @@ const SortableTag = SortableElement(
         `tag-list-item`,
         `theme-color-border`,
         `theme-color-fg`,
-        `theme-${theme}`
+        `theme-${theme}`,
+        {
+          'is-selected': isSelected,
+        }
       )}
       data-tag-name={tag.name}
     >

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -6,7 +6,11 @@
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
-  margin-left: 13px;
+  padding-left: 13px;
+
+  &:hover {
+    background-color: $studio-gray-0;
+  }
 }
 
 .tag-list {
@@ -112,6 +116,12 @@ input.tag-list-input {
     }
     &.button-trash {
       color: $studio-simplenote-blue-30;
+    }
+  }
+
+  .tag-list-item {
+    &:hover {
+      background-color: $studio-gray-60;
     }
   }
 }

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -11,6 +11,10 @@
   &:hover {
     background-color: $studio-gray-0;
   }
+
+  &.is-selected {
+    background-color: $studio-simplenote-blue-5;
+  }
 }
 
 .tag-list {

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -63,7 +63,6 @@
 }
 
 .tag-list-input {
-  cursor: text;
   flex: 1 1 auto;
   display: block;
   width: 50px;
@@ -90,6 +89,10 @@ button.tag-list-input {
   margin: 8px 0;
   overflow-x: hidden;
   text-align: left;
+}
+
+input.tag-list-input {
+  cursor: text;
 }
 
 .tag-list-editing {

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -66,10 +66,6 @@ optgroup {
   &.note-info-open {
     transform: translateX(-$note-info-width);
   }
-
-  &.navigation-open {
-    transform: translateX($navigation-bar-width);
-  }
 }
 
 .is-macos {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -248,7 +248,8 @@ span[dir='ltr'] {
     }
   }
 
-  .navigation-bar-item.is-selected {
+  .navigation-bar-item.is-selected,
+  .tag-list-item.is-selected {
     background-color: rgba($studio-simplenote-blue-50, 0.4);
 
     svg[class^='icon-'] {


### PR DESCRIPTION
### Fix

As part of the UI spring cleanup project, this PR works to resolve #2566.

This causes the navigation bar to open on top of other content rather than push it to the side. 
It updates the styles and colors used. 
It also adds an overlay to the other content when the navigation bar is open instead of reducing opacity.
It does not address the background color in dark mode as it will be addressed separately in #2616.

### Test

1. Test in both light and dark mode.
2. Ensure colors all look correct.
3. Ensure the navigation bar loads over top of content instead of shifting everything over.
4. Ensure there is an overlay on the rest of the content.

### Release

- Update navigation bar style and have it appear over content rather than push it to the side. 
