### PR TITLE
Add note's tags to history screen - Refactor notes revision and revision selector

### DIFF
--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -29,7 +29,6 @@ const NotePreview = React.lazy(() =>
 );
 
 type StateProps = {
-  hasRevisions: boolean;
   isFocusMode: boolean;
   isNavigationOpen: boolean;
   isNoteInfoOpen: boolean;
@@ -37,8 +36,6 @@ type StateProps = {
   isSmallScreen: boolean;
   keyboardShortcuts: boolean;
   keyboardShortcutsAreOpen: boolean;
-  openedNote: T.EntityId | null;
-  openedRevision: T.Note | null;
   showNoteList: boolean;
   showRevisions: boolean;
   showSortBar: boolean;
@@ -87,14 +84,11 @@ export class AppLayout extends Component<Props> {
   render = () => {
     const {
       showNoteList,
-      hasRevisions,
       isFocusMode = false,
       isNavigationOpen,
       isNoteInfoOpen,
       isNoteOpen,
       isSmallScreen,
-      openedNote,
-      openedRevision,
       showRevisions,
       showSortBar,
     } = this.props;
@@ -141,15 +135,10 @@ export class AppLayout extends Component<Props> {
             >
               <NoteToolbar aria-hidden={hiddenByRevisions} />
               {showRevisions ? (
-                <NoteRevisions
-                  aria-hidden={hiddenByRevisions}
-                  noteId={openedNote}
-                  note={openedRevision}
-                />
+                <NoteRevisions aria-hidden={hiddenByRevisions} />
               ) : (
                 <NoteEditor />
               )}
-              {hasRevisions && <RevisionSelector />}
             </main>
           )}
         </Suspense>
@@ -159,8 +148,6 @@ export class AppLayout extends Component<Props> {
 }
 
 const mapStateToProps: S.MapState<StateProps> = (state) => ({
-  hasRevisions:
-    state.ui.showRevisions && state.data.noteRevisions.has(state.ui.openedNote),
   keyboardShortcutsAreOpen: selectors.isDialogOpen(state, 'KEYBINDINGS'),
   keyboardShortcuts: state.settings.keyboardShortcuts,
   isFocusMode: state.settings.focusModeEnabled,
@@ -168,13 +155,6 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
   isNoteInfoOpen: state.ui.showNoteInfo,
   isNoteOpen: !state.ui.showNoteList,
   isSmallScreen: selectors.isSmallScreen(state),
-  openedRevision:
-    state.ui.openedRevision?.[0] === state.ui.openedNote
-      ? state.data.noteRevisions
-          .get(state.ui.openedNote)
-          ?.get(state.ui.openedRevision?.[1]) ?? null
-      : null,
-  openedNote: state.ui.openedNote,
   showNoteList: state.ui.showNoteList,
   showRevisions: state.ui.showRevisions,
   showSortBar: state.ui.filteredNotes.length > 0,

--- a/lib/note-revisions/index.tsx
+++ b/lib/note-revisions/index.tsx
@@ -3,70 +3,179 @@ import { connect } from 'react-redux';
 
 import NotePreview from '../components/note-preview';
 import TagChip from '../components/tag-chip';
+import RevisionSelector from '../revision-selector';
 import { noteCanonicalTags } from '../state/selectors';
+import isEmailTag from '../utils/is-email-tag';
 import { tagHashOf } from '../utils/tag-hash';
 
 import type * as S from '../state';
 import type * as T from '../types';
 
-type OwnProps = {
-  noteId: T.EntityId;
-  note?: T.Note;
-};
-
 type StateProps = {
-  tags: Array<{ name: T.TagName; deleted: boolean }>;
+  allTags: Map<T.TagHash, T.Tag>;
+  note: T.Note | undefined;
+  noteCanonicalTags: T.TagName[];
   noteId: T.EntityId | null;
-  note: T.Note | null;
+  revision: T.Note | undefined;
+  revisionIndex: number;
+  revisions: Map<number, T.Note> | undefined;
 };
 
-type Props = OwnProps &
-  StateProps &
+type DispatchProps = {
+  cancelRevision: () => any;
+  openRevision: (noteId: T.EntityId, version: number) => any;
+  restoreRevision: (noteId: T.EntityId, note: T.Note) => any;
+};
+
+type Props = StateProps &
+  DispatchProps &
   Pick<React.HTMLProps<HTMLDivElement>, 'aria-hidden'>;
 
-export class NoteRevisions extends Component<Props> {
+type State = {
+  includeDeletedTags: boolean;
+};
+
+export class NoteRevisions extends Component<Props, State> {
   static displayName = 'NoteRevisions';
 
-  render() {
-    const { note, noteId, tags, 'aria-hidden': ariaHidden } = this.props;
+  state: State = {
+    includeDeletedTags: true,
+  };
+
+  getTags() {
+    return this.props.noteCanonicalTags
+      .map((tagName) => {
+        const tagHash = tagHashOf(tagName);
+        return { name: tagName, deleted: !this.props.allTags.has(tagHash) };
+      })
+      .filter((tag) => {
+        return this.state.includeDeletedTags || !tag.deleted;
+      });
+  }
+
+  onAcceptRevision = () => {
+    const { noteId, note, revision, restoreRevision } = this.props;
+
+    if (!noteId || !note || !revision) {
+      return;
+    }
+
+    const noteEmailTags = note.tags.filter((tagName) => isEmailTag(tagName));
+    const revisionCanonicalTags = this.getTags().map(({ name }) => name);
+
+    restoreRevision(noteId, {
+      ...revision,
+      tags: [...noteEmailTags, ...revisionCanonicalTags],
+      systemTags: note.systemTags,
+    });
+  };
+
+  onSelectRevision = (revisionIndex: number) => {
+    const { noteId, revisions, openRevision } = this.props;
+
+    if (!noteId || !revisions) {
+      return;
+    }
+
+    const revision = [...revisions.keys()][revisionIndex];
+
+    openRevision(noteId, revision);
+  };
+
+  renderTags() {
+    const tags = this.getTags();
 
     return (
-      <div aria-hidden={ariaHidden} className="note-revisions">
-        <NotePreview noteId={noteId} note={note} />
-        <div className="tags">
-          {tags.map(({ name, deleted }) => (
-            <TagChip
-              key={name}
-              tagName={name}
-              interactive={false}
-              deleted={deleted}
-            />
-          ))}
+      <div className="tags">
+        {tags.map(({ name, deleted }) => (
+          <TagChip
+            key={name}
+            tagName={name}
+            interactive={false}
+            deleted={deleted}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  render() {
+    const {
+      'aria-hidden': ariaHidden,
+      cancelRevision,
+      noteId,
+      revision,
+      revisionIndex,
+      revisions,
+    } = this.props;
+
+    if (!noteId || !revisions) {
+      return null;
+    }
+
+    return (
+      <div className="note-revisions">
+        <div aria-hidden={ariaHidden} className="note-revision-preview">
+          <NotePreview noteId={noteId} note={revision} />
+          {this.renderTags()}
         </div>
+        <RevisionSelector
+          onAccept={this.onAcceptRevision}
+          onCancel={cancelRevision}
+          onSelect={this.onSelectRevision}
+          onToggleRestoreDeletedTags={(toggled) =>
+            this.setState({ includeDeletedTags: toggled })
+          }
+          restoreDeletedTags={this.state.includeDeletedTags}
+          revision={revision}
+          revisionsSize={revisions.size}
+          selectedIndex={revisionIndex}
+        />
       </div>
     );
   }
 }
 
-const mapStateToProps: S.MapState<StateProps, OwnProps> = (state, props) => {
-  const noteId = props.noteId ?? state.ui.openedNote;
-  const note = props.note ?? state.data.notes.get(noteId);
-  const restoreDeletedTags = state.ui.restoreDeletedTags;
+const mapStateToProps: S.MapState<StateProps> = (state) => {
+  const noteId = state.ui.openedNote;
+  const note = noteId ? state.data.notes.get(noteId) : undefined;
+  const revisions = noteId ? state.data.noteRevisions.get(noteId) : undefined;
 
-  const tags = noteCanonicalTags(state, note)
-    .map((tagName) => {
-      const tagHash = tagHashOf(tagName);
-      return { name: tagName, deleted: !state.data.tags.has(tagHash) };
-    })
-    .filter((tag) => {
-      return restoreDeletedTags || !tag.deleted;
-    });
+  const openedRevision =
+    state.ui.openedRevision?.[0] === state.ui.openedNote
+      ? state.ui.openedRevision?.[1] ?? null
+      : null;
+  const revision = openedRevision ? revisions?.get(openedRevision) : note;
+  const revisionIndex =
+    openedRevision && revisions
+      ? [...revisions.keys()].indexOf(openedRevision)
+      : -1;
 
   return {
-    tags,
-    noteId,
+    allTags: state.data.tags,
     note,
+    noteCanonicalTags: revision ? noteCanonicalTags(state, revision) : [],
+    noteId,
+    revision,
+    revisionIndex,
+    revisions,
   };
 };
 
-export default connect(mapStateToProps)(NoteRevisions);
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
+  openRevision: (noteId, version) => ({
+    type: 'OPEN_REVISION',
+    noteId,
+    version,
+  }),
+  cancelRevision: () => ({
+    type: 'CLOSE_REVISION',
+  }),
+  restoreRevision: (noteId, note) => ({
+    type: 'RESTORE_NOTE_REVISION',
+    noteId,
+    note,
+  }),
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(NoteRevisions);

--- a/lib/note-revisions/style.scss
+++ b/lib/note-revisions/style.scss
@@ -4,6 +4,12 @@
   flex: 1 1 auto;
   padding-top: 20px;
 
+  .note-revision-preview {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+  }
+
   .tags {
     display: flex;
     justify-content: flex-start;

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -6,10 +6,6 @@
   transition: all 0.3s ease-in-out;
   width: 100%;
 
-  &.is-visible {
-    bottom: 0;
-  }
-
   @media only screen and (max-width: $single-column) {
     width: 100%;
   }

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -132,9 +132,6 @@ export type SystemThemeUpdate = Action<
 >;
 export type ToggleAnalytics = Action<'TOGGLE_ANALYTICS'>;
 export type ToggleAutoHideMenuBar = Action<'TOGGLE_AUTO_HIDE_MENU_BAR'>;
-export type ToggleRestoringDeletedTags = Action<
-  'TOGGLE_RESTORING_DELETED_TAGS'
->;
 export type ToggleEditMode = Action<'TOGGLE_EDIT_MODE'>;
 export type ToggleFocusMode = Action<'TOGGLE_FOCUS_MODE'>;
 export type ToggleKeyboardShortcuts = Action<'KEYBOARD_SHORTCUTS_TOGGLE'>;
@@ -427,7 +424,6 @@ export type ActionType =
   | TagRefresh
   | ToggleAnalytics
   | ToggleAutoHideMenuBar
-  | ToggleRestoringDeletedTags
   | ToggleEditMode
   | ToggleFocusMode
   | ToggleKeyboardShortcuts

--- a/lib/state/selectors.ts
+++ b/lib/state/selectors.ts
@@ -66,31 +66,3 @@ export const noteCanonicalTags: S.Selector<T.TagName[]> = (
 ) => {
   return note.tags.filter((tagName) => !isEmailTag(tagName));
 };
-
-export const getRevision: S.Selector<T.Note | null> = (
-  state,
-  noteId: T.EntityId,
-  revisionVersion: number,
-  includeDeletedTags: boolean
-) => {
-  const note = state.data.notes.get(noteId);
-  const revisions = state.data.noteRevisions.get(noteId);
-  const revision = revisions?.get(revisionVersion);
-
-  if (!note || !revision) {
-    return null;
-  }
-
-  const noteEmailTags = note.tags.filter((tagName) => isEmailTag(tagName));
-  const revisionCanonicalTags = revision.tags.filter((tagName) => {
-    const tagHash = tagHashOf(tagName);
-    const hasTag = state.data.tags.has(tagHash);
-    return !isEmailTag(tagName) && (hasTag || includeDeletedTags);
-  });
-
-  return {
-    ...revision,
-    tags: [...noteEmailTags, ...revisionCanonicalTags],
-    systemTags: note.systemTags,
-  };
-};

--- a/lib/state/ui/actions.ts
+++ b/lib/state/ui/actions.ts
@@ -130,10 +130,6 @@ export const toggleRevisions: A.ActionCreator<A.ToggleRevisions> = () => ({
   type: 'REVISIONS_TOGGLE',
 });
 
-export const toggleRestoringDeletedTags: A.ActionCreator<A.ToggleRestoringDeletedTags> = () => ({
-  type: 'TOGGLE_RESTORING_DELETED_TAGS',
-});
-
 export const search: A.ActionCreator<A.Search> = (searchQuery: string) => ({
   type: 'SEARCH',
   searchQuery,

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -391,17 +391,6 @@ const showRevisions: A.Reducer<boolean> = (state = false, action) => {
   }
 };
 
-const restoreDeletedTags: A.Reducer<boolean> = (state = true, action) => {
-  switch (action.type) {
-    case 'TOGGLE_RESTORING_DELETED_TAGS':
-      return !state;
-    case 'REVISIONS_TOGGLE':
-      return true;
-    default:
-      return state;
-  }
-};
-
 const tagSuggestions: A.Reducer<T.TagHash[]> = (
   state = emptyList as T.TagHash[],
   action
@@ -425,7 +414,6 @@ export default combineReducers({
   numberOfMatchesInNote,
   openedNote,
   openedRevision,
-  restoreDeletedTags,
   searchQuery,
   selectedSearchMatchIndex,
   showAlternateLoginPrompt,


### PR DESCRIPTION
Related to comment: https://github.com/Automattic/simplenote-electron/pull/2817#discussion_r611979568

The goal of this refactor is to handle the toggle restoring deleted tags in note revisions component state instead of in Redux.

For this purpose, the revision selector component is now rendered inside the notes revision component and most of its logic has been moved to that component too.

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

_Same testing instructions as the [parent PR](https://github.com/Automattic/simplenote-electron/pull/2817)._