### PR TITLE
Fix: Add max height to dialog's content to prevent cut off

### DIFF
--- a/lib/dialog/style.scss
+++ b/lib/dialog/style.scss
@@ -1,15 +1,23 @@
+$dialog-max-height: 420px;
+$dialog-title-height: 56px;
+
 .dialog {
   display: flex;
   flex-direction: column;
   width: calc(100vw - 2rem);
   background: white;
   border-radius: 8px;
+  max-height: $dialog-max-height;
+
+  @media only screen and (max-height: $dialog-max-height) {
+    max-height: calc(100vh - 2rem);
+  }
 }
 
 .dialog-title-bar {
   display: flex;
   border-bottom: 1px solid $studio-gray-5;
-  height: 56px;
+  height: $dialog-title-height;
 
   .button {
     border: 0;
@@ -39,7 +47,12 @@
   display: flex;
   flex-direction: column;
   flex: 1 0 auto;
-  max-height: calc(100vh - 56px - 20px);
+  max-height: $dialog-max-height - $dialog-title-height;
+  overflow: auto;
+
+  @media only screen and (max-height: $dialog-max-height) {
+    max-height: calc(100vh - 2rem - #{$dialog-title-height});
+  }
 }
 
 .dialog-actions {

--- a/lib/dialog/style.scss
+++ b/lib/dialog/style.scss
@@ -39,6 +39,7 @@
   display: flex;
   flex-direction: column;
   flex: 1 0 auto;
+  max-height: calc(100vh - 56px - 20px);
 }
 
 .dialog-actions {


### PR DESCRIPTION
### Fix
<!--
**_(Required)_** Add a concise description of what you fixed. If this is related 
to an issue, add a link to it. If applicable, add screenshots, animations, or
videos to help illustrate the fix.
-->
Fixes: https://github.com/Automattic/simplenote-electron/issues/2750

If a dialog overflows the height of the window, the content of the dialog is cut off.

https://user-images.githubusercontent.com/14905380/113024622-40e08300-9187-11eb-9ecd-99201374fa6c.mp4

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1. Click the Menu button.
2. Click the "Keyboard Shortcuts" button.
3. Zoom in the window a couple of times (can be done via `View/Zoom In`).
4. Decrease the height of the browser window until it's smaller than the dialog height.
5. Observe that the dialog's content is not cut off and can be scrolled.

### Release

<!--
**_(Required)_** If the changes should be included in release notes, add a
concise statement below describing the change. For example:
Fixed crash that occurred when opening the navigation sidebar.
-->
Fixed cut off issue for dialogs when the window is too small.