### PR TITLE
Fix extra line breaks appearing in the note preview

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,7 +13,7 @@
 ### Fixes
 
 - Fixed extra line breaks issue when exporting notes [#2819](https://github.com/automattic/simplenote-electron/pull/2819)
-- Fixed displaying extra blank spaces in history screen [#2829](https://github.com/automattic/simplenote-electron/pull/2829)
+- Fixed displaying extra blank spaces in history screen [#2829](https://github.com/automattic/simplenote-electron/pull/2829), [#2867](https://github.com/automattic/simplenote-electron/pull/2867)
 - Fixed to apply selected tag to a new note by default [#2556](https://github.com/automattic/simplenote-electron/pull/2556)
 - Fixed spacing on unsynced notes warning message [#2797](https://github.com/automattic/simplenote-electron/pull/2797)
 - Fixed cut off issue for dialogs when the window is too small [#2815](https://github.com/automattic/simplenote-electron/pull/2815), [#2834](https://github.com/automattic/simplenote-electron/pull/2834)

--- a/lib/utils/render-note-to-html.ts
+++ b/lib/utils/render-note-to-html.ts
@@ -6,12 +6,19 @@ const enableCheckboxes = {
   replace: '<input type="checkbox" ',
 };
 
+const removeLineBreaks = {
+  type: 'output',
+  regex: '>\n',
+  replace: '>',
+};
+
 export const renderNoteToHtml = (content: string) => {
   return import(/* webpackChunkName: 'showdown' */ 'showdown').then(
     ({ default: showdown }) => {
       showdown.extension('enableCheckboxes', enableCheckboxes);
+      showdown.extension('removeLineBreaks', removeLineBreaks);
       const markdownConverter = new showdown.Converter({
-        extensions: ['enableCheckboxes'],
+        extensions: ['enableCheckboxes', 'removeLineBreaks'],
       });
       markdownConverter.setFlavor('github');
       markdownConverter.setOption('simpleLineBreaks', false); // override GFM


### PR DESCRIPTION
### Fix

Fixes #2866

While trying to preserve white space in the note preview it had a side effect of showing unintended line breaks as well.
This works to fix it by removing line breaks after closing HTML tags. 

Note: Preview still only shows one empty line even if there are multiple in between, this was consistent with previous behavior.

<details>
<summary>Before</summary>
<img width="656" alt="Screen Shot 2021-04-21 at 1 06 22 PM" src="https://user-images.githubusercontent.com/1326294/115585916-6eaa7a80-a2a2-11eb-8cfa-91270bc7876f.png">
</details>

<details>
<summary>After</summary>
<img width="602" alt="Screen Shot 2021-04-21 at 1 05 56 PM" src="https://user-images.githubusercontent.com/1326294/115585947-7702b580-a2a2-11eb-92e3-ab06b3a47f37.png">
</details>

### Test

1. Create a new note
2. Add sample content such as
```
Bulleted List:
- one
- to
- three

Checkoxes:
- [ ] box1
- [x] box2

The text.

Linebreak is above.
New line.
```
3. View preview
4. Ensure there is not unexpected space between lines


