### PR TITLE
Brute force the position of the delete tag indictor cross icon

### DIFF
--- a/lib/components/tag-chip/style.scss
+++ b/lib/components/tag-chip/style.scss
@@ -35,6 +35,9 @@
     .icon-cross-small {
       height: 14px;
       width: 14px;
+      position: absolute;
+      left: 1px;
+      top: 1px;
     }
   }
 }


### PR DESCRIPTION
### Fix

Fixes #2744

The delete tag cross indicator was not positioned properly on Windows.
This corrects the positioning.

Before:
![Screen Shot 2021-03-18 at 11 04 54 AM](https://user-images.githubusercontent.com/1326294/111639309-e7b53e80-87d9-11eb-92e1-fde09a7857cb.png)

After:
![Screen Shot 2021-03-18 at 11 05 20 AM](https://user-images.githubusercontent.com/1326294/111639336-ec79f280-87d9-11eb-8f7f-7787b6cee767.png)


### Test

1. Smoke test on windows and other apps.
2. Hover over a tag in the tag input field. 
3. Ensure the cross icon is centered in the circle.

### Release

- Fixes the positioning of the delete tag indicator cross icon on Windows.
