### PR TITLE
Fix: Set checkbox component `isStandard` prop optional

### DIFF
--- a/lib/controls/checkbox/index.tsx
+++ b/lib/controls/checkbox/index.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 type OwnProps = React.HTMLProps<HTMLInputElement> & {
   className?: string;
   onChange: () => any;
-  isStandard: boolean;
+  isStandard?: boolean;
 };
 
 function CheckboxControl({ className, isStandard, ...props }: OwnProps) {


### PR DESCRIPTION
### Fix
<!--
**_(Required)_** Add a concise description of what you fixed. If this is related 
to an issue, add a link to it. If applicable, add screenshots, animations, or
videos to help illustrate the fix.
-->

This [PR](https://github.com/Automattic/simplenote-electron/pull/2835) introduced a Typescript error in `RadioGroup` component because it's not setting the `isStandard` prop when rendering the checkboxes. I changed this prop to be optional so by default it renders the circle variant.

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

#### Standard checkboxes
1. Open a note
2. Click on actions button on the top-right corner
3. Observe that standard checkboxes are displayed properly

#### Default checkboxes
1. Open settings
2. Click on Display
3. Observe that default checkboxes are displayed properly
### Release

<!--
**_(Required)_** If the changes should be included in release notes, add a
concise statement below describing the change. For example:
Fixed crash that occurred when opening the navigation sidebar.
-->
N/A