### PR TITLE
Fix overflowing dialog content caused by long email address

### DIFF
--- a/lib/email-verification/index.tsx
+++ b/lib/email-verification/index.tsx
@@ -60,9 +60,9 @@ const EmailVerification: FunctionComponent<Props> = ({
         <WarningIcon />
       </span>
       <h2>Review Your Account</h2>
-      <p>
-        You are registered with Simplenote using the email{' '}
-        <strong>{email}</strong>.
+      <p>You are registered with Simplenote using the email:</p>
+      <p className="email-verification__email">
+        <strong>{email}</strong>
       </p>
       <p>
         Improvements to account security may result in account loss if you no

--- a/lib/email-verification/style.scss
+++ b/lib/email-verification/style.scss
@@ -45,6 +45,7 @@
   p {
     margin: 0 26px;
     margin-block-start: 0;
+    word-break: break-all;
   }
 
   p:not(:last-of-type) {

--- a/lib/email-verification/style.scss
+++ b/lib/email-verification/style.scss
@@ -45,7 +45,6 @@
   p {
     margin: 0 26px;
     margin-block-start: 0;
-    word-break: break-all;
   }
 
   p:not(:last-of-type) {
@@ -72,6 +71,10 @@
   &:focus {
     outline: 0;
   }
+}
+
+.email-verification__email {
+  word-break: break-all;
 }
 
 .theme-dark {


### PR DESCRIPTION
### Fix
Fixes #2709. Allow the dialog to wrap the email address to prevent the content
from overflowing the dialog container.

| Before | After |
| --- | --- |
| <img width="1226" alt="109825032-07a40a00-7bff-11eb-8895-837555f564af" src="https://user-images.githubusercontent.com/438664/109834478-da0f8e80-7c07-11eb-86da-efa03c102c53.png"> | <img width="1552" alt="Screen Shot 2021-03-03 at 09 59 03" src="https://user-images.githubusercontent.com/438664/109834509-e1cf3300-7c07-11eb-8469-c53ae79e72ba.png"> |

### Test
1. Visit the Simplenote desktop or web app.
1. Sign up with a fairly long email address.

Expected outcome: The email address wraps within the dialog rather than
overflowing the dialog.

### Release

`RELEASE-NOTES.md` was updated with:
- Fix overflowing dialog content when long email address is used during sign up.
