### PR TITLE
Fix: refresh note list after revision restored

### DIFF
--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -366,6 +366,7 @@ export const middleware: S.Middleware = (store) => {
       case 'CREATE_NOTE_WITH_ID':
       case 'IMPORT_NOTE_WITH_ID':
       case 'REMOTE_NOTE_UPDATE':
+      case 'RESTORE_NOTE_REVISION':
         searchState.notes.set(action.noteId, toSearchNote(action.note ?? {}));
         indexNote(action.noteId);
         queueSearch();


### PR DESCRIPTION
### Fix

Fixes #2664 

### Test

1. Have an unpinned note
2. Pin it
3. Restore to prior version with History slider
4. Note that it correctly moves in the notes list

### Release

Fixed a bug where the notes list was not updated after restoring a revision