### PR TITLE
Refactoring reducer states showTrash and openedTag with showCollection

### DIFF
--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -37,7 +37,6 @@ type StateProps = {
   showEmailVerification: boolean;
   showNavigation: boolean;
   showNoteInfo: boolean;
-  showTrash: boolean;
   theme: 'light' | 'dark';
 };
 
@@ -220,7 +219,6 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
   showEmailVerification: selectors.shouldShowEmailVerification(state),
   showNavigation: state.ui.showNavigation,
   showNoteInfo: state.ui.showNoteInfo,
-  showTrash: state.ui.showCollection.type === 'trash',
   theme: selectors.getTheme(state),
 });
 

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -220,7 +220,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
   showEmailVerification: selectors.shouldShowEmailVerification(state),
   showNavigation: state.ui.showNavigation,
   showNoteInfo: state.ui.showNoteInfo,
-  showTrash: state.ui.showTrash,
+  showTrash: state.ui.showCollection.type === 'trash',
   theme: selectors.getTheme(state),
 });
 

--- a/lib/menu-bar/index.tsx
+++ b/lib/menu-bar/index.tsx
@@ -72,11 +72,14 @@ export const MenuBar: FunctionComponent<Props> = ({
 
 const mapStateToProps: S.MapState<StateProps> = ({
   data,
-  ui: { openedTag, searchQuery, showTrash },
+  ui: { searchQuery, showCollection },
 }) => ({
-  openedTag: openedTag ? data.tags.get(openedTag) ?? null : null,
+  openedTag:
+    showCollection.type === 'tag' && showCollection.tagHash
+      ? data.tags.get(showCollection.tagHash) ?? null
+      : null,
   searchQuery,
-  showTrash,
+  showTrash: showCollection.type === 'trash',
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (

--- a/lib/menu-bar/index.tsx
+++ b/lib/menu-bar/index.tsx
@@ -25,8 +25,8 @@ type OwnProps = {
 };
 
 type StateProps = {
-  searchQuery: string;
   collection: T.Collection;
+  searchQuery: string;
 };
 
 type DispatchProps = {
@@ -37,9 +37,9 @@ type DispatchProps = {
 type Props = OwnProps & StateProps & DispatchProps;
 
 export const MenuBar: FunctionComponent<Props> = ({
+  collection,
   onNewNote,
   searchQuery,
-  collection,
   toggleNavigation,
 }) => {
   let placeholder;
@@ -76,10 +76,10 @@ export const MenuBar: FunctionComponent<Props> = ({
 };
 
 const mapStateToProps: S.MapState<StateProps> = ({
-  ui: { searchQuery, collection },
+  ui: { collection, searchQuery },
 }) => ({
-  searchQuery,
   collection,
+  searchQuery,
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (

--- a/lib/menu-bar/index.tsx
+++ b/lib/menu-bar/index.tsx
@@ -25,9 +25,8 @@ type OwnProps = {
 };
 
 type StateProps = {
-  openedTag: T.Tag | null;
   searchQuery: string;
-  showTrash: boolean;
+  showCollection: T.Collection;
 };
 
 type DispatchProps = {
@@ -39,16 +38,22 @@ type Props = OwnProps & StateProps & DispatchProps;
 
 export const MenuBar: FunctionComponent<Props> = ({
   onNewNote,
-  openedTag,
   searchQuery,
-  showTrash,
+  showCollection,
   toggleNavigation,
 }) => {
-  const placeholder = showTrash
-    ? 'Trash'
-    : openedTag
-    ? 'Notes With Selected Tag'
-    : 'All Notes';
+  let placeholder;
+  switch (showCollection.type) {
+    case 'tag':
+      placeholder = 'Notes With Selected Tag';
+      break;
+    case 'trash':
+      placeholder = 'Trash';
+      break;
+    default:
+      placeholder = 'All Notes';
+      break;
+  }
 
   const CmdOrCtrl = isMac ? 'Cmd' : 'Ctrl';
 
@@ -61,7 +66,7 @@ export const MenuBar: FunctionComponent<Props> = ({
       />
       <div className="notes-title">{placeholder}</div>
       <IconButton
-        disabled={showTrash}
+        disabled={showCollection.type === 'trash'}
         icon={<NewNoteIcon />}
         onClick={() => onNewNote(withoutTags(searchQuery))}
         title={`New Note • ${CmdOrCtrl}+Shift+I`}
@@ -71,15 +76,10 @@ export const MenuBar: FunctionComponent<Props> = ({
 };
 
 const mapStateToProps: S.MapState<StateProps> = ({
-  data,
   ui: { searchQuery, showCollection },
 }) => ({
-  openedTag:
-    showCollection.type === 'tag' && showCollection.tagHash
-      ? data.tags.get(showCollection.tagHash) ?? null
-      : null,
   searchQuery,
-  showTrash: showCollection.type === 'trash',
+  showCollection,
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (

--- a/lib/menu-bar/index.tsx
+++ b/lib/menu-bar/index.tsx
@@ -26,7 +26,7 @@ type OwnProps = {
 
 type StateProps = {
   searchQuery: string;
-  showCollection: T.Collection;
+  collection: T.Collection;
 };
 
 type DispatchProps = {
@@ -39,11 +39,11 @@ type Props = OwnProps & StateProps & DispatchProps;
 export const MenuBar: FunctionComponent<Props> = ({
   onNewNote,
   searchQuery,
-  showCollection,
+  collection,
   toggleNavigation,
 }) => {
   let placeholder;
-  switch (showCollection.type) {
+  switch (collection.type) {
     case 'tag':
       placeholder = 'Notes With Selected Tag';
       break;
@@ -66,7 +66,7 @@ export const MenuBar: FunctionComponent<Props> = ({
       />
       <div className="notes-title">{placeholder}</div>
       <IconButton
-        disabled={showCollection.type === 'trash'}
+        disabled={collection.type === 'trash'}
         icon={<NewNoteIcon />}
         onClick={() => onNewNote(withoutTags(searchQuery))}
         title={`New Note • ${CmdOrCtrl}+Shift+I`}
@@ -76,10 +76,10 @@ export const MenuBar: FunctionComponent<Props> = ({
 };
 
 const mapStateToProps: S.MapState<StateProps> = ({
-  ui: { searchQuery, showCollection },
+  ui: { searchQuery, collection },
 }) => ({
   searchQuery,
-  showCollection,
+  collection,
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -17,7 +17,7 @@ import * as T from '../types';
 type StateProps = {
   autoHideMenuBar: boolean;
   isDialogOpen: boolean;
-  openedTag: T.TagEntity | null;
+  openedTag: T.TagHash | null;
   showNavigation: boolean;
   showTrash: boolean;
 };
@@ -126,13 +126,16 @@ export class NavigationBar extends Component<Props> {
 
 const mapStateToProps: S.MapState<StateProps> = ({
   settings,
-  ui: { dialogs, openedTag, showNavigation, showTrash },
+  ui: { dialogs, showNavigation, showCollection },
 }) => ({
   autoHideMenuBar: settings.autoHideMenuBar,
   isDialogOpen: dialogs.length > 0,
-  openedTag,
+  openedTag:
+    showCollection.type === 'tag' && showCollection.tagHash
+      ? showCollection.tagHash
+      : null,
   showNavigation,
-  showTrash,
+  showTrash: showCollection.type === 'trash',
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -16,8 +16,8 @@ import * as T from '../types';
 
 type StateProps = {
   autoHideMenuBar: boolean;
-  isDialogOpen: boolean;
   collection: T.Collection;
+  isDialogOpen: boolean;
   showNavigation: boolean;
 };
 
@@ -126,11 +126,11 @@ export class NavigationBar extends Component<Props> {
 
 const mapStateToProps: S.MapState<StateProps> = ({
   settings,
-  ui: { dialogs, showNavigation, collection },
+  ui: { collection, dialogs, showNavigation },
 }) => ({
   autoHideMenuBar: settings.autoHideMenuBar,
-  isDialogOpen: dialogs.length > 0,
   collection,
+  isDialogOpen: dialogs.length > 0,
   showNavigation,
 });
 

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -17,7 +17,7 @@ import * as T from '../types';
 type StateProps = {
   autoHideMenuBar: boolean;
   isDialogOpen: boolean;
-  showCollection: T.Collection;
+  collection: T.Collection;
   showNavigation: boolean;
 };
 
@@ -60,7 +60,7 @@ export class NavigationBar extends Component<Props> {
   }: {
     selectedRow: 'all' | 'trash' | 'untagged';
   }) => {
-    return this.props.showCollection.type === selectedRow;
+    return this.props.collection.type === selectedRow;
   };
 
   render() {
@@ -126,11 +126,11 @@ export class NavigationBar extends Component<Props> {
 
 const mapStateToProps: S.MapState<StateProps> = ({
   settings,
-  ui: { dialogs, showNavigation, showCollection },
+  ui: { dialogs, showNavigation, collection },
 }) => ({
   autoHideMenuBar: settings.autoHideMenuBar,
   isDialogOpen: dialogs.length > 0,
-  showCollection,
+  collection,
   showNavigation,
 });
 

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -17,9 +17,8 @@ import * as T from '../types';
 type StateProps = {
   autoHideMenuBar: boolean;
   isDialogOpen: boolean;
-  openedTag: T.TagHash | null;
+  showCollection: T.Collection;
   showNavigation: boolean;
-  showTrash: boolean;
 };
 
 type DispatchProps = {
@@ -56,11 +55,12 @@ export class NavigationBar extends Component<Props> {
   };
 
   // Determine if the selected class should be applied for the 'all notes' or 'trash' rows
-  isSelected = ({ isTrashRow }: { isTrashRow: boolean }) => {
-    const { showTrash, openedTag } = this.props;
-    const isItemSelected = isTrashRow === showTrash;
-
-    return isItemSelected && !openedTag;
+  isSelected = ({
+    selectedRow,
+  }: {
+    selectedRow: 'all' | 'trash' | 'untagged';
+  }) => {
+    return this.props.showCollection.type === selectedRow;
   };
 
   render() {
@@ -75,13 +75,13 @@ export class NavigationBar extends Component<Props> {
           />
           <NavigationBarItem
             icon={<TrashIcon />}
-            isSelected={this.isSelected({ isTrashRow: true })}
+            isSelected={this.isSelected({ selectedRow: 'trash' })}
             label="Trash"
             onClick={this.onSelectTrash}
           />
           <NavigationBarItem
             icon={<NotesIcon />}
-            isSelected={this.isSelected({ isTrashRow: false })}
+            isSelected={this.isSelected({ selectedRow: 'all' })}
             label="All Notes"
             onClick={onShowAllNotes}
           />
@@ -130,12 +130,8 @@ const mapStateToProps: S.MapState<StateProps> = ({
 }) => ({
   autoHideMenuBar: settings.autoHideMenuBar,
   isDialogOpen: dialogs.length > 0,
-  openedTag:
-    showCollection.type === 'tag' && showCollection.tagHash
-      ? showCollection.tagHash
-      : null,
+  showCollection,
   showNavigation,
-  showTrash: showCollection.type === 'trash',
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -245,8 +245,7 @@ class NoteContentEditor extends Component<Props> {
           {
             searchTerms: getTerms(soFar),
             excludeIDs: selectedNoteId ? [selectedNoteId] : [],
-            openedTag: null,
-            showTrash: false,
+            showCollection: { type: 'all' },
             searchTags: tagsFromSearch(soFar),
             titleOnly: true,
           },

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -243,10 +243,10 @@ class NoteContentEditor extends Component<Props> {
 
         const notes = searchNotes(
           {
-            searchTerms: getTerms(soFar),
-            excludeIDs: selectedNoteId ? [selectedNoteId] : [],
             collection: { type: 'all' },
+            excludeIDs: selectedNoteId ? [selectedNoteId] : [],
             searchTags: tagsFromSearch(soFar),
+            searchTerms: getTerms(soFar),
             titleOnly: true,
           },
           5

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -245,7 +245,7 @@ class NoteContentEditor extends Component<Props> {
           {
             searchTerms: getTerms(soFar),
             excludeIDs: selectedNoteId ? [selectedNoteId] : [],
-            showCollection: { type: 'all' },
+            collection: { type: 'all' },
             searchTags: tagsFromSearch(soFar),
             titleOnly: true,
           },

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -342,9 +342,9 @@ const mapStateToProps: S.MapState<StateProps> = (state) => {
     openedNote: state.ui.openedNote,
     searchQuery: state.ui.searchQuery,
     showNoteList: state.ui.showNoteList,
+    showTrash: selectors.showTrash(state),
     tagResultsFound: state.ui.tagSuggestions.length,
     windowWidth: state.browser.windowWidth,
-    showTrash: selectors.showTrash(state),
   };
 };
 

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -341,10 +341,13 @@ const mapStateToProps: S.MapState<StateProps> = (state) => {
     noteDisplay: state.settings.noteDisplay,
     filteredNotes: state.ui.filteredNotes,
     openedNote: state.ui.openedNote,
-    openedTag: state.ui.openedTag,
+    openedTag:
+      state.ui.showCollection.type === 'tag' && state.ui.showCollection.tagHash
+        ? state.ui.showCollection.tagHash
+        : null,
     searchQuery: state.ui.searchQuery,
     showNoteList: state.ui.showNoteList,
-    showTrash: state.ui.showTrash,
+    showTrash: state.ui.showCollection.type === 'trash',
     tagResultsFound: state.ui.tagSuggestions.length,
     windowWidth: state.browser.windowWidth,
   };

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -25,7 +25,6 @@ type StateProps = {
   keyboardShortcuts: boolean;
   noteDisplay: T.ListDisplayMode;
   openedNote: T.EntityId | null;
-  openedTag: T.EntityId | null;
   searchQuery: string;
   showNoteList: boolean;
   showTrash: boolean;
@@ -341,15 +340,11 @@ const mapStateToProps: S.MapState<StateProps> = (state) => {
     noteDisplay: state.settings.noteDisplay,
     filteredNotes: state.ui.filteredNotes,
     openedNote: state.ui.openedNote,
-    openedTag:
-      state.ui.showCollection.type === 'tag' && state.ui.showCollection.tagHash
-        ? state.ui.showCollection.tagHash
-        : null,
     searchQuery: state.ui.searchQuery,
     showNoteList: state.ui.showNoteList,
-    showTrash: state.ui.showCollection.type === 'trash',
     tagResultsFound: state.ui.tagSuggestions.length,
     windowWidth: state.browser.windowWidth,
+    showTrash: selectors.showTrash(state),
   };
 };
 

--- a/lib/note-list/no-notes.tsx
+++ b/lib/note-list/no-notes.tsx
@@ -18,11 +18,8 @@ type EmptyNoteListPlaceholder = {
 const NoNotes = () => {
   const hasLoaded = useSelector((state: S.State) => state.ui.hasLoadedNotes);
   const searchQuery = useSelector((state: S.State) => state.ui.searchQuery);
-  const showTrash = useSelector(
-    (state: S.State) => state.ui.showCollection.type === 'trash'
-  );
-  const openedTag = useSelector(
-    (state: S.State) => state.ui.showCollection.tagHash
+  const showCollection = useSelector(
+    (state: S.State) => state.ui.showCollection
   );
   const dispatch = useDispatch();
 
@@ -44,40 +41,37 @@ const NoNotes = () => {
 
   const placeholderInfo = ({
     searchQuery,
-    openedTag,
-    showTrash,
+    showCollection,
   }): EmptyNoteListPlaceholder => {
     if (searchQuery.length > 0) {
       return { message: 'No Results', icon: null, button: getButton() };
     }
 
-    if (openedTag !== null) {
-      return {
-        message: `No notes tagged "${openedTag}"`,
-        icon: <TagIcon />,
-        button: null,
-      };
+    switch (showCollection.type) {
+      case 'tag':
+        return {
+          message: `No notes tagged "${showCollection.tagName}"`,
+          icon: <TagIcon />,
+          button: null,
+        };
+      case 'trash':
+        return {
+          message: 'Your trash is empty',
+          icon: <TrashIcon />,
+          button: null,
+        };
+      default:
+        return {
+          message: '',
+          icon: <NotesIcon />,
+          button: getButton(),
+        };
     }
-
-    if (showTrash) {
-      return {
-        message: 'Your trash is empty',
-        icon: <TrashIcon />,
-        button: null,
-      };
-    }
-
-    return {
-      message: '',
-      icon: <NotesIcon />,
-      button: getButton(),
-    };
   };
 
   const { message, icon, button } = placeholderInfo({
     searchQuery,
-    openedTag,
-    showTrash,
+    showCollection,
   });
 
   return (

--- a/lib/note-list/no-notes.tsx
+++ b/lib/note-list/no-notes.tsx
@@ -18,8 +18,12 @@ type EmptyNoteListPlaceholder = {
 const NoNotes = () => {
   const hasLoaded = useSelector((state: S.State) => state.ui.hasLoadedNotes);
   const searchQuery = useSelector((state: S.State) => state.ui.searchQuery);
-  const showTrash = useSelector((state: S.State) => state.ui.showTrash);
-  const openedTag = useSelector((state: S.State) => state.ui.openedTag);
+  const showTrash = useSelector(
+    (state: S.State) => state.ui.showCollection.type === 'trash'
+  );
+  const openedTag = useSelector(
+    (state: S.State) => state.ui.showCollection.tagHash
+  );
   const dispatch = useDispatch();
 
   const getButton = () => {

--- a/lib/note-list/no-notes.tsx
+++ b/lib/note-list/no-notes.tsx
@@ -16,9 +16,9 @@ type EmptyNoteListPlaceholder = {
 };
 
 const NoNotes = () => {
+  const collection = useSelector((state: S.State) => state.ui.collection);
   const hasLoaded = useSelector((state: S.State) => state.ui.hasLoadedNotes);
   const searchQuery = useSelector((state: S.State) => state.ui.searchQuery);
-  const collection = useSelector((state: S.State) => state.ui.collection);
   const dispatch = useDispatch();
 
   const getButton = () => {
@@ -38,8 +38,8 @@ const NoNotes = () => {
   };
 
   const placeholderInfo = ({
-    searchQuery,
     collection,
+    searchQuery,
   }): EmptyNoteListPlaceholder => {
     if (searchQuery.length > 0) {
       return { message: 'No Results', icon: null, button: getButton() };
@@ -68,8 +68,8 @@ const NoNotes = () => {
   };
 
   const { message, icon, button } = placeholderInfo({
-    searchQuery,
     collection,
+    searchQuery,
   });
 
   return (

--- a/lib/note-list/no-notes.tsx
+++ b/lib/note-list/no-notes.tsx
@@ -18,9 +18,7 @@ type EmptyNoteListPlaceholder = {
 const NoNotes = () => {
   const hasLoaded = useSelector((state: S.State) => state.ui.hasLoadedNotes);
   const searchQuery = useSelector((state: S.State) => state.ui.searchQuery);
-  const showCollection = useSelector(
-    (state: S.State) => state.ui.showCollection
-  );
+  const collection = useSelector((state: S.State) => state.ui.collection);
   const dispatch = useDispatch();
 
   const getButton = () => {
@@ -41,16 +39,16 @@ const NoNotes = () => {
 
   const placeholderInfo = ({
     searchQuery,
-    showCollection,
+    collection,
   }): EmptyNoteListPlaceholder => {
     if (searchQuery.length > 0) {
       return { message: 'No Results', icon: null, button: getButton() };
     }
 
-    switch (showCollection.type) {
+    switch (collection.type) {
       case 'tag':
         return {
-          message: `No notes tagged "${showCollection.tagName}"`,
+          message: `No notes tagged "${collection.tagName}"`,
           icon: <TagIcon />,
           button: null,
         };
@@ -71,7 +69,7 @@ const NoNotes = () => {
 
   const { message, icon, button } = placeholderInfo({
     searchQuery,
-    showCollection,
+    collection,
   });
 
   return (

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -3,19 +3,19 @@ import { connect } from 'react-redux';
 import SmallCrossIcon from '../icons/cross-small';
 import SmallSearchIcon from '../icons/search-small';
 import { State } from '../state';
+import * as selectors from '../state/selectors';
 import { focusSearchField, search } from '../state/ui/actions';
 
 import { registerSearchField } from '../state/ui/search-field-middleware';
 
 import type * as S from '../state';
-import type * as T from '../types';
+import * as T from '../types';
 
 const KEY_ESC = 27;
 
 type StateProps = {
-  openedTag: T.Tag | null;
+  openedTag: T.TagName | undefined;
   searchQuery: string;
-  showTrash: boolean;
 };
 
 type DispatchProps = {
@@ -71,9 +71,9 @@ export class SearchField extends Component<Props> {
   clearQuery = () => this.props.onSearch('');
 
   render() {
-    const { openedTag, searchQuery } = this.props;
+    const { searchQuery, openedTag } = this.props;
     const hasQuery = searchQuery.length > 0;
-    const placeholder = openedTag?.name ?? 'Search notes and tags';
+    const placeholder = openedTag ?? 'Search notes and tags';
 
     const screenReaderLabel =
       'Search ' + (openedTag ? 'notes with tag ' : '') + placeholder;
@@ -106,16 +106,9 @@ export class SearchField extends Component<Props> {
   }
 }
 
-const mapStateToProps: S.MapState<StateProps> = ({
-  data,
-  ui: { searchQuery, showCollection },
-}: State) => ({
-  openedTag:
-    showCollection.type === 'tag' && showCollection.tagHash
-      ? data.tags.get(showCollection.tagHash) ?? null
-      : null,
-  searchQuery,
-  showTrash: showCollection.type === 'trash',
+const mapStateToProps: S.MapState<StateProps> = (state: State) => ({
+  searchQuery: state.ui.searchQuery,
+  openedTag: selectors.openedTag(state),
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -108,11 +108,14 @@ export class SearchField extends Component<Props> {
 
 const mapStateToProps: S.MapState<StateProps> = ({
   data,
-  ui: { openedTag, searchQuery, showTrash },
+  ui: { searchQuery, showCollection },
 }: State) => ({
-  openedTag: openedTag ? data.tags.get(openedTag) ?? null : null,
+  openedTag:
+    showCollection.type === 'tag' && showCollection.tagHash
+      ? data.tags.get(showCollection.tagHash) ?? null
+      : null,
   searchQuery,
-  showTrash,
+  showTrash: showCollection.type === 'trash',
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -9,7 +9,7 @@ import { focusSearchField, search } from '../state/ui/actions';
 import { registerSearchField } from '../state/ui/search-field-middleware';
 
 import type * as S from '../state';
-import * as T from '../types';
+import type * as T from '../types';
 
 const KEY_ESC = 27;
 
@@ -71,7 +71,7 @@ export class SearchField extends Component<Props> {
   clearQuery = () => this.props.onSearch('');
 
   render() {
-    const { searchQuery, openedTag } = this.props;
+    const { openedTag, searchQuery } = this.props;
     const hasQuery = searchQuery.length > 0;
     const placeholder = openedTag ?? 'Search notes and tags';
 
@@ -107,8 +107,8 @@ export class SearchField extends Component<Props> {
 }
 
 const mapStateToProps: S.MapState<StateProps> = (state: State) => ({
-  searchQuery: state.ui.searchQuery,
   openedTag: selectors.openedTag(state),
+  searchQuery: state.ui.searchQuery,
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = (dispatch) => ({

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -14,7 +14,7 @@ import type * as T from '../types';
 const KEY_ESC = 27;
 
 type StateProps = {
-  openedTag: T.TagName | undefined;
+  openedTag: T.TagName | null;
   searchQuery: string;
 };
 

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -227,8 +227,9 @@ export const middleware: S.Middleware = (store) => {
         continue;
       }
 
-      const openedTag = showCollection.type === 'tag' && showCollection.tagHash;
-      if (openedTag && !note.tags.has(openedTag)) {
+      const openedTagHash =
+        showCollection.type === 'tag' && t(showCollection.tagName);
+      if (openedTagHash && !note.tags.has(openedTagHash)) {
         continue;
       }
 
@@ -413,7 +414,7 @@ export const middleware: S.Middleware = (store) => {
       case 'OPEN_TAG':
         searchState.showCollection = {
           type: 'tag',
-          tagHash: t(action.tagName),
+          tagName: action.tagName,
         };
         return next(withSearch(action));
 
@@ -449,9 +450,12 @@ export const middleware: S.Middleware = (store) => {
 
         if (
           searchState.showCollection.type === 'tag' &&
-          searchState.showCollection.tagHash === oldHash
+          searchState.showCollection.tagName === action.oldTagName
         ) {
-          searchState.showCollection = { type: 'tag', tagHash: newHash };
+          searchState.showCollection = {
+            type: 'tag',
+            tagName: action.newTagName,
+          };
         }
 
         searchState.notes.forEach((note, noteId) => {
@@ -541,7 +545,7 @@ export const middleware: S.Middleware = (store) => {
         // can always search for non-existent tags
         if (
           searchState.showCollection.type === 'tag' &&
-          searchState.showCollection.tagHash !== tagHash
+          searchState.showCollection.tagName !== action.tagName
         ) {
           return next(action);
         }

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -28,7 +28,7 @@ type SearchState = {
   searchQuery: string;
   searchTags: Set<T.TagHash>;
   searchTerms: string[];
-  showCollection: T.Collection;
+  collection: T.Collection;
   sortType: T.SortType;
   sortReversed: boolean;
   titleOnly: boolean | null;
@@ -67,7 +67,7 @@ export const middleware: S.Middleware = (store) => {
     searchQuery: '',
     searchTags: new Set(),
     searchTerms: [],
-    showCollection: { type: 'all' },
+    collection: { type: 'all' },
     sortType: store.getState().settings.sortType,
     sortReversed: store.getState().settings.sortReversed,
     titleOnly: false,
@@ -182,7 +182,7 @@ export const middleware: S.Middleware = (store) => {
       searchTerms,
       sortReversed,
       sortType,
-      showCollection,
+      collection,
       titleOnly,
     } = { ...searchState, ...args };
     const matches = new Set<T.EntityId>();
@@ -211,7 +211,7 @@ export const middleware: S.Middleware = (store) => {
         continue;
       }
 
-      const showTrash = showCollection.type === 'trash';
+      const showTrash = collection.type === 'trash';
       if (showTrash !== note.isTrashed) {
         continue;
       }
@@ -227,8 +227,7 @@ export const middleware: S.Middleware = (store) => {
         continue;
       }
 
-      const openedTagHash =
-        showCollection.type === 'tag' && t(showCollection.tagName);
+      const openedTagHash = collection.type === 'tag' && t(collection.tagName);
       if (openedTagHash && !note.tags.has(openedTagHash)) {
         continue;
       }
@@ -364,7 +363,7 @@ export const middleware: S.Middleware = (store) => {
       }
 
       case 'CREATE_NOTE_WITH_ID':
-        searchState.showCollection = { type: 'all' };
+        searchState.collection = { type: 'all' };
         searchState.notes.set(action.noteId, toSearchNote(action.note ?? {}));
         indexNote(action.noteId);
         queueSearch();
@@ -412,7 +411,7 @@ export const middleware: S.Middleware = (store) => {
       }
 
       case 'OPEN_TAG':
-        searchState.showCollection = {
+        searchState.collection = {
           type: 'tag',
           tagName: action.tagName,
         };
@@ -449,10 +448,10 @@ export const middleware: S.Middleware = (store) => {
         const newHash = t(action.newTagName);
 
         if (
-          searchState.showCollection.type === 'tag' &&
-          searchState.showCollection.tagName === action.oldTagName
+          searchState.collection.type === 'tag' &&
+          searchState.collection.tagName === action.oldTagName
         ) {
-          searchState.showCollection = {
+          searchState.collection = {
             type: 'tag',
             tagName: action.newTagName,
           };
@@ -486,11 +485,11 @@ export const middleware: S.Middleware = (store) => {
       }
 
       case 'SELECT_TRASH':
-        searchState.showCollection = { type: 'trash' };
+        searchState.collection = { type: 'trash' };
         return next(withSearch(action));
 
       case 'SHOW_ALL_NOTES':
-        searchState.showCollection = { type: 'all' };
+        searchState.collection = { type: 'all' };
         return next(withSearch(action));
 
       case 'SEARCH':
@@ -544,13 +543,13 @@ export const middleware: S.Middleware = (store) => {
         // it's okay to leave tag search terms in because we
         // can always search for non-existent tags
         if (
-          searchState.showCollection.type === 'tag' &&
-          searchState.showCollection.tagName !== action.tagName
+          searchState.collection.type === 'tag' &&
+          searchState.collection.tagName !== action.tagName
         ) {
           return next(action);
         }
 
-        searchState.showCollection = { type: 'all' };
+        searchState.collection = { type: 'all' };
         return next(withSearch(action));
       }
     }

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -22,13 +22,13 @@ type SearchNote = {
 };
 
 type SearchState = {
+  collection: T.Collection;
   hasSelectedFirstNote: boolean;
   excludeIDs: Array<T.EntityId> | null;
   notes: Map<T.EntityId, SearchNote>;
   searchQuery: string;
   searchTags: Set<T.TagHash>;
   searchTerms: string[];
-  collection: T.Collection;
   sortType: T.SortType;
   sortReversed: boolean;
   titleOnly: boolean | null;
@@ -61,13 +61,13 @@ export let searchNotes: (
 
 export const middleware: S.Middleware = (store) => {
   const searchState: SearchState = {
+    collection: { type: 'all' },
     excludeIDs: [],
     hasSelectedFirstNote: false,
     notes: new Map(),
     searchQuery: '',
     searchTags: new Set(),
     searchTerms: [],
-    collection: { type: 'all' },
     sortType: store.getState().settings.sortType,
     sortReversed: store.getState().settings.sortReversed,
     titleOnly: false,
@@ -176,13 +176,13 @@ export const middleware: S.Middleware = (store) => {
     maxResults = Infinity
   ): T.EntityId[] => {
     const {
+      collection,
       excludeIDs,
       notes,
       searchTags,
       searchTerms,
       sortReversed,
       sortType,
-      collection,
       titleOnly,
     } = { ...searchState, ...args };
     const matches = new Set<T.EntityId>();

--- a/lib/state/selectors.ts
+++ b/lib/state/selectors.ts
@@ -1,5 +1,6 @@
 import * as S from './';
 import * as T from '../types';
+import { tagHashOf } from '../utils/tag-hash';
 
 /**
  * "Narrow" views hide the note editor
@@ -45,3 +46,15 @@ export const noteHasPendingChanges: S.Selector<boolean> = (
 export const shouldShowEmailVerification: S.Selector<boolean> = ({
   data: { accountVerification: status },
 }) => status === 'unverified' || status === 'pending';
+
+export const openedTag: S.Selector<T.TagName | undefined> = ({
+  ui: { showCollection },
+}) => (showCollection.type === 'tag' && showCollection.tagName) || undefined;
+
+export const openedTagHash: S.Selector<T.TagHash | undefined> = (state) => {
+  const ot = openedTag(state);
+  return (ot && tagHashOf(ot)) || undefined;
+};
+
+export const showTrash: S.Selector<boolean> = ({ ui: { showCollection } }) =>
+  showCollection.type === 'trash';

--- a/lib/state/selectors.ts
+++ b/lib/state/selectors.ts
@@ -1,6 +1,5 @@
 import * as S from './';
 import * as T from '../types';
-import { tagHashOf } from '../utils/tag-hash';
 
 /**
  * "Narrow" views hide the note editor
@@ -47,14 +46,9 @@ export const shouldShowEmailVerification: S.Selector<boolean> = ({
   data: { accountVerification: status },
 }) => status === 'unverified' || status === 'pending';
 
-export const openedTag: S.Selector<T.TagName | undefined> = ({
+export const openedTag: S.Selector<T.TagName | null> = ({
   ui: { collection },
-}) => (collection.type === 'tag' && collection.tagName) || undefined;
-
-export const openedTagHash: S.Selector<T.TagHash | undefined> = (state) => {
-  const ot = openedTag(state);
-  return (ot && tagHashOf(ot)) || undefined;
-};
+}) => (collection.type === 'tag' && collection.tagName) || null;
 
 export const showTrash: S.Selector<boolean> = ({ ui: { collection } }) =>
   collection.type === 'trash';

--- a/lib/state/selectors.ts
+++ b/lib/state/selectors.ts
@@ -48,13 +48,13 @@ export const shouldShowEmailVerification: S.Selector<boolean> = ({
 }) => status === 'unverified' || status === 'pending';
 
 export const openedTag: S.Selector<T.TagName | undefined> = ({
-  ui: { showCollection },
-}) => (showCollection.type === 'tag' && showCollection.tagName) || undefined;
+  ui: { collection },
+}) => (collection.type === 'tag' && collection.tagName) || undefined;
 
 export const openedTagHash: S.Selector<T.TagHash | undefined> = (state) => {
   const ot = openedTag(state);
   return (ot && tagHashOf(ot)) || undefined;
 };
 
-export const showTrash: S.Selector<boolean> = ({ ui: { showCollection } }) =>
-  showCollection.type === 'trash';
+export const showTrash: S.Selector<boolean> = ({ ui: { collection } }) =>
+  collection.type === 'trash';

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -86,6 +86,24 @@ const editorSelection: A.Reducer<Map<
   }
 };
 
+const collection: A.Reducer<T.Collection> = (
+  state = { type: 'all' },
+  action
+) => {
+  switch (action.type) {
+    case 'OPEN_TAG':
+      return { type: 'tag', tagName: action.tagName };
+    case 'SELECT_TRASH':
+      return { type: 'trash' };
+    case 'SHOW_ALL_NOTES':
+      return { type: 'all' };
+    case 'TRASH_TAG':
+      return action.tagName === state.tagName ? { type: 'all' } : state;
+    default:
+      return state;
+  }
+};
+
 const dialogs: A.Reducer<T.DialogType[]> = (state = [], action) => {
   switch (action.type) {
     case 'CLOSE_DIALOG':
@@ -187,24 +205,6 @@ const openedRevision: A.Reducer<[T.EntityId, number] | null> = (
     case 'OPEN_REVISION':
       return [action.noteId, action.version];
 
-    default:
-      return state;
-  }
-};
-
-const collection: A.Reducer<T.Collection> = (
-  state = { type: 'all' },
-  action
-) => {
-  switch (action.type) {
-    case 'SELECT_TRASH':
-      return { type: 'trash' };
-    case 'SHOW_ALL_NOTES':
-      return { type: 'all' };
-    case 'OPEN_TAG':
-      return { type: 'tag', tagName: action.tagName };
-    case 'TRASH_TAG':
-      return action.tagName === state.tagName ? { type: 'all' } : state;
     default:
       return state;
   }

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -202,11 +202,9 @@ const showCollection: A.Reducer<T.Collection> = (
     case 'SHOW_ALL_NOTES':
       return { type: 'all' };
     case 'OPEN_TAG':
-      return { type: 'tag', tagHash: tagHashOf(action.tagName) };
+      return { type: 'tag', tagName: action.tagName };
     case 'TRASH_TAG':
-      return tagHashOf(action.tagName) === state.tagHash
-        ? { type: 'all' }
-        : state;
+      return action.tagName === state.tagName ? { type: 'all' } : state;
     default:
       return state;
   }

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -192,15 +192,21 @@ const openedRevision: A.Reducer<[T.EntityId, number] | null> = (
   }
 };
 
-const openedTag: A.Reducer<T.TagHash | null> = (state = null, action) => {
+const showCollection: A.Reducer<T.Collection> = (
+  state = { type: 'all' },
+  action
+) => {
   switch (action.type) {
     case 'SELECT_TRASH':
+      return { type: 'trash' };
     case 'SHOW_ALL_NOTES':
-      return null;
+      return { type: 'all' };
     case 'OPEN_TAG':
-      return tagHashOf(action.tagName);
+      return { type: 'tag', tagHash: tagHashOf(action.tagName) };
     case 'TRASH_TAG':
-      return tagHashOf(action.tagName) === state ? null : state;
+      return tagHashOf(action.tagName) === state.tagHash
+        ? { type: 'all' }
+        : state;
     default:
       return state;
   }
@@ -298,20 +304,6 @@ const showRevisions: A.Reducer<boolean> = (state = false, action) => {
   }
 };
 
-const showTrash: A.Reducer<boolean> = (state = false, action) => {
-  switch (action.type) {
-    case 'SELECT_TRASH':
-      return true;
-    case 'CREATE_NOTE_WITH_ID':
-    case 'OPEN_TAG':
-    case 'SHOW_ALL_NOTES': {
-      return false;
-    }
-    default:
-      return state;
-  }
-};
-
 const tagSuggestions: A.Reducer<T.TagHash[]> = (
   state = emptyList as T.TagHash[],
   action
@@ -333,14 +325,13 @@ export default combineReducers({
   numberOfMatchesInNote,
   openedNote,
   openedRevision,
-  openedTag,
   searchQuery,
   selectedSearchMatchIndex,
   showNavigation,
   showNoteInfo,
   showNoteList,
   showRevisions,
-  showTrash,
+  showCollection,
   simperiumConnected,
   tagSuggestions,
   unsyncedNoteIds,

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -192,7 +192,7 @@ const openedRevision: A.Reducer<[T.EntityId, number] | null> = (
   }
 };
 
-const showCollection: A.Reducer<T.Collection> = (
+const collection: A.Reducer<T.Collection> = (
   state = { type: 'all' },
   action
 ) => {
@@ -329,7 +329,7 @@ export default combineReducers({
   showNoteInfo,
   showNoteList,
   showRevisions,
-  showCollection,
+  collection,
   simperiumConnected,
   tagSuggestions,
   unsyncedNoteIds,

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -314,6 +314,7 @@ const tagSuggestions: A.Reducer<T.TagHash[]> = (
 };
 
 export default combineReducers({
+  collection,
   dialogs,
   editMode,
   editorSelection,
@@ -329,7 +330,6 @@ export default combineReducers({
   showNoteInfo,
   showNoteList,
   showRevisions,
-  collection,
   simperiumConnected,
   tagSuggestions,
   unsyncedNoteIds,

--- a/lib/tag-list/index.tsx
+++ b/lib/tag-list/index.tsx
@@ -20,7 +20,7 @@ import type * as T from '../types';
 
 type StateProps = {
   editingTags: boolean;
-  openedTag: T.TagHash | null;
+  openedTagHash: T.TagHash | undefined;
   sortTagsAlpha: boolean;
   theme: 'light' | 'dark';
   tags: Map<T.TagHash, T.Tag>;
@@ -92,7 +92,7 @@ const SortableTagList = SortableContainer(
   ({
     editingTags,
     items,
-    openedTag,
+    openedTagHash,
     openTag,
     sortTagsAlpha,
     theme,
@@ -100,7 +100,7 @@ const SortableTagList = SortableContainer(
   }: {
     editingTags: boolean;
     items: [T.TagHash, T.Tag][];
-    openedTag: T.TagHash | null;
+    openedTagHash: T.TagHash | undefined;
     openTag: (tagName: T.TagName) => any;
     sortTagsAlpha: boolean;
     theme: 'light' | 'dark';
@@ -113,7 +113,7 @@ const SortableTagList = SortableContainer(
           allowReordering={!sortTagsAlpha}
           editingActive={editingTags}
           index={index}
-          isSelected={openedTag === value[0]}
+          isSelected={openedTagHash === value[0]}
           selectTag={openTag}
           theme={theme}
           trashTag={trashTheTag}
@@ -137,7 +137,7 @@ export class TagList extends Component<Props> {
       editingTags,
       onEditTags,
       openTag,
-      openedTag,
+      openedTagHash,
       sortTagsAlpha,
       tags,
       theme,
@@ -178,7 +178,7 @@ export class TagList extends Component<Props> {
         <SortableTagList
           editingTags={editingTags}
           lockAxis="y"
-          openedTag={openedTag}
+          openedTagHash={openedTagHash}
           openTag={openTag}
           items={sortedTags}
           sortTagsAlpha={sortTagsAlpha}
@@ -196,16 +196,13 @@ const mapStateToProps: S.MapState<StateProps> = (state) => {
   const {
     data,
     settings: { sortTagsAlpha },
-    ui: { editingTags, showCollection },
+    ui: { editingTags },
   } = state;
   return {
     editingTags,
     sortTagsAlpha,
     tags: data.tags,
-    openedTag:
-      showCollection.type === 'tag' && showCollection.tagHash
-        ? showCollection.tagHash
-        : null,
+    openedTagHash: selectors.openedTagHash(state),
     theme: selectors.getTheme(state),
   };
 };

--- a/lib/tag-list/index.tsx
+++ b/lib/tag-list/index.tsx
@@ -196,13 +196,16 @@ const mapStateToProps: S.MapState<StateProps> = (state) => {
   const {
     data,
     settings: { sortTagsAlpha },
-    ui: { editingTags, openedTag },
+    ui: { editingTags, showCollection },
   } = state;
   return {
     editingTags,
     sortTagsAlpha,
     tags: data.tags,
-    openedTag,
+    openedTag:
+      showCollection.type === 'tag' && showCollection.tagHash
+        ? showCollection.tagHash
+        : null,
     theme: selectors.getTheme(state),
   };
 };

--- a/lib/tag-list/index.tsx
+++ b/lib/tag-list/index.tsx
@@ -12,6 +12,7 @@ import ReorderIcon from '../icons/reorder';
 import TagListInput from './input';
 import TrashIcon from '../icons/trash';
 import { openTag, toggleTagEditing } from '../state/ui/actions';
+import { tagHashOf } from '../utils/tag-hash';
 
 import * as selectors from './../state/selectors';
 
@@ -20,7 +21,7 @@ import type * as T from '../types';
 
 type StateProps = {
   editingTags: boolean;
-  openedTagHash: T.TagHash | undefined;
+  openedTag: T.TagName | null;
   sortTagsAlpha: boolean;
   theme: 'light' | 'dark';
   tags: Map<T.TagHash, T.Tag>;
@@ -100,7 +101,7 @@ const SortableTagList = SortableContainer(
   }: {
     editingTags: boolean;
     items: [T.TagHash, T.Tag][];
-    openedTagHash: T.TagHash | undefined;
+    openedTagHash: T.TagHash | null;
     openTag: (tagName: T.TagName) => any;
     sortTagsAlpha: boolean;
     theme: 'light' | 'dark';
@@ -136,7 +137,7 @@ export class TagList extends Component<Props> {
     const {
       editingTags,
       onEditTags,
-      openedTagHash,
+      openedTag,
       openTag,
       sortTagsAlpha,
       tags,
@@ -178,7 +179,7 @@ export class TagList extends Component<Props> {
         <SortableTagList
           editingTags={editingTags}
           lockAxis="y"
-          openedTagHash={openedTagHash}
+          openedTagHash={(openedTag && tagHashOf(openedTag)) || null}
           openTag={openTag}
           items={sortedTags}
           sortTagsAlpha={sortTagsAlpha}
@@ -200,7 +201,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => {
   } = state;
   return {
     editingTags,
-    openedTagHash: selectors.openedTagHash(state),
+    openedTag: selectors.openedTag(state),
     sortTagsAlpha,
     tags: data.tags,
     theme: selectors.getTheme(state),

--- a/lib/tag-list/index.tsx
+++ b/lib/tag-list/index.tsx
@@ -136,8 +136,8 @@ export class TagList extends Component<Props> {
     const {
       editingTags,
       onEditTags,
-      openTag,
       openedTagHash,
+      openTag,
       sortTagsAlpha,
       tags,
       theme,
@@ -200,9 +200,9 @@ const mapStateToProps: S.MapState<StateProps> = (state) => {
   } = state;
   return {
     editingTags,
+    openedTagHash: selectors.openedTagHash(state),
     sortTagsAlpha,
     tags: data.tags,
-    openedTagHash: selectors.openedTagHash(state),
     theme: selectors.getTheme(state),
   };
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -50,6 +50,12 @@ export type VerificationState =
   | 'unverified'
   | 'verified';
 
+export type Collection =
+  | { type: 'all' }
+  | { type: 'trash' }
+  | { type: 'tag'; tagHash: TagHash | null }
+  | { type: 'untagged' };
+
 ///////////////////////////////////////
 // Simperium Types
 ///////////////////////////////////////

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -53,7 +53,7 @@ export type VerificationState =
 export type Collection =
   | { type: 'all' }
   | { type: 'trash' }
-  | { type: 'tag'; tagHash: TagHash | null }
+  | { type: 'tag'; tagName: TagName }
   | { type: 'untagged' };
 
 ///////////////////////////////////////

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -52,8 +52,8 @@ export type VerificationState =
 
 export type Collection =
   | { type: 'all' }
-  | { type: 'trash' }
   | { type: 'tag'; tagName: TagName }
+  | { type: 'trash' }
   | { type: 'untagged' };
 
 ///////////////////////////////////////


### PR DESCRIPTION
### Fix
Since `showTrash`, `openedTag`, and the [upcoming] `untaggedNotes` states are mutually exclusive, we now combine the booleans into one, `showCollection`. This stops bugs like the one where filtering by trashed notes and then filtering by tags ends up finding only notes with that tag that are deleted.

### Screenshots

  <details>
    <summary>Simple filter usage</summary>

![simple](https://user-images.githubusercontent.com/13263478/109653073-2aaebb00-7b26-11eb-9658-315195ba045d.gif)
  </details>

<details>
    <summary>Renaming tag</summary>

![renaming](https://user-images.githubusercontent.com/13263478/109653144-45812f80-7b26-11eb-874e-6744c1aa31bd.gif)
  </details>

<details>
  <summary>Delete current tag</summary>

  ![delete-current-tag](https://user-images.githubusercontent.com/13263478/109653188-53cf4b80-7b26-11eb-975e-d0ab44ba744a.gif)
</details>

<details>
  <summary>Delete other tag</summary>

  ![delete-other-tag](https://user-images.githubusercontent.com/13263478/109653180-52058800-7b26-11eb-8781-36a93018f25f.gif)
</details>


### Test
#### Bug
1. Create note and delete it and create another note with a tag.
2. Open sidebar.
3. Click Trash, see that deleted note only shows up.
4. Click filter for that tag, see that no notes show up (with bug), and that the note with the tag should show up (bug fixed).

#### General
1. Create note with tag A.
2. Create note with tag B.
3. Create note and delete it.
4. Open sidebar.
5. Click Trash, see that deleted note shows up.
6. Click tag A, see that tag A note shows up.
7. Click All Notes, see that all notes are there again.
8. Rename tag A to C, see that search list does not change but tag is successfully updated.
9. Click tag B. Rename tag B to D, see that search list updates to show current note with tag changed.

### Release
No user-facing changes here.