### PR TITLE
Check if email is set when dismissing alternate login prompt

### DIFF
--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -92,7 +92,7 @@ const alternateLoginEmail: A.Reducer<string | null> = (
 ) => {
   switch (action.type) {
     case 'SHOW_ALTERNATE_LOGIN_PROMPT':
-      return atob(action.email);
+      return action.email ? atob(action.email) : null;
     case 'HIDE_ALTERNATE_LOGIN_PROMPT':
       return null;
     default:


### PR DESCRIPTION
### Fix

When dismissing the alternate login prompt the email is set to false. This caused an error when trying to decode the email with `atob`.
This adds a check to ensure the email is set before decoding.

Fixes #2734

### Test

1. Be logged into the app.
2. Sign up for a new account on web.
3. In the prompt choose to open the link in the app.
4. On the logout prompt in the app choose to cancel.
5. Notice the dialog is dismissed properly.

### Release

- Fixes bug when dismissing the logout view from the alternate login prompt.
