### PR TITLE
Autofocus delete tag button in when dialog opens

### DIFF
--- a/lib/dialogs/trash-tag-confirmation/index.tsx
+++ b/lib/dialogs/trash-tag-confirmation/index.tsx
@@ -34,6 +34,7 @@ const TrashTagConfirmation: FunctionComponent<Props> = ({
     </div>
     <div className="dialog-buttons">
       <button
+        autoFocus
         className="button-primary delete-tag"
         onClick={() => trashTag(tagName)}
       >


### PR DESCRIPTION
### Fix

This fixes #2757 
Currently when deleting a tag you need to edit the tag list, then click the trash icon next to the tag, then move over and click the delete tag button.
This puts focus on the delete tag button when the dialog is opened and allows you to hit return/enter on the keyboard to confirm the deletion.

### Test

1. Choose to delete a tag.
2. When the confirmation dialog opens press return/enter on the keyboard.
3. Ensure tag deletes and the confirmation dialog closes. 

### Release

- Autofocus the delete tag button when the confirmation dialog is opened.
