### PR TITLE
update tag chip test snapshot to match new icons added

### DIFF
--- a/lib/components/tag-chip/__snapshots__/test.tsx.snap
+++ b/lib/components/tag-chip/__snapshots__/test.tsx.snap
@@ -11,13 +11,17 @@ exports[`TagChip should not introduce visual regressions 1`] = `
   >
     <svg
       className="icon-cross-small"
-      height="22"
-      viewBox="0 0 22 22"
-      width="22"
+      viewBox="0 0 16 16"
       xmlns="http://www.w3.org/2000/svg"
     >
+      <rect
+        fill="none"
+        height="16"
+        width="16"
+        x="0"
+      />
       <path
-        d="M16.707 6.707l-1.414-1.414L11 9.586 6.707 5.293 5.293 6.707 9.586 11l-4.293 4.293 1.414 1.414L11 12.414l4.293 4.293 1.414-1.414L12.414 11z"
+        d="M13.66 3.76l-1.42-1.42L8 6.59 3.76 2.34 2.34 3.76 6.59 8l-4.25 4.24 1.42 1.42L8 9.41l4.24 4.25 1.42-1.42L9.41 8 13.66 3.76z"
       />
     </svg>
   </span>


### PR DESCRIPTION
### Fix

PR #2608 broke the Jest snapshot test for `tag-chip` because the icon used was updated in `develop` since creating that PR. This updates the snapshot to include the new icon so tests will pass.

### Test

1. Run jest tests and ensure they complete

