### PR TITLE
Disable note preview selection/copy when note actions is open

### DIFF
--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -185,7 +185,7 @@ const mapStateToProps: S.MapState<StateProps, OwnProps> = (state, props) => {
   const note = props.note ?? state.data.notes.get(noteId);
 
   return {
-    isFocused: state.ui.dialogs.length === 0 && !state.ui.showNoteInfo,
+    isFocused: state.ui.dialogs.length === 0 && !state.ui.showNoteActions,
     note,
     noteId,
     notes: state.data.notes,


### PR DESCRIPTION
### Fix

Fixes #2836

Currently when you view the markdown preview of a note and then open the note actions and try to use one of the Copy buttons to copy either the publish or internal link the content of the note is copied instead.

This resolves that by first checking to see if note actions is open before selecting the note content in the note preview component.

### Test

1. Open a note with markdown enabled and published.
2. Open the note actions menu for this note.
3. Ensure the Copy Internal Link button copies the link.
4. Ensure the Copy Link button works as well.
5. Toggle to view the markdown preview.
6. Test both buttons again and ensure they both still work.

### Release

None needed. 