### PR TITLE
Improve navigation accessibility

### DIFF
--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -115,10 +115,16 @@ export class AppLayout extends Component<Props> {
       </TransitionDelayEnter>
     );
 
+    const hiddenByRevisions = showRevisions ? true : undefined;
+
     return (
-      <div className={mainClasses}>
+      <div
+        className={mainClasses}
+        aria-hidden={isNavigationOpen ? true : undefined}
+      >
         <Suspense fallback={placeholder}>
           <aside
+            aria-hidden={hiddenByRevisions}
             aria-label="Notes list"
             className="app-layout__source-column theme-color-bg theme-color-fg"
           >
@@ -132,9 +138,13 @@ export class AppLayout extends Component<Props> {
               aria-label="Note editor"
               className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border"
             >
-              <NoteToolbar />
+              <NoteToolbar aria-hidden={hiddenByRevisions} />
               {showRevisions ? (
-                <NotePreview noteId={openedNote} note={openedRevision} />
+                <NotePreview
+                  aria-hidden={hiddenByRevisions}
+                  noteId={openedNote}
+                  note={openedRevision}
+                />
               ) : (
                 <NoteEditor />
               )}

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -39,6 +39,7 @@ type StateProps = {
   showEmailVerification: boolean;
   showNavigation: boolean;
   showNoteInfo: boolean;
+  showRevisions: boolean;
   theme: 'light' | 'dark';
 };
 
@@ -182,6 +183,7 @@ class AppComponent extends Component<Props> {
       showEmailVerification,
       showNavigation,
       showNoteInfo,
+      showRevisions,
       theme,
     } = this.props;
 
@@ -201,7 +203,11 @@ class AppComponent extends Component<Props> {
       <div className={appClasses}>
         {showEmailVerification && <EmailVerification />}
         {showAlternateLoginPrompt && <AlternateLoginPrompt />}
-        {isDevConfig && <DevBadge />}
+        {isDevConfig && (
+          <DevBadge
+            aria-hidden={showNavigation || showRevisions ? true : undefined}
+          />
+        )}
         <div className={mainClasses}>
           {showNavigation && <NavigationBar />}
           <AppLayout />
@@ -223,6 +229,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
   showEmailVerification: selectors.shouldShowEmailVerification(state),
   showNavigation: state.ui.showNavigation,
   showNoteInfo: state.ui.showNoteInfo,
+  showRevisions: state.ui.showRevisions,
   theme: selectors.getTheme(state),
 });
 

--- a/lib/components/dev-badge/index.tsx
+++ b/lib/components/dev-badge/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 
-const DevBadge = () => (
-  <div aria-hidden="true" className="dev-badge">
-    DEV
-  </div>
-);
+const DevBadge = (props: React.HTMLProps<HTMLDivElement>) => {
+  return (
+    <div className="dev-badge" {...props}>
+      DEV
+    </div>
+  );
+};
 
 export default DevBadge;

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -30,9 +30,13 @@ type DispatchProps = {
   openNote: (noteId: T.EntityId) => any;
 };
 
-type Props = OwnProps & StateProps & DispatchProps;
+type Props = OwnProps &
+  StateProps &
+  DispatchProps &
+  React.HTMLProps<HTMLDivElement>;
 
 export const NotePreview: FunctionComponent<Props> = ({
+  'aria-hidden': ariaHidden,
   editNote,
   isFocused,
   note,
@@ -162,7 +166,7 @@ export const NotePreview: FunctionComponent<Props> = ({
   }, [note?.content, searchQuery, showRenderedView]);
 
   return (
-    <div className="note-detail-wrapper">
+    <div aria-hidden={ariaHidden} className="note-detail-wrapper">
       <div className="note-detail note-detail-preview">
         <div
           ref={previewNode}

--- a/lib/components/slider/index.tsx
+++ b/lib/components/slider/index.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEventHandler, FunctionComponent } from 'react';
 
-type Props = {
+type OwnProps = {
   disabled: boolean;
   onChange: ChangeEventHandler<HTMLInputElement>;
   min: number;
@@ -8,7 +8,10 @@ type Props = {
   value: number;
 };
 
+type Props = OwnProps & React.HTMLProps<HTMLInputElement>;
+
 export const Slider: FunctionComponent<Props> = ({
+  'aria-valuetext': ariaValueText,
   disabled,
   min,
   max,
@@ -16,6 +19,7 @@ export const Slider: FunctionComponent<Props> = ({
   onChange,
 }) => (
   <input
+    aria-valuetext={ariaValueText}
     aria-label="Select revision"
     className="slider"
     disabled={disabled}

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import onClickOutside from 'react-onclickoutside';
+import FocusTrap from 'focus-trap-react';
 
 import ConnectionStatus from '../connection-status';
 import isEmailTag from '../utils/is-email-tag';
@@ -26,7 +26,7 @@ type StateProps = {
 
 type DispatchProps = {
   onAbout: () => any;
-  onOutsideClick: () => any;
+  onFocusTrapDeactivate: () => any;
   onSettings: () => any;
   onShowAllNotes: () => any;
   onShowUntaggedNotes: () => any;
@@ -38,17 +38,22 @@ type Props = StateProps & DispatchProps;
 
 export class NavigationBar extends Component<Props> {
   static displayName = 'NavigationBar';
+  isMounted = false;
 
-  // Used by onClickOutside wrapper
-  handleClickOutside = () => {
-    const { isDialogOpen, onOutsideClick, showNavigation } = this.props;
+  componentDidMount() {
+    this.isMounted = true;
+  }
 
-    if (isDialogOpen) {
-      return;
-    }
+  componentWillUnmount() {
+    this.isMounted = false;
+  }
 
-    if (showNavigation) {
-      onOutsideClick();
+  handleFocusTrapDeactivate = () => {
+    const { onFocusTrapDeactivate, showNavigation } = this.props;
+
+    // isMounted prevents reopening sidebar after navigation event
+    if (showNavigation && this.isMounted) {
+      onFocusTrapDeactivate();
     }
   };
 
@@ -70,85 +75,94 @@ export class NavigationBar extends Component<Props> {
   render() {
     const {
       autoHideMenuBar,
+      isDialogOpen,
       onAbout,
       onSettings,
       onShowAllNotes,
       onShowUntaggedNotes,
       tags,
     } = this.props;
+
     const tagCount = Array.from(tags).filter(
       ([_, { name }]) => !isEmailTag(name)
     ).length;
 
     return (
-      <div className="navigation-bar theme-color-bg theme-color-fg theme-color-border">
-        <div className="navigation-bar__folders theme-color-border">
-          <NavigationBarItem
-            icon={<SettingsIcon />}
-            label="Settings"
-            onClick={onSettings}
-          />
-          <NavigationBarItem
-            icon={<TrashIcon />}
-            isSelected={this.isSelected({ selectedRow: 'trash' })}
-            label="Trash"
-            onClick={this.onSelectTrash}
-          />
-          <NavigationBarItem
-            icon={<NotesIcon />}
-            isSelected={this.isSelected({ selectedRow: 'all' })}
-            label="All Notes"
-            onClick={onShowAllNotes}
-          />
-        </div>
-        <div className="navigation-bar__tags theme-color-border">
-          {(tagCount && (
-            <>
-              <TagList />
-              <div className="navigation-bar__folders navigation-bar__untagged theme-color-border">
-                <NavigationBarItem
-                  icon={<UntaggedNotesIcon />}
-                  isSelected={this.isSelected({ selectedRow: 'untagged' })}
-                  label="Untagged Notes"
-                  onClick={onShowUntaggedNotes}
-                />
-              </div>
-            </>
-          )) ||
-            null}
-        </div>
-
-        <div className="navigation-bar__tools theme-color-border">
-          <div className="navigation-bar__server-connection">
-            <ConnectionStatus />
+      <FocusTrap
+        paused={isDialogOpen}
+        focusTrapOptions={{
+          clickOutsideDeactivates: true,
+          onDeactivate: this.handleFocusTrapDeactivate,
+        }}
+      >
+        <div className="navigation-bar theme-color-bg theme-color-fg theme-color-border">
+          <div className="navigation-bar__folders theme-color-border">
+            <NavigationBarItem
+              icon={<NotesIcon />}
+              isSelected={this.isSelected({ selectedRow: 'all' })}
+              label="All Notes"
+              onClick={onShowAllNotes}
+            />
+            <NavigationBarItem
+              icon={<TrashIcon />}
+              isSelected={this.isSelected({ selectedRow: 'trash' })}
+              label="Trash"
+              onClick={this.onSelectTrash}
+            />
+            <NavigationBarItem
+              icon={<SettingsIcon />}
+              label="Settings"
+              onClick={onSettings}
+            />
+          </div>
+          <div className="navigation-bar__tags theme-color-border">
+            {(tagCount && (
+              <>
+                <TagList />
+                <div className="navigation-bar__folders navigation-bar__untagged theme-color-border">
+                  <NavigationBarItem
+                    icon={<UntaggedNotesIcon />}
+                    isSelected={this.isSelected({ selectedRow: 'untagged' })}
+                    label="Untagged Notes"
+                    onClick={onShowUntaggedNotes}
+                  />
+                </div>
+              </>
+            )) ||
+              null}
+          </div>
+          <div className="navigation-bar__tools theme-color-border">
+            <div className="navigation-bar__server-connection">
+              <ConnectionStatus />
+            </div>
+          </div>
+          <div className="navigation-bar__footer">
+            <button
+              type="button"
+              className="navigation-bar__footer-item theme-color-fg-dim"
+              onClick={this.props.showKeyboardShortcuts}
+            >
+              Keyboard Shortcuts
+            </button>
+          </div>
+          <div className="navigation-bar__footer">
+            <button
+              type="button"
+              className="navigation-bar__footer-item theme-color-fg-dim"
+              onClick={this.onHelpClicked}
+            >
+              Help &amp; Support
+            </button>
+            <button
+              type="button"
+              className="navigation-bar__footer-item theme-color-fg-dim"
+              onClick={onAbout}
+            >
+              About
+            </button>
           </div>
         </div>
-        <div className="navigation-bar__footer">
-          <button
-            type="button"
-            className="navigation-bar__footer-item theme-color-fg-dim"
-            onClick={this.props.showKeyboardShortcuts}
-          >
-            Keyboard Shortcuts
-          </button>
-        </div>
-        <div className="navigation-bar__footer">
-          <button
-            type="button"
-            className="navigation-bar__footer-item theme-color-fg-dim"
-            onClick={this.onHelpClicked}
-          >
-            Help &amp; Support
-          </button>
-          <button
-            type="button"
-            className="navigation-bar__footer-item theme-color-fg-dim"
-            onClick={onAbout}
-          >
-            About
-          </button>
-        </div>
-      </div>
+      </FocusTrap>
     );
   }
 }
@@ -167,7 +181,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   onAbout: () => actions.ui.showDialog('ABOUT'),
-  onOutsideClick: actions.ui.toggleNavigation,
+  onFocusTrapDeactivate: actions.ui.toggleNavigation,
   onShowAllNotes: actions.ui.showAllNotes,
   onShowUntaggedNotes: actions.ui.showUntaggedNotes,
   onSettings: () => actions.ui.showDialog('SETTINGS'),
@@ -175,7 +189,4 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   showKeyboardShortcuts: () => actions.ui.showDialog('KEYBINDINGS'),
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(onClickOutside(NavigationBar));
+export default connect(mapStateToProps, mapDispatchToProps)(NavigationBar);

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -1,14 +1,12 @@
 .navigation-bar-item {
-  height: 44px;
   padding-left: 16px;
-  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   text-align: left;
 
   .button {
     border: 0;
-    border-bottom: 1px solid;
+    border-top: 1px solid;
     border-radius: 0;
     font-size: 16px;
     font-weight: 400;
@@ -30,7 +28,7 @@
     background-color: $studio-simplenote-blue-5;
 
     button {
-      border-bottom: none;
+      border-top: none;
 
       svg[class^='icon-'] {
         fill: $studio-simplenote-blue-50;
@@ -54,11 +52,11 @@
 
 /* this is the last child (Settings) and prevents a double border on the bottom */
 .navigation-bar-item:first-child .button {
-  border-bottom: none !important;
+  border-top: none !important;
 }
 
 .navigation-bar-item.is-selected + .navigation-bar-item .button {
-  border-bottom: none;
+  border-top: none;
 }
 
 .theme-dark {

--- a/lib/navigation-bar/style.scss
+++ b/lib/navigation-bar/style.scss
@@ -7,7 +7,6 @@
   padding-top: $toolbar-height;
   width: $navigation-bar-width;
   height: 100%;
-  overflow: hidden;
   border-right: 1px solid;
   z-index: 2;
   transition: transform 200ms ease-in-out;
@@ -20,7 +19,7 @@
 .navigation-bar__folders {
   display: flex;
   flex: none;
-  flex-direction: column-reverse;
+  flex-direction: column;
   border-bottom: 1px solid;
 }
 

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -39,15 +39,18 @@ type DispatchProps = {
   trashNote: () => any;
 };
 
-type Props = DispatchProps & StateProps;
+type Props = DispatchProps & StateProps & React.HTMLProps<HTMLDivElement>;
 
 export class NoteToolbar extends Component<Props> {
   static displayName = 'NoteToolbar';
 
   render() {
-    const { note } = this.props;
+    const { 'aria-hidden': ariaHidden, note } = this.props;
     return (
-      <div className="note-toolbar-wrapper theme-color-border">
+      <div
+        aria-hidden={ariaHidden}
+        className="note-toolbar-wrapper theme-color-border"
+      >
         {note?.deleted ? this.renderTrashed() : this.renderNormal()}
       </div>
     );

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -1,11 +1,9 @@
 .tag-list-item {
   display: flex;
   font-size: 16px;
-  height: 44px;
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
-  padding-left: 13px;
 
   &:hover {
     background-color: $studio-gray-0;
@@ -77,10 +75,8 @@
   flex: 1 1 auto;
   display: block;
   width: 50px;
-  height: 2em;
   line-height: 2em;
-  margin: 8px 13px 8px 0;
-  padding: 0;
+  padding: 6px 0 5px 13px;
   border: none;
   text-overflow: ellipsis;
   font-size: 100%;
@@ -90,14 +86,9 @@
   &.is-selected {
     color: $studio-simplenote-blue-50;
   }
-
-  &:focus {
-    outline: none;
-  }
 }
 
 button.tag-list-input {
-  margin: 8px 0;
   overflow-x: hidden;
   text-align: left;
 }
@@ -109,6 +100,11 @@ input.tag-list-input {
 .tag-list-editing {
   .tag-list-input {
     cursor: text;
+    margin-right: 13px;
+
+    &:focus {
+      outline: none;
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8962,6 +8962,22 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
+    "focus-trap": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.3.0.tgz",
+      "integrity": "sha512-BBzvFfkPg5PqrVVCdQ1YOIVNKGvqG9YNVkiAUQFuDM66N8J9uADhs6mlYKrd30ofDJIzEniBnBKM7GO45iCzKQ==",
+      "requires": {
+        "tabbable": "^5.1.5"
+      }
+    },
+    "focus-trap-react": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-8.4.2.tgz",
+      "integrity": "sha512-yuItOIwgriOBMrbHDqbWMpQjGVs9SbtugYrT0vs0yPjHiPKja3NZ9dBMxDQrV1JhyojGK5d6j7ayqBS7Kcm9xQ==",
+      "requires": {
+        "focus-trap": "^6.3.0"
+      }
+    },
     "focus-visible": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.1.0.tgz",
@@ -19524,6 +19540,11 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "tabbable": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.1.6.tgz",
+      "integrity": "sha512-KSlGaSX9PbL7FHDTn2dB+zv61prkY8BeGioTsKfeN7dKhw5uz1S4U2iFaWMK4GR8oU+5OFBkFuxbMsaUxVVlrQ=="
     },
     "table": {
       "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "electron-updater": "4.3.1",
     "electron-window-state": "5.0.3",
     "file-saver": "2.0.2",
+    "focus-trap-react": "^8.4.2",
     "focus-visible": "5.1.0",
     "gridicons": "3.3.1",
     "highlight.js": "10.1.1",


### PR DESCRIPTION
### Fix

Fixes #979 and fixes #980. Improve navigation accessibility via the following:

- Add focus trap to navigation sidebar and revisions selector. 
- Hide unrelated content while navigation sidebar or revisions selector is open. 
- Reorder navigation elements to match visual presentation. 
- Adjust styles to improve active focus indication. 

<details>
<summary>VoiceOver Interaction: Navigation</summary>

https://user-images.githubusercontent.com/438664/109722627-90289900-7b72-11eb-97a9-fb9b47e3d0e6.mov

</details>

<details>
<summary>VoiceOver Interaction: Revisions Selector</summary>

https://user-images.githubusercontent.com/438664/109820267-75016c00-7bfa-11eb-884c-c2beb85dbd2e.mov

</details>

| Styles Before | Styles After |
| --- | --- |
| ![styles-before](https://user-images.githubusercontent.com/438664/109722991-21980b00-7b73-11eb-8cd7-dbe177b1c7b4.png) | ![styles-after](https://user-images.githubusercontent.com/438664/109724609-75a3ef00-7b75-11eb-9316-1ade74966c26.png) |

### Test

#### Scenario 1

1. Enable macOS VoiceOver or similar screen reader technology.
1. Open the navigation sidebar by pressing the menu button in the top-left
   corner of the screen.

Expected Outcome:

* The first element in the navigation has focus.
* Moving selection backwards does not move focus past "All Items" menu item.
* Moving selection forwards does not move focus past "About" menu item.
* Pressing <kbd>Esc</kbd> dismisses the navigation, deactivates the focus
  trap, and returns focus to the "Menu" button.
* Clicking outside of the navigation dismisses the navigation, deactivates the focus
  trap, and returns focus to the "Menu" button.

#### Scenario 2

1. Enable macOS VoiceOver or similar screen reader technology.
1. Open the navigation sidebar by pressing the menu button in the top-left
   corner of the screen.
1. Open "About" dialog by pressing the "About" link at the end of the navigation
   list.

Expected Outcome:

* Navigation focus trap is disabled while dialog is open.
* Dialog contents are focused.
* Dismissing the dialog with <kbd>Esc</kbd> causes "About" link to regain focus.

#### Scenario 3

1. Enable macOS VoiceOver or similar screen reader technology.
1. Open the revisions selector by pressing the history button in the top-right
   corner of the screen.

Expected Outcome:

* The first element in the navigation has focus.
* Moving selection backwards does not move focus past "History" heading.
* Moving selection forwards does not move focus past "Restore" button.
* Pressing <kbd>Esc</kbd> dismisses the navigation, deactivates the focus
  trap, and returns focus to the note editor.
* Clicking outside of the navigation dismisses the navigation, deactivates the focus
  trap, and returns focus to the note editor.

### Release

`RELEASE-NOTES.md` was updated with:

- Improve navigation sidebar and revision selector accessibility for keyboards and screen readers.
