### PR TITLE
When deleting last tag when inside the untagged view, switch to all notes view

### DIFF
--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -566,7 +566,6 @@ export const middleware: S.Middleware = (store) => {
           store.getState().data.tags.size <= 1
         ) {
           searchState.collection = { type: 'all' };
-          store.dispatch(showAllNotes());
         }
         return next(withSearch(action));
       }

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -218,7 +218,10 @@ export type SetSystemTag = Action<
   'SET_SYSTEM_TAG',
   { note: T.NoteEntity; tagName: T.SystemTag; shouldHaveTag: boolean }
 >;
-export type TrashTag = Action<'TRASH_TAG', { tagName: T.TagName }>;
+export type TrashTag = Action<
+  'TRASH_TAG',
+  { tagName: T.TagName; remainingTags?: number }
+>;
 
 /*
  * Simperium operations

--- a/lib/state/data/middleware.ts
+++ b/lib/state/data/middleware.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from 'uuid';
 
+import { tagHashOf } from '../../utils/tag-hash';
 import exportZipArchive from '../../utils/export';
 
 import type * as A from '../action-types';
@@ -107,6 +108,21 @@ export const middleware: S.Middleware = (store) => (
         type: 'TRASH_NOTE',
         noteId: state.ui.openedNote,
       });
+
+    case 'TRASH_TAG':
+      // for the love of all things beautiful and holy…
+      // make a function to separate email-tags from normal tags
+      // and use that to get the count of tags, even a new selector
+      // numberOfTags(state) -> number :: assumes a "tag" is not an email
+      return store.getState().data.tags.has(tagHashOf(action.tagName))
+        ? next({
+            ...action,
+            remainingTags:
+              [...store.getState().data.tags.values()].filter(
+                (tag) => !tag.name.includes('@')
+              ).length - 1,
+          })
+        : null;
 
     default:
       return next(action);

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 
+import { tagHashOf } from '../../utils/tag-hash';
 import {
   withCheckboxCharacters,
   withCheckboxSyntax,
@@ -98,8 +99,15 @@ const collection: A.Reducer<T.Collection> = (
       return { type: 'all' };
     case 'SHOW_UNTAGGED_NOTES':
       return { type: 'untagged' };
-    case 'TRASH_TAG':
-      return action.tagName === state.tagName ? { type: 'all' } : state;
+    case 'TRASH_TAG': {
+      const openedTagIsGone =
+        state.type === 'tag' &&
+        tagHashOf(state.tagName) === tagHashOf(action.tagName);
+      const lastTagDisappeared =
+        state.type === 'untagged' && action?.remainingTags === 0;
+
+      return openedTagIsGone || lastTagDisappeared ? { type: 'all' } : state;
+    }
     default:
       return state;
   }


### PR DESCRIPTION
See #2687 

this patch removes the double-dispatch introduced to jump to the all-notes view
when deleting the last tag. that dispatch introduced the unwanted side-effect
of closing the navigation bar.

in this version of the code we introduce a new data point to the `TRASH_TAG`
action which represents the number of remaining tags in the account _after_
trashing the one being removed. the collection reducer and any other reducer
can then use that count to make decisions on how to update without needing
to introduce update cycles.