### PR TITLE
Fixing duplicate file name issue in exports

### DIFF
--- a/lib/utils/export/to-zip.ts
+++ b/lib/utils/export/to-zip.ts
@@ -86,9 +86,8 @@ const appendTags = (note) => {
  * @returns {[Array, Object]} final note list and accumulating filename counts
  */
 const toUniqueNames = ([notes, nameCounts], note) => {
-  nameCounts.set(note.fileName, (nameCounts.get(note.fileName) ?? -1) + 1);
-  const count = nameCounts.get(note.fileName);
-
+  const count = nameCounts.get(note.fileName) ?? 0;
+  nameCounts.set(note.fileName, count + 1);
   const fileName = count > 0 ? `${note.fileName} (${count})` : note.fileName;
 
   return [[...notes, { ...note, fileName }], nameCounts];

--- a/lib/utils/export/to-zip.ts
+++ b/lib/utils/export/to-zip.ts
@@ -25,8 +25,7 @@ const addFilename = (note) => ({
     .filter(identity) // remove blank lines
     .concat('untitled') // use this as a default if there are no non-blank lines
     .shift() // take the first remaining line
-    .slice(0, FILENAME_LENGTH) // and truncate to some reasonable number of characters
-    .replace(/[.,:() [\]]/g, '-'), // Still some characters which can cause issues in our way of checking for duplicate file names. Removing more here.
+    .slice(0, FILENAME_LENGTH), // and truncate to some reasonable number of characters
 });
 
 /**
@@ -87,11 +86,11 @@ const appendTags = (note) => {
  * @returns {[Array, Object]} final note list and accumulating filename counts
  */
 const toUniqueNames = ([notes, nameCounts], note) => {
-  const newNameCounts = update(nameCounts, note.fileName, (n) =>
+  const encodedFileName = btoa(note.fileName);
+  const newNameCounts = update(nameCounts, encodedFileName, (n) =>
     n || 0 === n ? n + 1 : 0
   );
-
-  const count = newNameCounts[note.fileName];
+  const count = newNameCounts[encodedFileName];
   const fileName = count > 0 ? `${note.fileName} (${count})` : note.fileName;
 
   return [[...notes, { ...note, fileName }], newNameCounts];

--- a/lib/utils/export/to-zip.ts
+++ b/lib/utils/export/to-zip.ts
@@ -25,7 +25,8 @@ const addFilename = (note) => ({
     .filter(identity) // remove blank lines
     .concat('untitled') // use this as a default if there are no non-blank lines
     .shift() // take the first remaining line
-    .slice(0, FILENAME_LENGTH), // and truncate to some reasonable number of characters
+    .slice(0, FILENAME_LENGTH) // and truncate to some reasonable number of characters
+    .replace(/[.,:() [\]]/g, '-'), // Still some characters which can cause issues in our way of checking for duplicate file names. Removing more here.
 });
 
 /**
@@ -89,6 +90,7 @@ const toUniqueNames = ([notes, nameCounts], note) => {
   const newNameCounts = update(nameCounts, note.fileName, (n) =>
     n || 0 === n ? n + 1 : 0
   );
+
   const count = newNameCounts[note.fileName];
   const fileName = count > 0 ? `${note.fileName} (${count})` : note.fileName;
 


### PR DESCRIPTION
### Fix

When trying to export notes there are some instances where notes with the same title will overwrite each other. This is caused by some characters in the titles that can break our method for checking for duplicate file names. This can be demonstrated by using markdown images as the first line, or title of notes.

For example, if you have two notes with this content:
```
![Simplenote.com](https://github.com/Automattic/simplenote-electron/raw/develop/resources/images/icon_512x512.png)

File 1
```

```
![Simplenote.com](https://github.com/Automattic/simplenote-electron/raw/develop/resources/images/icon_512x512.png)

File 2
```

Only one txt file will be exported because the file names would end up the same and overwrite each other.

The root cause identified (lodash.update was interpreting the "filename" as a property path, thus interpreting. and array-like indexing with brackets. This removes the update function and uses a Map to check for duplicates instead.

### Test

1. Create multiple notes with the same markdown image as the first line.
2. Try to export the notes.
3. Ensure all notes are exported.

### Release

- Fix bug in note export to avoid duplicate filenames when certain characters were used in the note title.
