### PR TITLE
Make keyboard shortcuts for searching always active regardless of keyboard shortcut preference

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -77,7 +77,7 @@ class AppComponent extends Component<Props> {
   handleShortcut = (event: KeyboardEvent) => {
     const { hotkeysEnabled } = this.props;
 
-    // Handle search shortcuts even if keyboardshortcuts are disabled.
+    // Handle search shortcuts even if keyboard shortcuts are disabled.
     if (!window.electron || !isMac) {
       this.handleBrowserSearchShortcut(event);
     }

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -76,6 +76,12 @@ class AppComponent extends Component<Props> {
 
   handleShortcut = (event: KeyboardEvent) => {
     const { hotkeysEnabled } = this.props;
+
+    // Handle search shortcuts even if keyboardshortcuts are disabled.
+    if (!window.electron || !isMac) {
+      this.handleBrowserSearchShortcut(event);
+    }
+
     if (!hotkeysEnabled) {
       return;
     }
@@ -116,11 +122,8 @@ class AppComponent extends Component<Props> {
     // Is either cmd or ctrl pressed? (But not both)
     const cmdOrCtrl = (ctrlKey || metaKey) && ctrlKey !== metaKey;
 
-    if (
-      (cmdOrCtrl && shiftKey && 's' === key) ||
-      (cmdOrCtrl && !shiftKey && 'f' === key)
-    ) {
-      this.props.focusSearchField();
+    if (cmdOrCtrl && shiftKey && 'i' === key) {
+      this.props.createNote();
 
       event.stopPropagation();
       event.preventDefault();
@@ -134,9 +137,20 @@ class AppComponent extends Component<Props> {
       event.preventDefault();
       return false;
     }
+  };
 
-    if (cmdOrCtrl && shiftKey && 'i' === key) {
-      this.props.createNote();
+  handleBrowserSearchShortcut = (event: KeyboardEvent) => {
+    const { ctrlKey, metaKey, shiftKey } = event;
+    const key = event.key.toLowerCase();
+
+    // Is either cmd or ctrl pressed? (But not both)
+    const cmdOrCtrl = (ctrlKey || metaKey) && ctrlKey !== metaKey;
+
+    if (
+      (cmdOrCtrl && shiftKey && 's' === key) ||
+      (cmdOrCtrl && !shiftKey && 'f' === key)
+    ) {
+      this.props.focusSearchField();
 
       event.stopPropagation();
       event.preventDefault();

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -76,9 +76,10 @@ class AppComponent extends Component<Props> {
 
   handleShortcut = (event: KeyboardEvent) => {
     const { hotkeysEnabled } = this.props;
+    const shouldHandleBrowserShortcuts = !window.electron || !isMac;
 
     // Handle search shortcuts even if keyboard shortcuts are disabled.
-    if (!window.electron || !isMac) {
+    if (shouldHandleBrowserShortcuts) {
       this.handleBrowserSearchShortcut(event);
     }
 
@@ -104,7 +105,7 @@ class AppComponent extends Component<Props> {
       this.props.clearSearch();
     }
 
-    if (!window.electron || !isMac) {
+    if (shouldHandleBrowserShortcuts) {
       this.handleBrowserShortcut(event);
     }
 


### PR DESCRIPTION
### Fix

This PR resolves #2651.
Currently, the browser's built-in search doesn't work well with the note editor. For content not in view in the editor, the search is not able to find and select matching content.
For this reason, we are going to keep the keyboard shortcut for searching always on regardless of the keyboard shortcut preference.

### Test

1. Disable keyboard shortcuts from Settings > Tools.
2. Ensure Ctrl or Cmd + F take you to the search field in Simplenote instead of browser search.
3. Ensure other keyboard shortcuts are disabled.
4. Enable keyboard shortcuts from Settings > Tools.
5. Ensure all keyboard shortcuts still work.

### Release

- Enable keyboard shortcut for search even when keyboard shortcut preference is set to be disabled. 