### PR TITLE
Add a title bar space for Mac Electron

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,7 @@ jobs:
             set +e
             rm -rf release/github
             rm -rf release/linux-unpacked
+            rm release/builder-debug.yml
       - persist_to_workspace:
           root: ~/simplenote
           paths:
@@ -171,6 +172,7 @@ jobs:
             set +e
             rm -rf release/github
             rm -rf release/mac
+            rm release/builder-debug.yml
       - persist_to_workspace:
           root: /Users/distiller/simplenote
           paths:
@@ -209,6 +211,11 @@ jobs:
             # package.json's `certificateSubjectName` to find the imported cert.
             Import-PfxCertificate -FilePath C:\Users\circleci\simplenote-electron\resources\certificates\win.p12 -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
             npx electron-builder --win -p onTag
+      - run:
+          name: Release cleanup
+          command: |
+            set +e
+            rm release/builder-debug.yml
       - persist_to_workspace:
           root: C:\Users\circleci\simplenote-electron
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,6 @@ jobs:
       - run:
           name: Release cleanup
           command: |
-            set +e
             rm release/builder-debug.yml
       - persist_to_workspace:
           root: C:\Users\circleci\simplenote-electron

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -71,7 +71,6 @@ module.exports = function main() {
       height: mainWindowState.height,
       minWidth: 370,
       minHeight: 520,
-      titleBarStyle: 'hidden',
       show: false,
       webPreferences: {
         contextIsolation: true,

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -91,6 +91,7 @@ module.exports = function main() {
     ) {
       mainWindow.openDevTools({ mode: 'detach' });
     }
+    mainWindow.openDevTools({ mode: 'detach' });
 
     // Configure and set the application menu
     const menuTemplate = createMenuTemplate();

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -91,7 +91,6 @@ module.exports = function main() {
     ) {
       mainWindow.openDevTools({ mode: 'detach' });
     }
-    mainWindow.openDevTools({ mode: 'detach' });
 
     // Configure and set the application menu
     const menuTemplate = createMenuTemplate();

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -29,6 +29,11 @@ module.exports = function main() {
   let mainWindow = null;
   let isAuthenticated;
 
+  // Fixes rendering bug on Linux when sandbox === true (Electron 11.0)
+  if (process.platform === 'linux') {
+    app.disableHardwareAcceleration();
+  }
+
   app.on('will-finish-launching', function () {
     setTimeout(updater.ping.bind(updater), config.updater.delay);
     app.on('open-url', function (event, url) {
@@ -89,7 +94,9 @@ module.exports = function main() {
       'test' !== process.env.NODE_ENV &&
       (isDev || process.argv.includes('--devtools'))
     ) {
-      mainWindow.openDevTools({ mode: 'detach' });
+      mainWindow.openDevTools({
+        mode: 'detach',
+      });
     }
 
     // Configure and set the application menu

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -208,22 +208,25 @@ class AppComponent extends Component<Props> {
     });
 
     return (
-      <div className={appClasses}>
-        {showEmailVerification && <EmailVerification />}
-        {showAlternateLoginPrompt && <AlternateLoginPrompt />}
-        {isDevConfig && (
-          <DevBadge
-            aria-hidden={showNavigation || showRevisions ? true : undefined}
-          />
-        )}
-        <div className={mainClasses}>
-          {showNavigation && <NavigationBar />}
-          <AppLayout />
-          {showNoteInfo && <NoteInfo />}
-          {showNoteActions && <NoteActions />}
+      <>
+        {isElectron && isMac && <div className="mac-title-bar"></div>}
+        <div className={appClasses}>
+          {showEmailVerification && <EmailVerification />}
+          {showAlternateLoginPrompt && <AlternateLoginPrompt />}
+          {isDevConfig && (
+            <DevBadge
+              aria-hidden={showNavigation || showRevisions ? true : undefined}
+            />
+          )}
+          <div className={mainClasses}>
+            {showNavigation && <NavigationBar />}
+            <AppLayout />
+            {showNoteInfo && <NoteInfo />}
+            {showNoteActions && <NoteActions />}
+          </div>
+          <DialogRenderer appProps={this.props} />
         </div>
-        <DialogRenderer appProps={this.props} />
-      </div>
+      </>
     );
   }
 }

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -208,25 +208,22 @@ class AppComponent extends Component<Props> {
     });
 
     return (
-      <>
-        {isElectron && isMac && <div className="mac-title-bar"></div>}
-        <div className={appClasses}>
-          {showEmailVerification && <EmailVerification />}
-          {showAlternateLoginPrompt && <AlternateLoginPrompt />}
-          {isDevConfig && (
-            <DevBadge
-              aria-hidden={showNavigation || showRevisions ? true : undefined}
-            />
-          )}
-          <div className={mainClasses}>
-            {showNavigation && <NavigationBar />}
-            <AppLayout />
-            {showNoteInfo && <NoteInfo />}
-            {showNoteActions && <NoteActions />}
-          </div>
-          <DialogRenderer appProps={this.props} />
+      <div className={appClasses}>
+        {showEmailVerification && <EmailVerification />}
+        {showAlternateLoginPrompt && <AlternateLoginPrompt />}
+        {isDevConfig && (
+          <DevBadge
+            aria-hidden={showNavigation || showRevisions ? true : undefined}
+          />
+        )}
+        <div className={mainClasses}>
+          {showNavigation && <NavigationBar />}
+          <AppLayout />
+          {showNoteInfo && <NoteInfo />}
+          {showNoteActions && <NoteActions />}
         </div>
-      </>
+        <DialogRenderer appProps={this.props} />
+      </div>
     );
   }
 }

--- a/lib/boot.ts
+++ b/lib/boot.ts
@@ -5,6 +5,7 @@ import { parse } from 'cookie';
 import getConfig from '../get-config';
 import { boot as bootWithoutAuth } from './boot-without-auth';
 import { boot as bootLoggingOut } from './logging-out';
+import { isElectron } from './utils/platform';
 
 const config = getConfig();
 
@@ -59,7 +60,13 @@ const clearStorage = (): Promise<void> =>
       .catch(() => resolveStorage());
   });
 
-const forceReload = () => history.go();
+const forceReload = () => {
+  if (isElectron) {
+    window.electron?.send('reload');
+  } else {
+    window.history.go();
+  }
+};
 
 const loadAccount = () => {
   const storedUserData = localStorage.getItem('stored_user');

--- a/lib/navigation-bar/style.scss
+++ b/lib/navigation-bar/style.scss
@@ -12,10 +12,6 @@
   transition: transform 200ms ease-in-out;
 }
 
-.is-macos .navigation-bar {
-  padding-top: $toolbar-height + 26px;
-}
-
 .navigation-bar__folders {
   display: flex;
   flex: none;

--- a/lib/note-actions/style.scss
+++ b/lib/note-actions/style.scss
@@ -1,7 +1,3 @@
-.is-macos .note-actions {
-  top: $toolbar-height + 16px + 26px;
-}
-
 .note-actions {
   width: 200px;
   position: absolute;

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -19,10 +19,6 @@
   width: 64px;
 }
 
-.is-electron.is-macos .note-toolbar-wrapper .offline-badge {
-  margin-top: -11px;
-}
-
 body[data-theme='dark'] .note-toolbar-wrapper .offline-badge {
   border: solid 1px $studio-gray-80;
   box-shadow: 0 2px 4px 0 rgba(255, 255, 255, 0.02);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6964,14 +6964,22 @@
       }
     },
     "electron": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-9.1.0.tgz",
-      "integrity": "sha512-VRAF8KX1m0py9I9sf0kw1kWfeC87mlscfFcbcRdLBsNJ44/GrJhi3+E8rKbpHUeZNQxsPaVA5Zu5Lxb6dV/scQ==",
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.5.tgz",
+      "integrity": "sha512-z0xYB3sPr0qZcDrHUUWqooPKe3yUzBDxQcgQe3f2TLstA84JIFXBoaIJCPh/fJW0+JdF/ZFVeK2SNgLhYtRV+Q==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
-        "@types/node": "^12.0.12",
+        "@types/node": "^14.6.2",
         "extract-zip": "^1.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.14.41",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
+          "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+          "dev": true
+        }
       }
     },
     "electron-builder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1478,6 +1478,30 @@
         }
       }
     },
+    "@electron/universal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.0.4.tgz",
+      "integrity": "sha512-ajZoumi4XwqwmZe8YVhu4XGkZBCPyWZsVCQONPTIe9TUlleSN+dic3YpXlaWcilx/HOzTdldTKtabNTeI0gDoA==",
+      "dev": true,
+      "requires": {
+        "@malept/cross-spawn-promise": "^1.1.0",
+        "asar": "^3.0.3",
+        "debug": "^4.3.1",
+        "dir-compare": "^2.4.0",
+        "fs-extra": "^9.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
     "@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
@@ -2504,6 +2528,58 @@
         }
       }
     },
+    "@malept/cross-spawn-promise": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "@material-ui/core": {
       "version": "4.11.0",
       "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.0.tgz",
@@ -2869,9 +2945,9 @@
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.6.tgz",
-      "integrity": "sha512-ecNRHw4clCkowNOBJH1e77nvbPxHYnWIXMv1IAoG/9+MYGkgoyr3Ppxr7XYFNL41V422EDhyV4/4SSK8L2mlig==",
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.11.tgz",
+      "integrity": "sha512-mZsifGG4QeQ7hlkhO56u7zt/ycBgGxSVsFI/6lGTU34VtwkiqrrSDgw0+ygs8kFGWcXnFQWMrzF2h7TtDFNixA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -3012,6 +3088,17 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/plist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.2.tgz",
+      "integrity": "sha512-ULqvZNGMv0zRFvqn8/4LSPtnmN4MfhlPNtJCTpKuIIxGVGZ2rYWzFXrvEBoh9CVyqSE7D6YFRJ1hydLHI6kbWw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*",
+        "xmlbuilder": ">=11.0.1"
+      }
     },
     "@types/prettier": {
       "version": "2.1.6",
@@ -3249,6 +3336,13 @@
       "resolved": "https://registry.npmjs.org/@types/valid-url/-/valid-url-1.0.3.tgz",
       "integrity": "sha512-+33x29mg+ecU88ODdWpqaie2upIuRkhujVLA7TuJjM823cNMbeggfI6NhxewaRaRF8dy+g33e4uIg/m5Mb3xDQ==",
       "dev": true
+    },
+    "@types/verror": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.4.tgz",
+      "integrity": "sha512-OjJdqx6QlbyZw9LShPwRW+Kmiegeg3eWNI41MQQKaG3vjdU2L9SRElntM51HmHBY1cu7izxQJ1lMYioQh3XMBg==",
+      "dev": true,
+      "optional": true
     },
     "@types/warning": {
       "version": "3.0.0",
@@ -3876,64 +3970,122 @@
       }
     },
     "app-builder-bin": {
-      "version": "3.5.9",
-      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.5.9.tgz",
-      "integrity": "sha512-NSjtqZ3x2kYiDp3Qezsgukx/AUzKPr3Xgf9by4cYt05ILWGAptepeeu0Uv+7MO+41o6ujhLixTou8979JGg2Kg==",
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.5.12.tgz",
+      "integrity": "sha512-lQARM2AielmFoBeIo6LZigAe+58Wwe07ZWkt+wVeDxzyieNmeWjlvz/V5dKzinydwdHd+CNswN86sww46yijjA==",
       "dev": true
     },
     "app-builder-lib": {
-      "version": "22.7.0",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.7.0.tgz",
-      "integrity": "sha512-blRKwV8h0ztualXS50ciCTo39tbuDGNS+ldcy8+KLvKXuT6OpYnSJ7M6MSfPT+xWatshMHJV1rJx3Tl+k/Sn/g==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.10.5.tgz",
+      "integrity": "sha512-/W8nlGamJCtKlQtsMWwU9vb+cX4pTNY+rJWCuc7oXUykVSMS50W7LhQusIjCelNfymUQ1XCu6cXEY/ylqhX12A==",
       "dev": true,
       "requires": {
         "7zip-bin": "~5.0.3",
         "@develar/schema-utils": "~2.6.5",
+        "@electron/universal": "1.0.4",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "22.7.0",
-        "builder-util-runtime": "8.7.1",
+        "builder-util": "22.10.5",
+        "builder-util-runtime": "8.7.3",
         "chromium-pickle-js": "^0.2.0",
-        "debug": "^4.2.0",
-        "ejs": "^3.1.3",
-        "electron-publish": "22.7.0",
-        "fs-extra": "^9.0.0",
-        "hosted-git-info": "^3.0.4",
+        "debug": "^4.3.2",
+        "ejs": "^3.1.6",
+        "electron-publish": "22.10.5",
+        "fs-extra": "^9.1.0",
+        "hosted-git-info": "^3.0.8",
         "is-ci": "^2.0.0",
-        "isbinaryfile": "^4.0.6",
-        "js-yaml": "^3.14.0",
+        "istextorbinary": "^5.12.0",
+        "js-yaml": "^4.0.0",
         "lazy-val": "^1.0.4",
         "minimatch": "^3.0.4",
-        "normalize-package-data": "^2.5.0",
+        "normalize-package-data": "^3.0.0",
         "read-config-file": "6.0.0",
         "sanitize-filename": "^1.6.3",
-        "semver": "^7.3.2",
+        "semver": "^7.3.4",
         "temp-file": "^3.3.7"
       },
       "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
         "builder-util-runtime": {
-          "version": "8.7.1",
-          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.1.tgz",
-          "integrity": "sha512-uEBH1nAnTvzjcsrh2XI3qOzJ39h0+9kuIuwj+kCc3a07TZNGShfJcai8fFzL3mNgGjEFxoq+XMssR11r+FOFSg==",
+          "version": "8.7.3",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.3.tgz",
+          "integrity": "sha512-1Q2ReBqFblimF5g/TLg2+0M5Xzv0Ih5LxJ/BMWXvEy/e6pQKeeEpbkPMGsN6OiQgkygaZo5VXCXIjOkOQG5EoQ==",
           "dev": true,
           "requires": {
-            "debug": "^4.2.0",
+            "debug": "^4.3.2",
             "sax": "^1.2.4"
           }
         },
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
         },
         "hosted-git-info": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-          "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+          "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "normalize-package-data": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
+          "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^4.0.1",
+            "resolve": "^1.20.0",
+            "semver": "^7.3.4",
+            "validate-npm-package-license": "^3.0.1"
+          },
+          "dependencies": {
+            "hosted-git-info": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+              "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -4148,6 +4300,27 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "asar": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/asar/-/asar-3.0.3.tgz",
+      "integrity": "sha512-k7zd+KoR+n8pl71PvgElcoKHrVNiSXtw7odKbyNpmgKe7EGRF9Pnu3uLOukD37EvavKwVFxOUpqXTIZC5B5Pmw==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "chromium-pickle-js": "^0.2.0",
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        }
+      }
     },
     "asn1": {
       "version": "0.2.4",
@@ -4637,6 +4810,12 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "binaryextensions": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-4.15.0.tgz",
+      "integrity": "sha512-MkUl3szxXolQ2scI1PM14WOT951KnaTNJ0eMKg7WzOI4kvSxyNo/Cygx4LOBNhwyINhAuSQpJW1rYD9aBSxGaw==",
+      "dev": true
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -4785,19 +4964,19 @@
       "optional": true
     },
     "boxen": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
-      "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.0.1.tgz",
+      "integrity": "sha512-49VBlw+PrWEF51aCmy7QIteYPIFZxSpvqBdP/2itCPPlJ49kj9zg/XPRFrdkne2W+CfwXUls8exMvu1RysZpKA==",
       "dev": true,
       "requires": {
         "ansi-align": "^3.0.0",
-        "camelcase": "^5.3.1",
-        "chalk": "^3.0.0",
-        "cli-boxes": "^2.2.0",
-        "string-width": "^4.1.0",
-        "term-size": "^2.1.0",
-        "type-fest": "^0.8.1",
-        "widest-line": "^3.1.0"
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.0",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4815,10 +4994,16 @@
             "color-convert": "^2.0.1"
           }
         },
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "dev": true
+        },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -4859,9 +5044,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -4888,10 +5073,21 @@
           }
         },
         "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
         }
       }
     },
@@ -5069,6 +5265,12 @@
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
+    "buffer-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -5088,22 +5290,22 @@
       "dev": true
     },
     "builder-util": {
-      "version": "22.7.0",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.7.0.tgz",
-      "integrity": "sha512-UV3MKL0mwjMq2y9JlBf28Cegpj0CrIXcjGkO0TXn+QZ6Yy9rY6lHOuUvpQ19ct2Qh1o+QSwH3Q1nKUf5viJBBg==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.10.5.tgz",
+      "integrity": "sha512-/MkLhmyo1gU3xMwXJxccQaRj/9tm5eTd6ZyebTf8SYouY4r3hRser+LxhOm/f8Z9W6oJvfPe0jc9TFsxYfMcsg==",
       "dev": true,
       "requires": {
         "7zip-bin": "~5.0.3",
         "@types/debug": "^4.1.5",
-        "@types/fs-extra": "^9.0.1",
-        "app-builder-bin": "3.5.9",
+        "@types/fs-extra": "^9.0.7",
+        "app-builder-bin": "3.5.12",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "8.7.1",
-        "chalk": "^4.0.0",
-        "debug": "^4.2.0",
-        "fs-extra": "^9.0.0",
+        "builder-util-runtime": "8.7.3",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.2",
+        "fs-extra": "^9.1.0",
         "is-ci": "^2.0.0",
-        "js-yaml": "^3.14.0",
+        "js-yaml": "^4.0.0",
         "source-map-support": "^0.5.19",
         "stat-mode": "^1.0.0",
         "temp-file": "^3.3.7"
@@ -5118,20 +5320,26 @@
             "color-convert": "^2.0.1"
           }
         },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
         "builder-util-runtime": {
-          "version": "8.7.1",
-          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.1.tgz",
-          "integrity": "sha512-uEBH1nAnTvzjcsrh2XI3qOzJ39h0+9kuIuwj+kCc3a07TZNGShfJcai8fFzL3mNgGjEFxoq+XMssR11r+FOFSg==",
+          "version": "8.7.3",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.3.tgz",
+          "integrity": "sha512-1Q2ReBqFblimF5g/TLg2+0M5Xzv0Ih5LxJ/BMWXvEy/e6pQKeeEpbkPMGsN6OiQgkygaZo5VXCXIjOkOQG5EoQ==",
           "dev": true,
           "requires": {
-            "debug": "^4.2.0",
+            "debug": "^4.3.2",
             "sax": "^1.2.4"
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5154,9 +5362,9 @@
           "dev": true
         },
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -5167,6 +5375,15 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -5608,6 +5825,57 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
       "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
       "dev": true
+    },
+    "cli-truncate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
+      "integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "slice-ansi": "^1.0.0",
+        "string-width": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true,
+          "optional": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "clipboard": {
       "version": "2.0.6",
@@ -6110,6 +6378,16 @@
             "lines-and-columns": "^1.1.6"
           }
         }
+      }
+    },
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "buffer": "^5.1.0"
       }
     },
     "crc-32": {
@@ -6704,6 +6982,35 @@
         }
       }
     },
+    "dir-compare": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-2.4.0.tgz",
+      "integrity": "sha512-l9hmu8x/rjVC9Z2zmGzkhOEowZvW7pmYws5CWHutg8u1JgvsKWMx7Q/UODeu4djLZ4FgW5besw5yvMQnBHzuCA==",
+      "dev": true,
+      "requires": {
+        "buffer-equal": "1.0.0",
+        "colors": "1.0.3",
+        "commander": "2.9.0",
+        "minimatch": "3.0.4"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        }
+      }
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -6720,28 +7027,53 @@
       "dev": true
     },
     "dmg-builder": {
-      "version": "22.7.0",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.7.0.tgz",
-      "integrity": "sha512-5Ea2YEz6zSNbyGzZD+O9/MzmaXb6oa15cSKWo4JQ1xP4rorOpte7IOj2jcwYjtc+Los2gu1lvT314OC1OZIWgg==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.10.5.tgz",
+      "integrity": "sha512-58FEpfH8PEFqjbUNka4bYr52snRT8+LSXrP4gy6EZWOVICbOlmTOYj988pfoLam5C5iXb3odmyUQqwWOxlsEUw==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "22.7.0",
-        "builder-util": "22.7.0",
-        "fs-extra": "^9.0.0",
-        "iconv-lite": "^0.5.1",
-        "js-yaml": "^3.14.0",
+        "app-builder-lib": "22.10.5",
+        "builder-util": "22.10.5",
+        "dmg-license": "^1.0.8",
+        "fs-extra": "^9.1.0",
+        "iconv-lite": "^0.6.2",
+        "js-yaml": "^4.0.0",
         "sanitize-filename": "^1.6.3"
       },
       "dependencies": {
-        "iconv-lite": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
-          "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
           "dev": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "argparse": "^2.0.1"
           }
         }
+      }
+    },
+    "dmg-license": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.8.tgz",
+      "integrity": "sha512-47GOb6b4yVzpovXC34heXElpH++ICg9GuWBeOTaokUNLAoAdWpE4VehudYEEtu96j2jXsgQWYf78nW7r+0Y3eg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/plist": "^3.0.1",
+        "@types/verror": "^1.10.3",
+        "ajv": "^6.10.0",
+        "cli-truncate": "^1.1.0",
+        "crc": "^3.8.0",
+        "iconv-corefoundation": "^1.1.5",
+        "plist": "^3.0.1",
+        "smart-buffer": "^4.0.2",
+        "verror": "^1.10.0"
       }
     },
     "dns-equal": {
@@ -6948,6 +7280,16 @@
         }
       }
     },
+    "editions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-6.1.0.tgz",
+      "integrity": "sha512-h6nWEyIocfgho9J3sTSuhU/WoFOu1hTX75rPBebNrbF38Y9QFDjCDizYXdikHTySW7Y3mSxli8bpDz9RAtc7rA==",
+      "dev": true,
+      "requires": {
+        "errlop": "^4.0.0",
+        "version-range": "^1.0.0"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6955,9 +7297,9 @@
       "dev": true
     },
     "ejs": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.5.tgz",
-      "integrity": "sha512-dldq3ZfFtgVTJMLjOe+/3sROTzALlL9E34V4/sDtUd/KlBSS0s6U1/+WPE1B4sj9CXHJpL1M6rhNJnc9Wbal9w==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+      "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
       "dev": true,
       "requires": {
         "jake": "^10.6.1"
@@ -6983,27 +7325,36 @@
       }
     },
     "electron-builder": {
-      "version": "22.7.0",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.7.0.tgz",
-      "integrity": "sha512-t6E3oMutpST64YWbZCg7HodEwJOsnjUF1vnDIHm2MW6CFZPX8tlCK6efqaV66LU0E0Nkp/JH6TE5bCqQ1+VdPQ==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.10.5.tgz",
+      "integrity": "sha512-0q/289UUJUhRou6lZKDz/wzK6WprIQ6VXMTmaI+w9qXvSNugPC9UA5s2zXInOkjZOvO/xKnjeyiavrVSHYF3tA==",
       "dev": true,
       "requires": {
-        "@types/yargs": "^15.0.5",
-        "app-builder-lib": "22.7.0",
+        "@types/yargs": "^15.0.13",
+        "app-builder-lib": "22.10.5",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "22.7.0",
-        "builder-util-runtime": "8.7.1",
-        "chalk": "^4.0.0",
-        "dmg-builder": "22.7.0",
-        "fs-extra": "^9.0.0",
+        "builder-util": "22.10.5",
+        "builder-util-runtime": "8.7.3",
+        "chalk": "^4.1.0",
+        "dmg-builder": "22.10.5",
+        "fs-extra": "^9.1.0",
         "is-ci": "^2.0.0",
         "lazy-val": "^1.0.4",
         "read-config-file": "6.0.0",
         "sanitize-filename": "^1.6.3",
-        "update-notifier": "^4.1.0",
-        "yargs": "^15.3.1"
+        "update-notifier": "^5.1.0",
+        "yargs": "^16.2.0"
       },
       "dependencies": {
+        "@types/yargs": {
+          "version": "15.0.13",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
+          "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -7020,19 +7371,19 @@
           }
         },
         "builder-util-runtime": {
-          "version": "8.7.1",
-          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.1.tgz",
-          "integrity": "sha512-uEBH1nAnTvzjcsrh2XI3qOzJ39h0+9kuIuwj+kCc3a07TZNGShfJcai8fFzL3mNgGjEFxoq+XMssR11r+FOFSg==",
+          "version": "8.7.3",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.3.tgz",
+          "integrity": "sha512-1Q2ReBqFblimF5g/TLg2+0M5Xzv0Ih5LxJ/BMWXvEy/e6pQKeeEpbkPMGsN6OiQgkygaZo5VXCXIjOkOQG5EoQ==",
           "dev": true,
           "requires": {
-            "debug": "^4.2.0",
+            "debug": "^4.3.2",
             "sax": "^1.2.4"
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -7040,14 +7391,14 @@
           }
         },
         "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
           "dev": true,
           "requires": {
             "string-width": "^4.2.0",
             "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
+            "wrap-ansi": "^7.0.0"
           }
         },
         "color-convert": {
@@ -7066,9 +7417,9 @@
           "dev": true
         },
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -7079,16 +7430,6 @@
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "dev": true
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
         },
         "has-flag": {
           "version": "4.0.0",
@@ -7102,34 +7443,10 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -7156,9 +7473,9 @@
           }
         },
         "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -7166,34 +7483,32 @@
             "strip-ansi": "^6.0.0"
           }
         },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
         "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
           "dev": true,
           "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
             "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
           }
         },
         "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
+          "version": "20.2.7",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+          "dev": true
         }
       }
     },
@@ -7257,19 +7572,19 @@
       }
     },
     "electron-publish": {
-      "version": "22.7.0",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.7.0.tgz",
-      "integrity": "sha512-hmU69xlb6vvAV3QfpHYDlkdZMFdBAgDbptoxbLFrnTq5bOkcL8AaDbvxeoZ4+lvqgs29NwqGpkHo2oN+p/hCfg==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.10.5.tgz",
+      "integrity": "sha512-dHyuazv3P3j1Xyv7pdwTwAvxWab2pCb0G0Oa6qWQoCc4b1/mRGY00M7AvYW1cPuUijj9zYAf1HmXfM6MifaMlA==",
       "dev": true,
       "requires": {
-        "@types/fs-extra": "^9.0.1",
+        "@types/fs-extra": "^9.0.7",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "22.7.0",
-        "builder-util-runtime": "8.7.1",
-        "chalk": "^4.0.0",
-        "fs-extra": "^9.0.0",
+        "builder-util": "22.10.5",
+        "builder-util-runtime": "8.7.3",
+        "chalk": "^4.1.0",
+        "fs-extra": "^9.1.0",
         "lazy-val": "^1.0.4",
-        "mime": "^2.4.5"
+        "mime": "^2.5.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7282,19 +7597,19 @@
           }
         },
         "builder-util-runtime": {
-          "version": "8.7.1",
-          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.1.tgz",
-          "integrity": "sha512-uEBH1nAnTvzjcsrh2XI3qOzJ39h0+9kuIuwj+kCc3a07TZNGShfJcai8fFzL3mNgGjEFxoq+XMssR11r+FOFSg==",
+          "version": "8.7.3",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.3.tgz",
+          "integrity": "sha512-1Q2ReBqFblimF5g/TLg2+0M5Xzv0Ih5LxJ/BMWXvEy/e6pQKeeEpbkPMGsN6OiQgkygaZo5VXCXIjOkOQG5EoQ==",
           "dev": true,
           "requires": {
-            "debug": "^4.2.0",
+            "debug": "^4.3.2",
             "sax": "^1.2.4"
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -7317,9 +7632,9 @@
           "dev": true
         },
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -7579,6 +7894,12 @@
         "has": "^1.0.3",
         "object-is": "^1.1.2"
       }
+    },
+    "errlop": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/errlop/-/errlop-4.1.0.tgz",
+      "integrity": "sha512-vul6gGBuVt0M2TPi1/WrcL86+Hb3Q2Tpu3TME3sbVhZrYf7J1ZMHCodI25RQKCVurh56qTfvgM0p3w5cT4reSQ==",
+      "dev": true
     },
     "errno": {
       "version": "0.1.8",
@@ -8796,9 +9117,9 @@
       "optional": true
     },
     "filelist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz",
-      "integrity": "sha512-8zSK6Nu0DQIC08mUC46sWGXi+q3GGpKydAG36k+JDba6VRpkevvOWUW5a/PhShij4+vHT9M+ghgG7eM+a9JDUQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
+      "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
@@ -9325,18 +9646,18 @@
       }
     },
     "global-dirs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
-      "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
+      "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
       "dev": true,
       "requires": {
-        "ini": "1.3.7"
+        "ini": "2.0.0"
       },
       "dependencies": {
         "ini": {
-          "version": "1.3.7",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
-          "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+          "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
           "dev": true
         }
       }
@@ -9469,6 +9790,12 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -9948,6 +10275,17 @@
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
       "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
+    "iconv-corefoundation": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.5.tgz",
+      "integrity": "sha512-hI4m7udfV04OcjleOmDaR4gwXnH4xumxN+ZmywHDiKf2CmAzsT9SVYe7Y4pdnQbyZfXwAQyrElykbE5PrPRfmQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "cli-truncate": "^1.1.0",
+        "node-addon-api": "^1.6.3"
+      }
+    },
     "iconv-lite": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
@@ -10385,13 +10723,13 @@
       "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
     "is-installed-globally": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
-      "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
       "dev": true,
       "requires": {
-        "global-dirs": "^2.0.1",
-        "is-path-inside": "^3.0.1"
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
       }
     },
     "is-negative-zero": {
@@ -10401,9 +10739,9 @@
       "dev": true
     },
     "is-npm": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
-      "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+      "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
       "dev": true
     },
     "is-number": {
@@ -10465,9 +10803,9 @@
       }
     },
     "is-path-inside": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
     },
     "is-plain-obj": {
@@ -10567,12 +10905,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "isbinaryfile": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.6.tgz",
-      "integrity": "sha512-ORrEy+SNVqUhrCaal4hA4fBzhggQQ+BaLntyPOdoEiwlKZW9BZiJXjg3RMiruE4tPEI3pyVPpySHQF/dKWperg==",
-      "dev": true
     },
     "isemail": {
       "version": "3.2.0",
@@ -10687,6 +11019,17 @@
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "istextorbinary": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-5.12.0.tgz",
+      "integrity": "sha512-wLDRWD7qpNTYubk04+q3en1+XZGS4vYWK0+SxNSXJLaITMMEK+J3o/TlOMyULeH1qozVZ9uUkKcyMA8odyxz8w==",
+      "dev": true,
+      "requires": {
+        "binaryextensions": "^4.15.0",
+        "editions": "^6.1.0",
+        "textextensions": "^5.11.0"
       }
     },
     "jake": {
@@ -14889,6 +15232,13 @@
         }
       }
     },
+    "node-addon-api": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "dev": true,
+      "optional": true
+    },
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
@@ -15910,6 +16260,27 @@
       "dev": true,
       "requires": {
         "semver-compare": "^1.0.0"
+      }
+    },
+    "plist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
+      "integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^9.0.7",
+        "xmldom": "^0.5.0"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "popper.js": {
@@ -17014,9 +17385,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -18369,6 +18740,13 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "smart-buffer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+      "dev": true,
+      "optional": true
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -19659,12 +20037,6 @@
         }
       }
     },
-    "term-size": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
-      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
-      "dev": true
-    },
     "terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -19742,6 +20114,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "textextensions": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-5.12.0.tgz",
+      "integrity": "sha512-IYogUDaP65IXboCiPPC0jTLLBzYlhhw2Y4b0a2trPgbHNGGGEfuHE6tds+yDcCf4mpNDaGISFzwSSezcXt+d6w==",
       "dev": true
     },
     "throat": {
@@ -20281,22 +20659,23 @@
       "dev": true
     },
     "update-notifier": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.3.tgz",
-      "integrity": "sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
+      "integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
       "dev": true,
       "requires": {
-        "boxen": "^4.2.0",
-        "chalk": "^3.0.0",
+        "boxen": "^5.0.0",
+        "chalk": "^4.1.0",
         "configstore": "^5.0.1",
         "has-yarn": "^2.1.0",
         "import-lazy": "^2.1.0",
         "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.3.1",
-        "is-npm": "^4.0.0",
+        "is-installed-globally": "^0.4.0",
+        "is-npm": "^5.0.0",
         "is-yarn-global": "^0.3.0",
-        "latest-version": "^5.0.0",
-        "pupa": "^2.0.1",
+        "latest-version": "^5.1.0",
+        "pupa": "^2.1.1",
+        "semver": "^7.3.4",
         "semver-diff": "^3.1.1",
         "xdg-basedir": "^4.0.0"
       },
@@ -20311,9 +20690,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -20340,6 +20719,15 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -20550,6 +20938,21 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "version-compare": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/version-compare/-/version-compare-1.1.0.tgz",
+      "integrity": "sha512-zVKtPOJTC9x23lzS4+4D7J+drq80BXVYAmObnr5zqxxFVH7OffJ1lJlAS7LYsQNV56jx/wtbw0UV7XHLrvd6kQ==",
+      "dev": true
+    },
+    "version-range": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/version-range/-/version-range-1.1.0.tgz",
+      "integrity": "sha512-R1Ggfg2EXamrnrV3TkZ6yBNgITDbclB3viwSjbZ3+eK0VVNK4ajkYJTnDz5N0bIMYDtK9MUBvXJUnKO5RWWJ6w==",
+      "dev": true,
+      "requires": {
+        "version-compare": "^1.0.0"
       }
     },
     "vfile": {
@@ -21475,9 +21878,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -21600,10 +22003,24 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
     },
+    "xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "optional": true
+    },
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "xmldom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
+      "dev": true,
+      "optional": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "concurrently": "5.2.0",
     "css-loader": "3.6.0",
     "debug": "4.1.1",
-    "electron": "9.1.0",
+    "electron": "12.0.5",
     "electron-builder": "22.7.0",
     "electron-notarize": "1.0.0",
     "enzyme": "3.11.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "css-loader": "3.6.0",
     "debug": "4.1.1",
     "electron": "12.0.5",
-    "electron-builder": "22.7.0",
+    "electron-builder": "22.10.5",
     "electron-notarize": "1.0.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -61,6 +61,7 @@ optgroup {
   width: 100%;
   height: 100%;
 }
+
 .mac-title-bar {
   background-color: #f4f4f4;
   height: 28px;

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -62,8 +62,8 @@ optgroup {
   height: 100%;
 }
 .mac-title-bar {
-  height: 28px;
   background-color: #f4f4f4;
+  height: 28px;
   -webkit-app-region: drag;
 }
 

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -61,38 +61,14 @@ optgroup {
   width: 100%;
   height: 100%;
 }
+.mac-title-bar {
+  height: 28px;
+  background-color: #f4f4f4;
+  -webkit-app-region: drag;
+}
 
-.is-macos {
-  .note-toolbar-wrapper {
-    box-sizing: border-box;
-    -webkit-app-region: drag;
-    padding: 40px 0 30px;
-  }
-
-  .new-note-toolbar__button-sidebar {
-    border-right: 0;
-    padding-right: 0;
-  }
-
-  .menu-bar {
-    padding: 40px 15px 30px;
-    box-sizing: border-box;
-    -webkit-app-region: drag;
-  }
-
-  .note-toolbar-placeholder {
-    height: 71px;
-    -webkit-app-region: drag;
-  }
-
-  .note-info {
-    padding-top: 10px;
-  }
-
-  .button,
-  .search-field {
-    -webkit-app-region: no-drag;
-  }
+.mac-title-bar + .app {
+  top: 28px;
 }
 
 .login__draggable-area {

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -62,16 +62,6 @@ optgroup {
   height: 100%;
 }
 
-.mac-title-bar {
-  background-color: #f4f4f4;
-  height: 28px;
-  -webkit-app-region: drag;
-}
-
-.mac-title-bar + .app {
-  top: 28px;
-}
-
 .login__draggable-area {
   height: 100px;
   position: absolute;

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -161,6 +161,10 @@ body[data-theme='dark'] {
   background-color: $studio-gray-90;
   color: $studio-gray-20;
 
+  .mac-title-bar {
+    background-color: #323436;
+  }
+
   .theme-color-bg {
     background-color: $studio-gray-90;
   }


### PR DESCRIPTION
### Fix

Previously we had been adding specific styles to different components for only Mac Electron app to prevent things from overlapping the window buttons.

This removes those and instead enables the default title bar.

To have this work well I also updated the Electron dependency to fix some issues with the rounded corners. With that also updated Electron Builder.

Resolves #2886

The Electron update introduced two issues one where logging out wouldn't refresh to the login screen. The other the Linux build wouldn't render properly.
Both of those have fixes here as well.

<details>
<summary>Before</summary>
<img width="1292" alt="Screen Shot 2021-04-23 at 9 06 44 PM" src="https://user-images.githubusercontent.com/1326294/115940428-ee3d7280-a477-11eb-933f-3a662c7a02fb.png">
<img width="1250" alt="Screen Shot 2021-04-23 at 9 06 05 PM" src="https://user-images.githubusercontent.com/1326294/115940431-f0073600-a477-11eb-9ab6-27f465569cba.png">
</details>
<details>
<summary>After</summary>
<img width="1219" alt="Screen Shot 2021-05-03 at 9 16 37 AM" src="https://user-images.githubusercontent.com/1326294/116879087-97ae0200-abf6-11eb-8988-012c13c68897.png">
<img width="1286" alt="Screen Shot 2021-05-03 at 9 16 08 AM" src="https://user-images.githubusercontent.com/1326294/116879098-9a105c00-abf6-11eb-8836-c3c0263cd2e3.png">
</details>

### Test

1. Run Mac Electron app.
2. Ensure bar appears at the top with the app below it as usual.
3. Check other Electron builds to ensure they work as expected.

### Release

- Added title bar area to the Mac Electron app
- Updated Electron and Electron Builder dependencies
