### PR TITLE
Fix the alignment of new note icon in focus mode

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,7 +8,7 @@
 - Added a checklist icon to the note toolbar [#2603](https://github.com/Automattic/simplenote-electron/pull/2603)
 - Updated tag renaming to be more consistent in the app and across platforms [#2602](https://github.com/Automattic/simplenote-electron/pull/2602)
 - Moved the note revision slider to the bottom of the note [#2586](https://github.com/Automattic/simplenote-electron/pull/2586), [#2662](https://github.com/Automattic/simplenote-electron/pull/2662)
-- Added the new note icon to the toolbar when in focus mode [#2596](https://github.com/Automattic/simplenote-electron/pull/2596)
+- Added the new note icon to the toolbar when in focus mode [#2596](https://github.com/Automattic/simplenote-electron/pull/2596), [#2671](https://github.com/Automattic/simplenote-electron/pull/2671)
 - Updated the icon set [#2623](https://github.com/Automattic/simplenote-electron/pull/2623)
 - Updated tag editing styles [#2584](https://github.com/Automattic/simplenote-electron/pull/2584)
 - Adjusted note list width and font weights [#2631](https://github.com/Automattic/simplenote-electron/pull/2631)

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -117,6 +117,10 @@
   height: $toolbar-height;
   line-height: $toolbar-height;
   padding-right: 13px;
+
+  svg {
+    margin-bottom: 2px;
+  }
 }
 
 .is-focus-mode .new-note-toolbar__button-sidebar {

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -118,8 +118,12 @@
   line-height: $toolbar-height;
   padding-right: 13px;
 
+  .icon-button {
+    margin-top: 6px;
+  }
+
   svg {
-    margin-bottom: 2px;
+    vertical-align: baseline;
   }
 }
 

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -80,8 +80,10 @@ optgroup {
   }
 
   .new-note-toolbar__button-sidebar {
+    border-right: 0;
     height: 70px;
     line-height: 70px;
+    padding-right: 0;
   }
 
   .menu-bar {

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -81,8 +81,6 @@ optgroup {
 
   .new-note-toolbar__button-sidebar {
     border-right: 0;
-    height: 70px;
-    line-height: 70px;
     padding-right: 0;
   }
 


### PR DESCRIPTION
### Fix

When adding in the new note icon in focus mode the alignment did not fit with the other icons.
This PR aligns it better.
Also on Mac Electron only it removes the dividing line between the focus mode icon and the new note icon when in focus mode. It did not work well and overlapped the Mac window buttons. 
Spoke with @SylvesterWilmott about it removing the dividing line here seemed like the best option.
Resolves #2658

macOS Electron
<img width="342" alt="Screen Shot 2021-02-12 at 7 51 44 AM" src="https://user-images.githubusercontent.com/1326294/107764884-4bde7180-6d07-11eb-8ecf-a31051bdf058.png">

Browser
![Screen Shot 2021-02-12 at 7 52 25 AM](https://user-images.githubusercontent.com/1326294/107764906-5567d980-6d07-11eb-8175-4bd5b22077d1.png)



### Test

1. Open focus mode on macOS Electron.
2. Ensure the dividing line between the new note and the focus mode does not appear.
3. Ensure the icons are aligned properly.
4. Ensure icons align properly in browsers as well.

### Release

<!-- **_(Required)_** Add a concise statement to `RELEASE-NOTES.md` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
`RELEASE-NOTES.md` was updated with: -->
