### PR TITLE
Fix: extra blank space rendering in note preview component

### DIFF
--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -170,12 +170,10 @@ export const NotePreview: FunctionComponent<Props> = ({
       <div className="note-detail note-detail-preview">
         <div
           ref={previewNode}
-          className="note-detail-markdown theme-color-bg theme-color-fg"
+          className="note-detail-markdown theme-color-bg theme-color-fg note-preview"
           data-markdown-root
         >
-          <div style={{ whiteSpace: 'pre' }}>
-            {!showRenderedView && withCheckboxCharacters(note?.content ?? '')}
-          </div>
+          {!showRenderedView && withCheckboxCharacters(note?.content ?? '')}
         </div>
       </div>
     </div>

--- a/lib/components/note-preview/style.scss
+++ b/lib/components/note-preview/style.scss
@@ -1,3 +1,3 @@
 .note-preview {
-  white-space: pre;
+  white-space: pre-wrap;
 }

--- a/lib/components/note-preview/style.scss
+++ b/lib/components/note-preview/style.scss
@@ -1,0 +1,3 @@
+.note-preview {
+  white-space: pre;
+}

--- a/scss/_components.scss
+++ b/scss/_components.scss
@@ -10,6 +10,7 @@
 @import 'components/tag-chip/style';
 @import 'components/transition-delay-enter/style';
 @import 'components/transition-fade-in-out/style';
+@import 'components/note-preview/style';
 @import 'controls/checkbox/style';
 @import 'controls/toggle/style';
 @import 'dialog/style';


### PR DESCRIPTION
### Fix
<!--
**_(Required)_** Add a concise description of what you fixed. If this is related 
to an issue, add a link to it. If applicable, add screenshots, animations, or
videos to help illustrate the fix.
-->

Fixes https://github.com/Automattic/simplenote-electron/issues/2828

For rendering extra blank spaces properly in the `note-preview` component, the `div` used for rendering the note requires the CSS property `white-space` to be set to `pre`. This was already done in a [wrapper `div`](https://github.com/Automattic/simplenote-electron/blob/491bd8a9b91f319a861b554219747cdfecba5f2a/lib/components/note-preview/index.tsx#L176) but it was being removed from DOM due to [this effect](https://github.com/Automattic/simplenote-electron/blob/491bd8a9b91f319a861b554219747cdfecba5f2a/lib/components/note-preview/index.tsx#L162:L164).

To solve this, I created a new class for `note-preview` component that contains `white-space: pre-wrap` and is set to the parent `div`. Note that I'm using `pre-wrap` value because otherwise the content is not properly wrapped.

https://user-images.githubusercontent.com/14905380/113896684-765e1f80-97ca-11eb-8edd-76984391c605.mp4

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1. Open a note
2. Add text
3. Indent some lines and/or add more than one space between words
4. Click on history button
5. Observe that extra blank spaces are properly displayed

### Release

<!--
**_(Required)_** If the changes should be included in release notes, add a
concise statement below describing the change. For example:
Fixed crash that occurred when opening the navigation sidebar.
-->
Fixed displaying extra blank spaces in history screen