### PR TITLE
Update placeholder when selected tag is renamed

### DIFF
--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -107,6 +107,12 @@ const collection: A.Reducer<T.Collection> = (
   switch (action.type) {
     case 'OPEN_TAG':
       return { type: 'tag', tagName: action.tagName };
+    case 'RENAME_TAG': {
+      if (state.type === 'tag' && state.tagName === action.oldTagName) {
+        return { type: 'tag', tagName: action.newTagName };
+      }
+      return state;
+    }
     case 'SELECT_TRASH':
       return { type: 'trash' };
     case 'SHOW_ALL_NOTES':


### PR DESCRIPTION
### Fix

Currently, if you select a tag and then rename it the placeholder and menu bar title does not change to reflect the renamed tag.
Fixes #2770

### Test

1. Select a tag.
2. Rename the tag.
3. Ensure the menubar title updates to reflect the renamed tag.

### Release

- Fixes issue when you rename a selected tag, the menubar title is updated to reflect the new tag name.
