### PR TITLE
Fix checkbox rendering and click logic

### DIFF
--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -105,35 +105,42 @@ export const NotePreview: FunctionComponent<Props> = ({
 
           return;
         }
+      }
 
-        if (node.className === 'task-list-item') {
-          event.preventDefault();
-          event.stopPropagation();
+      // There are times when showdown will put lists inside of the same
+      // UL as a tasklist. This causes those lists to look like they are
+      // checkboxes. This insures that we are only getting true checkboxes.
+      const element =
+        event?.target?.tagName === 'INPUT'
+          ? event.target.parentElement
+          : event.target;
+      if (element?.children[0]?.tagName === 'INPUT') {
+        event.preventDefault();
+        event.stopPropagation();
 
-          const allTasks = previewNode!.current.querySelectorAll(
-            '[data-markdown-root] .task-list-item'
-          );
-          const taskIndex = Array.prototype.indexOf.call(allTasks, node);
+        const allTasks = previewNode!.current.querySelectorAll(
+          '[data-markdown-root] .task-list-item'
+        );
+        const taskIndex = Array.prototype.indexOf.call(allTasks, element);
 
-          let matchCount = 0;
-          const content = note.content.replace(
-            checkboxRegex,
-            (match, prespace, inside, postspace) => {
-              const newCheckbox =
-                matchCount++ === taskIndex
-                  ? inside === ' '
-                    ? '- [x]'
-                    : '- [ ]'
-                  : inside === ' '
-                  ? '- [ ]'
-                  : '- [x]';
-              return prespace + newCheckbox + postspace;
-            }
-          );
+        let matchCount = 0;
+        const content = note.content.replace(
+          checkboxRegex,
+          (match, prespace, inside, postspace) => {
+            const newCheckbox =
+              matchCount++ === taskIndex
+                ? inside === ' '
+                  ? '- [x]'
+                  : '- [ ]'
+                : inside === ' '
+                ? '- [ ]'
+                : '- [x]';
+            return prespace + newCheckbox + postspace;
+          }
+        );
 
-          editNote(noteId, { content });
-          return;
-        }
+        editNote(noteId, { content });
+        return;
       }
     };
     previewNode.current?.addEventListener('click', handleClick, true);

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -117,7 +117,7 @@ export const NotePreview: FunctionComponent<Props> = ({
           let matchCount = 0;
 
           const content = note.content.replace(
-            /(- \[x\]|- \[ \])/g,
+            /^(- \[x\])|(- \[ \])/gm,
             (match) => {
               return matchCount++ === taskIndex
                 ? match === '- [ ]'
@@ -135,7 +135,7 @@ export const NotePreview: FunctionComponent<Props> = ({
     previewNode.current?.addEventListener('click', handleClick, true);
     return () =>
       previewNode.current?.removeEventListener('click', handleClick, true);
-  }, [note]);
+  }, [note.content]);
 
   useEffect(() => {
     if (!previewNode.current) {

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
 
-import checkboxRegex from '../../utils/task-transform';
+import { checkboxRegex } from '../../utils/task-transform';
 import renderToNode from '../../note-detail/render-to-node';
 import { viewExternalUrl } from '../../utils/url-utils';
 import { withCheckboxCharacters } from '../../utils/task-transform';

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
 
+import checkboxRegex from '../../utils/task-transform';
 import renderToNode from '../../note-detail/render-to-node';
 import { viewExternalUrl } from '../../utils/url-utils';
 import { withCheckboxCharacters } from '../../utils/task-transform';
@@ -116,7 +117,7 @@ export const NotePreview: FunctionComponent<Props> = ({
 
           let matchCount = 0;
           const content = note.content.replace(
-            /^(\s*)- \[( |x|X)\](\s)/gm,
+            checkboxRegex,
             (match, prespace, inside, postspace) => {
               const newCheckbox =
                 matchCount++ === taskIndex

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -115,15 +115,18 @@ export const NotePreview: FunctionComponent<Props> = ({
           const taskIndex = Array.prototype.indexOf.call(allTasks, node);
 
           let matchCount = 0;
-
           const content = note.content.replace(
-            /^(- \[x\])|(- \[ \])/gim,
-            (match) => {
-              return matchCount++ === taskIndex
-                ? match === '- [ ]'
-                  ? '- [x]'
-                  : '- [ ]'
-                : match;
+            /^(\s*)- \[( |x|X)\](\s)/gm,
+            (match, prespace, inside, postspace) => {
+              const newCheckbox =
+                matchCount++ === taskIndex
+                  ? inside === ' '
+                    ? '- [x]'
+                    : '- [ ]'
+                  : inside === ' '
+                  ? '- [ ]'
+                  : '- [x]';
+              return prespace + newCheckbox + postspace;
             }
           );
 
@@ -141,7 +144,6 @@ export const NotePreview: FunctionComponent<Props> = ({
     if (!previewNode.current) {
       return;
     }
-
     if (note?.content && showRenderedView) {
       renderToNode(previewNode.current, note!.content, searchQuery);
     } else {

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -117,7 +117,7 @@ export const NotePreview: FunctionComponent<Props> = ({
           let matchCount = 0;
 
           const content = note.content.replace(
-            /^(- \[x\])|(- \[ \])/gm,
+            /^(- \[x\])|(- \[ \])/gim,
             (match) => {
               return matchCount++ === taskIndex
                 ? match === '- [ ]'

--- a/lib/utils/task-transform.ts
+++ b/lib/utils/task-transform.ts
@@ -1,6 +1,6 @@
 export const withCheckboxCharacters = (s: string): string =>
   s.replace(
-    /^(\s*(?:[-+*\u2022]\s)?)- \[( |x|X)\](\s)/gm,
+    /^(\s*)- \[( |x|X)\](\s)/gm,
     (match, prespace, inside, postspace) =>
       prespace + (inside === ' ' ? '\ue000' : '\ue001') + postspace
   );

--- a/lib/utils/task-transform.ts
+++ b/lib/utils/task-transform.ts
@@ -1,6 +1,8 @@
+export const checkboxRegex: RegExp = /^(\s*)- \[( |x|X)\](\s)/gm;
+
 export const withCheckboxCharacters = (s: string): string =>
   s.replace(
-    /^(\s*)- \[( |x|X)\](\s)/gm,
+    checkboxRegex,
     (match, prespace, inside, postspace) =>
       prespace + (inside === ' ' ? '\ue000' : '\ue001') + postspace
   );

--- a/lib/utils/task-transform.ts
+++ b/lib/utils/task-transform.ts
@@ -1,3 +1,10 @@
+/**
+ * Regex to find valid checkboxes within a string
+ *
+ * Checkboxes are valid if they:
+ * - exist as the first non-whitespace on a line
+ * - take one of the following forms ( - [ ] | - [x] | - [X])
+ */
 export const checkboxRegex: RegExp = /^(\s*)- \[( |x|X)\](\s)/gm;
 
 export const withCheckboxCharacters = (s: string): string =>


### PR DESCRIPTION
### Fix
Fixes:

This should not render a checkbox:

```
- - [ ]
```

In the note below click the checkbox in this line whilst in markdown mode: `Creme - [x] Brulee`. In develop you will notice that it will check a check box when it should do nothing.

### Test
1. Use the note below
2. Click all instances of checkboxes,`- [ ]`, and `- [x]` in edit mode
3. Click all instances of checkboxes,`- [ ]`, and `- [x]` in markdown mode

### Release

- Fixed issues with checkboxes


Use this note to test:
```
Crème Bruléee

Creme - [x] Brulee

Creme Brule

Creme Brulee

Creme Bruleedsdsdsds

Brulee

 sdsdsds
 sdsdsdsd
 sdsdsds
 sdsdsdsd
 ujyuyu
 dsdsdsds
 ddfdf
ssss

- [x] efefdf
- [ ] sfsfsff
- [x] cdffdfd
- [ ] dsdsddsddsdsdsdsdsd
- [ ] dfsfdfd
- [ ] cddfsfdfvdf
- [x] dssfsfdfdf

This is a bunch of text

yup
- [x] hi
- [ ] one
- [x] two
- [ ] three
- [x] four
- [ ] five

- [x] hi
	- [x] hello🤷‍♀️😍
	- [x] again	
	- [x] some changes
	- [x] some other changes
 
   - [x] test

Creme - [x] Brulee

- [x] hell

indents
	one hello - [x] testing
		two
			three
```