### PR TITLE
Only show tags heading in navigation if there is at least one tag

### DIFF
--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -98,16 +98,18 @@ export class NavigationBar extends Component<Props> {
           />
         </div>
         <div className="navigation-bar__tags theme-color-border">
-          <TagList />
           {(tagCount && (
-            <div className="navigation-bar__folders navigation-bar__untagged theme-color-border">
-              <NavigationBarItem
-                icon={<UntaggedNotesIcon />}
-                isSelected={this.isSelected({ selectedRow: 'untagged' })}
-                label="Untagged Notes"
-                onClick={onShowUntaggedNotes}
-              />
-            </div>
+            <>
+              <TagList />
+              <div className="navigation-bar__folders navigation-bar__untagged theme-color-border">
+                <NavigationBarItem
+                  icon={<UntaggedNotesIcon />}
+                  isSelected={this.isSelected({ selectedRow: 'untagged' })}
+                  label="Untagged Notes"
+                  onClick={onShowUntaggedNotes}
+                />
+              </div>
+            </>
           )) ||
             null}
         </div>

--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import onClickOutside from 'react-onclickoutside';
 
 import ConnectionStatus from '../connection-status';
+import isEmailTag from '../utils/is-email-tag';
 import NavigationBarItem from './item';
 import TagList from '../tag-list';
 import NotesIcon from '../icons/notes';
@@ -20,7 +21,7 @@ type StateProps = {
   collection: T.Collection;
   isDialogOpen: boolean;
   showNavigation: boolean;
-  tagCount: number;
+  tags: Map<T.TagHash, T.Tag>;
 };
 
 type DispatchProps = {
@@ -73,8 +74,11 @@ export class NavigationBar extends Component<Props> {
       onSettings,
       onShowAllNotes,
       onShowUntaggedNotes,
-      tagCount,
+      tags,
     } = this.props;
+    const tagCount = Array.from(tags).filter(
+      ([_, { name }]) => !isEmailTag(name)
+    ).length;
 
     return (
       <div className="navigation-bar theme-color-bg theme-color-fg theme-color-border">
@@ -158,7 +162,7 @@ const mapStateToProps: S.MapState<StateProps> = ({
   collection,
   isDialogOpen: dialogs.length > 0,
   showNavigation,
-  tagCount: data.tags.size,
+  tags: data.tags,
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {


### PR DESCRIPTION
### Fix
This resolves #2722

In the other Simplenote apps the Tag heading only appears if there is at least one tag. Currently, we display it regardless if there are tags or not. This PR updates to match the other apps.

**Screenshots**

**Before:**
<img width="846" alt="Screen Shot 2021-03-18 at 2 34 23 PM" src="https://user-images.githubusercontent.com/1326294/111670864-17267400-87f7-11eb-8a75-e88b14e74380.png">
<img width="845" alt="Screen Shot 2021-03-18 at 2 34 08 PM" src="https://user-images.githubusercontent.com/1326294/111670867-17bf0a80-87f7-11eb-86b1-908567db4e93.png">


**After:**
<img width="854" alt="Screen Shot 2021-03-18 at 2 31 54 PM" src="https://user-images.githubusercontent.com/1326294/111670694-e0e8f480-87f6-11eb-98c5-1d2308d03dfc.png">
<img width="852" alt="Screen Shot 2021-03-18 at 2 31 34 PM" src="https://user-images.githubusercontent.com/1326294/111670695-e21a2180-87f6-11eb-829d-1748bf50268e.png">


### Test

1. Delete all tags.
2. Ensure the Tags heading does not appear in the left navigation menu.
3. Add at least one tag.
4. Ensure the Tags heading does now appear.
5. Test with and without having collaborators added to a note.

### Release

- Removes the tag heading from the navigation menu when there are no tags.