### PR TITLE
Fix adding note from trash so it takes you back to All Notes

### DIFF
--- a/lib/menu-bar/index.tsx
+++ b/lib/menu-bar/index.tsx
@@ -69,7 +69,6 @@ export const MenuBar: FunctionComponent<Props> = ({
       />
       <div className="notes-title">{placeholder}</div>
       <IconButton
-        disabled={collection.type === 'trash'}
         icon={<NewNoteIcon />}
         onClick={() => onNewNote(withoutTags(searchQuery))}
         title={`New Note • ${CmdOrCtrl}+Shift+I`}

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -105,6 +105,12 @@ const collection: A.Reducer<T.Collection> = (
   action
 ) => {
   switch (action.type) {
+    case 'CREATE_NOTE_WITH_ID': {
+      if (state.type === 'trash') {
+        return { type: 'all' };
+      }
+      return state;
+    }
     case 'OPEN_TAG':
       return { type: 'tag', tagName: action.tagName };
     case 'SELECT_TRASH':


### PR DESCRIPTION
### Fix

Fixes #2743 which was a regression.

This enables the new note button when in the trash and ensures you are switched to the All Notes view when creating a new note from the trash.

### Test

1. Open trash.
2. Ensure you can click the new note button.
3. Ensure when you create the new note it takes you to the All Note view.

### Release

- Fixes a regression allowing the adding of a new note from the trash view.
