### PR TITLE
[Tooling] Mark *.enc configure files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.configure-files/*.enc binary


### PR DESCRIPTION
## Why?

So that GitHub does not mislead us about them being empty when they are actually not or showing us useless diffs of their content.

## To test

 - Create a branch on top of this one.
 - Modify one of the `.configure-files/*.enc` files. You can do that by modifying the hash in the `.configure` file to point to an old hash, then run `fastlane run configure_apply` for example.
 - Create a (draft) PR on GitHub to supposedly merge this branch.
 - Check that the diff on GitHub shows the `*.enc` file as something like "binary file differs" – instead of showing a textual diff with garbage content, or suggesting that the file is empty, like it GitHub has been doing in the past with those files recently.
 - Close the draft PR.