### PR TITLE
Improve note Action and Info focus management

### DIFF
--- a/lib/components/clipboard-button/index.tsx
+++ b/lib/components/clipboard-button/index.tsx
@@ -1,8 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
-import PropTypes from 'prop-types';
 import Clipboard from 'clipboard';
 
-function ClipboardButton({ linkText, text }) {
+type Props = {
+  container?: React.RefObject<HTMLElement>;
+  linkText: string;
+  text: string;
+};
+
+function ClipboardButton({ container, linkText, text }: Props) {
   const buttonRef = useRef();
   const textCallback = useRef();
   const successCallback = useRef();
@@ -30,6 +35,7 @@ function ClipboardButton({ linkText, text }) {
   // create the `Clipboard` object on mount and destroy on unmount
   useEffect(() => {
     const clipboard = new Clipboard(buttonRef.current, {
+      container: container?.current || undefined,
       text: () => textCallback.current(),
     });
     clipboard.on('success', () => successCallback.current());
@@ -43,11 +49,5 @@ function ClipboardButton({ linkText, text }) {
     </button>
   );
 }
-
-ClipboardButton.propTypes = {
-  disabled: PropTypes.bool,
-  linkText: PropTypes.string,
-  text: PropTypes.string,
-};
 
 export default ClipboardButton;

--- a/lib/note-actions/index.tsx
+++ b/lib/note-actions/index.tsx
@@ -36,6 +36,7 @@ type Props = StateProps & DispatchProps;
 export class NoteActions extends Component<Props> {
   static displayName = 'NoteActions';
   isMounted = false;
+  containerRef = React.createRef<HTMLDivElement>();
 
   componentDidMount() {
     this.isMounted = true;
@@ -75,7 +76,10 @@ export class NoteActions extends Component<Props> {
           onDeactivate: this.handleFocusTrapDeactivate,
         }}
       >
-        <div className="note-actions theme-color-bg theme-color-fg theme-color-border">
+        <div
+          className="note-actions theme-color-bg theme-color-fg theme-color-border"
+          ref={this.containerRef}
+        >
           <div className="note-actions-panel theme-color-border">
             <label
               className="note-actions-item"
@@ -115,8 +119,11 @@ export class NoteActions extends Component<Props> {
             </label>
 
             <div className="note-actions-item note-actions-internal-link">
-              {/* <p className="note-actions-detail note-actions-link-text theme-color-fg-dim">{`simplenote://note/${noteId}`}</p> */}
-              <ClipboardButton text={noteLink} linkText="Copy Internal Link" />
+              <ClipboardButton
+                container={this.containerRef}
+                text={noteLink}
+                linkText="Copy Internal Link"
+              />
             </div>
 
             {hasRevisions && (
@@ -153,16 +160,16 @@ export class NoteActions extends Component<Props> {
             </label>
             <div
               className={classNames('note-actions-item', {
-                'note-actions-item-disabled': !isPublished,
+                'note-actions-item-disabled': !isPublished || !publishURL,
               })}
             >
-              {isPublished && (
-                /* <p className="note-actions-detail note-actions-link-text theme-color-fg-dim">
-                {publishURL}
-              </p> */
-                <ClipboardButton text={publishURL} linkText="Copy Link" />
-              )}
-              {isPublished || (
+              {isPublished && publishURL ? (
+                <ClipboardButton
+                  container={this.containerRef}
+                  text={publishURL}
+                  linkText="Copy Link"
+                />
+              ) : (
                 <span className="note-actions-disabled">Copy Link</span>
               )}
             </div>

--- a/lib/note-info/index.tsx
+++ b/lib/note-info/index.tsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import Modal from 'react-modal';
 import { connect } from 'react-redux';
-import FocusTrap from 'focus-trap-react';
 
 import LastSyncTime from '../components/last-sync-time';
 import SmallCrossIcon from '../icons/cross-small';
@@ -20,7 +19,7 @@ type StateProps = {
 };
 
 type DispatchProps = {
-  onFocusTrapDeactivate: () => any;
+  onModalCose: () => any;
 };
 
 type Props = StateProps & DispatchProps;
@@ -28,69 +27,42 @@ type Props = StateProps & DispatchProps;
 export class NoteInfo extends Component<Props> {
   static displayName = 'NoteInfo';
 
-  handleFocusTrapDeactivate = this.props.onFocusTrapDeactivate;
-
   render() {
-    const { noteId, note, theme } = this.props;
+    const { noteId, note, onModalCose, theme } = this.props;
     const creationDate = note.creationDate * 1000;
     const modificationDate = note.modificationDate
       ? note.modificationDate * 1000
       : null;
 
     return (
-      <FocusTrap
-        focusTrapOptions={{
-          clickOutsideDeactivates: true,
-          onDeactivate: this.handleFocusTrapDeactivate,
-        }}
+      <Modal
+        key="note-info-modal"
+        className="dialog-renderer__content note-info theme-color-border theme-color-bg theme-color-fg"
+        contentLabel="Document"
+        isOpen
+        onRequestClose={onModalCose}
+        overlayClassName="dialog-renderer__overlay"
+        portalClassName={`dialog-renderer__portal theme-${theme}`}
       >
-        <Modal
-          key="note-info-modal"
-          className="dialog-renderer__content note-info theme-color-border theme-color-bg theme-color-fg"
-          contentLabel="Document"
-          isOpen
-          onRequestClose={this.handleFocusTrapDeactivate}
-          overlayClassName="dialog-renderer__overlay"
-          portalClassName={`dialog-renderer__portal theme-${theme}`}
-        >
-          <div className="note-info-panel note-info-stats theme-color-border theme-color-fg-dim">
-            <div className="note-info-header theme-color-border">
-              <h2 className="panel-title theme-color-fg">Document</h2>
-              <button
-                type="button"
-                aria-label="Close note info"
-                className="about-done button icon-button"
-                onClick={this.handleFocusTrapDeactivate}
-              >
-                <SmallCrossIcon />
-              </button>
-            </div>
-            {modificationDate && (
-              <p className="note-info-item">
-                <span className="note-info-item-text">
-                  <span className="note-info-name theme-color-fg">
-                    Modified
-                  </span>
-                  <span className="note-info-detail theme-color-fg-dim">
-                    <time dateTime={new Date(modificationDate).toISOString()}>
-                      {new Date(modificationDate).toLocaleString([], {
-                        year: 'numeric',
-                        month: 'short',
-                        day: 'numeric',
-                        hour: 'numeric',
-                        minute: 'numeric',
-                      })}
-                    </time>
-                  </span>
-                </span>
-              </p>
-            )}
+        <div className="note-info-panel note-info-stats theme-color-border theme-color-fg-dim">
+          <div className="note-info-header theme-color-border">
+            <h2 className="panel-title theme-color-fg">Document</h2>
+            <button
+              type="button"
+              aria-label="Close note info"
+              className="about-done button icon-button"
+              onClick={onModalCose}
+            >
+              <SmallCrossIcon />
+            </button>
+          </div>
+          {modificationDate && (
             <p className="note-info-item">
               <span className="note-info-item-text">
-                <span className="note-info-name theme-color-fg">Created</span>
+                <span className="note-info-name theme-color-fg">Modified</span>
                 <span className="note-info-detail theme-color-fg-dim">
-                  <time dateTime={new Date(creationDate).toISOString()}>
-                    {new Date(creationDate).toLocaleString([], {
+                  <time dateTime={new Date(modificationDate).toISOString()}>
+                    {new Date(modificationDate).toLocaleString([], {
                       year: 'numeric',
                       month: 'short',
                       day: 'numeric',
@@ -101,36 +73,50 @@ export class NoteInfo extends Component<Props> {
                 </span>
               </span>
             </p>
-            <p className="note-info-item">
-              <span className="note-info-item-text">
-                <span className="note-info-name theme-color-fg">Last sync</span>
-                <span className="note-info-detail theme-color-fg-dim">
-                  <LastSyncTime noteId={noteId} />
-                </span>
+          )}
+          <p className="note-info-item">
+            <span className="note-info-item-text">
+              <span className="note-info-name theme-color-fg">Created</span>
+              <span className="note-info-detail theme-color-fg-dim">
+                <time dateTime={new Date(creationDate).toISOString()}>
+                  {new Date(creationDate).toLocaleString([], {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: 'numeric',
+                  })}
+                </time>
               </span>
-            </p>
-            <p className="note-info-item">
-              <span className="note-info-item-text">
-                <span className="note-info-name theme-color-fg">Words</span>
-                <span className="note-info-detail theme-color-fg-dim">
-                  {wordCount(note.content)}
-                </span>
+            </span>
+          </p>
+          <p className="note-info-item">
+            <span className="note-info-item-text">
+              <span className="note-info-name theme-color-fg">Last sync</span>
+              <span className="note-info-detail theme-color-fg-dim">
+                <LastSyncTime noteId={noteId} />
               </span>
-            </p>
-            <p className="note-info-item">
-              <span className="note-info-item-text">
-                <span className="note-info-name theme-color-fg">
-                  Characters
-                </span>
-                <span className="note-info-detail theme-color-fg-dim">
-                  {characterCount(note.content)}
-                </span>
+            </span>
+          </p>
+          <p className="note-info-item">
+            <span className="note-info-item-text">
+              <span className="note-info-name theme-color-fg">Words</span>
+              <span className="note-info-detail theme-color-fg-dim">
+                {wordCount(note.content)}
               </span>
-            </p>
-          </div>
-          <References></References>
-        </Modal>
-      </FocusTrap>
+            </span>
+          </p>
+          <p className="note-info-item">
+            <span className="note-info-item-text">
+              <span className="note-info-name theme-color-fg">Characters</span>
+              <span className="note-info-detail theme-color-fg-dim">
+                {characterCount(note.content)}
+              </span>
+            </span>
+          </p>
+        </div>
+        <References></References>
+      </Modal>
     );
   }
 }
@@ -168,7 +154,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => {
 };
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
-  onFocusTrapDeactivate: actions.ui.toggleNoteInfo,
+  onModalCose: actions.ui.toggleNoteInfo,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteInfo);

--- a/lib/note-info/index.tsx
+++ b/lib/note-info/index.tsx
@@ -19,7 +19,7 @@ type StateProps = {
 };
 
 type DispatchProps = {
-  onModalCose: () => any;
+  onModalClose: () => any;
 };
 
 type Props = StateProps & DispatchProps;
@@ -28,7 +28,7 @@ export class NoteInfo extends Component<Props> {
   static displayName = 'NoteInfo';
 
   render() {
-    const { noteId, note, onModalCose, theme } = this.props;
+    const { noteId, note, onModalClose, theme } = this.props;
     const creationDate = note.creationDate * 1000;
     const modificationDate = note.modificationDate
       ? note.modificationDate * 1000
@@ -40,7 +40,7 @@ export class NoteInfo extends Component<Props> {
         className="dialog-renderer__content note-info theme-color-border theme-color-bg theme-color-fg"
         contentLabel="Document"
         isOpen
-        onRequestClose={onModalCose}
+        onRequestClose={onModalClose}
         overlayClassName="dialog-renderer__overlay"
         portalClassName={`dialog-renderer__portal theme-${theme}`}
       >
@@ -51,7 +51,7 @@ export class NoteInfo extends Component<Props> {
               type="button"
               aria-label="Close note info"
               className="about-done button icon-button"
-              onClick={onModalCose}
+              onClick={onModalClose}
             >
               <SmallCrossIcon />
             </button>
@@ -154,7 +154,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => {
 };
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
-  onModalCose: actions.ui.toggleNoteInfo,
+  onModalClose: actions.ui.toggleNoteInfo,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteInfo);


### PR DESCRIPTION
### Fix
- Remove redundant focus management within note Info. React Modal provides its own focus trap logic, so wrapping with `FocusTrap` is unnecessary.
- Support ClipboardButton within focus trap for note actions. In order for clipboard.js to function properly within a focus trap, we [must set a `container`](https://clipboardjs.com/#advanced-usage) that is "reachable" from within the focus trap.

### Test
1. Open Simplenote.
1. Click note Actions button (three dots in circle) in the top-right.
1. Click "Copy Internal Link."
1. Click "Copy Link."

_Expected Outcome:_ Both internal and public links should be within clipboard
history.

### Release

n/a
