### PR TITLE
Update the expanded note list preview to be three lines instead of four

### DIFF
--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -44,7 +44,7 @@
 
   .expanded .note-list-item-excerpt {
     white-space: normal;
-    max-height: 88px;
+    max-height: 63px;
   }
 
   &.is-empty {

--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -42,7 +42,7 @@ export const getTitle = (content) => {
  * Generate preview for note list
  *
  * Should gather the first non-whitespace content
- * for up to four lines and up to 200 characters
+ * for up to three lines and up to 200 characters
  *
  * @param content
  */

--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -79,14 +79,14 @@ const getPreview = (content: string, searchQuery?: string) => {
     }
   }
 
-  // implicit else: if the query didn't match, fall back to first four lines
+  // implicit else: if the query didn't match, fall back to first three lines
   let index = content.indexOf('\n');
 
   if (index === -1) {
     return '';
   }
 
-  while (index > -1 && lines < 4) {
+  while (index > -1 && lines < 3) {
     const nextNewline = content.indexOf('\n', index);
     if (-1 === nextNewline) {
       return preview + content.slice(index).trim();


### PR DESCRIPTION
### Fix

This will take care of one of the remaining tasks on issue #2560.
Currently, we display 4 lines of a note in the note list preview when the display is set to be expanded. The new designs call for 3 lines instead. This updates that.

### Test

1. Have at least one note with more than four lines of content after the title.
2. Set the note display to be expanded.
3. Ensure the note list preview shows only three lines of the note.

### Release

- Updates the number of lines in the note preview to be three lines in expanded display.