### PR TITLE
Updating the styles for the search UI and highlighting

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1129,6 +1129,28 @@ class NoteContentEditor extends Component<Props> {
     this.editor.setSelection(range);
     this.editor.revealLineInCenter(range.startLineNumber);
     this.focusEditor();
+
+    const newDecorations = [];
+    this.matchesInNote.forEach((match) => {
+      let decoration = {};
+      if (match.range === range) {
+        decoration = {
+          range: match.range,
+          options: { inlineClassName: 'selected-search' },
+        };
+      } else {
+        decoration = {
+          range: match.range,
+          options: { inlineClassName: 'search-decoration' },
+        };
+      }
+      newDecorations.push(decoration);
+    });
+
+    this.decorations = this.editor.deltaDecorations(
+      this.decorations,
+      newDecorations
+    );
   };
 
   render() {

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -58,6 +58,14 @@
     justify-content: center;
     height: 100vh;
   }
+
+  .search-match {
+    background-color: transparent;
+    color: $studio-simplenote-blue-50;
+    padding-left: 0;
+    padding-right: 0;
+    border-radius: 0;
+  }
 }
 
 .note-list-placeholder {
@@ -95,6 +103,10 @@
       color: $studio-simplenote-blue-30;
     }
   }
+
+  .note-list .search-match {
+    color: $studio-simplenote-blue-30;
+  }
 }
 
 .note-list-items {
@@ -120,15 +132,13 @@
   font-size: 14px;
   font-weight: 500;
   line-height: normal;
-  color: $studio-gray-70;
-  background: rgba($studio-gray-5, 0.5);
-  padding: 5px 30px;
+  color: $studio-gray-50;
+  padding: 5px 16px;
 }
 
 .note-list-item {
   cursor: pointer;
   display: flex;
-  padding-left: 8px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   font-family: 'Simplenote Tasks', $sans, sans-serif;
   min-height: 64px;
@@ -140,13 +150,16 @@
 
   .note-list-item-status {
     display: flex;
-    padding: 12px 8px 0 0;
+    padding: 12px 0 0 0;
+    width: 28px;
+    flex-shrink: 0;
   }
 
   .note-list-item-pinner {
     color: transparent;
     height: 16px;
     width: 16px;
+    margin: 0 auto;
 
     svg {
       vertical-align: top;

--- a/lib/search-field/style.scss
+++ b/lib/search-field/style.scss
@@ -21,7 +21,10 @@
   }
 
   .icon-button {
+    align-items: center;
+    display: flex;
     flex: 0 0 auto;
+    justify-content: center;
   }
 
   .icon-cross-small {

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -42,7 +42,7 @@ export class TagSuggestions extends Component<Props> {
         {filteredTags.length > 0 && (
           <div className="tag-suggestions">
             <div className="note-list-header">Search by Tag</div>
-            <ul className="tag-suggestions-list">
+            <ul className="tag-suggestions-list theme-color-border">
               {filteredTags.map((tagId) => (
                 <li
                   key={tagId}

--- a/lib/tag-suggestions/style.scss
+++ b/lib/tag-suggestions/style.scss
@@ -5,6 +5,7 @@
     list-style-type: none;
     padding: 0;
     margin: 0;
+    border-bottom: 1px solid;
 
     .tag-suggestion-row {
       height: 36px;
@@ -16,9 +17,7 @@
 
     .tag-suggestion {
       font-size: 16px;
-      margin-left: 30px;
-      border-bottom-style: solid;
-      border-bottom-width: 1px;
+      margin-left: 28px;
       overflow-x: hidden;
       text-overflow: ellipsis;
     }

--- a/lib/utils/note-utils.ts
+++ b/lib/utils/note-utils.ts
@@ -69,8 +69,13 @@ const getPreview = (content: string, searchQuery?: string) => {
       );
       const matches = regExp.exec(content);
       if (matches && matches.length > 0) {
-        preview = matches[0];
-
+        // Remove blank lines and note title from the search note preview
+        preview = matches[0]
+          .split('\n')
+          .filter(
+            (line) => line !== '\r' && line !== '' && line !== getTitle(content)
+          )
+          .join('\n');
         // don't return half of a surrogate pair
         return isLowSurrogate(preview.charCodeAt(0))
           ? preview.slice(1)

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -108,16 +108,17 @@ optgroup {
 }
 
 .search-match {
-  background-color: $studio-simplenote-blue-50;
+  background-color: $studio-simplenote-blue-5;
   border-radius: 3px;
   padding-left: 2px;
   padding-right: 2px;
-  color: $studio-white;
 
   &[data-current-match='true'] {
     background-color: $studio-yellow-60;
   }
 }
-.theme-dark .note-list-item-selected .search-match {
-  background-color: $studio-simplenote-blue-20;
+
+.theme-dark .search-match {
+  background-color: rgba($studio-simplenote-blue-50, 0.4);
+  color: $studio-white;
 }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -91,7 +91,11 @@ span[dir='ltr'] {
     border: 3px solid gray;
   }
   .search-decoration {
-    background-color: rgba($studio-simplenote-blue-40, 0.6);
+    background-color: $studio-simplenote-blue-5;
+  }
+  .selected-search {
+    background-color: $studio-yellow-20;
+    padding: 2px 0;
   }
 }
 
@@ -253,13 +257,20 @@ span[dir='ltr'] {
     }
   }
 
+  .search-decoration {
+    background-color: $studio-simplenote-blue-50;
+  }
+  .selected-search {
+    background-color: $studio-yellow-30;
+    color: $studio-gray-90;
+  }
+
   .settings-group p {
     color: $studio-gray-5;
   }
 
   .note-list-header {
     color: $studio-gray-30;
-    background-color: rgba(50, 52, 54, 0.5);
   }
 
   .note-list {


### PR DESCRIPTION
### Fix

This PR updates the styles of the search UI and search highlighting to match the new designs. These are the areas it updates:

- Fix the note list search preview to not show empty note lines and not show the note title twice.
- Fixes the search highlighting styles and better differentiates the currently selected search match in the visible note.
- Update the styles of the search tag and note headings and note previews.

Resolves #2562

**Screenshots**

**Before:**
<img width="814" alt="Screen Shot 2021-03-19 at 10 42 48 AM" src="https://user-images.githubusercontent.com/1326294/111789431-e5b5b300-889f-11eb-9ef8-036eb2df1653.png">
<img width="819" alt="Screen Shot 2021-03-19 at 10 43 00 AM" src="https://user-images.githubusercontent.com/1326294/111789446-e8180d00-889f-11eb-90b6-cae6dd5be582.png">


**After:**
<img width="776" alt="Screen Shot 2021-03-19 at 10 41 20 AM" src="https://user-images.githubusercontent.com/1326294/111789254-b0a96080-889f-11eb-90f7-a7bc3dd04688.png">
<img width="784" alt="Screen Shot 2021-03-29 at 8 56 23 AM" src="https://user-images.githubusercontent.com/1326294/112833165-b99eec80-906c-11eb-95da-959f8ffc2317.png">


### Test

1. Smoke test in light and dark mode.
2. Search for different terms and ensure styling matches.
3. Ensure note title is not showing twice in the note list for search results.
4. Ensure empty lines do not appear in the note list for search results.

### Release

- Update the styling of the search UI including the search highlighting.
