### PR TITLE
Fix cut off close button for Review Your Account dialog

### DIFF
--- a/lib/email-verification/style.scss
+++ b/lib/email-verification/style.scss
@@ -13,8 +13,8 @@
 .email-verification__dismiss {
   display: flex;
   height: 60px;
+  align-items: center;
   justify-content: flex-end;
-  line-height: 60px;
   margin: 0 16px;
   width: 100%;
 


### PR DESCRIPTION
### Fix
Fixes #2704. The previous usage of line-height for vertical centering caused
macOS Safari to render the close button with only half of the icon visible.

| Before | After |
| --- | --- |
| <img width="1552" alt="Screen Shot 2021-03-03 at 09 38 32" src="https://user-images.githubusercontent.com/438664/109830959-9cf5cd00-7c04-11eb-9747-1c9c0b3a6d55.png"> | <img width="1552" alt="Screen Shot 2021-03-03 at 09 38 12" src="https://user-images.githubusercontent.com/438664/109830936-95cebf00-7c04-11eb-94f3-c43241e6109d.png"> |

### Test
1. Visit Simplenote app in macOS Safari.
1. Sign up for a new account.

Expected Outcome: Review Your Account dialog is displayed and close button is
not cut off. You can see the entire "X" icon.

### Release

`RELEASE-NOTES.md` was updated with: 

* Fix cut off dialog close button in macOS Safari.
