### PR TITLE
Fix: Remove unwanted context menu items

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@
 - Tag input now inserts tags when a space is used or when clicking outside of the input area [#2607](https://github.com/Automattic/simplenote-electron/pull/2607)
 - Updated Monaco editor to 0.22.0 to fix duplicate character inputs on Firefox [#2611](https://github.com/Automattic/simplenote-electron/pull/2611)
 - Updated keyboard shortcut keys to display correctly based on platform [#2601](https://github.com/Automattic/simplenote-electron/pull/2601)
+- Fixed a bug causing duplicate and unwanted items to appear in the context menu [#2669](https://github.com/Automattic/simplenote-electron/pull/2669)
 
 ## [v2.6.0]
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -12,6 +12,7 @@ import {
   Selection,
   SelectionDirection,
 } from 'monaco-editor';
+import * as monacoactions from 'monaco-editor/esm/vs/platform/actions/common/actions';
 
 import { searchNotes, tagsFromSearch } from './search';
 import actions from './state/actions';
@@ -176,6 +177,30 @@ class NoteContentEditor extends Component<Props> {
     this.props.storeHasFocus(this.hasFocus);
     window.addEventListener('toggleChecklist', this.handleChecklist, true);
     this.toggleShortcuts(true);
+
+    /* remove unwanted context menu items */
+    const menus = monacoactions.MenuRegistry._menuItems;
+    const contextMenuEntry = [...menus].find(
+      (entry) => entry[0]._debugName === 'EditorContext'
+    );
+    const contextMenuLinks = contextMenuEntry[1];
+    const removableIds = [
+      'editor.action.changeAll',
+      'editor.action.clipboardCutAction',
+      'editor.action.clipboardCopyAction',
+      'editor.action.clipboardPasteAction',
+      'editor.action.quickCommand',
+    ];
+    const removeById = (list, ids) => {
+      let node = list._first;
+      do {
+        const shouldRemove = ids.includes(node.element?.command?.id);
+        if (shouldRemove) {
+          list._remove(node);
+        }
+      } while ((node = node.next));
+    };
+    removeById(contextMenuLinks, removableIds);
   }
 
   componentWillUnmount() {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -95,21 +95,6 @@ span[dir='ltr'] {
   }
 }
 
-/* Hide unwanted items in the context menu.
-   This removes the first item (Change All Occurrences) and the last (Command Palette).
-   The nth-child's remove Cut(7) and Copy(9) so we can add keybindings to them.
-   We may need to adjust these rules if a Monaco update adds more default items,
-   OR if we add/remove/reorder menu items sometime in the future :(
-   See: https://github.com/microsoft/monaco-editor/issues/1280
-*/
-.monaco-menu .monaco-action-bar.vertical .action-item:first-child,
-.monaco-menu .monaco-action-bar.vertical .action-item:nth-child(7),
-.monaco-menu .monaco-action-bar.vertical .action-item:nth-child(9),
-.monaco-menu .monaco-action-bar.vertical .action-item:nth-last-child(2),
-.monaco-menu .monaco-action-bar.vertical .action-item:last-child {
-  display: none !important;
-}
-
 /* Safari requires that it be displayed absolute so that it takes the full height
 */
 .note-content-editor-shell {


### PR DESCRIPTION
### Fix

**2.7.0 Hotfix.** Resolves #2668

### Test

Right-click. Verify no odd options are shown:

<img width="290" alt="Screen Shot 2021-02-11 at 4 07 20 PM" src="https://user-images.githubusercontent.com/52152/107715028-3c1d4980-6c83-11eb-9d0e-219488781f19.png">


### Release

Fixed a bug causing duplicate and unwanted items to appear in the context menu.