### PR TITLE
Re-add so that when adding a new tag to a note a space will submit the tag

### DIFF
--- a/lib/tag-input/index.tsx
+++ b/lib/tag-input/index.tsx
@@ -13,6 +13,7 @@ import type * as T from '../types';
 
 const KEY_TAB = 9;
 const KEY_ENTER = 13;
+const KEY_SPACE = 32;
 const KEY_RIGHT = 39;
 const KEY_COMMA = 188;
 
@@ -122,6 +123,7 @@ export class TagInput extends Component<Props> {
     invoke(
       {
         [KEY_ENTER]: this.submitTag,
+        [KEY_SPACE]: this.submitTag,
         [KEY_COMMA]: this.submitTag,
         [KEY_TAB]: this.interceptTabPress,
         [KEY_RIGHT]: this.interceptRightArrow,


### PR DESCRIPTION
### Fix

This was added previously in PR #2607 but then I overwrote those changes in PR #2602 by mistake.
Adding it back here so that when you type a Space key when adding tags to a note it will submit the tag.
This resolves #2659 and resolves #2660.

### Test

1. Open a note.
2. Enter a tag from the tag input at the bottom.
3. Try to type a space character.
4. Notice the tag is added instead of a space character.

### Release

- Fix tag input from the note editor to insert tags when a space is used
