### PR TITLE
Fixing tooltip so it leaves properly for disabled buttons

### DIFF
--- a/lib/icon-button/style.scss
+++ b/lib/icon-button/style.scss
@@ -9,6 +9,7 @@
 
   &:disabled {
     opacity: 0.4;
+    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
### Fix

Fixes #2745 

Currently, when a button is disabled the tooltip isn't dismissed properly in Chrome. This fixes that so it is dismissed as expected.

### Test

1. Test in Chrome.
2. Visit a note with no revisions
3. Hover over the History button in the note toolbar. 
4. Ensure when you leave the button the tooltip dismisses.

### Release

- Fix dismissing the tooltip for disabled buttons. 