### PR TITLE
Fix/hide clear search button

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,6 +18,7 @@
 - Fixed spacing on unsynced notes warning message [#2797](https://github.com/automattic/simplenote-electron/pull/2797)
 - Fixed cut off issue for dialogs when the window is too small [#2815](https://github.com/automattic/simplenote-electron/pull/2815), [#2834](https://github.com/automattic/simplenote-electron/pull/2834)
 - Fixed unnecessary separators in the Electron builds File and Edit menus when not yet logged in (props @Klauswk) [#2724](https://github.com/automattic/simplenote-electron/pull/2724)
+- Fixed the clear search button so it does not appear unless there is a search term to clear [#2862](https://github.com/automattic/simplenote-electron/pull/2862)
 
 ## [v2.9.0]
 

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -95,14 +95,15 @@ export class SearchField extends Component<Props> {
           value={searchQuery}
           spellCheck={false}
         />
-        <button
-          aria-label="Clear search"
-          className="icon-button"
-          hidden={!hasQuery}
-          onClick={this.clearQuery}
-        >
-          <SmallCrossIcon />
-        </button>
+        {hasQuery && (
+          <button
+            aria-label="Clear search"
+            className="icon-button"
+            onClick={this.clearQuery}
+          >
+            <SmallCrossIcon />
+          </button>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
### Fix

Fixes #2860

Currently, the `X` icon in the search field, used to clear the search term, is always present. It should only show when there is a search term to clear. This fixes that.

Before:
<img width="377" alt="Screen Shot 2021-04-20 at 10 54 48 AM" src="https://user-images.githubusercontent.com/1326294/115408011-e5724580-a1c6-11eb-81b7-14d49ad65b22.png">

After:
<img width="377" alt="Screen Shot 2021-04-20 at 10 54 32 AM" src="https://user-images.githubusercontent.com/1326294/115408023-e7d49f80-a1c6-11eb-9730-4ba19d050eed.png">


### Test

1. Open Simplenote.
2. Ensure `X` icon does not show in search field.
3. Add a search term.
4. Ensure `X` icon does now appear.
5. Click the `X` icon
6. Ensure the search term is removed.

### Release

NA