### PR TITLE
[feature] Add setting to exclude tags from default view

### DIFF
--- a/lib/dialogs/list-settings-group.tsx
+++ b/lib/dialogs/list-settings-group.tsx
@@ -1,0 +1,86 @@
+import React, { FunctionComponent, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import PanelTitle from '../components/panel-title';
+
+type ItemsType = string[];
+
+type Props = {
+  description?: string;
+  items: ItemsType;
+  onChange: Function;
+  pattern?: string;
+  placeholder?: string;
+  title: string;
+};
+
+const ListSettingsGroup: FunctionComponent<Props> = ({
+  description,
+  items,
+  onChange,
+  pattern,
+  placeholder,
+  title,
+}) => {
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    console.log(`Items = ${items.join(',')}`);
+  }, [items]);
+
+  const onTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
+  };
+
+  const onDone = () => {
+    const newItems = items.concat(value).sort();
+    onChange(newItems);
+    setValue('');
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      onDone();
+    }
+  };
+
+  return (
+    <div className="settings-group">
+      <PanelTitle headingLevel={3}>{title}</PanelTitle>
+      {description && <p>{description}</p>}
+      <div className="settings-items theme-color-border">
+        {items.map((item: string, i: number) => (
+          <div
+            className="settings-item theme-color-border"
+            key={`${item}-${i}`}
+          >
+            <div className="settings-item-label">{item}</div>
+          </div>
+        ))}
+        <div className="settings-item theme-color-border">
+          <input
+            className="settings-item-text-input transparent-input"
+            title="Enter a new item"
+            onBlur={onDone}
+            onChange={onTextChange}
+            onKeyDown={onKeyDown}
+            pattern={pattern}
+            placeholder={placeholder}
+            spellCheck={false}
+            value={value}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+ListSettingsGroup.propTypes = {
+  description: PropTypes.string,
+  items: PropTypes.any,
+  onChange: PropTypes.func.isRequired,
+  pattern: PropTypes.string,
+  placeholder: PropTypes.string,
+  title: PropTypes.string.isRequired,
+};
+
+export default ListSettingsGroup;

--- a/lib/dialogs/list-settings-group.tsx
+++ b/lib/dialogs/list-settings-group.tsx
@@ -1,6 +1,7 @@
-import React, { FunctionComponent, useEffect, useState } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import PropTypes from 'prop-types';
 import PanelTitle from '../components/panel-title';
+import TrashIcon from '../icons/trash';
 
 type ItemsType = string[];
 
@@ -23,18 +24,16 @@ const ListSettingsGroup: FunctionComponent<Props> = ({
 }) => {
   const [value, setValue] = useState('');
 
-  useEffect(() => {
-    console.log(`Items = ${items.join(',')}`);
-  }, [items]);
-
   const onTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);
   };
 
   const onDone = () => {
-    const newItems = items.concat(value).sort();
-    onChange(newItems);
-    setValue('');
+    if (value.length > 0) {
+      const newItems = items.concat(value).sort();
+      onChange(newItems);
+      setValue('');
+    }
   };
 
   const onKeyDown = (event: React.KeyboardEvent) => {
@@ -43,17 +42,27 @@ const ListSettingsGroup: FunctionComponent<Props> = ({
     }
   };
 
+  const onClick = (name: string) => {
+    const newItems = items
+      .filter((str) => name.length > 0 && name !== str)
+      .sort();
+    onChange(newItems);
+  };
+
   return (
     <div className="settings-group">
       <PanelTitle headingLevel={3}>{title}</PanelTitle>
       {description && <p>{description}</p>}
       <div className="settings-items theme-color-border">
-        {items.map((item: string, i: number) => (
-          <div
-            className="settings-item theme-color-border"
-            key={`${item}-${i}`}
-          >
+        {items.map((item: string) => (
+          <div className="settings-item theme-color-border" key={item}>
             <div className="settings-item-label">{item}</div>
+            <div
+              style={{ cursor: 'pointer' }}
+              className="settings-item-control"
+            >
+              <TrashIcon onClick={() => onClick(item)} />
+            </div>
           </div>
         ))}
         <div className="settings-item theme-color-border">

--- a/lib/dialogs/settings/panels/display.tsx
+++ b/lib/dialogs/settings/panels/display.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { isElectron, isMac } from '../../../utils/platform';
 import RadioGroup from '../../radio-settings-group';
 import SettingsGroup, { Item } from '../../settings-group';
+import ListSettingsGroup from '../../list-settings-group';
 import ToggleGroup from '../../toggle-settings-group';
 import actions from '../../../state/actions';
 
@@ -13,6 +14,7 @@ import * as T from '../../../types';
 type StateProps = {
   activeTheme: T.Theme;
   autoHideMenuBar: boolean;
+  hiddenTags: T.HiddenTags;
   lineLength: T.LineLength;
   noteDisplay: T.ListDisplayMode;
   sortIsReversed: boolean;
@@ -22,6 +24,7 @@ type StateProps = {
 
 type DispatchProps = {
   setActiveTheme: (theme: T.Theme) => any;
+  setHiddenTags: (hiddenTags: T.HiddenTags) => any;
   setLineLength: (lineLength: T.LineLength) => any;
   setNoteDisplay: (displayMode: T.ListDisplayMode) => any;
   setSortType: (sortType: T.SortType) => any;
@@ -89,6 +92,15 @@ const DisplayPanel: FunctionComponent<Props> = (props) => (
       <Item title="Sort Alphabetically" slug="alpha" />
     </SettingsGroup>
 
+    <ListSettingsGroup
+      title="Excluded tags"
+      description="These tags will not be shown in All Notes"
+      items={props.hiddenTags}
+      onChange={props.setHiddenTags}
+      pattern="[^ ,]"
+      placeholder="Please enter a tag name"
+    />
+
     <SettingsGroup
       title="Theme"
       slug="theme"
@@ -121,6 +133,7 @@ const DisplayPanel: FunctionComponent<Props> = (props) => (
 const mapStateToProps: S.MapState<StateProps> = ({ settings }) => ({
   activeTheme: settings.theme,
   autoHideMenuBar: settings.autoHideMenuBar,
+  hiddenTags: settings.hiddenTags,
   lineLength: settings.lineLength,
   noteDisplay: settings.noteDisplay,
   sortIsReversed: settings.sortReversed,
@@ -130,6 +143,7 @@ const mapStateToProps: S.MapState<StateProps> = ({ settings }) => ({
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   setActiveTheme: actions.settings.activateTheme,
+  setHiddenTags: actions.settings.setHiddenTags,
   setLineLength: actions.settings.setLineLength,
   setNoteDisplay: actions.settings.setNoteDisplay,
   setSortType: actions.settings.setSortType,

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -21,6 +21,7 @@ import * as T from '../types';
 
 type StateProps = {
   filteredNotes: T.EntityId[];
+  hiddenTags: T.HiddenTags; // Needed to re-render when hiddenTags changes.
   isSmallScreen: boolean;
   keyboardShortcuts: boolean;
   noteDisplay: T.ListDisplayMode;
@@ -340,6 +341,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => {
     keyboardShortcuts: state.settings.keyboardShortcuts,
     noteDisplay: state.settings.noteDisplay,
     filteredNotes: state.ui.filteredNotes,
+    hiddenTags: state.settings.hiddenTags,
     openedNote: state.ui.openedNote,
     openedTag: state.ui.openedTag,
     searchQuery: state.ui.searchQuery,

--- a/lib/note-list/note-cell.tsx
+++ b/lib/note-list/note-cell.tsx
@@ -25,10 +25,12 @@ type OwnProps = {
 type StateProps = {
   displayMode: T.ListDisplayMode;
   hasPendingChanges: boolean;
+  hiddenTags: T.HiddenTags;
   isOffline: boolean;
   isOpened: boolean;
   lastUpdated: number;
   note?: T.Note;
+  openedTag: T.Brand<string, 'EntityId'> | T.Brand<string, 'TagHash'> | null;
   searchQuery: string;
 };
 
@@ -70,12 +72,14 @@ export class NoteCell extends Component<Props> {
     const {
       displayMode,
       hasPendingChanges,
+      hiddenTags,
       isOffline,
       isOpened,
       lastUpdated,
       noteId,
       note,
       openNote,
+      openedTag,
       pinNote,
       searchQuery,
       style,
@@ -83,6 +87,12 @@ export class NoteCell extends Component<Props> {
 
     if (!note) {
       return <div>{"Couldn't find note"}</div>;
+    }
+
+    const isAllNotes = openedTag === null;
+    const isHidden = note.tags.some((tag) => hiddenTags.includes(tag));
+    if (isAllNotes && isHidden) {
+      return null;
     }
 
     const { title, preview } = noteTitleAndPreview(note, searchQuery);
@@ -173,10 +183,12 @@ const mapStateToProps: S.MapState<StateProps, OwnProps> = (
 ) => ({
   displayMode: state.settings.noteDisplay,
   hasPendingChanges: selectors.noteHasPendingChanges(state, noteId),
+  hiddenTags: state.settings.hiddenTags,
   isOffline: state.simperium.connectionStatus === 'offline',
   isOpened: state.ui.openedNote === noteId,
   lastUpdated: state.simperium.lastRemoteUpdate.get(noteId) ?? -Infinity,
   note: state.data.notes.get(noteId),
+  openedTag: state.ui.openedTag,
   searchQuery: state.ui.searchQuery,
 });
 

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -52,6 +52,10 @@ export type SetSpellCheck = Action<
   { spellCheckEnabled: boolean }
 >;
 export type SetTheme = Action<'setTheme', { theme: T.Theme }>;
+export type SetHiddenTags = Action<
+  'setHiddenTags',
+  { hiddenTags: T.HiddenTags }
+>;
 
 /*
  * Normal action types
@@ -379,6 +383,7 @@ export type ActionType =
   | SetAutoHideMenuBar
   | SetChangeVersion
   | SetFocusMode
+  | SetHiddenTags
   | SetLineLength
   | SetNoteDisplay
   | SetSortReversed

--- a/lib/state/electron/middleware.ts
+++ b/lib/state/electron/middleware.ts
@@ -49,6 +49,10 @@ export const middleware: S.Middleware = ({ dispatch, getState }) => {
         dispatch(actions.ui.createNote());
         return;
 
+      case 'setHiddenTags':
+        dispatch(actions.settings.setHiddenTags(command.hiddenTags));
+        return;
+
       case 'setLineLength':
         dispatch(actions.settings.setLineLength(command.lineLength));
         return;

--- a/lib/state/settings/actions.ts
+++ b/lib/state/settings/actions.ts
@@ -20,6 +20,13 @@ export const setLineLength: A.ActionCreator<A.SetLineLength> = (
   lineLength,
 });
 
+export const setHiddenTags: A.ActionCreator<A.SetHiddenTags> = (
+  hiddenTags: T.HiddenTags
+) => ({
+  type: 'setHiddenTags',
+  hiddenTags,
+});
+
 export const toggleKeyboardShortcuts: A.ActionCreator<A.ToggleKeyboardShortcuts> = () => ({
   type: 'KEYBOARD_SHORTCUTS_TOGGLE',
 });

--- a/lib/state/settings/reducer.ts
+++ b/lib/state/settings/reducer.ts
@@ -52,6 +52,15 @@ const lineLength: A.Reducer<T.LineLength> = (state = 'narrow', action) => {
   }
 };
 
+const hiddenTags: A.Reducer<T.HiddenTags> = (state = [], action) => {
+  switch (action.type) {
+    case 'setHiddenTags':
+      return action.hiddenTags;
+    default:
+      return state;
+  }
+};
+
 const markdownEnabled: A.Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'SET_SYSTEM_TAG':
@@ -148,6 +157,7 @@ export default combineReducers({
   accountName,
   autoHideMenuBar,
   focusModeEnabled,
+  hiddenTags,
   keyboardShortcuts,
   lineLength,
   markdownEnabled,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -72,6 +72,7 @@ export type ListDisplayMode = 'expanded' | 'comfy' | 'condensed';
 export type SortType = 'alphabetical' | 'creationDate' | 'modificationDate';
 export type Theme = 'system' | 'light' | 'dark';
 export type TranslatableString = Brand<string, 'TranslatableString'>;
+export type HiddenTags = string[];
 
 ///////////////////////////////////////
 // Language and Platform


### PR DESCRIPTION
### Fix

This adds a feature to allow certain tags to be excluded from the default view (All Notes). When the default view is shown, any note that contains at least one tag listed under hidden tags will not be visible in the notes list.

This only affects the notes list under All Notes. The tags are still visible in the tag list, and any items that would be hidden under All Notes will be visible when viewing that tag.

The list of hidden tags can be changed in Display Settings.

### Test

1. Go to settings. Click on Display.
2. Scroll down until you see Hidden tags.
3. Add at least one tag name and hit 'Enter'.
4. All notes that contain that tag will no longer be visible under All Notes.
5. Click the trash icon to delete the tag, and it will be listed again.

### Release

* Add feature to allow notes to be hidden from All Notes by tag name.
