### PR TITLE
Update the revision slider so that it does not cover the bottom of long notes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,7 +7,7 @@
 - Added a sort order bar to the note list [#2542](https://github.com/Automattic/simplenote-electron/pull/2542)
 - Added a checklist icon to the note toolbar [#2603](https://github.com/Automattic/simplenote-electron/pull/2603)
 - Updated tag renaming to be more consistent in the app and across platforms [#2602](https://github.com/Automattic/simplenote-electron/pull/2602)
-- Moved the note revision slider to the bottom of the note [#2586](https://github.com/Automattic/simplenote-electron/pull/2586)
+- Moved the note revision slider to the bottom of the note [#2586](https://github.com/Automattic/simplenote-electron/pull/2586), [#2662](https://github.com/Automattic/simplenote-electron/pull/2662)
 - Added the new note icon to the toolbar when in focus mode [#2596](https://github.com/Automattic/simplenote-electron/pull/2596)
 - Updated the icon set [#2623](https://github.com/Automattic/simplenote-electron/pull/2623)
 - Updated tag editing styles [#2584](https://github.com/Automattic/simplenote-electron/pull/2584)

--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -126,13 +126,13 @@ export class AppLayout extends Component<Props> {
           </div>
           {editorVisible && (
             <div className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border">
-              {hasRevisions && <RevisionSelector />}
               <NoteToolbar />
               {showRevisions ? (
                 <NotePreview noteId={openedNote} note={openedRevision} />
               ) : (
                 <NoteEditor />
               )}
+              {hasRevisions && <RevisionSelector />}
             </div>
           )}
         </Suspense>

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -71,9 +71,13 @@ export class RevisionSelector extends Component<Props> {
 
     const leftPos = Number(
       // Based on ((selected - min) * 100) / (max - min);
-      (((selectedIndex === -1 ? revisions?.size : selectedIndex) - 1) * 100) /
+      // min is equal to 1
+      // max is the number of size of revisions -1.
+      (((selectedIndex === -1 ? revisions?.size - 1 : selectedIndex) - 1) *
+        100) /
         (revisions?.size - 2)
     );
+
     const datePos = `calc(${leftPos}% + (${8 - leftPos * 0.15}px))`;
 
     const revisionDate = format(

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -2,10 +2,9 @@
   border-top: 1px solid;
   height: 178px;
   padding: 19px 20px 20px;
-  position: absolute;
+  position: relative;
   transition: all 0.3s ease-in-out;
   width: 100%;
-  z-index: 1000;
 
   &.is-visible {
     bottom: 0;


### PR DESCRIPTION
### Fix

With the update to the slider position, it was sitting over top the bottom of long notes. So you couldn't see changes happening at the end no matter how far you scrolled.
This also fixes a problem with the position of the date above the slider.

This resolves #2655

### Test

1. Have a note with enough content that fills the editor.
2. Open the history for the note.
3. Ensure you can scroll and see all the note content.
4. Ensure the revision date is centered above the slider handle.
5. Ensure the date is not cut off the side of the app.

### Release

- Fix the revision slider so that the full note is visible and the position of the revision date.