### PR TITLE
Fix search selections when content is changed

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -381,8 +381,9 @@ class NoteContentEditor extends Component<Props> {
       this.state.editor === 'full' &&
       (this.props.selectedSearchMatchIndex ?? 0) > this.matchesInNote.length - 1
     ) {
-      this.setSearchSelection(this.matchesInNote.length - 1);
-      this.props.storeSearchSelection(this.matchesInNote.length - 1);
+      const newIndex = Math.max(this.matchesInNote.length - 1, 0);
+      this.setSearchSelection(newIndex);
+      this.props.storeSearchSelection(newIndex);
     }
 
     if (

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -374,6 +374,17 @@ class NoteContentEditor extends Component<Props> {
       this.setDecorators();
     }
 
+    // If content is changed so that the selected search index is greater then the number of matches
+    // then select the last match instead
+    if (
+      this.editor &&
+      this.state.editor === 'full' &&
+      (this.props.selectedSearchMatchIndex ?? 0) > this.matchesInNote.length - 1
+    ) {
+      this.setSearchSelection(this.matchesInNote.length - 1);
+      this.props.storeSearchSelection(this.matchesInNote.length - 1);
+    }
+
     if (
       this.editor &&
       this.state.editor === 'full' &&


### PR DESCRIPTION
### Fix

Fixes  #2809

Update:
There are still a few issues search selection when the content of the note has changed. I've changed this back to a draft to come back and address sometime in the future. 

Currently, when you search for a term, change the selected search match, then edit the content to remove a search match the selected search indicators can become incorrect. For example, it could say you are at match 4 of 3.
This corrects that.

### Test

1. Have a note with multiple instances of `word` in it
2. Search for `word`
3. Move the current match position in a note with > button or with Ctrl/Cmd+G, so that it becomes greater than one (e.g. 5 of 5)
4. Start removing the instances of `word` until one remains ~> the indicator will show 5 of 1

### Release

- Fixed issue where the search results navigation bar could show incorrect position if the content of a note was changed.
