### PR TITLE
Add error boundary

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -139,6 +139,10 @@ module.exports = function main() {
       importNotes(filePath, mainWindow);
     });
 
+    ipcMain.on('reload', function () {
+      mainWindow.reload();
+    });
+
     mainWindowState.manage(mainWindow);
 
     // this TERRIBLE HACK forces vscode to call window.open(url) rather than window.open()

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -9,6 +9,7 @@ const validChannels = [
   'importNotes',
   'noteImportChannel',
   'reallyCloseWindow',
+  'reload',
   'setAutoHideMenuBar',
   'tokenLogin',
   'wpLogin',

--- a/lib/boot-with-auth.tsx
+++ b/lib/boot-with-auth.tsx
@@ -4,7 +4,7 @@ if (__TEST__) {
 
 import React from 'react';
 import App from './app';
-import ErrorBoundary from './error-boundary';
+import { ErrorBoundaryWithAnalytics } from './error-boundary';
 import Modal from 'react-modal';
 import getConfig from '../get-config';
 import { makeStore } from './state';
@@ -45,11 +45,13 @@ export const bootWithToken = (
     });
 
     render(
-      <ErrorBoundary isDevConfig={isDevConfig(config?.development)}>
-        <Provider store={store}>
+      <Provider store={store}>
+        <ErrorBoundaryWithAnalytics
+          isDevConfig={isDevConfig(config?.development)}
+        >
           <App isDevConfig={isDevConfig(config?.development)} />
-        </Provider>
-      </ErrorBoundary>,
+        </ErrorBoundaryWithAnalytics>
+      </Provider>,
       document.getElementById('root')
     );
   });

--- a/lib/boot-with-auth.tsx
+++ b/lib/boot-with-auth.tsx
@@ -4,6 +4,7 @@ if (__TEST__) {
 
 import React from 'react';
 import App from './app';
+import ErrorBoundary from './error-boundary';
 import Modal from 'react-modal';
 import getConfig from '../get-config';
 import { makeStore } from './state';
@@ -44,9 +45,11 @@ export const bootWithToken = (
     });
 
     render(
-      <Provider store={store}>
-        <App isDevConfig={isDevConfig(config?.development)} />
-      </Provider>,
+      <ErrorBoundary isDevConfig={isDevConfig(config?.development)}>
+        <Provider store={store}>
+          <App isDevConfig={isDevConfig(config?.development)} />
+        </Provider>
+      </ErrorBoundary>,
       document.getElementById('root')
     );
   });

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -7,8 +7,10 @@ import { validatePassword } from './utils/validate-password';
 import Modal from 'react-modal';
 import classNames from 'classnames';
 import AboutDialog from './dialogs/about';
+import ErrorBoundary from './error-boundary';
 
 import getConfig from '../get-config';
+import isDevConfig from './utils/is-dev-config';
 
 import '../scss/style.scss';
 
@@ -142,42 +144,44 @@ class AppWithoutAuth extends Component<Props, State> {
       : 'light';
 
     return (
-      <div className={`app theme-${systemTheme}`}>
-        <AuthApp
-          accountCreationRequested={
-            this.state.authStatus === 'account-creation-requested'
-          }
-          authPending={this.state.authStatus === 'submitting'}
-          emailSentTo={this.state.emailSentTo}
-          hasInsecurePassword={this.state.authStatus === 'insecure-password'}
-          hasInvalidCredentials={
-            this.state.authStatus === 'invalid-credentials'
-          }
-          hasLoginError={this.state.authStatus === 'unknown-error'}
-          login={this.authenticate}
-          tokenLogin={this.tokenLogin}
-          resetErrors={() =>
-            this.setState({ authStatus: 'unsubmitted', emailSentTo: '' })
-          }
-          requestSignup={this.requestSignup}
-        />
-        {this.state.showAbout && (
-          <Modal
-            key="aboutDialogModal"
-            className="dialog-renderer__content"
-            contentLabel=""
-            isOpen
-            onRequestClose={this.onDismissDialog}
-            overlayClassName="dialog-renderer__overlay"
-            portalClassName={classNames(
-              'dialog-renderer__portal',
-              'theme-' + systemTheme
-            )}
-          >
-            <AboutDialog key="about" closeDialog={this.onDismissDialog} />
-          </Modal>
-        )}
-      </div>
+      <ErrorBoundary isDevConfig={isDevConfig(config?.development)}>
+        <div className={`app theme-${systemTheme}`}>
+          <AuthApp
+            accountCreationRequested={
+              this.state.authStatus === 'account-creation-requested'
+            }
+            authPending={this.state.authStatus === 'submitting'}
+            emailSentTo={this.state.emailSentTo}
+            hasInsecurePassword={this.state.authStatus === 'insecure-password'}
+            hasInvalidCredentials={
+              this.state.authStatus === 'invalid-credentials'
+            }
+            hasLoginError={this.state.authStatus === 'unknown-error'}
+            login={this.authenticate}
+            tokenLogin={this.tokenLogin}
+            resetErrors={() =>
+              this.setState({ authStatus: 'unsubmitted', emailSentTo: '' })
+            }
+            requestSignup={this.requestSignup}
+          />
+          {this.state.showAbout && (
+            <Modal
+              key="aboutDialogModal"
+              className="dialog-renderer__content"
+              contentLabel=""
+              isOpen
+              onRequestClose={this.onDismissDialog}
+              overlayClassName="dialog-renderer__overlay"
+              portalClassName={classNames(
+                'dialog-renderer__portal',
+                'theme-' + systemTheme
+              )}
+            >
+              <AboutDialog key="about" closeDialog={this.onDismissDialog} />
+            </Modal>
+          )}
+        </div>
+      </ErrorBoundary>
     );
   }
 }

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -10,7 +10,6 @@ import AboutDialog from './dialogs/about';
 import ErrorBoundary from './error-boundary';
 
 import getConfig from '../get-config';
-import isDevConfig from './utils/is-dev-config';
 
 import '../scss/style.scss';
 
@@ -144,7 +143,7 @@ class AppWithoutAuth extends Component<Props, State> {
       : 'light';
 
     return (
-      <ErrorBoundary isDevConfig={isDevConfig(config?.development)}>
+      <ErrorBoundary>
         <div className={`app theme-${systemTheme}`}>
           <AuthApp
             accountCreationRequested={

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -143,8 +143,8 @@ class AppWithoutAuth extends Component<Props, State> {
       : 'light';
 
     return (
-      <ErrorBoundary>
-        <div className={`app theme-${systemTheme}`}>
+      <div className={`app theme-${systemTheme}`}>
+        <ErrorBoundary>
           <AuthApp
             accountCreationRequested={
               this.state.authStatus === 'account-creation-requested'
@@ -179,8 +179,8 @@ class AppWithoutAuth extends Component<Props, State> {
               <AboutDialog key="about" closeDialog={this.onDismissDialog} />
             </Modal>
           )}
-        </div>
-      </ErrorBoundary>
+        </ErrorBoundary>
+      </div>
     );
   }
 }

--- a/lib/error-boundary/index.tsx
+++ b/lib/error-boundary/index.tsx
@@ -6,6 +6,8 @@ import { isElectron } from '../utils/platform';
 import { connect } from 'react-redux';
 
 import * as S from '../state';
+import * as T from '../types';
+import * as selectors from '../state/selectors';
 
 const helpEmail = 'mailto:support@simplenote.com?subject=Simplenote%20Support';
 
@@ -16,9 +18,9 @@ type ErrorMessageProps = {
 const ErrorMessage: FunctionComponent<ErrorMessageProps> = ({
   allowAnalytics,
 }) => (
-  <div className="error-message">
-    <div className="error-message__content">
-      <div className="error-message__icon">
+  <div className="error-message theme-color-bg">
+    <div className="error-message__content theme-color-fg">
+      <div className="error-message__icon theme-color-fg-dim">
         <WarningIcon />
       </div>
       <h1 className="error-message__heading">Oops!</h1>
@@ -85,6 +87,7 @@ type ErrorBoundaryWithSentryOwnProps = {
 
 type ErrorBoundaryWithSentryStateProps = {
   allowAnalytics: boolean;
+  theme: T.Theme;
 };
 
 type ErrorBoundaryWithSentryProps = ErrorBoundaryWithSentryOwnProps &
@@ -94,15 +97,20 @@ const ErrorBoundaryWithSentry: FunctionComponent<ErrorBoundaryWithSentryProps> =
   allowAnalytics,
   children,
   isDevConfig,
+  theme,
 }) => {
-  return isDevConfig || !allowAnalytics ? (
-    <ErrorBoundary>{children}</ErrorBoundary>
-  ) : (
-    <Sentry.ErrorBoundary
-      fallback={() => <ErrorMessage allowAnalytics={allowAnalytics} />}
-    >
-      {children}
-    </Sentry.ErrorBoundary>
+  return (
+    <div className={`theme-${theme}`}>
+      {isDevConfig || !allowAnalytics ? (
+        <ErrorBoundary>{children}</ErrorBoundary>
+      ) : (
+        <Sentry.ErrorBoundary
+          fallback={() => <ErrorMessage allowAnalytics={allowAnalytics} />}
+        >
+          {children}
+        </Sentry.ErrorBoundary>
+      )}
+    </div>
   );
 };
 
@@ -110,6 +118,7 @@ const mapStateToProps: S.MapState<ErrorBoundaryWithSentryStateProps> = (
   state
 ) => ({
   allowAnalytics: !!state.data.analyticsAllowed,
+  theme: selectors.getTheme(state),
 });
 
 export const ErrorBoundaryWithAnalytics = connect(mapStateToProps)(

--- a/lib/error-boundary/index.tsx
+++ b/lib/error-boundary/index.tsx
@@ -9,14 +9,13 @@ const helpEmail = 'mailto:support@simplenote.com?subject=Simplenote%20Support';
 const ErrorMessage: FunctionComponent = () => (
   <div className="error-message">
     <div className="error-message__content">
-      <div className="error-message__icon theme-color-fg-dim">
+      <div className="error-message__icon">
         <WarningIcon />
       </div>
-      <h1 className="error-message__heading">An Error Occurred</h1>
+      <h1 className="error-message__heading">Oops!</h1>
       <p>
-        Sorry, something appears to have gone wrong. Rest assured that our
-        systems have captured the details of the error so that we may work to
-        fix the issue. Please reload the application.
+        We’re sorry — something went wrong. Our team has been notified so that
+        we can work to fix the issue. Please refresh or try again later.
       </p>
       <div className="error-message__action">
         <button
@@ -29,11 +28,11 @@ const ErrorMessage: FunctionComponent = () => (
             }
           }}
         >
-          Reload Application
+          Refresh application
         </button>
       </div>
-      <p>
-        If you continue to encounter issues, please email us at{' '}
+      <p className="error-message__footnote">
+        If the problem persists, please email us at{' '}
         <a
           href={helpEmail}
           onClick={(e) => {
@@ -42,8 +41,8 @@ const ErrorMessage: FunctionComponent = () => (
           }}
         >
           support@simplenote.com
-        </a>{' '}
-        and one of our Happiness Engineers will be in touch.
+        </a>
+        .
       </p>
     </div>
   </div>

--- a/lib/error-boundary/index.tsx
+++ b/lib/error-boundary/index.tsx
@@ -1,0 +1,62 @@
+import React, { Component, FunctionComponent } from 'react';
+import * as Sentry from '@sentry/react';
+import WarningIcon from '../icons/warning';
+import { viewExternalUrl } from '../utils/url-utils';
+
+const helpEmail = 'mailto:support@simplenote.com?subject=Simplenote%20Support';
+
+const ErrorMessage: FunctionComponent = () => (
+  <div className="error-message">
+    <div className="error-message__content">
+      <div className="error-message__icon theme-color-fg-dim">
+        <WarningIcon />
+      </div>
+      <h1 className="error-message__heading">An Error Occurred</h1>
+      <p>
+        Sorry, something appears to have gone wrong. Rest assured that our
+        systems have captured the details of the error so that we may work to
+        fix the issue. Please reload the application.
+      </p>
+      <div className="error-message__action">
+        <button
+          className="button button-primary"
+          onClick={() => window.history.go()}
+        >
+          Reload application
+        </button>
+      </div>
+      <p>
+        If you continue to encounter issues, please email us at{' '}
+        <a
+          href={helpEmail}
+          onClick={(e) => {
+            e.preventDefault();
+            viewExternalUrl(helpEmail);
+          }}
+        >
+          support@simplenote.com
+        </a>{' '}
+        and one of our Happiness Engineers will be in touch.
+      </p>
+    </div>
+  </div>
+);
+
+type ErrorBoundaryProps = {
+  isDevConfig: boolean;
+};
+
+const ErrorBoundary: FunctionComponent<ErrorBoundaryProps> = ({
+  children,
+  isDevConfig,
+}) => {
+  return isDevConfig ? (
+    <>{children}</>
+  ) : (
+    <Sentry.ErrorBoundary fallback={ErrorMessage}>
+      {children}
+    </Sentry.ErrorBoundary>
+  );
+};
+
+export default ErrorBoundary;

--- a/lib/error-boundary/index.tsx
+++ b/lib/error-boundary/index.tsx
@@ -29,7 +29,7 @@ const ErrorMessage: FunctionComponent = () => (
             }
           }}
         >
-          Reload application
+          Reload Application
         </button>
       </div>
       <p>

--- a/lib/error-boundary/index.tsx
+++ b/lib/error-boundary/index.tsx
@@ -2,6 +2,7 @@ import React, { Component, FunctionComponent } from 'react';
 import * as Sentry from '@sentry/react';
 import WarningIcon from '../icons/warning';
 import { viewExternalUrl } from '../utils/url-utils';
+import { isElectron } from '../utils/platform';
 
 const helpEmail = 'mailto:support@simplenote.com?subject=Simplenote%20Support';
 
@@ -20,7 +21,13 @@ const ErrorMessage: FunctionComponent = () => (
       <div className="error-message__action">
         <button
           className="button button-primary"
-          onClick={() => window.history.go()}
+          onClick={() => {
+            if (isElectron) {
+              window.electron?.send('reload');
+            } else {
+              window.history.go();
+            }
+          }}
         >
           Reload application
         </button>

--- a/lib/error-boundary/style.scss
+++ b/lib/error-boundary/style.scss
@@ -1,0 +1,32 @@
+.error-message {
+  align-items: center;
+  flex-direction: column;
+  display: flex;
+  height: 100vh;
+  padding: 2rem 1rem;
+}
+
+.error-message__content {
+  align-items: center;
+  max-width: 30em;
+  font-size: 16px;
+}
+
+.error-message__heading {
+  text-align: center;
+}
+
+.error-message__icon {
+  height: 48px;
+  margin: 0 auto;
+  width: 48px;
+
+  .icon-warning {
+    height: 100%;
+    width: 100%;
+  }
+}
+
+.error-message__action {
+  text-align: center;
+}

--- a/lib/error-boundary/style.scss
+++ b/lib/error-boundary/style.scss
@@ -1,25 +1,24 @@
 .error-message {
   align-items: center;
-  flex-direction: column;
   display: flex;
+  flex-direction: column;
   height: 100vh;
+  overflow-y: auto;
   padding: 2rem 1rem;
 }
 
 .error-message__content {
   align-items: center;
-  max-width: 30em;
   font-size: 16px;
-}
-
-.error-message__heading {
+  max-width: 306px;
+  margin: auto 0;
   text-align: center;
 }
-
 .error-message__icon {
-  height: 48px;
-  margin: 0 auto;
-  width: 48px;
+  color: $studio-gray-50;
+  height: 80px;
+  margin: 0 auto 0.5rem;
+  width: 80px;
 
   .icon-warning {
     height: 100%;
@@ -27,6 +26,21 @@
   }
 }
 
-.error-message__action {
+.error-message__heading {
+  font-size: 36px;
+  margin: 0 0 0.25em 0;
   text-align: center;
+}
+
+.error-message p {
+  margin: 0 0 1.67em 0;
+}
+
+.error-message__action {
+  margin-bottom: 1.67em;
+}
+
+.error-message__footnote {
+  color: $studio-gray-60;
+  font-size: 14px;
 }

--- a/lib/error-boundary/style.scss
+++ b/lib/error-boundary/style.scss
@@ -2,6 +2,7 @@
   align-items: center;
   display: flex;
   flex-direction: column;
+  flex: 1;
   height: 100vh;
   overflow-y: auto;
   padding: 2rem 1rem;

--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -26,6 +26,7 @@ declare global {
       send(command: 'clearCookies'): void;
       send(command: 'importNotes', filePath: string);
       send(command: 'reallyCloseWindow'): void;
+      send(command: 'reload');
       send(command: 'setAutoHideMenuBar', newValue: boolean);
       send(command: 'wpLogin', url: string);
     };

--- a/scss/_components.scss
+++ b/scss/_components.scss
@@ -25,6 +25,7 @@
 @import 'dialogs/share/style';
 @import 'dialogs/trash-tag-confirmation/style';
 @import 'dialogs/button-group/style';
+@import 'error-boundary/style';
 @import 'email-verification/style';
 @import 'icon-button/style';
 @import 'icons/style';


### PR DESCRIPTION
### Fix
Fixes #879. Add error boundary to provide the user a helpful message and action,
rather than an empty white page.

| Small Screens | Large Screens |
| --- | --- |
| <img width="1552" alt="error-boundary-small" src="https://user-images.githubusercontent.com/438664/110167307-31a22b80-7dbb-11eb-829f-1d550bf8a438.png"> | <img width="1552" alt="error-boundary-large" src="https://user-images.githubusercontent.com/438664/110167295-2e0ea480-7dbb-11eb-8536-67517b26944f.png"> |

| Dark Theme | Analytics Opt-In |
| --- | --- |
| <img width="1552" alt="error-boundary-large-dark" src="https://user-images.githubusercontent.com/438664/110167329-36ff7600-7dbb-11eb-8a99-23cc4c320a5b.png"> | <img width="1552" alt="error-boundary-analytics" src="https://user-images.githubusercontent.com/438664/110167314-349d1c00-7dbb-11eb-8d15-76129b90e2d1.png"> |

### Test
Testing requires introducing an intentional error to the code. After doing so,
the new error boundary should be displayed.

It is important to note that the app has two initialization paths: authenticated
and unauthenticated. To fully test, one must introduce an error in each of these
paths.

### Release
Improve error handling and messaging within the app.
