### PR TITLE
Fixing an overflow issue where scrollbars were always shown on electron tag list

### DIFF
--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -143,3 +143,8 @@ input.tag-list-input {
     }
   }
 }
+
+.is-electron .tag-list-items {
+  padding-bottom: 2px;
+  padding-top: 2px;
+}


### PR DESCRIPTION
### Fix

In the Electron app, the tag list was constantly showing a vertical scrollbar even when none was needed. 
This works to resolve that so the scroll doesn't appear until the list is too long. 

### Test

1. View in Electron App.
2. Have only one tag added.
3. View the list of tags.
4. Ensure there is no vertical scroll.
5. Add more tags ensuring scrollbars appear once tags fill the space in the list.

### Release

- Fix to only show scrollbars on the tag list when needed.
