### PR TITLE
Fix so that notes imported with tags will have the tags sync properly

### DIFF
--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -374,7 +374,6 @@ export const initSimperium = (
 
       // other note editing actions however
       // should trigger an immediate sync
-      case 'IMPORT_NOTE_WITH_ID':
       case 'MARKDOWN_NOTE':
       case 'PIN_NOTE':
       case 'PUBLISH_NOTE':
@@ -383,6 +382,17 @@ export const initSimperium = (
       case 'TRASH_NOTE':
         queueNoteUpdate(action.noteId, 10);
         return result;
+
+      case 'IMPORT_NOTE_WITH_ID': {
+        action.note.tags.forEach((tag) => {
+          const tagHash = t(tag);
+          if (!prevState.data.tags.has(tagHash)) {
+            queueTagUpdate(tagHash, 10);
+          }
+        });
+        queueNoteUpdate(action.noteId, 10);
+        return result;
+      }
 
       case 'DELETE_NOTE_FOREVER':
         setTimeout(() => noteBucket.remove(action.noteId), 10);


### PR DESCRIPTION
### Fix

Currently, when importing Simplenote or Evernote files if any notes have tags, the tags will not sync properly.
They will appear only in the app which imports the notes.

This resolves that and syncs the tags properly when notes are imported.

### Test

1. Import notes which have tags.
2. Check the same account on other versions of the app.
3. Ensure tags have been added properly to both the note and tag list.

### Release

- Fix to ensure that tags on imported notes are added and synced properly.
