### PR TITLE
Improve recognizability of inline code elements

### DIFF
--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -173,6 +173,12 @@
     font-size: 85%;
   }
 
+  p > code {
+    background-color: $studio-gray-5;
+    border-radius: 2px;
+    padding: 3px;
+  }
+
   table {
     border-collapse: collapse;
     border-spacing: 0;
@@ -206,6 +212,10 @@
     border-radius: 3px;
     box-shadow: inset 0 0 0 #959da5;
   }
+}
+
+.theme-dark .note-detail-markdown p > code {
+  background-color: $studio-gray-70;
 }
 
 .monaco-editor.monaco-editor .detected-link {


### PR DESCRIPTION
### Fix
Fixes #1891. Increase recognizability of inline code elements in Markdown
previews by applying a subtle background color to them.

| Before | After | After (Dark) |
| --- | --- | --- |
| <img width="738" alt="before" src="https://user-images.githubusercontent.com/438664/110700122-3862e100-81b5-11eb-8d6c-1a53e21a36e1.png"> | <img width="741" alt="after" src="https://user-images.githubusercontent.com/438664/110700159-40228580-81b5-11eb-913c-d270367ea28e.png"> | <img width="743" alt="after-dark" src="https://user-images.githubusercontent.com/438664/110700187-47499380-81b5-11eb-9b05-d89127b964dd.png"> |


### Test
1. Create a new note.
1. Click note Info button in the top-right.
1. Enable Markdown formatting.
1. Add an inline code block to the note content.
1. Click Preview button in the top-right.

_Expected Outcome:_ The inline code element is styled with a monospace typeface
and a background color different than rest of the content.

### Release
Improve recognizability of inline code elements.
