### PR TITLE
Make Focus Mode toggle action's name consistent

### DIFF
--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -80,7 +80,7 @@ export class NoteToolbar extends Component<Props> {
             <IconButton
               icon={<SidebarIcon />}
               onClick={this.props.toggleFocusMode}
-              title="Toggle Sidebar"
+              title="Toggle Focus Mode"
             />
           </div>
           <div className="note-toolbar__button note-toolbar-back">


### PR DESCRIPTION
### Fix
<!--
**_(Required)_** Add a concise description of what you fixed. If this is related 
to an issue, add a link to it. If applicable, add screenshots, animations, or
videos to help illustrate the fix.
-->
Fixes https://github.com/Automattic/simplenote-electron/issues/2764

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1. Start the app
1. Go to View > Focus Mode => sidebar's visibility is toggled
1. Click on the Toggle Sidebar toolbar icon => sidebar's visibility is toggled, now the tooltip is `Focus Mode` for consistency

### Release

<!--
**_(Required)_** If the changes should be included in release notes, add a
concise statement below describing the change. For example:
Fixed crash that occurred when opening the navigation sidebar.
-->
Makes Focus Mode/Toggle Sidebar naming consistent