### PR TITLE
Fix: Add overflow to changes list section of unsynchronized confirmation dialog

### DIFF
--- a/lib/dialogs/unsynchronized/style.scss
+++ b/lib/dialogs/unsynchronized/style.scss
@@ -31,6 +31,7 @@
   .change-list {
     border-bottom: 1px solid $studio-gray-5;
     border-top: 1px solid $studio-gray-5;
+    overflow-y: auto;
 
     ul {
       list-style: none;


### PR DESCRIPTION
### Fix
<!--
**_(Required)_** Add a concise description of what you fixed. If this is related 
to an issue, add a link to it. If applicable, add screenshots, animations, or
videos to help illustrate the fix.
-->

Fixes https://github.com/Automattic/simplenote-electron/issues/2716

This PR adds overflow to the changes list section of the unsynchronized confirmation dialog, this will enable scroll if the list is too long while keeping the action buttons visible.

https://user-images.githubusercontent.com/14905380/112972237-571f1c80-9150-11eb-8d72-206f794bcfce.mp4

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1.  Go offline to prevent saving notes.
2. Create 10 or more notes.
3. Make the window height as small as possible.
4. Exit the application.
5. Observe that the unsynchronized confirmation dialog displays all the content and that the changes list is scrollable.

### Release

<!--
**_(Required)_** If the changes should be included in release notes, add a
concise statement below describing the change. For example:
Fixed crash that occurred when opening the navigation sidebar.
-->
N/A