### PR TITLE
Fix some styling issues on the unsynchronized notes dialog

### DIFF
--- a/lib/dialogs/unsynchronized/style.scss
+++ b/lib/dialogs/unsynchronized/style.scss
@@ -8,7 +8,6 @@
   .dialog-title-text {
     font-size: 16px;
     font-weight: 600;
-    padding-left: 16px;
     text-align: left;
   }
 
@@ -42,10 +41,15 @@
     li {
       display: flex;
       padding: 4px 0;
+      align-items: center;
     }
 
     li span {
-      padding-left: 17px;
+      padding-left: 5px;
+      padding-right: 16px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
 
     .icon-attention {


### PR DESCRIPTION
### Fix

Currently, in the unsynchronized notes dialog, there are a few styling issues.
- The title bar was too far to the right.
- Long note titles which were unsynchronized would break out of the dialog.
- Unsynchronized note titles were not centered properly.

This PR addresses all of them and Resolves #2758 and Resolves #2759

### Test

1. Make sure there is no connection with the server
2. Create a note with a long title, containing no spaces
3. Try closing the app or logging out
4. Ensure the title of the dialog aligns with the rest of the dialog content
5. Ensure the long file name doesn't break out of the dialog
6. Ensure the file names are vertically centered. 

### Release

- Fixes some styling issues with the unsynchronized note warning dialog.
