### PR TITLE
[DO NOT MERGE] Add note's tags to history screen - Use action generator

### DIFF
--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -382,7 +382,7 @@ export const middleware: S.Middleware = (store) => {
         return next(action);
       case 'IMPORT_NOTE_WITH_ID':
       case 'REMOTE_NOTE_UPDATE':
-      case 'APPLY_NOTE_REVISION':
+      case 'RESTORE_NOTE_REVISION':
         searchState.notes.set(action.noteId, toSearchNote(action.note ?? {}));
         indexNote(action.noteId);
         queueSearch();

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -221,14 +221,6 @@ export type RestoreNoteRevision = Action<
   'RESTORE_NOTE_REVISION',
   {
     noteId: T.EntityId;
-    version: number;
-    includeDeletedTags: boolean;
-  }
->;
-export type ApplyNoteRevision = Action<
-  'APPLY_NOTE_REVISION',
-  {
-    noteId: T.EntityId;
     note: T.Note;
   }
 >;
@@ -349,7 +341,6 @@ export type ActionType =
   | AcknowledgePendingChange
   | AddCollaborator
   | AddNoteTag
-  | ApplyNoteRevision
   | ChangeConnectionStatus
   | CloseNote
   | CloseNoteActions

--- a/lib/state/data/middleware.ts
+++ b/lib/state/data/middleware.ts
@@ -78,35 +78,6 @@ export const middleware: S.Middleware = (store) => (
         note: action.note,
       });
 
-    case 'RESTORE_NOTE_REVISION': {
-      const revision = state.data.noteRevisions
-        .get(action.noteId)
-        ?.get(action.version);
-
-      if (!revision) {
-        return;
-      }
-
-      const note = state.data.notes.get(action.noteId);
-      const noteEmailTags =
-        note?.tags.filter((tagName) => isEmailTag(tagName)) ?? [];
-
-      const revisionCanonicalTags = revision.tags.filter((tagName) => {
-        const tagHash = tagHashOf(tagName);
-        const hasTag = state.data.tags.has(tagHash);
-        return !isEmailTag(tagName) && (hasTag || action.includeDeletedTags);
-      });
-
-      return next({
-        type: 'APPLY_NOTE_REVISION',
-        noteId: action.noteId,
-        note: {
-          ...revision,
-          tags: [...noteEmailTags, ...revisionCanonicalTags],
-        },
-      });
-    }
-
     case 'RESTORE_OPEN_NOTE':
       if (!state.ui.openedNote) {
         return;

--- a/lib/state/data/reducer.ts
+++ b/lib/state/data/reducer.ts
@@ -108,7 +108,7 @@ export const notes: A.Reducer<Map<T.EntityId, T.Note>> = (
 
     case 'NOTE_BUCKET_UPDATE':
     case 'REMOTE_NOTE_UPDATE':
-    case 'APPLY_NOTE_REVISION':
+    case 'RESTORE_NOTE_REVISION':
       return new Map(state).set(action.noteId, action.note);
 
     case 'IMPORT_NOTE_WITH_ID': {
@@ -437,7 +437,7 @@ export const tags: A.Reducer<Map<T.TagHash, T.Tag>> = (
       return next;
     }
 
-    case 'APPLY_NOTE_REVISION': {
+    case 'RESTORE_NOTE_REVISION': {
       const next = new Map(state);
       action.note.tags.forEach((tagName) => {
         const tagHash = t(tagName);

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -351,7 +351,7 @@ export const initSimperium = (
         return result;
       }
 
-      case 'APPLY_NOTE_REVISION': {
+      case 'RESTORE_NOTE_REVISION': {
         action.note.tags.map(t).forEach((tagHash) => {
           if (!prevState.data.tags.has(tagHash)) {
             queueTagUpdate(tagHash, 10);

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -251,7 +251,7 @@ const openedRevision: A.Reducer<[T.EntityId, number] | null> = (
 ) => {
   switch (action.type) {
     case 'CLOSE_REVISION':
-    case 'APPLY_NOTE_REVISION':
+    case 'RESTORE_NOTE_REVISION':
       return null;
 
     case 'OPEN_REVISION':
@@ -384,7 +384,7 @@ const showRevisions: A.Reducer<boolean> = (state = false, action) => {
     case 'OPEN_NOTE':
     case 'SELECT_NOTE':
     case 'CREATE_NOTE_WITH_ID':
-    case 'APPLY_NOTE_REVISION':
+    case 'RESTORE_NOTE_REVISION':
       return false;
     default:
       return state;


### PR DESCRIPTION
This PR shows a potential alternative for generating a Redux action based on data from the state.

The idea I introduced here is similar to [Thunk actions](https://github.com/reduxjs/redux-thunk) but quite simplified just to demonstrate how it could work. Basically I added a middleware that checks if the action is a function, if so it does a call with the current state and uses the return as the action to be passed to the next middleware. This way we could dispatch functions (aka action generators) that produce an action object based on the current state.

This option could help us to free up the middlewares and migrate some logic we're doing in the middlewares to actions. One good example for this would be the [`CREATE_NOTE` action](https://github.com/Automattic/simplenote-electron/blob/2c36f8a97d8a0b8206d49079c6571e35daf55fa1/lib/state/data/middleware.ts#L18-L47), here we’re using a Redux action to generate another one based on data from the state.