### PR TITLE
Updating general dialog styles to match new design

### DIFF
--- a/lib/dialog-renderer/style.scss
+++ b/lib/dialog-renderer/style.scss
@@ -7,13 +7,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba($studio-white, 0.75);
-}
-
-.theme-dark {
-  .dialog-renderer__overlay {
-    background: rgba($studio-gray-100, 0.75);
-  }
+  background: rgba($studio-black, 0.2);
 }
 
 .dialog-renderer__content {

--- a/lib/dialog/index.tsx
+++ b/lib/dialog/index.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import CrossIcon from '../icons/cross';
+import CrossIconSmall from '../icons/cross-small';
 
 export class Dialog extends Component {
   static propTypes = {
@@ -33,7 +33,6 @@ export class Dialog extends Component {
       >
         {!hideTitleBar && (
           <div className="dialog-title-bar theme-color-border">
-            <div className="dialog-title-side" />
             <h2 className="dialog-title-text">{title}</h2>
             <div className="dialog-title-side">
               {!!onDone && (
@@ -43,7 +42,7 @@ export class Dialog extends Component {
                   className="button"
                   onClick={onDone}
                 >
-                  <CrossIcon />
+                  <CrossIconSmall />
                 </button>
               )}
             </div>

--- a/lib/dialog/style.scss
+++ b/lib/dialog/style.scss
@@ -3,14 +3,14 @@
   flex-direction: column;
   width: calc(100vw - 2rem);
   background: white;
-  border-radius: $border-radius;
-  border: 1px solid $studio-gray-5;
-  box-shadow: 0 2px 4px 2px rgba($studio-gray-90, 0.15);
+  border-radius: 8px;
+  border: 0;
 }
 
 .dialog-title-bar {
   display: flex;
   border-bottom: 1px solid $studio-gray-5;
+  height: 56px;
 
   .button {
     border: 0;
@@ -30,9 +30,10 @@
 
 .dialog-title-text {
   flex: 1 1 auto;
-  margin: 15px 0;
-  text-align: center;
-  font-size: 1em;
+  margin: 15px 0 0 16px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 16px;
 }
 
 .dialog-content {


### PR DESCRIPTION
### Fix

There are a couple of other PRs (#2685 and #2653) that are in the works that touch the dialog styles. Instead of making changes in them individually, I'm pushing this to make the general changes to dialogs, and then the individual ones can get any overrides they need. 

**New Designs**
![Screen Shot 2021-03-04 at 2 54 43 PM](https://user-images.githubusercontent.com/1326294/110014930-bdec1a00-7cf9-11eb-970c-54c6df348f7e.png)
![Screen Shot 2021-03-04 at 2 55 21 PM](https://user-images.githubusercontent.com/1326294/110014942-c17fa100-7cf9-11eb-9df0-ac682815af18.png)

**Screenshots**
![Screen Shot 2021-03-04 at 2 59 47 PM](https://user-images.githubusercontent.com/1326294/110015518-51254f80-7cfa-11eb-8706-71c667b826b7.png)
![Screen Shot 2021-03-04 at 2 59 15 PM](https://user-images.githubusercontent.com/1326294/110015532-55516d00-7cfa-11eb-8915-6cc549970fb9.png)

The content of the dialogs will be updated in the other PRs.

It makes the following changes:

- Left aligns dialog title.
- Makes the dialog corners more round.
- Removes border from the dialog.
- Removes the shadow from the dialog.
- Changes the overlay color.
- Changes size of the close dialog icon.

### Test

1. Smoke test in both dark and light mode.
2. Ensure dialogs match the general style.

### Release

- Update styling of dialogs throughout the app.
