### PR TITLE
Remove the spellcheck option from edit menu on electron builds

### DIFF
--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -74,14 +74,6 @@ const buildEditMenu = (settings, isAuthenticated, editMode) => {
         click: editorCommandSender({ action: 'findAgain' }),
         accelerator: 'CommandOrControl+G',
       },
-      ...(isAuthenticated ? [{ type: 'separator' }] : []),
-      {
-        label: 'C&heck Spelling',
-        visible: isAuthenticated,
-        type: 'checkbox',
-        checked: settings.spellCheckEnabled,
-        click: appCommandSender({ action: 'toggleSpellCheck' }),
-      },
     ],
   };
 };


### PR DESCRIPTION
### Fix

This resolves #2648. In light of #2410 this menu item is confusing. Until we add back in spellcheck this removes the spellcheck option from the edit menu in the desktop apps.

### Test

1. On Windows and Linux install artifacts from this PR.
2. Visit the Edit menu at the top.
3. Ensure Spellcheck does not show.

### Release

- Remove the spellcheck option from the edit menu.
