### PR TITLE
Explicitly treat encoded files as binaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Explicitly treat .enc files as binaries to prevent GitHub from occasionally
+# reporting changes to these files as "empty" instead of saying "binary file
+# not shown"
+*.enc binary


### PR DESCRIPTION
This builds off https://github.com/Automattic/simplenote-electron/pull/2719, which I originally discarded because it referenced a folder that's not used by this project.

@codebykat pointed out that we do use encrypted files in this project, so I replicated the change.

I originally considered restricting this to `resources/secrets/` but decided to use a more wider patter to be future proof.

### Test
No test required, this is just a Git config and we've verified it in other repos. Still, you can see it in action [here](https://github.com/Automattic/simplenote-electron/commit/c21419ab31284bcdc2eb5a9b94cabac498d2f892) (even though it behaves werdly there 🤔 )

### Release

Not changelog update required.