### PR TITLE
Fix offline badge position in electron

### DIFF
--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -14,7 +14,7 @@
   font-size: 12px;
   height: 24px;
   line-height: 24px;
-  margin-top: 16px;
+  margin-top: 10px;
   text-align: center;
   width: 64px;
 }

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -19,7 +19,7 @@
   width: 64px;
 }
 
-.is-electron .note-toolbar-wrapper .offline-badge {
+.is-electron.is-macos .note-toolbar-wrapper .offline-badge {
   margin-top: -11px;
 }
 


### PR DESCRIPTION
### Fix

Currently in the Windows and Linux Electron builds the offline badge which appears in the note toolbar is not aligned properly.

This PR resolves #2761 by fixing the styling.

### Test

1. In an Electron build on Linux or Windows
2. Go Offline
3. Ensure badge appears properly and is not cut off.

### Release

- Fix position of Offline badge indicator in Electron builds. 
