### PR TITLE
Set Unusual Line Terminators option to 'Auto'

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v2.8.0]
+
+### Fixes
+
+- Added `unusualLineTerminators: auto` to Monaco Editor options to auto remove line terminators like line separators (LS) or paragraph separator (PS) [#2698](https://github.com/Automattic/simplenote-electron/issues/2698)
+
 ## [v2.7.0]
 
 ### Enhancements

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Added `unusualLineTerminators: auto` to Monaco Editor options to auto remove line terminators like line separators (LS) or paragraph separator (PS) [#2698](https://github.com/Automattic/simplenote-electron/issues/2698)
+- Added `unusualLineTerminators: auto` to Monaco Editor options to auto remove line terminators like line separators (LS) or paragraph separator (PS) [#2713](https://github.com/Automattic/simplenote-electron/pull/2713)
 
 ## [v2.7.0]
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## [v2.8.0]
-
-### Fixes
-
-- Added `unusualLineTerminators: auto` to Monaco Editor options to auto remove line terminators like line separators (LS) or paragraph separator (PS) [#2713](https://github.com/Automattic/simplenote-electron/pull/2713)
-
 ## [v2.7.0]
 
 ### Enhancements

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1196,6 +1196,7 @@ class NoteContentEditor extends Component<Props> {
               scrollBeyondLastLine: false,
               selectionHighlight: false,
               suggestOnTriggerCharacters: true,
+              unusualLineTerminators: 'auto',
               wordWrap: 'bounded',
               wrappingStrategy: isSafari ? 'simple' : 'advanced',
               wordWrapColumn: 400,


### PR DESCRIPTION
### Fix
Fixes #2698

Allows Monaco editor to auto remove unusual line terminators.

### Release
`RELEASE-NOTES.md` was updated with:
> Added `unusualLineTerminators: auto` to Monaco Editor options to auto remove line terminators like line separators (LS) or paragraph separator (PS) [#2698](https://github.com/Automattic/simplenote-electron/issues/2698)
