### PR TITLE
Cherry-pick "Check if email is set when dismissing prompt"

### DIFF
--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -92,7 +92,7 @@ const alternateLoginEmail: A.Reducer<string | null> = (
 ) => {
   switch (action.type) {
     case 'SHOW_ALTERNATE_LOGIN_PROMPT':
-      return atob(action.email);
+      return action.email ? atob(action.email) : null;
     case 'HIDE_ALTERNATE_LOGIN_PROMPT':
       return null;
     default:


### PR DESCRIPTION
This is a cherry-pick of #2735, which landed in 2.7.1, into 2.8.0.

Once this is merged we should:

- open a new PR to merge 2.8.0 into `develop` to get the fix there, too
- potentially ship a new beta for 2.8.0