### PR TITLE
[DO NOT MERGE] Add note's tags to history screen - Add cross slice reducer

### DIFF
--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -382,7 +382,7 @@ export const middleware: S.Middleware = (store) => {
         return next(action);
       case 'IMPORT_NOTE_WITH_ID':
       case 'REMOTE_NOTE_UPDATE':
-      case 'APPLY_NOTE_REVISION':
+      case 'RESTORE_NOTE_REVISION':
         searchState.notes.set(action.noteId, toSearchNote(action.note ?? {}));
         indexNote(action.noteId);
         queueSearch();

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -225,13 +225,6 @@ export type RestoreNoteRevision = Action<
     includeDeletedTags: boolean;
   }
 >;
-export type ApplyNoteRevision = Action<
-  'APPLY_NOTE_REVISION',
-  {
-    noteId: T.EntityId;
-    note: T.Note;
-  }
->;
 export type SetSystemTag = Action<
   'SET_SYSTEM_TAG',
   { note: T.NoteEntity; tagName: T.SystemTag; shouldHaveTag: boolean }
@@ -349,7 +342,6 @@ export type ActionType =
   | AcknowledgePendingChange
   | AddCollaborator
   | AddNoteTag
-  | ApplyNoteRevision
   | ChangeConnectionStatus
   | CloseNote
   | CloseNoteActions

--- a/lib/state/data/middleware.ts
+++ b/lib/state/data/middleware.ts
@@ -78,35 +78,6 @@ export const middleware: S.Middleware = (store) => (
         note: action.note,
       });
 
-    case 'RESTORE_NOTE_REVISION': {
-      const revision = state.data.noteRevisions
-        .get(action.noteId)
-        ?.get(action.version);
-
-      if (!revision) {
-        return;
-      }
-
-      const note = state.data.notes.get(action.noteId);
-      const noteEmailTags =
-        note?.tags.filter((tagName) => isEmailTag(tagName)) ?? [];
-
-      const revisionCanonicalTags = revision.tags.filter((tagName) => {
-        const tagHash = tagHashOf(tagName);
-        const hasTag = state.data.tags.has(tagHash);
-        return !isEmailTag(tagName) && (hasTag || action.includeDeletedTags);
-      });
-
-      return next({
-        type: 'APPLY_NOTE_REVISION',
-        noteId: action.noteId,
-        note: {
-          ...revision,
-          tags: [...noteEmailTags, ...revisionCanonicalTags],
-        },
-      });
-    }
-
     case 'RESTORE_OPEN_NOTE':
       if (!state.ui.openedNote) {
         return;

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -251,7 +251,7 @@ const openedRevision: A.Reducer<[T.EntityId, number] | null> = (
 ) => {
   switch (action.type) {
     case 'CLOSE_REVISION':
-    case 'APPLY_NOTE_REVISION':
+    case 'RESTORE_NOTE_REVISION':
       return null;
 
     case 'OPEN_REVISION':
@@ -384,7 +384,7 @@ const showRevisions: A.Reducer<boolean> = (state = false, action) => {
     case 'OPEN_NOTE':
     case 'SELECT_NOTE':
     case 'CREATE_NOTE_WITH_ID':
-    case 'APPLY_NOTE_REVISION':
+    case 'RESTORE_NOTE_REVISION':
       return false;
     default:
       return state;

--- a/lib/tag-field/index.tsx
+++ b/lib/tag-field/index.tsx
@@ -289,7 +289,7 @@ const mapStateToProps: S.MapState<StateProps> = (state) => {
   const tags = noteId ? noteTags(state, note) : [];
 
   return {
-    tags: tags.filter(({ deleted }) => !deleted),
+    tags: tags.filter(({ name, deleted }) => !isEmailTag(name) && !deleted),
     keyboardShortcuts: state.settings.keyboardShortcuts,
     noteId,
     note,


### PR DESCRIPTION
This PR shows an example of how to share data between reduce slicers.

The idea exposed here is based on the [Redux documentation](https://redux.js.org/recipes/structuring-reducers/beyond-combinereducers#sharing-data-between-slice-reducers) about how to do a cross slice reducer when you use `combineReducers`.