### PR TITLE
Fix support email link in new account creation flow

### DIFF
--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -100,7 +100,15 @@ export class Auth extends Component<Props> {
             </p>
             <p className="accountRequested__footer theme-color-fg-dim">
               Didn&apos;t get an email? You may already have an account. Contact{' '}
-              <a href="mailto:support@simplenote.com">support@simplenote.com</a>{' '}
+              <a
+                onClick={(event) => {
+                  event.preventDefault();
+                  viewExternalUrl('mailto:support@simplenote.com');
+                }}
+                href="mailto:support@simplenote.com"
+              >
+                support@simplenote.com
+              </a>{' '}
               for help.
             </p>
             <button


### PR DESCRIPTION
### Fix

When creating a new account the link to the support email would not work. This resolves #2749 where it was reported.

### Test

1. Open the App and log out if logged in.
2. Click to sign up for a new account
3. Enter email address
4. Click the support email link on the next screen.
5. Ensure it opens your default mail client to send the email.

### Release

- Fix a bug where the support email link in the new account creation flow did not work.
