### PR TITLE
Fix: Remove fixed height from tab panels

### DIFF
--- a/lib/components/tab-panels/style.scss
+++ b/lib/components/tab-panels/style.scss
@@ -35,7 +35,6 @@
 }
 
 .tab-panels__panel {
-  height: 30.5em;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
### Fix
<!--
**_(Required)_** Add a concise description of what you fixed. If this is related 
to an issue, add a link to it. If applicable, add screenshots, animations, or
videos to help illustrate the fix.
-->

When navigating to `Settings/Display` the content was displaying two scroll bars, one set by the dialog content (introduced in this recent [PR](https://github.com/Automattic/simplenote-electron/pull/2815)) and the other by the tab panels component due to having a fixed height.

Since the dialog component is already setting a max height, we don't really need to specify a fixed height in the tab panels so I removed that CSS propery.

Before|After
--|--
<img width="660" alt="Screenshot 2021-04-09 at 16 41 17" src="https://user-images.githubusercontent.com/14905380/114197272-76892700-9952-11eb-95fe-f6b1ec8ad402.png">|<img width="649" alt="Screenshot 2021-04-09 at 16 41 28" src="https://user-images.githubusercontent.com/14905380/114197279-7852ea80-9952-11eb-9951-f421c9116d4d.png">


### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1. Go to Settings
2. Click on Display
3. Observe that the content can be scrolled and that there's only one scroll bar

### Release

<!--
**_(Required)_** If the changes should be included in release notes, add a
concise statement below describing the change. For example:
Fixed crash that occurred when opening the navigation sidebar.
-->
N/A