### PR TITLE
Update the heights of a few dialogs to be larger then the default max-height

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -16,7 +16,7 @@
 - Fixed displaying extra blank spaces in history screen [#2829](https://github.com/automattic/simplenote-electron/pull/2829)
 - Fixed to apply selected tag to a new note by default [#2556](https://github.com/automattic/simplenote-electron/pull/2556)
 - Fixed spacing on unsynced notes warning message [#2797](https://github.com/automattic/simplenote-electron/pull/2797)
-- Fixed cut off issue for dialogs when the window is too small [#2815](https://github.com/automattic/simplenote-electron/pull/2815), [#2834](https://github.com/automattic/simplenote-electron/pull/2834)
+- Fixed cut off issue for dialogs when the window is too small [#2815](https://github.com/automattic/simplenote-electron/pull/2815), [#2834](https://github.com/automattic/simplenote-electron/pull/2834), [#2863](https://github.com/automattic/simplenote-electron/pull/2863)
 - Fixed unnecessary separators in the Electron builds File and Edit menus when not yet logged in (props @Klauswk) [#2724](https://github.com/automattic/simplenote-electron/pull/2724)
 
 ## [v2.9.0]

--- a/lib/components/tab-panels/style.scss
+++ b/lib/components/tab-panels/style.scss
@@ -35,6 +35,7 @@
 }
 
 .tab-panels__panel {
+  height: 30.5em;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
 }

--- a/lib/dialogs/about/style.scss
+++ b/lib/dialogs/about/style.scss
@@ -2,6 +2,7 @@
   .dialog {
     position: relative;
     max-width: 472px;
+    max-height: calc(100vh - 2rem);
 
     // For overriding theme settings.
     // TODO: Improve theme management so this isn't necessary
@@ -15,6 +16,7 @@
 
   .dialog-content {
     padding: 30px 20px 20px;
+    max-height: calc(100vh - 2rem - 70px);
   }
 
   a {

--- a/lib/dialogs/keybindings/style.scss
+++ b/lib/dialogs/keybindings/style.scss
@@ -2,10 +2,12 @@
   .dialog {
     max-width: 500px;
     margin: auto;
+    max-height: calc(100vh - 2rem);
   }
 
   .dialog-content {
     padding: 10px 20px 20px;
+    max-height: calc(100vh - 2rem - 56px);
   }
 
   ul {

--- a/lib/dialogs/settings/style.scss
+++ b/lib/dialogs/settings/style.scss
@@ -1,6 +1,14 @@
 .settings {
   max-width: 630px;
 
+  &.dialog {
+    max-height: calc(100vh - 2rem);
+
+    .dialog-content {
+      max-height: calc(100vh - 2rem - 56px);
+    }
+  }
+
   input[type='radio'] {
     cursor: pointer;
   }


### PR DESCRIPTION
### Fix

Fixes #2859
Fixes #2861

There had been a `max-height` set for the default of all dialogs used. This turned out to be too small for a few dialogs.
This increases the height for the Keybindings, Settings, About, and Collaborate dialogs to better fit.

<details>
<summary>Before</summary>
<img width="734" alt="Screen Shot 2021-04-20 at 12 53 42 PM" src="https://user-images.githubusercontent.com/1326294/115427036-781ae080-a1d7-11eb-99ad-8e879fa99bac.png">
<img width="734" alt="Screen Shot 2021-04-20 at 12 53 33 PM" src="https://user-images.githubusercontent.com/1326294/115427039-794c0d80-a1d7-11eb-9a0f-b17440c73a5b.png">
<img width="829" alt="Screen Shot 2021-04-20 at 12 53 25 PM" src="https://user-images.githubusercontent.com/1326294/115427041-794c0d80-a1d7-11eb-87ff-28ea529c1827.png">
<img width="800" alt="Screen Shot 2021-04-20 at 12 53 16 PM" src="https://user-images.githubusercontent.com/1326294/115427042-79e4a400-a1d7-11eb-80d9-3840dfb9b192.png">

</details>
<details>
<summary>After</summary>
<img width="781" alt="Screen Shot 2021-04-20 at 12 51 50 PM" src="https://user-images.githubusercontent.com/1326294/115426813-41dd6100-a1d7-11eb-8d9a-6a6202e1d167.png">
<img width="759" alt="Screen Shot 2021-04-20 at 12 51 35 PM" src="https://user-images.githubusercontent.com/1326294/115426814-430e8e00-a1d7-11eb-8131-035f6ec9491b.png">
<img width="740" alt="Screen Shot 2021-04-20 at 12 51 24 PM" src="https://user-images.githubusercontent.com/1326294/115426817-430e8e00-a1d7-11eb-8fe5-354b8a0efe03.png">
<img width="735" alt="Screen Shot 2021-04-20 at 12 51 10 PM" src="https://user-images.githubusercontent.com/1326294/115426823-443fbb00-a1d7-11eb-9474-b4a83631f97e.png">
</details>

### Test

1. Open About Dialog.
2. Ensure the full content can be seen.
3. Open the keyboard shortcuts help dialog.
4. Ensure it is larger and can see more of the content.
5. Open the Settings dialog.
6. Ensure the first Account screen can all be seen.
7. Open the Collaborate dialog for a note.
8. Ensure it appears with increased size.

