### PR TITLE
Reduce the number of colors used throughout the app

### DIFF
--- a/lib/alternate-login-prompt/style.scss
+++ b/lib/alternate-login-prompt/style.scss
@@ -7,7 +7,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba($studio-gray-20, 0.75);
+  background: rgba($studio-black, 0.3);
 }
 
 .alternate-login__dismiss {
@@ -72,10 +72,7 @@
 }
 
 .theme-dark {
-  .alternate-login__overlay {
-    background: rgba($studio-gray-100, 0.75);
-  }
   .alternate-login__button-row .button-borderless {
-    color: $studio-simplenote-blue-30;
+    color: $studio-simplenote-blue-20;
   }
 }

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -4,11 +4,11 @@
 
 .login.is-electron {
   input.validate:invalid {
-    box-shadow: 0 0 1.5px 1px red;
+    box-shadow: 0 0 1.5px 1px $studio-red-50;
   }
 
   input.validate:invalid:focus {
-    outline-color: red;
+    outline-color: $studio-red-50;
   }
 }
 
@@ -39,7 +39,7 @@
     text-align: center;
     width: 90%;
     .is-error {
-      color: $studio-red-60;
+      color: $studio-red-50;
     }
   }
 
@@ -94,14 +94,14 @@
   }
 
   a.login__forgot {
-    color: $studio-gray-60;
+    color: $studio-gray-50;
     text-decoration: none;
   }
 
   .login__forgot,
   .login__signup,
   .terms {
-    color: $studio-gray-60;
+    color: $studio-gray-50;
     display: block;
     font-size: 14px;
     margin: 16px auto;
@@ -120,7 +120,7 @@
 
   .or {
     background: $studio-white;
-    color: $studio-gray-60;
+    color: $studio-gray-50;
     display: block;
     font-size: 15px;
     font-style: italic;
@@ -194,7 +194,7 @@
   .login__signup a,
   .login__auth-message a,
   .terms a {
-    color: $studio-simplenote-blue-30;
+    color: $studio-simplenote-blue-20;
   }
 
   .login__auth-message.is-error {
@@ -213,7 +213,7 @@
     color: $studio-gray-30;
   }
   input {
-    border-color: $studio-gray-60;
+    border-color: $studio-gray-50;
 
     &:disabled {
       color: $studio-gray-50;
@@ -221,13 +221,13 @@
     }
 
     &:read-only {
-      border-color: $studio-gray-60;
+      border-color: $studio-gray-50;
       background-color: rgba(255, 255, 255, 0.07);
     }
 
     &:focus {
-      border-color: $studio-simplenote-blue-30;
-      box-shadow: 0 0 0 1px $studio-simplenote-blue-30;
+      border-color: $studio-simplenote-blue-20;
+      box-shadow: 0 0 0 1px $studio-simplenote-blue-20;
     }
   }
 }

--- a/lib/components/tab-panels/style.scss
+++ b/lib/components/tab-panels/style.scss
@@ -30,8 +30,8 @@
 }
 
 .theme-dark .tab-panels__tab-list li.is-active {
-  color: $studio-simplenote-blue-30;
-  border-bottom-color: $studio-simplenote-blue-30;
+  color: $studio-simplenote-blue-20;
+  border-bottom-color: $studio-simplenote-blue-20;
 }
 
 .tab-panels__panel {

--- a/lib/dialogs/import/dropzone/style.scss
+++ b/lib/dialogs/import/dropzone/style.scss
@@ -101,7 +101,7 @@
   .importer-dropzone {
     .drop-instructions {
       span {
-        color: $studio-blue-30;
+        color: $studio-simplenote-blue-20;
       }
     }
     &.is-accepted {

--- a/lib/dialogs/import/source-importer/executor/style.scss
+++ b/lib/dialogs/import/source-importer/executor/style.scss
@@ -49,7 +49,7 @@
 
 .source-importer-executor__error {
   margin-bottom: 0.75em;
-  color: $studio-red-40;
+  color: $studio-red-50;
   line-height: 1.3;
 }
 

--- a/lib/dialogs/unsynchronized/style.scss
+++ b/lib/dialogs/unsynchronized/style.scss
@@ -55,7 +55,7 @@
     }
 
     .icon-attention {
-      color: $studio-orange-30;
+      color: $studio-orange-20;
       height: 25px;
       width: 19px;
     }
@@ -88,6 +88,6 @@
   }
 
   .export-unsynchronized {
-    color: $studio-simplenote-blue-30;
+    color: $studio-simplenote-blue-20;
   }
 }

--- a/lib/email-verification/style.scss
+++ b/lib/email-verification/style.scss
@@ -7,7 +7,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba($studio-gray-20, 0.75);
+  background: rgba($studio-black, 0.3);
 }
 
 .email-verification__dismiss {
@@ -78,10 +78,7 @@
 }
 
 .theme-dark {
-  .email-verification__overlay {
-    background: rgba($studio-gray-100, 0.75);
-  }
   .email-verification__button-row .button-borderless {
-    color: $studio-simplenote-blue-30;
+    color: $studio-simplenote-blue-20;
   }
 }

--- a/lib/error-boundary/style.scss
+++ b/lib/error-boundary/style.scss
@@ -42,6 +42,6 @@
 }
 
 .error-message__footnote {
-  color: $studio-gray-60;
+  color: $studio-gray-50;
   font-size: 14px;
 }

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -578,7 +578,7 @@ class NoteContentEditor extends Component<Props> {
       colors: {
         'editor.foreground': '#ffffff',
         'editor.background': '#1d2327', // $studio-gray-90
-        'editor.selectionBackground': '#50575e', // $studio-gray-60
+        'editor.selectionBackground': '#646970', // $studio-gray-50
         'scrollbarSlider.activeBackground': '#646970', // $studio-gray-50
         'scrollbarSlider.background': '#2c3338', // $studio-gray-80
         'scrollbarSlider.hoverBackground': '#1d2327', // $studio-gray-90

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -56,7 +56,7 @@
   border: 0;
   line-height: 1.5em;
   font-size: 16px;
-  color: $studio-gray-60;
+  color: $studio-gray-50;
   background: $studio-white;
   resize: none;
   -webkit-tap-highlight-color: transparent;

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -100,12 +100,12 @@
     }
 
     button {
-      color: $studio-simplenote-blue-30;
+      color: $studio-simplenote-blue-20;
     }
   }
 
   .note-list .search-match {
-    color: $studio-simplenote-blue-30;
+    color: $studio-simplenote-blue-20;
   }
 }
 

--- a/lib/tag-input/style.scss
+++ b/lib/tag-input/style.scss
@@ -43,5 +43,5 @@
 }
 
 .tag-input__suggestion {
-  color: $studio-gray-40;
+  color: $studio-gray-50;
 }

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -118,13 +118,13 @@ input.tag-list-input {
       color: $studio-gray-50;
     }
     &.button-trash {
-      color: $studio-simplenote-blue-30;
+      color: $studio-simplenote-blue-20;
     }
   }
 
   .tag-list-item {
     &:hover {
-      background-color: $studio-gray-60;
+      background-color: $studio-gray-80;
     }
   }
 }
@@ -132,7 +132,7 @@ input.tag-list-input {
 .theme-light {
   .icon-button {
     &.button-trash {
-      color: $studio-simplenote-blue-30;
+      color: $studio-simplenote-blue-20;
     }
     &.button-reorder {
       color: $studio-gray-10;

--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -65,11 +65,11 @@ button {
 
 // Danger buttons
 .button-danger {
-  color: $studio-red-40;
-  border-color: $studio-red-40;
+  color: $studio-red-50;
+  border-color: $studio-red-50;
 
   &:active {
-    background: $studio-red-40;
+    background: $studio-red-50;
     color: $studio-white;
   }
 }
@@ -86,7 +86,7 @@ button {
 
 .button-borderless.button-danger {
   &:active {
-    color: darken($studio-red-40, 20%);
+    color: darken($studio-red-50, 20%);
   }
 }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -125,7 +125,7 @@ span[dir='ltr'] {
 
 .theme-light {
   background-color: $studio-white;
-  color: $studio-gray-60;
+  color: $studio-gray-50;
 
   .theme-color-bg {
     background-color: $studio-white;
@@ -181,7 +181,7 @@ span[dir='ltr'] {
 
   ::-webkit-scrollbar-thumb {
     background-color: $studio-gray-80;
-    border-color: $studio-gray-60;
+    border-color: $studio-gray-50;
   }
   ::-webkit-scrollbar-thumb:hover {
     background-color: $studio-gray-90;
@@ -191,12 +191,12 @@ span[dir='ltr'] {
   }
 
   .button-borderless {
-    color: $studio-simplenote-blue-30;
+    color: $studio-simplenote-blue-20;
 
     &[disabled],
     &:disabled {
       svg[class^='icon-'] {
-        fill: $studio-gray-60;
+        fill: $studio-gray-50;
       }
     }
   }
@@ -293,7 +293,7 @@ span[dir='ltr'] {
 
     .note-list-item-pinned:not(.note-list-item-selected) {
       .note-list-item-pinner {
-        color: $studio-simplenote-blue-30;
+        color: $studio-simplenote-blue-20;
       }
     }
 
@@ -328,7 +328,7 @@ span[dir='ltr'] {
     table {
       th,
       td {
-        border-color: $studio-gray-60;
+        border-color: $studio-gray-50;
       }
       tr:nth-child(2n) {
         background-color: $studio-gray-80;
@@ -342,7 +342,7 @@ span[dir='ltr'] {
     background-color: $studio-gray-90;
 
     button svg {
-      fill: $studio-simplenote-blue-30;
+      fill: $studio-simplenote-blue-20;
     }
   }
 }


### PR DESCRIPTION
### Fix

As a starting point to update the way we specify and use colors throughout the app in CSS this starts by reducing the number we use.

This is a list of the replacements this does.

- $studio-simplenote-blue-30 -> $studio-simplenote-blue-20
- $studio-gray-60 -> $studio-gray-50
- $studio-red-40 -> $studio-red-50
- red -> $studio-red-50
- $studio-blue-30 -> $studio-simplenote-blue-20
- $studio-red-60 -> $studio-red-50
- $studio-orange-30 -> $studio-orange-20
- $studio-gray-40 -> $studio-gray-50

### Todo

- [x] Edit tags handle is not visible when hovered in dark mode
The above was updated to have the tag list hover color to match the navigation bar hover above it.

### Test

1. Smoke test in light and dark mode to ensure things still look good.

### Release

- Reduced the number of colors used throughout the project.
