### PR TITLE
Add: Standard checkbox style

### DIFF
--- a/lib/controls/checkbox/index.tsx
+++ b/lib/controls/checkbox/index.tsx
@@ -4,11 +4,17 @@ import classNames from 'classnames';
 type OwnProps = React.HTMLProps<HTMLInputElement> & {
   className?: string;
   onChange: () => any;
+  isStandard: boolean;
 };
 
-function CheckboxControl({ className, ...props }: OwnProps) {
+function CheckboxControl({ className, isStandard, ...props }: OwnProps) {
   return (
-    <span className={classNames('checkbox-control', [className])}>
+    <span
+      className={classNames('checkbox-control', [
+        className,
+        { 'checkbox-standard': isStandard },
+      ])}
+    >
       <input type="checkbox" {...props} />
       <span className="checkbox-control-base">
         <span className="checkbox-control-checked" />

--- a/lib/controls/checkbox/style.scss
+++ b/lib/controls/checkbox/style.scss
@@ -62,7 +62,7 @@ $checkbox-sprite: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5
     }
   }
 
-  &.standard {
+  &.checkbox-standard {
     width: 18px;
     height: 18px;
 

--- a/lib/controls/checkbox/style.scss
+++ b/lib/controls/checkbox/style.scss
@@ -1,3 +1,5 @@
+$checkbox-sprite: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0OCA0OCI+PHJlY3QgeD0iMCIgZmlsbD0ibm9uZSIgd2lkdGg9IjQ4IiBoZWlnaHQ9IjQ4Ii8+PHBhdGggZmlsbD0iIzY0Njk3MCIgZD0iTTE5IDVMMTkgNXYxNEg1VjVIMTlNMTkgM0g1QzMuODk1IDMgMyAzLjg5NSAzIDV2MTRjMCAxLjEwNSAwLjg5NSAyIDIgMmgxNGMxLjEwNSAwIDItMC44OTUgMi0yVjVDMjEgMy44OTUgMjAuMTA1IDMgMTkgM3pNNDMgM0gyOWMtMS4xMDUgMC0yIDAuODk1LTIgMnYxNGMwIDEuMTA1IDAuODk1IDIgMiAyaDE0YzEuMTA1IDAgMi0wLjg5NSAyLTJWNUM0NSAzLjg5NSA0NC4xMDUgMyA0MyAzek0zNC4xNCAxNi44NWwtNC4zOC00LjM3IDEuNDItMS40MiAzIDMgNi42My02LjYzIDEuNDEgMS40MkwzNC4xNCAxNi44NXoiLz48cGF0aCBmaWxsPSIjOGM4Zjk0IiBkPSJNMTkgMjlMMTkgMjl2MTRINVYyOUgxOU0xOSAyN0g1Yy0xLjEwNSAwLTIgMC44OTUtMiAydjE0YzAgMS4xMDUgMC44OTUgMiAyIDJoMTRjMS4xMDUgMCAyLTAuODk1IDItMlYyOUMyMSAyNy44OTUgMjAuMTA1IDI3IDE5IDI3ek00MyAyN0gyOWMtMS4xMDUgMC0yIDAuODk1LTIgMnYxNGMwIDEuMTA1IDAuODk1IDIgMiAyaDE0YzEuMTA1IDAgMi0wLjg5NSAyLTJWMjlDNDUgMjcuODk1IDQ0LjEwNSAyNyA0MyAyN3pNMzQuMTQgNDAuODVsLTQuMzgtNC4zNyAxLjQyLTEuNDIgMyAzIDYuNjMtNi42MyAxLjQxIDEuNDJMMzQuMTQgNDAuODV6Ii8+PC9zdmc+';
+
 .checkbox-control {
   -webkit-touch-callout: none;
   width: 16px;
@@ -57,6 +59,28 @@
 
     .checkbox-control-checked {
       opacity: 1;
+    }
+  }
+
+  &.standard {
+    width: 18px;
+    height: 18px;
+
+    .checkbox-control-base,
+    .checkbox-control-checked {
+      background-image: url($checkbox-sprite);
+      background-repeat: no-repeat;
+      background-size: 36px 36px;
+      border-radius: 0;
+      border: 0;
+      fill: $studio-gray-50;
+    }
+    .checkbox-control-base {
+      background-position: 0 0;
+    }
+    .checkbox-control-checked {
+      background-color: transparent;
+      background-position: -18px 0;
     }
   }
 }

--- a/lib/note-actions/index.tsx
+++ b/lib/note-actions/index.tsx
@@ -93,8 +93,8 @@ export class NoteActions extends Component<Props> {
               <span className="note-actions-item-control">
                 <CheckboxControl
                   id="note-actions-pin-checkbox"
-                  className="theme-color-border"
                   checked={isPinned}
+                  className="standard"
                   onChange={() => {
                     this.pinNote(!isPinned);
                   }}
@@ -113,6 +113,7 @@ export class NoteActions extends Component<Props> {
                 <CheckboxControl
                   id="note-actions-markdown-checkbox"
                   checked={isMarkdown}
+                  className="standard"
                   onChange={() => {
                     this.markdownNote(!isMarkdown);
                   }}
@@ -158,6 +159,7 @@ export class NoteActions extends Component<Props> {
                 <CheckboxControl
                   id="note-actions-publish-checkbox"
                   checked={isPublished}
+                  className="standard"
                   onChange={() => {
                     this.publishNote(!isPublished);
                   }}

--- a/lib/note-actions/index.tsx
+++ b/lib/note-actions/index.tsx
@@ -94,7 +94,7 @@ export class NoteActions extends Component<Props> {
                 <CheckboxControl
                   id="note-actions-pin-checkbox"
                   checked={isPinned}
-                  className="standard"
+                  isStandard
                   onChange={() => {
                     this.pinNote(!isPinned);
                   }}
@@ -113,7 +113,7 @@ export class NoteActions extends Component<Props> {
                 <CheckboxControl
                   id="note-actions-markdown-checkbox"
                   checked={isMarkdown}
-                  className="standard"
+                  isStandard
                   onChange={() => {
                     this.markdownNote(!isMarkdown);
                   }}
@@ -159,7 +159,7 @@ export class NoteActions extends Component<Props> {
                 <CheckboxControl
                   id="note-actions-publish-checkbox"
                   checked={isPublished}
-                  className="standard"
+                  isStandard
                   onChange={() => {
                     this.publishNote(!isPublished);
                   }}

--- a/lib/note-actions/style.scss
+++ b/lib/note-actions/style.scss
@@ -1,5 +1,3 @@
-$checkbox-sprite: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0OCA0OCI+PHJlY3QgeD0iMCIgZmlsbD0ibm9uZSIgd2lkdGg9IjQ4IiBoZWlnaHQ9IjQ4Ii8+PHBhdGggZmlsbD0iIzY0Njk3MCIgZD0iTTE5IDVMMTkgNXYxNEg1VjVIMTlNMTkgM0g1QzMuODk1IDMgMyAzLjg5NSAzIDV2MTRjMCAxLjEwNSAwLjg5NSAyIDIgMmgxNGMxLjEwNSAwIDItMC44OTUgMi0yVjVDMjEgMy44OTUgMjAuMTA1IDMgMTkgM3pNNDMgM0gyOWMtMS4xMDUgMC0yIDAuODk1LTIgMnYxNGMwIDEuMTA1IDAuODk1IDIgMiAyaDE0YzEuMTA1IDAgMi0wLjg5NSAyLTJWNUM0NSAzLjg5NSA0NC4xMDUgMyA0MyAzek0zNC4xNCAxNi44NWwtNC4zOC00LjM3IDEuNDItMS40MiAzIDMgNi42My02LjYzIDEuNDEgMS40MkwzNC4xNCAxNi44NXoiLz48cGF0aCBmaWxsPSIjOGM4Zjk0IiBkPSJNMTkgMjlMMTkgMjl2MTRINVYyOUgxOU0xOSAyN0g1Yy0xLjEwNSAwLTIgMC44OTUtMiAydjE0YzAgMS4xMDUgMC44OTUgMiAyIDJoMTRjMS4xMDUgMCAyLTAuODk1IDItMlYyOUMyMSAyNy44OTUgMjAuMTA1IDI3IDE5IDI3ek00MyAyN0gyOWMtMS4xMDUgMC0yIDAuODk1LTIgMnYxNGMwIDEuMTA1IDAuODk1IDIgMiAyaDE0YzEuMTA1IDAgMi0wLjg5NSAyLTJWMjlDNDUgMjcuODk1IDQ0LjEwNSAyNyA0MyAyN3pNMzQuMTQgNDAuODVsLTQuMzgtNC4zNyAxLjQyLTEuNDIgMyAzIDYuNjMtNi42MyAxLjQxIDEuNDJMMzQuMTQgNDAuODV6Ii8+PC9zdmc+';
-
 .is-macos .note-actions {
   top: $toolbar-height + 16px + 26px;
 }
@@ -73,28 +71,11 @@ $checkbox-sprite: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5
   }
 
   .note-actions-item-control .checkbox-control {
-    bottom: 3px;
+    bottom: 1px;
 
     input {
       cursor: pointer;
     }
-  }
-
-  .note-actions-item-control .checkbox-control .checkbox-control-base,
-  .note-actions-item-control .checkbox-control .checkbox-control-checked {
-    background-image: url($checkbox-sprite);
-    background-repeat: no-repeat;
-    background-size: 36px 36px;
-    border-radius: 0;
-    border: 0;
-    fill: $studio-gray-50;
-  }
-  .note-actions-item-control .checkbox-control .checkbox-control-base {
-    background-position: 0 0;
-  }
-  .note-actions-item-control .checkbox-control .checkbox-control-checked {
-    background-color: transparent;
-    background-position: -18px 0;
   }
 
   .spinner__circle {


### PR DESCRIPTION
### Fix
<!--
**_(Required)_** Add a concise description of what you fixed. If this is related 
to an issue, add a link to it. If applicable, add screenshots, animations, or
videos to help illustrate the fix.
-->

I noticed that a recent [PR](https://github.com/Automattic/simplenote-electron/pull/2622) introduced the standard version of checkbox. Since this could be used in different parts of the app, I decided to make it generic and add a specific class name (`standard`) into the checkbox component.

This PR also introduce a style fix for the size of the check box:

Before|After
--|--
<img width="212" alt="Screenshot 2021-04-09 at 17 48 43" src="https://user-images.githubusercontent.com/14905380/114206700-e4861c00-995b-11eb-978b-9d6d62e320f7.png">|<img width="208" alt="Screenshot 2021-04-09 at 17 49 00" src="https://user-images.githubusercontent.com/14905380/114206724-e8b23980-995b-11eb-9864-542e65463a02.png">


### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

#### Standard checkboxes
1. Open a note
2. Click on actions button on the top-right corner
3. Observe that standard checkboxes are displayed properly

#### Default checkboxes
1. Open settings
2. Click on Display
3. Observe that default checkboxes are displayed properly

### Release

<!--
**_(Required)_** If the changes should be included in release notes, add a
concise statement below describing the change. For example:
Fixed crash that occurred when opening the navigation sidebar.
-->
N/A