### PR TITLE
Fix: Normalize line break when exporting notes

### DIFF
--- a/lib/utils/export/export-notes.ts
+++ b/lib/utils/export/export-notes.ts
@@ -1,11 +1,10 @@
 import { partition, sortBy } from 'lodash';
 
+import normalizeLineBreak from './normalize-line-break';
 import isEmailTag from '../is-email-tag';
 
 import * as T from '../../types';
 import { ExportNote } from './types';
-
-export const LF_ONLY_NEWLINES = /(?!\r)\n/g;
 
 const exportNotes = (notes: Map<T.EntityId, T.Note>) => {
   const activeNotes: ExportNote[] = [];
@@ -19,7 +18,7 @@ const exportNotes = (notes: Map<T.EntityId, T.Note>) => {
     const parsedNote = Object.assign(
       {
         id,
-        content: note.content.replace(LF_ONLY_NEWLINES, '\r\n'),
+        content: normalizeLineBreak(note.content),
         creationDate: new Date(note.creationDate * 1000).toISOString(),
         lastModified: new Date(note.modificationDate * 1000).toISOString(),
       },

--- a/lib/utils/export/normalize-line-break.ts
+++ b/lib/utils/export/normalize-line-break.ts
@@ -1,0 +1,8 @@
+/**
+ * Normalize line break characters to CRLF
+ * @param content string Content to normalize
+ */
+const normalizeLineBreak = (content: string) =>
+  content.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n');
+
+export default normalizeLineBreak;

--- a/lib/utils/export/test/normalize-line-breaks.ts
+++ b/lib/utils/export/test/normalize-line-breaks.ts
@@ -1,0 +1,11 @@
+import normalizeLineBreak from '../normalize-line-break';
+
+describe('Normalize line break', () => {
+  const text = 'Line 1\nLine 2\r\nLine 3\n\r\nLine 5\r\n\nLine 5';
+  const normalizedText =
+    'Line 1\r\nLine 2\r\nLine 3\r\n\r\nLine 5\r\n\r\nLine 5';
+
+  it('should convert LF to CRLF', () => {
+    expect(normalizeLineBreak(text)).toBe(normalizedText);
+  });
+});

--- a/lib/utils/export/to-zip.ts
+++ b/lib/utils/export/to-zip.ts
@@ -1,7 +1,7 @@
 import sanitize from 'sanitize-filename';
 import { identity } from 'lodash';
 
-import { LF_ONLY_NEWLINES } from './export-notes';
+import normalizeLineBreak from './normalize-line-break';
 
 const FILENAME_LENGTH = 40;
 const TAG_LINE_LENGTH = 75;
@@ -100,7 +100,7 @@ export const noteExportToZip = (notes) => {
 
       zip.file(
         'source/notes.json',
-        JSON.stringify(notes, null, 2).replace(LF_ONLY_NEWLINES, '\r\n')
+        normalizeLineBreak(JSON.stringify(notes, null, 2))
       );
 
       notes.activeNotes


### PR DESCRIPTION
### Fix
<!--
**_(Required)_** Add a concise description of what you fixed. If this is related 
to an issue, add a link to it. If applicable, add screenshots, animations, or
videos to help illustrate the fix.
-->

Fixes https://github.com/Automattic/simplenote-electron/issues/2646


## Context
Depending on the platform (Windows/MacOS), the monaco editor uses a different default line break (EOL) ([check documentation](https://microsoft.github.io/monaco-editor/api/enums/monaco.editor.defaultendofline.html)). I did some tests creating notes on Windows/MacOS and I verified that notes have a different line break.

This shouldn't be a problem but I realised that for notes created on Windows, when they're exported the line breaks are not properly transformed, here is an example with a couple of notes, each one created in a different platform:

**MacOS:**
<img width="119" alt="Screenshot 2021-03-31 at 19 42 42" src="https://user-images.githubusercontent.com/14905380/113187554-47d7c600-9259-11eb-931a-022b364f1c62.png">
```
original text: "MacOS\nLine 1\nLine 2\n\nLine 3"
exported text: "MacOS\r\nLine 1\r\nLine 2\r\n\r\nLine 3"
```

**Windows:**
<img width="148" alt="Screenshot 2021-03-31 at 19 42 37" src="https://user-images.githubusercontent.com/14905380/113187583-4f976a80-9259-11eb-9df7-c26ee9eb8444.png">
```
original text: "Windows\r\nLine 1\r\nLine 2\r\n\r\nLine 3"
exported text: "Windows\r\r\nLine 1\r\r\nLine 2\r\r\n\r\r\nLine 3"
```

As you can see in the Windows example, the `\r\n` sequence is transformed to `\r\r\n` which can lead to issues depending on how the app interprets the `\r` char. Here are some examples on how different apps on Windows handle this case:
<img src=https://user-images.githubusercontent.com/40906847/107325466-bebbd280-6ae4-11eb-9b9b-1d399a8b1cdb.png>

## Solution

My approach has been to create a normalize function that first converts all `\r\n` into `\n` chars and then does a second pass and converts all `\n` into `\r\n`. This way we keep all the exported notes with CRLF line break format.

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1. Create a note with the single line break and double line breaks on the Windows Electron app
2. Export the note through File > Export Notes...
3. Create a note with the single line break and double line breaks on the MacOS Electron app
4. Export the note through File > Export Notes...
5. Check the `source/notes.json` file from the ZIP files (exported notes) and verify that the content of all notes have CRLF line break (`\r\n`)
6. On Windows, extract the notes and open up the .txt file with Notepad
7. Observe that no extra line breaks can be seen on Notepad
8. Open up the same .txt file with WordPad, observe that no line break show up on the note
9. Open the same .txt file with Notepad++ (or a text editor that shows hidden characters), observe that there are only CRLF line breaks

### Release

<!--
**_(Required)_** If the changes should be included in release notes, add a
concise statement below describing the change. For example:
Fixed crash that occurred when opening the navigation sidebar.
-->
Fixed extra line breaks issue when exporting notes