### PR TITLE
Keyboard shortcuts: Fix Ctrl+G and other intermittently-firing shortcuts on Win/Linux

### DIFF
--- a/desktop/menus/utils.js
+++ b/desktop/menus/utils.js
@@ -24,7 +24,7 @@ const editorCommandSender = (arg) => {
 
 const commandSender = (commandName, arg) => {
   return (item, focusedWindow) => {
-    if (focusedWindow) {
+    if (typeof focusedWindow !== 'undefined') {
       focusedWindow.webContents.send(commandName, arg);
     }
   };

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -77,7 +77,7 @@ class AppComponent extends Component<Props> {
 
   handleShortcut = (event: KeyboardEvent) => {
     const { hotkeysEnabled } = this.props;
-    const shouldHandleBrowserShortcuts = !window.electron || !isMac;
+    const shouldHandleBrowserShortcuts = !window.electron;
 
     // Handle search shortcuts even if keyboard shortcuts are disabled.
     if (shouldHandleBrowserShortcuts) {
@@ -116,7 +116,6 @@ class AppComponent extends Component<Props> {
   // handle all keyboard shortcuts that are duplicated in the Electron menus
   // this listener is only called in browsers, as otherwise the
   // menu will trigger them via the provided Accelerator, so we don't need a listener
-  // n.b. we're also running this on Win/Linux builds as they seem to be broken otherwise
   handleBrowserShortcut = (event: KeyboardEvent) => {
     const { ctrlKey, metaKey, shiftKey } = event;
     const key = event.key.toLowerCase();


### PR DESCRIPTION
### Fix

Fixes #2420 

Some keyboard shortcuts were silently failing on Win/Linux builds. After adding logging and debugging this I was able to determine that the `if focusedWindow` check was failing. I still don't know exactly why, as this works on OSX.

Changing it to explicitly check if the `focusedWindow` is `undefined` seems to fix the issue in my testing. I have only tested this on Windows, not Linux.

After some research, I think it would be safe to remove this guard entirely. The [documentation](https://github.com/electron/electron/blob/master/docs/api/menu-item.md) does state that it can be `undefined`, but only in the case where no window is open, which only applies to OSX. (confirmed by a comment [here](https://github.com/electron/electron/issues/24144))

### Test

1. Download the Windows and/or Linux builds from CircleCI
2. Try all keyboard shortcuts, including Ctrl+G, and verify they all work with no errors in the console

### Release

Fixed a bug that caused Ctrl+G and some other shortcuts to fail on Windows/Linux builds