### PR TITLE
Fix slider slider handle alignment

### DIFF
--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -9,9 +9,7 @@
 
   // Track
   &::-webkit-slider-runnable-track {
-    display: flex;
-    align-items: center;
-    height: 3px;
+    height: 4px;
     border-radius: 2px;
   }
   &::-moz-range-track {
@@ -32,9 +30,10 @@
     border: 2px solid;
     appearance: none;
     transition: 0.15s ease-in-out;
+    transform: translateY(calc(-50% + 2px));
 
     &:active {
-      transform: scale(1.15);
+      transform: translateY(calc(-50% + 2px)) scale(1.15);
     }
   }
   &::-moz-range-thumb {


### PR DESCRIPTION
### Fix
Fixes #2710. Chrome didn’t apply the flex box styles in the same way as Safari or
Electron. This resulted in a misaligned drag handle in Chrome.

These changes replace flex box styles with a negative `translateY` to
vertically center the handle. The slider track increased its height by
1px to avoid a need to split a pixel to find the vertical middle.

| Before | After |
| --- | --- |
| <img width="1552" alt="slider-before" src="https://user-images.githubusercontent.com/438664/110174124-47b4e980-7dc5-11eb-93ee-fa2e1b8c2348.png"> | <img width="1552" alt="slider-after" src="https://user-images.githubusercontent.com/438664/110174143-4daaca80-7dc5-11eb-9fa3-f8aaaaccaafc.png"> |

### Test
1. Open Simplenote in Chrome.
1. Open the revision selector by clicking the History button in the top-right.

_Expected Outcome:_ The slider handle is vertically aligned in the slider track.

### Release

Fix slider handle alignment in Chrome.
