### PR TITLE
Improve keyboard and screen reader accessibility

### DIFF
--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -118,14 +118,20 @@ export class AppLayout extends Component<Props> {
     return (
       <div className={mainClasses}>
         <Suspense fallback={placeholder}>
-          <div className="app-layout__source-column theme-color-bg theme-color-fg">
+          <aside
+            aria-label="Notes list"
+            className="app-layout__source-column theme-color-bg theme-color-fg"
+          >
             <MenuBar />
             <SearchField />
             <NoteList />
             {showSortBar && <SortOrderSelector />}
-          </div>
+          </aside>
           {editorVisible && (
-            <div className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border">
+            <main
+              aria-label="Note editor"
+              className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border"
+            >
               <NoteToolbar />
               {showRevisions ? (
                 <NotePreview noteId={openedNote} note={openedRevision} />
@@ -133,7 +139,7 @@ export class AppLayout extends Component<Props> {
                 <NoteEditor />
               )}
               {hasRevisions && <RevisionSelector />}
-            </div>
+            </main>
           )}
         </Suspense>
       </div>

--- a/lib/components/dev-badge/index.tsx
+++ b/lib/components/dev-badge/index.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 
 const DevBadge = () => {
-  return <div className="dev-badge">DEV</div>;
+  return (
+    <div aria-hidden="true" className="dev-badge">
+      DEV
+    </div>
+  );
 };
 
 export default DevBadge;

--- a/lib/components/dev-badge/index.tsx
+++ b/lib/components/dev-badge/index.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 
-const DevBadge = () => {
-  return (
-    <div aria-hidden="true" className="dev-badge">
-      DEV
-    </div>
-  );
-};
+const DevBadge = () => (
+  <div aria-hidden="true" className="dev-badge">
+    DEV
+  </div>
+);
 
 export default DevBadge;

--- a/lib/icon-button/index.tsx
+++ b/lib/icon-button/index.tsx
@@ -15,16 +15,9 @@ export const IconButton = ({ icon, title, ...props }: Props) => (
     enterDelay={200}
     title={title}
   >
-    <span>
-      <button
-        className="icon-button"
-        type="button"
-        data-title={title}
-        {...props}
-      >
-        {icon}
-      </button>
-    </span>
+    <button className="icon-button" type="button" data-title={title} {...props}>
+      {icon}
+    </button>
   </Tooltip>
 );
 

--- a/lib/icon-button/index.tsx
+++ b/lib/icon-button/index.tsx
@@ -15,7 +15,13 @@ export const IconButton = ({ icon, title, ...props }: Props) => (
     enterDelay={200}
     title={title}
   >
-    <button className="icon-button" type="button" data-title={title} {...props}>
+    <button
+      aria-label={title}
+      className="icon-button"
+      type="button"
+      data-title={title}
+      {...props}
+    >
       {icon}
     </button>
   </Tooltip>

--- a/lib/index.ejs
+++ b/lib/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title><%= htmlWebpackPlugin.options.title %></title>

--- a/lib/index.ejs
+++ b/lib/index.ejs
@@ -6,7 +6,7 @@
     <meta name="app-build-reference" content="<%= htmlWebpackPlugin.options[ 'build-reference' ] %>">
     <meta name="node-version" content="<%= htmlWebpackPlugin.options[ 'node-version' ] %>">
     <meta name="build-platform" content="<%= htmlWebpackPlugin.options[ 'build-platform' ] %>">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
     <div id="root"></div>

--- a/lib/menu-bar/index.tsx
+++ b/lib/menu-bar/index.tsx
@@ -67,7 +67,9 @@ export const MenuBar: FunctionComponent<Props> = ({
         onClick={toggleNavigation}
         title={`Menu • ${CmdOrCtrl}+Shift+U`}
       />
-      <div className="notes-title">{placeholder}</div>
+      <div className="notes-title" aria-hidden="true">
+        {placeholder}
+      </div>
       <IconButton
         disabled={collection.type === 'trash'}
         icon={<NewNoteIcon />}

--- a/lib/menu-bar/index.tsx
+++ b/lib/menu-bar/index.tsx
@@ -14,6 +14,7 @@ import NewNoteIcon from '../icons/new-note';
 import MenuIcon from '../icons/menu';
 import { withoutTags } from '../utils/filter-notes';
 import { createNote, toggleNavigation } from '../state/ui/actions';
+import * as selectors from '../state/selectors';
 
 import * as S from '../state';
 import type * as T from '../types';
@@ -26,6 +27,7 @@ type OwnProps = {
 
 type StateProps = {
   collection: T.Collection;
+  openedTag: T.TagName | null;
   searchQuery: string;
 };
 
@@ -38,6 +40,7 @@ type Props = OwnProps & StateProps & DispatchProps;
 
 export const MenuBar: FunctionComponent<Props> = ({
   collection,
+  openedTag,
   onNewNote,
   searchQuery,
   toggleNavigation,
@@ -45,7 +48,7 @@ export const MenuBar: FunctionComponent<Props> = ({
   let placeholder;
   switch (collection.type) {
     case 'tag':
-      placeholder = 'Notes With Selected Tag';
+      placeholder = openedTag;
       break;
     case 'trash':
       placeholder = 'Trash';
@@ -80,11 +83,10 @@ export const MenuBar: FunctionComponent<Props> = ({
   );
 };
 
-const mapStateToProps: S.MapState<StateProps> = ({
-  ui: { collection, searchQuery },
-}) => ({
-  collection,
-  searchQuery,
+const mapStateToProps: S.MapState<StateProps> = (state) => ({
+  collection: state.ui.collection,
+  openedTag: selectors.openedTag(state),
+  searchQuery: state.ui.searchQuery,
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps, OwnProps> = (

--- a/lib/menu-bar/index.tsx
+++ b/lib/menu-bar/index.tsx
@@ -67,7 +67,7 @@ export const MenuBar: FunctionComponent<Props> = ({
         onClick={toggleNavigation}
         title={`Menu • ${CmdOrCtrl}+Shift+U`}
       />
-      <div className="notes-title" aria-hidden="true">
+      <div id="notes-title" className="notes-title" aria-hidden="true">
         {placeholder}
       </div>
       <IconButton

--- a/lib/menu-bar/style.scss
+++ b/lib/menu-bar/style.scss
@@ -1,6 +1,6 @@
 .menu-bar {
   height: $toolbar-height;
-  padding: 20px 15px;
+  padding: 0 15px;
   border-bottom: 1px solid $studio-gray-5;
   display: flex;
   justify-content: space-between;
@@ -10,6 +10,13 @@
   .notes-title {
     font-size: 16px;
     font-weight: 500;
+    flex: 0 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .icon-button {
+    flex: 0 0 auto;
   }
 
   .icon-button svg.icon-menu {

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -149,6 +149,19 @@ const createCompositeNoteList = (
   ];
 };
 
+const sidebarTitle = (collection: T.Collection) => {
+  switch (collection.type) {
+    case 'tag':
+      return 'Notes With Selected Tag';
+    case 'trash':
+      return 'Trash';
+    case 'untagged':
+      return 'Untagged Notes';
+    default:
+      return 'All Notes';
+  }
+};
+
 export class NoteList extends Component<Props> {
   static displayName = 'NoteList';
 
@@ -213,19 +226,6 @@ export class NoteList extends Component<Props> {
     this.toggleShortcuts(false);
   }
 
-  computedLabel() {
-    switch (this.props.collection.type) {
-      case 'tag':
-        return 'Notes With Selected Tag';
-      case 'trash':
-        return 'Trash';
-      case 'untagged':
-        return 'Untagged Notes';
-      default:
-        return 'All Notes';
-    }
-  }
-
   handleShortcut = (event: KeyboardEvent) => {
     if (!this.props.keyboardShortcuts) {
       return;
@@ -280,6 +280,7 @@ export class NoteList extends Component<Props> {
 
   render() {
     const {
+      collection,
       filteredNotes,
       noteDisplay,
       onEmptyTrash,
@@ -326,10 +327,10 @@ export class NoteList extends Component<Props> {
                 {({ height, width }) => (
                   <List
                     // Ideally aria-label is changed to aria-labelledby to
-                    // reference the existing notes title element instead of
+                    // reference the existing #notes-title element instead of
                     // computing the label, but is not currently possible due to
                     // a limitation with react-virtualized. https://git.io/JqLvR
-                    aria-label={this.computedLabel()}
+                    aria-label={sidebarTitle(collection)}
                     ref={this.list}
                     estimatedRowSize={24 + 18 + 21 * 4}
                     height={height}

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -20,6 +20,7 @@ import * as S from '../state';
 import * as T from '../types';
 
 type StateProps = {
+  collection: T.Collection;
   filteredNotes: T.EntityId[];
   isSmallScreen: boolean;
   keyboardShortcuts: boolean;
@@ -212,6 +213,19 @@ export class NoteList extends Component<Props> {
     this.toggleShortcuts(false);
   }
 
+  computedLabel() {
+    switch (this.props.collection.type) {
+      case 'tag':
+        return 'Notes With Selected Tag';
+      case 'trash':
+        return 'Trash';
+      case 'untagged':
+        return 'Untagged Notes';
+      default:
+        return 'All Notes';
+    }
+  }
+
   handleShortcut = (event: KeyboardEvent) => {
     if (!this.props.keyboardShortcuts) {
       return;
@@ -311,6 +325,10 @@ export class NoteList extends Component<Props> {
               <AutoSizer>
                 {({ height, width }) => (
                   <List
+                    // Ideally aria-label is changed to aria-labelledby to
+                    // reference the existing notes title element instead of
+                    // computing the label https://git.io/JqLvR
+                    aria-label={this.computedLabel()}
                     ref={this.list}
                     estimatedRowSize={24 + 18 + 21 * 4}
                     height={height}
@@ -320,6 +338,7 @@ export class NoteList extends Component<Props> {
                     rowHeight={heightCache.rowHeight}
                     rowRenderer={renderNoteRow}
                     scrollToIndex={selectedIndex}
+                    tabIndex={null}
                     width={width}
                   />
                 )}
@@ -335,6 +354,7 @@ export class NoteList extends Component<Props> {
 
 const mapStateToProps: S.MapState<StateProps> = (state) => {
   return {
+    collection: state.ui.collection,
     isSmallScreen: selectors.isSmallScreen(state),
     keyboardShortcuts: state.settings.keyboardShortcuts,
     noteDisplay: state.settings.noteDisplay,

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -327,7 +327,8 @@ export class NoteList extends Component<Props> {
                   <List
                     // Ideally aria-label is changed to aria-labelledby to
                     // reference the existing notes title element instead of
-                    // computing the label https://git.io/JqLvR
+                    // computing the label, but is not currently possible due to
+                    // a limitation with react-virtualized. https://git.io/JqLvR
                     aria-label={this.computedLabel()}
                     ref={this.list}
                     estimatedRowSize={24 + 18 + 21 * 4}

--- a/lib/note-list/index.tsx
+++ b/lib/note-list/index.tsx
@@ -26,6 +26,7 @@ type StateProps = {
   keyboardShortcuts: boolean;
   noteDisplay: T.ListDisplayMode;
   openedNote: T.EntityId | null;
+  openedTag: T.TagName | null;
   searchQuery: string;
   showNoteList: boolean;
   showTrash: boolean;
@@ -149,10 +150,13 @@ const createCompositeNoteList = (
   ];
 };
 
-const sidebarTitle = (collection: T.Collection) => {
+const sidebarTitle = (
+  collection: T.Collection,
+  openedTag: T.TagName | null
+) => {
   switch (collection.type) {
     case 'tag':
-      return 'Notes With Selected Tag';
+      return openedTag;
     case 'trash':
       return 'Trash';
     case 'untagged':
@@ -285,6 +289,7 @@ export class NoteList extends Component<Props> {
       noteDisplay,
       onEmptyTrash,
       openedNote,
+      openedTag,
       searchQuery,
       showTrash,
       tagResultsFound,
@@ -330,7 +335,7 @@ export class NoteList extends Component<Props> {
                     // reference the existing #notes-title element instead of
                     // computing the label, but is not currently possible due to
                     // a limitation with react-virtualized. https://git.io/JqLvR
-                    aria-label={sidebarTitle(collection)}
+                    aria-label={sidebarTitle(collection, openedTag)}
                     ref={this.list}
                     estimatedRowSize={24 + 18 + 21 * 4}
                     height={height}
@@ -362,6 +367,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => {
     noteDisplay: state.settings.noteDisplay,
     filteredNotes: state.ui.filteredNotes,
     openedNote: state.ui.openedNote,
+    openedTag: selectors.openedTag(state),
     searchQuery: state.ui.searchQuery,
     showNoteList: state.ui.showNoteList,
     showTrash: selectors.showTrash(state),

--- a/lib/note-list/note-cell.tsx
+++ b/lib/note-list/note-cell.tsx
@@ -119,7 +119,7 @@ export class NoteCell extends Component<Props> {
 
           <button
             aria-label={`Edit note ${title}`}
-            className="note-list-item-text theme-color-border"
+            className="note-list-item-text theme-color-border focus-visible"
             onClick={() => openNote(noteId)}
           >
             <div className="note-list-item-title">

--- a/lib/note-list/note-cell.tsx
+++ b/lib/note-list/note-cell.tsx
@@ -104,8 +104,8 @@ export class NoteCell extends Component<Props> {
     const decorators = getTerms(searchQuery).map(makeFilterDecorator);
 
     return (
-      <div style={style} className={classes}>
-        <div className="note-list-item-status">
+      <div style={style} className={classes} role="row">
+        <div className="note-list-item-status" role="cell">
           <div
             className={pinnerClasses}
             tabIndex={0}
@@ -119,6 +119,7 @@ export class NoteCell extends Component<Props> {
           className="note-list-item-text theme-color-border"
           tabIndex={0}
           onClick={() => openNote(noteId)}
+          role="cell"
         >
           <div className="note-list-item-title">
             <span>
@@ -146,7 +147,10 @@ export class NoteCell extends Component<Props> {
             </div>
           )}
         </div>
-        <div className="note-list-item-status-right theme-color-border">
+        <div
+          className="note-list-item-status-right theme-color-border"
+          role="cell"
+        >
           {hasPendingChanges && (
             <span
               className={classNames('note-list-item-pending-changes', {

--- a/lib/note-list/note-cell.tsx
+++ b/lib/note-list/note-cell.tsx
@@ -100,71 +100,70 @@ export class NoteCell extends Component<Props> {
     const pinnerClasses = classNames('note-list-item-pinner', {
       'note-list-item-pinned': isPinned,
     });
+    const pinnerLabel = isPinned ? `Unpin note ${title}` : `Pin note ${title}`;
 
     const decorators = getTerms(searchQuery).map(makeFilterDecorator);
 
     return (
       <div style={style} className={classes} role="row">
-        <div className="note-list-item-status" role="cell">
-          <div
-            className={pinnerClasses}
-            tabIndex={0}
-            onClick={() => pinNote(noteId, !isPinned)}
-          >
-            <SmallPinnedIcon />
-          </div>
-        </div>
-
-        <div
-          className="note-list-item-text theme-color-border"
-          tabIndex={0}
-          onClick={() => openNote(noteId)}
-          role="cell"
-        >
-          <div className="note-list-item-title">
-            <span>
-              {decorateWith(decorators, withCheckboxCharacters(title))}
-            </span>
-          </div>
-          {'expanded' === displayMode && preview.length > 0 && (
-            <div className="note-list-item-excerpt theme-color-fg-dim">
-              {withCheckboxCharacters(preview)
-                .split('\n')
-                .map((line, index) => (
-                  <React.Fragment key={index}>
-                    {index > 0 && <br />}
-                    {decorateWith(decorators, line.slice(0, 200))}
-                  </React.Fragment>
-                ))}
-            </div>
-          )}
-          {'comfy' === displayMode && preview.length > 0 && (
-            <div className="note-list-item-excerpt theme-color-fg-dim">
-              {decorateWith(
-                decorators,
-                withCheckboxCharacters(preview).slice(0, 200)
-              )}
-            </div>
-          )}
-        </div>
-        <div
-          className="note-list-item-status-right theme-color-border"
-          role="cell"
-        >
-          {hasPendingChanges && (
-            <span
-              className={classNames('note-list-item-pending-changes', {
-                'is-offline': isOffline,
-              })}
+        <div className="note-list-item-content" role="cell">
+          <div className="note-list-item-status">
+            <button
+              aria-label={pinnerLabel}
+              className={pinnerClasses}
+              onClick={() => pinNote(noteId, !isPinned)}
             >
-              <SmallSyncIcon />
-            </span>
-          )}
-          {isPublished && (
-            <span className="note-list-item-published-icon">
-              <PublishIcon />
-            </span>
-          )}
+              <SmallPinnedIcon />
+            </button>
+          </div>
+
+          <button
+            aria-label={`Edit note ${title}`}
+            className="note-list-item-text theme-color-border"
+            onClick={() => openNote(noteId)}
+          >
+            <div className="note-list-item-title">
+              <span>
+                {decorateWith(decorators, withCheckboxCharacters(title))}
+              </span>
+            </div>
+            {'expanded' === displayMode && preview.length > 0 && (
+              <div className="note-list-item-excerpt theme-color-fg-dim">
+                {withCheckboxCharacters(preview)
+                  .split('\n')
+                  .map((line, index) => (
+                    <React.Fragment key={index}>
+                      {index > 0 && <br />}
+                      {decorateWith(decorators, line.slice(0, 200))}
+                    </React.Fragment>
+                  ))}
+              </div>
+            )}
+            {'comfy' === displayMode && preview.length > 0 && (
+              <div className="note-list-item-excerpt theme-color-fg-dim">
+                {decorateWith(
+                  decorators,
+                  withCheckboxCharacters(preview).slice(0, 200)
+                )}
+              </div>
+            )}
+          </button>
+          <div className="note-list-item-status-right theme-color-border">
+            {hasPendingChanges && (
+              <span
+                className={classNames('note-list-item-pending-changes', {
+                  'is-offline': isOffline,
+                })}
+              >
+                <SmallSyncIcon />
+              </span>
+            )}
+            {isPublished && (
+              <span className="note-list-item-published-icon">
+                <PublishIcon />
+              </span>
+            )}
+          </div>
         </div>
       </div>
     );

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -140,6 +140,10 @@
     color: transparent;
     height: 16px;
     width: 16px;
+
+    svg {
+      vertical-align: top;
+    }
   }
 
   .note-list-item-text {

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -34,8 +34,14 @@
     .note-list-item {
       min-height: 43px;
     }
+    .note-list-item-status {
+      align-items: center;
+      padding-bottom: 3px;
+      padding-top: 0;
+    }
     .note-list-item-text {
       padding-bottom: 0;
+      padding-top: 0;
     }
     .note-list-item-excerpt {
       display: none;
@@ -133,7 +139,8 @@
   }
 
   .note-list-item-status {
-    padding: 9px 8px 0 0;
+    display: flex;
+    padding: 12px 8px 0 0;
   }
 
   .note-list-item-pinner {
@@ -151,10 +158,6 @@
     overflow: hidden;
     padding: 9px 0;
     border-bottom: 1px solid;
-
-    &:focus {
-      outline: none;
-    }
   }
 
   .note-list-item-title,

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -127,6 +127,11 @@
   font-family: 'Simplenote Tasks', $sans, sans-serif;
   min-height: 64px;
 
+  .note-list-item-content {
+    display: flex;
+    width: 100%;
+  }
+
   .note-list-item-status {
     padding: 9px 8px 0 0;
   }
@@ -151,6 +156,7 @@
   .note-list-item-title,
   .note-list-item-excerpt {
     white-space: nowrap;
+    text-align: left;
     text-overflow: ellipsis;
     overflow: hidden;
   }

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -67,7 +67,7 @@ export class NoteToolbar extends Component<Props> {
     return !note ? (
       <div className="note-toolbar-placeholder theme-color-border" />
     ) : (
-      <div className="note-toolbar">
+      <div aria-label="note actions" role="toolbar" className="note-toolbar">
         <div className="note-toolbar__column-left">
           <div className="note-toolbar__button new-note-toolbar__button-sidebar theme-color-border">
             <IconButton

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -73,21 +73,24 @@ export class SearchField extends Component<Props> {
   render() {
     const { openedTag, searchQuery } = this.props;
     const hasQuery = searchQuery.length > 0;
-    const placeholder = openedTag ?? 'Search notes and tags';
 
-    const screenReaderLabel =
-      'Search ' + (openedTag ? 'notes with tag ' : '') + placeholder;
+    const description =
+      'Search ' +
+      (openedTag ? 'notes with tag ' + openedTag : 'notes and tags');
 
     return (
       <div className="search-field theme-color-fg theme-color-border">
-        <button onClick={this.props.focusSearchField} className="icon-button">
+        <button
+          aria-label="Focus search field"
+          onClick={this.props.focusSearchField}
+          className="icon-button"
+        >
           <SmallSearchIcon />
         </button>
         <input
-          aria-label={screenReaderLabel}
           ref={this.inputField}
           type="search"
-          placeholder={placeholder}
+          placeholder={description}
           onChange={this.update}
           onKeyUp={this.interceptEsc}
           value={searchQuery}

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -75,8 +75,7 @@ export class SearchField extends Component<Props> {
     const hasQuery = searchQuery.length > 0;
 
     const description =
-      'Search ' +
-      (openedTag ? 'notes with tag ' + openedTag : 'notes and tags');
+      'Search ' + (openedTag ? 'notes in ' + openedTag : 'notes and tags');
 
     return (
       <div className="search-field theme-color-fg theme-color-border">

--- a/lib/search-field/style.scss
+++ b/lib/search-field/style.scss
@@ -13,6 +13,7 @@
     border: 0;
     appearance: none;
     font-size: 16px;
+    text-overflow: ellipsis !important;
 
     &:focus {
       outline: none;

--- a/lib/search-field/style.scss
+++ b/lib/search-field/style.scss
@@ -3,7 +3,7 @@
   flex-direction: row;
   align-items: center;
   width: 100%;
-  padding: 6px 5px 5px 20px;
+  padding: 6px 5px 5px 14px;
   border-bottom: 1px solid;
   height: $toolbar-height;
 
@@ -21,10 +21,6 @@
 
   .icon-button {
     flex: 0 0 auto;
-  }
-
-  .icon-button:first-child() {
-    text-align: left;
   }
 
   .icon-cross-small {

--- a/lib/tag-field/index.tsx
+++ b/lib/tag-field/index.tsx
@@ -240,6 +240,7 @@ export class TagField extends Component<Props, OwnState> {
     return (
       <div ref={this.container} className="tag-field">
         <div
+          aria-label="List of tags for the current note, click a tag to remove it"
           className={classNames('tag-editor', {
             'has-selection': this.hasSelection(),
           })}
@@ -247,6 +248,7 @@ export class TagField extends Component<Props, OwnState> {
           onKeyDown={this.onKeyDown}
         >
           <input
+            aria-hidden="true"
             className="hidden-tag"
             tabIndex={-1}
             ref={this.storeHiddenTag}


### PR DESCRIPTION
### Fix
Related to https://github.com/Automattic/simplenote-electron/issues/1935#issuecomment-791742151, this addresses several issue that inhibited keyboard 
and screen reader users from navigation the application easily.

Summary of changes:

- Add ARIA roles for virtualized list
- Improve accessibility of notes list
- Reduce noise in screen reader audio
- Increase accuracy of search field descriptions
- Adjust search button styles to improve tap area
- Increase accuracy of tag list accessibility labels
- Allow scaling to improve accessibility
- Improve ARIA descriptions for application layout
- Add ARIA label for all icon buttons
- Set language for HTML document

| Issue Count Before | Issue Count After |
| --- | --- |
| <img width="1552" alt="axe-devtools-before" src="https://user-images.githubusercontent.com/438664/110390189-38cf7080-802b-11eb-8bf1-b2dbe823fca9.png"> | <img width="1552" alt="axe-devtools-after" src="https://user-images.githubusercontent.com/438664/110391240-d5464280-802c-11eb-9c77-e4ebd28b635b.png"> |

The remaining issues identified by the axe DevTools fall into three categories:

1. Issues that require design input (e.g. text color legibility).
1. Issues with the third-party Monaco editor (e.g. lack of ARIA attributes).
1. Issues that are not applicable to the Simplenote web application (e.g. lack of level-one heading).

### Test
1. Launch Simplenote web or desktop app.
1. Enable macOS VoiceOver or screen reader.
1. Navigate the application.

_Expected Outcome:_ No major issues block navigating the application.

### Release

Improved accessibility of the application for keyboard and screen reader users.
