### PR TITLE
Adding Untagged Notes to Sidebar

### DIFF
--- a/lib/icons/untagged-notes.tsx
+++ b/lib/icons/untagged-notes.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function UntaggedNotesIcon() {
+  return (
+    <svg
+      className="icon-untagged-notes"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+    >
+      <rect x="0" fill="none" width="24" height="24" />
+      <path d="M15.79 7.21c0.552 0 1 0.448 1 1s-0.448 1-1 1 -1-0.448-1-1S15.238 7.21 15.79 7.21zM11.5 7.48L13.12 6H18v4.88l-1.48 1.62 1.34 1.42L20 11.71V4h-7.71l-2.21 2.14L11.5 7.48zM21 19.59L4.41 3 3 4.41l4.3 4.3L4 12c-0.388 0.39-0.388 1.02 0 1.41L10.59 20c0.39 0.388 1.02 0.388 1.41 0l3.29-3.29 4.3 4.3L21 19.59zM11.28 17.88l-5.16-5.17 2.59-2.59 5.17 5.17L11.28 17.88z" />
+    </svg>
+  );
+}

--- a/lib/menu-bar/index.tsx
+++ b/lib/menu-bar/index.tsx
@@ -50,6 +50,9 @@ export const MenuBar: FunctionComponent<Props> = ({
     case 'trash':
       placeholder = 'Trash';
       break;
+    case 'untagged':
+      placeholder = 'Untagged Notes';
+      break;
     default:
       placeholder = 'All Notes';
       break;

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -77,7 +77,7 @@ export class NavigationBar extends Component<Props> {
         <div className="navigation-bar__folders theme-color-border">
           <NavigationBarItem
             icon={<NotesIcon />}
-            isSelected={this.isSelected({ row: 'untagged' })}
+            isSelected={this.isSelected({ selectedRow: 'untagged' })}
             label="Untagged Notes"
             onClick={onShowUntaggedNotes}
           />

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -26,6 +26,7 @@ type DispatchProps = {
   onOutsideClick: () => any;
   onSettings: () => any;
   onShowAllNotes: () => any;
+  onShowUntaggedNotes: () => any;
   selectTrash: () => any;
   showKeyboardShortcuts: () => any;
 };
@@ -64,10 +65,22 @@ export class NavigationBar extends Component<Props> {
   };
 
   render() {
-    const { autoHideMenuBar, onAbout, onSettings, onShowAllNotes } = this.props;
+    const {
+      autoHideMenuBar,
+      onAbout,
+      onSettings,
+      onShowAllNotes,
+      onShowUntaggedNotes,
+    } = this.props;
     return (
       <div className="navigation-bar theme-color-bg theme-color-fg theme-color-border">
         <div className="navigation-bar__folders theme-color-border">
+          <NavigationBarItem
+            icon={<NotesIcon />}
+            isSelected={this.isSelected({ row: 'untagged' })}
+            label="Untagged Notes"
+            onClick={onShowUntaggedNotes}
+          />
           <NavigationBarItem
             icon={<SettingsIcon />}
             label="Settings"
@@ -138,6 +151,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   onAbout: () => actions.ui.showDialog('ABOUT'),
   onOutsideClick: actions.ui.toggleNavigation,
   onShowAllNotes: actions.ui.showAllNotes,
+  onShowUntaggedNotes: actions.ui.showUntaggedNotes,
   onSettings: () => actions.ui.showDialog('SETTINGS'),
   selectTrash: actions.ui.selectTrash,
   showKeyboardShortcuts: () => actions.ui.showDialog('KEYBINDINGS'),

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -8,6 +8,7 @@ import TagList from '../tag-list';
 import NotesIcon from '../icons/notes';
 import TrashIcon from '../icons/trash';
 import SettingsIcon from '../icons/settings';
+import UntaggedNotesIcon from '../icons/untagged-notes';
 import { viewExternalUrl } from '../utils/url-utils';
 import actions from '../state/actions';
 
@@ -19,6 +20,7 @@ type StateProps = {
   collection: T.Collection;
   isDialogOpen: boolean;
   showNavigation: boolean;
+  tagCount: number;
 };
 
 type DispatchProps = {
@@ -71,16 +73,12 @@ export class NavigationBar extends Component<Props> {
       onSettings,
       onShowAllNotes,
       onShowUntaggedNotes,
+      tagCount,
     } = this.props;
+
     return (
       <div className="navigation-bar theme-color-bg theme-color-fg theme-color-border">
         <div className="navigation-bar__folders theme-color-border">
-          <NavigationBarItem
-            icon={<NotesIcon />}
-            isSelected={this.isSelected({ selectedRow: 'untagged' })}
-            label="Untagged Notes"
-            onClick={onShowUntaggedNotes}
-          />
           <NavigationBarItem
             icon={<SettingsIcon />}
             label="Settings"
@@ -101,7 +99,19 @@ export class NavigationBar extends Component<Props> {
         </div>
         <div className="navigation-bar__tags theme-color-border">
           <TagList />
+          {(tagCount && (
+            <div className="navigation-bar__folders navigation-bar__untagged theme-color-border">
+              <NavigationBarItem
+                icon={<UntaggedNotesIcon />}
+                isSelected={this.isSelected({ selectedRow: 'untagged' })}
+                label="Untagged Notes"
+                onClick={onShowUntaggedNotes}
+              />
+            </div>
+          )) ||
+            null}
         </div>
+
         <div className="navigation-bar__tools theme-color-border">
           <div className="navigation-bar__server-connection">
             <ConnectionStatus />
@@ -138,6 +148,7 @@ export class NavigationBar extends Component<Props> {
 }
 
 const mapStateToProps: S.MapState<StateProps> = ({
+  data,
   settings,
   ui: { collection, dialogs, showNavigation },
 }) => ({
@@ -145,6 +156,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
   collection,
   isDialogOpen: dialogs.length > 0,
   showNavigation,
+  tagCount: data.tags.size,
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {

--- a/lib/navigation-bar/style.scss
+++ b/lib/navigation-bar/style.scss
@@ -34,6 +34,10 @@
   padding: 12px 0 0;
 }
 
+.navigation-bar__untagged {
+  border-top: 1px solid;
+}
+
 .navigation-bar__tools {
   flex: 1 0 auto;
   padding: 10px 0;

--- a/lib/note-list/no-notes.tsx
+++ b/lib/note-list/no-notes.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import NotesIcon from '../icons/notes';
 import TagIcon from '../icons/tag';
 import TrashIcon from '../icons/trash';
+import UntaggedNotesIcon from '../icons/untagged-notes';
 
 import actions from '../state/actions';
 
@@ -56,6 +57,12 @@ const NoNotes = () => {
         return {
           message: 'Your trash is empty',
           icon: <TrashIcon />,
+          button: null,
+        };
+      case 'untagged':
+        return {
+          message: 'No untagged notes',
+          icon: <UntaggedNotesIcon />,
           button: null,
         };
       default:

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -6,6 +6,7 @@ import { getTitle } from '../utils/note-utils';
 import type * as A from '../state/action-types';
 import type * as S from '../state';
 import type * as T from '../types';
+import { showAllNotes } from '../state/ui/actions';
 
 const emptyList = [] as unknown[];
 
@@ -557,7 +558,16 @@ export const middleware: S.Middleware = (store) => {
           return next(action);
         }
 
-        searchState.collection = { type: 'all' };
+        // if currently filtering by untagged notes and you're deleting
+        // the last remaining note, reset filter to all. Checking for size
+        // 1 because the deletion hasn't gone through at this point yet.
+        if (
+          searchState.collection.type === 'untagged' &&
+          store.getState().data.tags.size <= 1
+        ) {
+          searchState.collection = { type: 'all' };
+          store.dispatch(showAllNotes());
+        }
         return next(withSearch(action));
       }
     }

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -227,6 +227,10 @@ export const middleware: S.Middleware = (store) => {
         continue;
       }
 
+      if (collection.type === 'untagged' && note.tags.size) {
+        continue;
+      }
+
       const openedTagHash = collection.type === 'tag' && t(collection.tagName);
       if (openedTagHash && !note.tags.has(openedTagHash)) {
         continue;
@@ -349,7 +353,6 @@ export const middleware: S.Middleware = (store) => {
       return rawNext(action);
     };
 
-    searchState.showUntagged = false;
     switch (action.type) {
       case 'ADD_NOTE_TAG': {
         const note = searchState.notes.get(action.noteId);
@@ -494,9 +497,7 @@ export const middleware: S.Middleware = (store) => {
         return next(withSearch(action));
 
       case 'SHOW_UNTAGGED_NOTES':
-        searchState.openedTag = null;
-        searchState.showTrash = false;
-        searchState.showUntagged = true;
+        searchState.collection = { type: 'untagged' };
         return next(withSearch(action));
 
       case 'SEARCH':

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -566,7 +566,6 @@ export const middleware: S.Middleware = (store) => {
           store.getState().data.tags.size <= 1
         ) {
           searchState.collection = { type: 'all' };
-          store.dispatch(showAllNotes());
         }
         return next(withSearch(action));
       }

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -349,6 +349,7 @@ export const middleware: S.Middleware = (store) => {
       return rawNext(action);
     };
 
+    searchState.showUntagged = false;
     switch (action.type) {
       case 'ADD_NOTE_TAG': {
         const note = searchState.notes.get(action.noteId);
@@ -490,6 +491,12 @@ export const middleware: S.Middleware = (store) => {
 
       case 'SHOW_ALL_NOTES':
         searchState.collection = { type: 'all' };
+        return next(withSearch(action));
+
+      case 'SHOW_UNTAGGED_NOTES':
+        searchState.openedTag = null;
+        searchState.showTrash = false;
+        searchState.showUntagged = true;
         return next(withSearch(action));
 
       case 'SEARCH':

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -218,7 +218,10 @@ export type SetSystemTag = Action<
   'SET_SYSTEM_TAG',
   { note: T.NoteEntity; tagName: T.SystemTag; shouldHaveTag: boolean }
 >;
-export type TrashTag = Action<'TRASH_TAG', { tagName: T.TagName }>;
+export type TrashTag = Action<
+  'TRASH_TAG',
+  { tagName: T.TagName; remainingTags?: number }
+>;
 
 /*
  * Simperium operations

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -102,7 +102,7 @@ export type SetUnsyncedNoteIds = Action<
 >;
 export type ShowAllNotes = Action<'SHOW_ALL_NOTES'>;
 export type ShowUntaggedNotes = Action<'SHOW_UNTAGGED_NOTES'>;
-  
+
 export type ShowDialog = Action<
   'SHOW_DIALOG',
   {

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -101,6 +101,7 @@ export type SetUnsyncedNoteIds = Action<
   { noteIds: T.EntityId[] }
 >;
 export type ShowAllNotes = Action<'SHOW_ALL_NOTES'>;
+export type ShowUntaggedNotes = Action<'SHOW_UNTAGGED_NOTES'>;
 export type ShowDialog = Action<'SHOW_DIALOG', { dialog: T.DialogType }>;
 export type StoreEditorSelection = Action<
   'STORE_EDITOR_SELECTION',
@@ -389,6 +390,7 @@ export type ActionType =
   | SetTheme
   | SetUnsyncedNoteIds
   | ShowAllNotes
+  | ShowUntaggedNotes
   | ShowDialog
   | StoreEditorSelection
   | StoreNumberOfMatchesInNote

--- a/lib/state/data/middleware.ts
+++ b/lib/state/data/middleware.ts
@@ -6,6 +6,7 @@ import exportZipArchive from '../../utils/export';
 import type * as A from '../action-types';
 import type * as S from '../';
 import type * as T from '../../types';
+import { numberOfNonEmailTags } from '../selectors';
 
 export const middleware: S.Middleware = (store) => (
   next: (action: A.ActionType) => A.ActionType
@@ -110,17 +111,10 @@ export const middleware: S.Middleware = (store) => (
       });
 
     case 'TRASH_TAG':
-      // for the love of all things beautiful and holy…
-      // make a function to separate email-tags from normal tags
-      // and use that to get the count of tags, even a new selector
-      // numberOfTags(state) -> number :: assumes a "tag" is not an email
-      return store.getState().data.tags.has(tagHashOf(action.tagName))
+      return state.data.tags.has(tagHashOf(action.tagName))
         ? next({
             ...action,
-            remainingTags:
-              [...store.getState().data.tags.values()].filter(
-                (tag) => !tag.name.includes('@')
-              ).length - 1,
+            remainingTags: numberOfNonEmailTags(state) - 1,
           })
         : null;
 

--- a/lib/state/data/middleware.ts
+++ b/lib/state/data/middleware.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from 'uuid';
 
+import { tagHashOf } from '../../utils/tag-hash';
 import exportZipArchive from '../../utils/export';
 
 import type * as A from '../action-types';
@@ -107,6 +108,21 @@ export const middleware: S.Middleware = (store) => (
         type: 'TRASH_NOTE',
         noteId: state.ui.openedNote,
       });
+
+    case 'TRASH_TAG':
+      // for the love of all things beautiful and holy…
+      // make a function to separate email-tags from normal tags
+      // and use that to get the count of tags, even a new selector
+      // numberOfTags(state) -> number :: assumes a "tag" is not an email
+      return store.getState().data.tags.has(tagHashOf(action.tagName))
+        ? next({
+            ...action,
+            remainingTags:
+              [...store.getState().data.tags.values()].filter(
+                (tag) => !tag.name.includes('@')
+              ).length - 1,
+          })
+        : null;
 
     default:
       return next(action);

--- a/lib/state/selectors.ts
+++ b/lib/state/selectors.ts
@@ -1,5 +1,6 @@
 import * as S from './';
 import * as T from '../types';
+import isEmailTag from '../utils/is-email-tag';
 
 /**
  * "Narrow" views hide the note editor
@@ -54,3 +55,8 @@ export const showTrash: S.Selector<boolean> = ({ ui: { collection } }) =>
   collection.type === 'trash';
 export const isDialogOpen = (state: S.State, name: T.DialogType['type']) =>
   state.ui.dialogs.find(({ type }) => type === name) !== undefined;
+
+export const numberOfNonEmailTags: S.Selector<number> = ({ data }) =>
+  [...data.tags.values()]
+    .filter((tag) => !isEmailTag(tag.name))
+    .map((tag) => tag.name).length;

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -84,6 +84,10 @@ export const showAllNotes: A.ActionCreator<A.ShowAllNotes> = () => ({
   type: 'SHOW_ALL_NOTES',
 });
 
+export const showUntaggedNotes: A.ActionCreator<A.ShowUntaggedNotes> = () => ({
+  type: 'SHOW_UNTAGGED_NOTES',
+});
+
 export const showDialog: A.ActionCreator<A.ShowDialog> = (
   dialog: T.DialogType
 ) => ({

--- a/lib/state/ui/middleware.ts
+++ b/lib/state/ui/middleware.ts
@@ -60,6 +60,7 @@ export const middleware: S.Middleware = (store) => (
     }
 
     case 'SHOW_ALL_NOTES':
+    case 'SHOW_UNTAGGED_NOTES':
     case 'SELECT_TRASH':
       // this middleware runs after the search middleware which is important
       // because we're reading the new search results which came as a result

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 
+import { tagHashOf } from '../../utils/tag-hash';
 import {
   withCheckboxCharacters,
   withCheckboxSyntax,
@@ -98,8 +99,15 @@ const collection: A.Reducer<T.Collection> = (
       return { type: 'all' };
     case 'SHOW_UNTAGGED_NOTES':
       return { type: 'untagged' };
-    case 'TRASH_TAG':
-      return action.tagName === state.tagName ? { type: 'all' } : state;
+    case 'TRASH_TAG': {
+      const openedTagIsGone =
+        state.type === 'tag' &&
+        tagHashOf(state.tagName) === tagHashOf(action.tagName);
+      const lastTagDisappeared =
+        state.type === 'untagged' && action?.remainingTags === 0;
+
+      return openedTagIsGone || lastTagDisappeared ? { type: 'all' } : state;
+    }
     default:
       return state;
   }

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -138,6 +138,7 @@ const editingTags: A.Reducer<boolean> = (state = false, action) => {
     case 'OPEN_TAG':
     case 'SELECT_TRASH':
     case 'SHOW_ALL_NOTES':
+    case 'SHOW_UNTAGGED_NOTES':
     case 'NAVIGATION_TOGGLE':
       return false;
     default:
@@ -276,6 +277,7 @@ const showNavigation: A.Reducer<boolean> = (state = false, action) => {
     case 'OPEN_TAG':
     case 'SELECT_TRASH':
     case 'SHOW_ALL_NOTES':
+    case 'SHOW_UNTAGGED_NOTES':
       return false;
     case 'SHOW_DIALOG':
       if (action.dialog === 'SETTINGS') {

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -1,6 +1,5 @@
 import { combineReducers } from 'redux';
 
-import { tagHashOf } from '../../utils/tag-hash';
 import {
   withCheckboxCharacters,
   withCheckboxSyntax,
@@ -97,6 +96,8 @@ const collection: A.Reducer<T.Collection> = (
       return { type: 'trash' };
     case 'SHOW_ALL_NOTES':
       return { type: 'all' };
+    case 'SHOW_UNTAGGED_NOTES':
+      return { type: 'untagged' };
     case 'TRASH_TAG':
       return action.tagName === state.tagName ? { type: 'all' } : state;
     default:

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -1,5 +1,4 @@
 .tag-list-item {
-  border-bottom: 1px solid;
   display: flex;
   font-size: 16px;
   height: 44px;
@@ -17,10 +16,14 @@
   }
 }
 
+.tag-list-item:not(:last-child) {
+  border-bottom: 1px solid;
+}
+
 .tag-list {
   display: flex;
   flex-direction: column;
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   overflow: hidden;
 
   .tag-list-title {


### PR DESCRIPTION
Fixes #1230 

### Fix
* Adds "Untagged Notes" filter to sidebar.
* Incidentally, found bug where filtering Trash notes and then filtering by a tag results in searching for that tag in Trash notes only. I'm assuming that's not the desired behaviour and corrected it; however I can easily change it back.  **_NOTE_: This bug has been fixed with state refactor.**

### Test
#### Untagged Notes
1. Create note with no tags and a note with tags.
2. Open sidebar.
3. Click on "Untagged Notes".
4. See that only the note with no tags shows up in list.

### Screenshots
<details>
  <summary>Before</summary>
  <img src="https://user-images.githubusercontent.com/13263478/108815033-64f1e880-7579-11eb-8d8d-94037c51ad5f.gif" width="100%"/>
</details>

<details>
  <summary>No untagged notes</summary>
  
![no-untagged](https://user-images.githubusercontent.com/13263478/110157645-0c5af080-7dae-11eb-8073-a80ca9edc187.gif)
</details>

<details>
  <summary>Delete tags</summary>
  
![delete-tags-reset-untagged](https://user-images.githubusercontent.com/13263478/110175727-dcb8e200-7dc7-11eb-9b06-70ab2be4732f.gif)

</details>

<details>
  <summary>Long list of tags</summary>
  
![tag-lots](https://user-images.githubusercontent.com/13263478/110157759-2f85a000-7dae-11eb-9100-5a270ccf4800.gif)
</details>

### Release
`RELEASE-NOTES.md` was updated with:
```
### Enhancements

- Added Untagged Notes filter to sidebar.

### Fixes

- Fixed bug where selecting Trash filter and then filtering on a tag resulted in a filter where only notes with that tag in the Trash were shown.
```