### PR TITLE
Fix padding on unsynced notes warning dialog

### DIFF
--- a/lib/dialogs/unsynchronized/style.scss
+++ b/lib/dialogs/unsynchronized/style.scss
@@ -22,6 +22,7 @@
     font-size: 14px;
     margin: 12px 0;
     padding-left: 16px;
+    padding-right: 16px;
   }
 
   .explanation-secondary {


### PR DESCRIPTION
### Fix

Related to #2776 this still was not fully fixed on Windows. The main warning content would get too close to the right edge of the dialog. This addresses that.

**Before**
<img width="370" alt="Screenshot 2021-03-22 at 16 15 15" src="https://user-images.githubusercontent.com/73365754/112003821-ea8d9780-8b29-11eb-9e69-8b15bb275967.png">

**After**
![Screen Shot 2021-03-29 at 9 16 06 AM](https://user-images.githubusercontent.com/1326294/112835482-b35e3f80-906f-11eb-9d9b-5ea9d75f93a3.png)


### Test

1. Make sure there is no connection with the server
2. Create a note with a long title, containing no spaces
3. Try closing the app
4. Ensure the error message has proper spacing on the right edge

### Release

- Fix spacing on unsynced notes warning message. 