### PR TITLE
Fix unnecessary separators in login

### DIFF
--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -45,25 +45,21 @@ const buildEditMenu = (settings, isAuthenticated, editMode) => {
       { type: 'separator' },
       {
         label: '&Trash Note',
-        visible: isAuthenticated,
         click: appCommandSender({ action: 'trashNote' }),
       },
       ...(isAuthenticated ? [{ type: 'separator' }] : []),
       {
         label: 'Search &Notes…',
-        visible: isAuthenticated,
         click: appCommandSender({ action: 'focusSearchField' }),
         accelerator: 'CommandOrControl+Shift+S',
       },
       {
         label: '&Find in Note',
-        visible: isAuthenticated,
         click: appCommandSender({ action: 'focusSearchField' }),
         accelerator: 'CommandOrControl+F',
       },
       {
         label: 'Find A&gain',
-        visible: isAuthenticated,
         click: editorCommandSender({ action: 'findAgain' }),
         accelerator: 'CommandOrControl+G',
       },

--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -23,32 +23,25 @@ const buildEditMenu = (settings, isAuthenticated, editMode) => {
     accelerator: 'CommandOrControl+A',
   };
 
+  const editModeOptions = editMode
+    ? [
+        undo,
+        redo,
+        {
+          type: 'separator',
+        },
+      ]
+    : [];
+
   // menu items with roles don't respect visibility, so we have to do this the hard way
   if (!editMode) {
     selectAll['role'] = 'selectAll';
   }
 
-  return {
-    label: '&Edit',
-    submenu: [
-      undo,
-      redo,
-      {
-        type: 'separator',
-      },
-      {
-        label: '&Cut',
-        role: 'cut',
-      },
-      {
-        label: 'C&opy',
-        role: 'copy',
-      },
-      {
-        label: '&Paste',
-        role: 'paste',
-      },
-      selectAll,
+  let menuExtras = [];
+
+  if (isAuthenticated) {
+    menuExtras = [
       { type: 'separator' },
       {
         label: '&Trash Note',
@@ -74,8 +67,36 @@ const buildEditMenu = (settings, isAuthenticated, editMode) => {
         click: editorCommandSender({ action: 'findAgain' }),
         accelerator: 'CommandOrControl+G',
       },
-    ],
+    ];
+  }
+
+  const defaultSubmenuAdditions = [
+    {
+      label: '&Cut',
+      role: 'cut',
+    },
+    {
+      label: 'C&opy',
+      role: 'copy',
+    },
+    {
+      label: '&Paste',
+      role: 'paste',
+    },
+    selectAll,
+    { type: 'separator' },
+  ];
+
+  const submenu = editModeOptions
+    .concat(defaultSubmenuAdditions)
+    .concat(menuExtras);
+
+  const fileMenu = {
+    label: '&Edit',
+    submenu,
   };
+
+  return fileMenu;
 };
 
 module.exports = buildEditMenu;

--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -23,7 +23,7 @@ const buildEditMenu = (settings, isAuthenticated, editMode) => {
     accelerator: 'CommandOrControl+A',
   };
 
-  const editModeOptions = editMode
+  const editModeMenuOptions = editMode
     ? [
         undo,
         redo,
@@ -38,10 +38,10 @@ const buildEditMenu = (settings, isAuthenticated, editMode) => {
     selectAll['role'] = 'selectAll';
   }
 
-  let menuExtras = [];
+  let authenticatedMenuOptions = [];
 
   if (isAuthenticated) {
-    menuExtras = [
+    authenticatedMenuOptions = [
       { type: 'separator' },
       {
         label: '&Trash Note',
@@ -87,9 +87,9 @@ const buildEditMenu = (settings, isAuthenticated, editMode) => {
     { type: 'separator' },
   ];
 
-  const submenu = editModeOptions
+  const submenu = editModeMenuOptions
     .concat(defaultSubmenuAdditions)
-    .concat(menuExtras);
+    .concat(authenticatedMenuOptions);
 
   const fileMenu = {
     label: '&Edit',

--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -47,7 +47,7 @@ const buildEditMenu = (settings, isAuthenticated, editMode) => {
         label: '&Trash Note',
         click: appCommandSender({ action: 'trashNote' }),
       },
-      ...(isAuthenticated ? [{ type: 'separator' }] : []),
+      { type: 'separator' },
       {
         label: 'Search &Notes…',
         click: appCommandSender({ action: 'focusSearchField' }),

--- a/desktop/menus/file-menu.js
+++ b/desktop/menus/file-menu.js
@@ -5,38 +5,42 @@ const { appCommandSender } = require('./utils');
 const buildFileMenu = (isAuthenticated) => {
   isAuthenticated = isAuthenticated || false;
 
-  const submenu = [
-    {
-      label: '&New Note',
-      visible: isAuthenticated,
-      accelerator: 'CommandOrControl+Shift+I',
-      click: appCommandSender({ action: 'newNote' }),
-    },
-    ...(isAuthenticated ? [{ type: 'separator' }] : []),
-    {
-      label: '&Import Notes…',
-      visible: isAuthenticated,
-      click: appCommandSender({
-        action: 'showDialog',
-        dialog: 'IMPORT',
-      }),
-    },
-    {
-      label: '&Export Notes…',
-      visible: isAuthenticated,
-      accelerator: 'CommandOrControl+Shift+E',
-      click: appCommandSender({
-        action: 'exportNotes',
-      }),
-    },
-    ...(isAuthenticated ? [{ type: 'separator' }] : []),
-    {
-      label: '&Print…',
-      visible: isAuthenticated,
-      accelerator: 'CommandOrControl+P',
-      click: appCommandSender({ action: 'printNote' }),
-    },
-  ];
+  let submenu = [];
+
+  if (isAuthenticated) {
+    submenu = [
+      {
+        label: '&New Note',
+        visible: isAuthenticated,
+        accelerator: 'CommandOrControl+Shift+I',
+        click: appCommandSender({ action: 'newNote' }),
+      },
+      ...(isAuthenticated ? [{ type: 'separator' }] : []),
+      {
+        label: '&Import Notes…',
+        visible: isAuthenticated,
+        click: appCommandSender({
+          action: 'showDialog',
+          dialog: 'IMPORT',
+        }),
+      },
+      {
+        label: '&Export Notes…',
+        visible: isAuthenticated,
+        accelerator: 'CommandOrControl+Shift+E',
+        click: appCommandSender({
+          action: 'exportNotes',
+        }),
+      },
+      ...(isAuthenticated ? [{ type: 'separator' }] : []),
+      {
+        label: '&Print…',
+        visible: isAuthenticated,
+        accelerator: 'CommandOrControl+P',
+        click: appCommandSender({ action: 'printNote' }),
+      },
+    ];
+  }
 
   const defaultSubmenuAdditions = [
     { type: 'separator' },

--- a/desktop/menus/file-menu.js
+++ b/desktop/menus/file-menu.js
@@ -14,7 +14,7 @@ const buildFileMenu = (isAuthenticated) => {
         accelerator: 'CommandOrControl+Shift+I',
         click: appCommandSender({ action: 'newNote' }),
       },
-      ...(isAuthenticated ? [{ type: 'separator' }] : []),
+      { type: 'separator' },
       {
         label: '&Import Notes…',
         click: appCommandSender({
@@ -29,7 +29,7 @@ const buildFileMenu = (isAuthenticated) => {
           action: 'exportNotes',
         }),
       },
-      ...(isAuthenticated ? [{ type: 'separator' }] : []),
+      { type: 'separator' },
       {
         label: '&Print…',
         accelerator: 'CommandOrControl+P',

--- a/desktop/menus/file-menu.js
+++ b/desktop/menus/file-menu.js
@@ -11,14 +11,12 @@ const buildFileMenu = (isAuthenticated) => {
     submenu = [
       {
         label: '&New Note',
-        visible: isAuthenticated,
         accelerator: 'CommandOrControl+Shift+I',
         click: appCommandSender({ action: 'newNote' }),
       },
       ...(isAuthenticated ? [{ type: 'separator' }] : []),
       {
         label: '&Import Notes…',
-        visible: isAuthenticated,
         click: appCommandSender({
           action: 'showDialog',
           dialog: 'IMPORT',
@@ -26,7 +24,6 @@ const buildFileMenu = (isAuthenticated) => {
       },
       {
         label: '&Export Notes…',
-        visible: isAuthenticated,
         accelerator: 'CommandOrControl+Shift+E',
         click: appCommandSender({
           action: 'exportNotes',
@@ -35,7 +32,6 @@ const buildFileMenu = (isAuthenticated) => {
       ...(isAuthenticated ? [{ type: 'separator' }] : []),
       {
         label: '&Print…',
-        visible: isAuthenticated,
         accelerator: 'CommandOrControl+P',
         click: appCommandSender({ action: 'printNote' }),
       },


### PR DESCRIPTION
### Fix

While on login screen, a few separators were add unnecessary on File and Edit menu.

![image](https://user-images.githubusercontent.com/17770979/110340005-8b973100-8007-11eb-88b8-27a91bb53d02.png)

![image](https://user-images.githubusercontent.com/17770979/110340022-90f47b80-8007-11eb-8aa6-1a2242a61009.png)

This changes fix these issue checking if the separator is necessary before adding.

![image](https://user-images.githubusercontent.com/17770979/110340177-baada280-8007-11eb-91bf-91804154dbff.png)

![image](https://user-images.githubusercontent.com/17770979/110340191-c00aed00-8007-11eb-813e-4127737170a8.png)



### Test
> 1. Download the Windows and/or Linux builds from CircleCI.
> 2. Go to login page.
> 3. Check if the separators are correct.
> 4. Login.
> 5. Check if the addicional options are add.

### Release
- Fix unnecessary separators in the Electron builds File and Edit menus when not yet logged in.
