### PR TITLE
Update method of setting theme selection

### DIFF
--- a/lib/alternate-login-prompt/index.tsx
+++ b/lib/alternate-login-prompt/index.tsx
@@ -79,7 +79,7 @@ const AlternateLoginPrompt: FunctionComponent<Props> = ({
       onRequestClose={dismiss}
       contentLabel="Log out?"
       overlayClassName="alternate-login__overlay"
-      portalClassName={classNames('alternate-login__portal', 'theme-' + theme)}
+      portalClassName={classNames('alternate-login__portal')}
     >
       {displayAlternateLoginPrompt}
     </Modal>

--- a/lib/alternate-login-prompt/style.scss
+++ b/lib/alternate-login-prompt/style.scss
@@ -71,7 +71,7 @@
   }
 }
 
-.theme-dark {
+body[data-theme='dark'] {
   .alternate-login__button-row .button-borderless {
     color: $studio-simplenote-blue-20;
   }

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -68,6 +68,7 @@ class AppComponent extends Component<Props> {
 
   componentDidMount() {
     window.electron?.send('setAutoHideMenuBar', this.props.autoHideMenuBar);
+    document.body.dataset.theme = this.props.theme;
 
     this.toggleShortcuts(true);
 
@@ -75,8 +76,13 @@ class AppComponent extends Component<Props> {
     __TEST__ && window.testEvents.push('booted');
   }
 
+  componentDidUpdate() {
+    document.body.dataset.theme = this.props.theme;
+  }
+
   componentWillUnmount() {
     this.toggleShortcuts(false);
+    delete document.body.dataset.theme;
   }
 
   handleShortcut = (event: KeyboardEvent) => {
@@ -190,7 +196,7 @@ class AppComponent extends Component<Props> {
       theme,
     } = this.props;
 
-    const appClasses = classNames('app', `theme-${theme}`, {
+    const appClasses = classNames('app', {
       'is-line-length-full': lineLength === 'full',
       'touch-enabled': 'ontouchstart' in document.body,
     });

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -177,7 +177,7 @@
   }
 }
 
-.theme-dark .login {
+body[data-theme='dark'] .login {
   h1 {
     color: $studio-white;
   }

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -43,8 +43,13 @@ class AppWithoutAuth extends Component<Props, State> {
     showAbout: false,
   };
 
+  systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+
   componentDidMount() {
     window.electron?.receive('appCommand', this.onAppCommand);
+    document.body.dataset.theme = this.systemTheme;
 
     window.electron?.receive('tokenLogin', (url) => {
       const { searchParams } = new URL(url);
@@ -137,13 +142,8 @@ class AppWithoutAuth extends Component<Props, State> {
   };
 
   render() {
-    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
-      .matches
-      ? 'dark'
-      : 'light';
-
     return (
-      <div className={`app theme-${systemTheme}`}>
+      <div className="app">
         <ErrorBoundary>
           <AuthApp
             accountCreationRequested={
@@ -171,10 +171,7 @@ class AppWithoutAuth extends Component<Props, State> {
               isOpen
               onRequestClose={this.onDismissDialog}
               overlayClassName="dialog-renderer__overlay"
-              portalClassName={classNames(
-                'dialog-renderer__portal',
-                'theme-' + systemTheme
-              )}
+              portalClassName={classNames('dialog-renderer__portal')}
             >
               <AboutDialog key="about" closeDialog={this.onDismissDialog} />
             </Modal>

--- a/lib/components/progress-bar/style.scss
+++ b/lib/components/progress-bar/style.scss
@@ -1,8 +1,8 @@
 .progress-bar {
-  @at-root .theme-light & {
+  @at-root body[data-theme='light'] & {
     background-color: $studio-gray-5;
   }
-  @at-root .theme-dark & {
+  @at-root body[data-theme='dark'] & {
     background-color: $studio-gray-80;
   }
 }

--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -66,7 +66,7 @@
   }
 }
 
-.theme-dark {
+body[data-theme='dark'] {
   .slider {
     // Track
     &::-webkit-slider-runnable-track {
@@ -104,7 +104,7 @@
   }
 }
 
-.theme-light {
+body[data-theme='light'] {
   .slider {
     // Track
     &::-webkit-slider-runnable-track {

--- a/lib/components/spinner/style.scss
+++ b/lib/components/spinner/style.scss
@@ -1,8 +1,8 @@
 .spinner__circle {
-  @at-root .theme-light & {
+  @at-root body[data-theme='light'] & {
     color: $studio-gray-5;
   }
-  @at-root .theme-dark & {
+  @at-root body[data-theme='dark'] & {
     color: $studio-gray-80;
   }
 

--- a/lib/components/tab-panels/style.scss
+++ b/lib/components/tab-panels/style.scss
@@ -19,17 +19,18 @@
       border-bottom-color: transparent;
     }
 
-    &.is-active {
-      color: $studio-simplenote-blue-50;
-      border-bottom-color: $studio-simplenote-blue-50;
-    }
     &:active {
       color: $studio-white;
     }
   }
 }
 
-.theme-dark .tab-panels__tab-list li.is-active {
+body[data-theme='light'] .tab-panels__tab-list li.is-active {
+  color: $studio-simplenote-blue-50;
+  border-bottom-color: $studio-simplenote-blue-50;
+}
+
+body[data-theme='dark'] .tab-panels__tab-list li.is-active {
   color: $studio-simplenote-blue-20;
   border-bottom-color: $studio-simplenote-blue-20;
 }

--- a/lib/components/tag-chip/style.scss
+++ b/lib/components/tag-chip/style.scss
@@ -49,7 +49,7 @@
   }
 }
 
-.theme-dark {
+body[data-theme='dark'] {
   .tag-chip {
     background: $studio-gray-70;
     color: $studio-white;

--- a/lib/dialog-renderer/index.tsx
+++ b/lib/dialog-renderer/index.tsx
@@ -47,7 +47,7 @@ export class DialogRenderer extends Component<Props> {
             isOpen
             onRequestClose={closeDialog}
             overlayClassName="dialog-renderer__overlay"
-            portalClassName={`dialog-renderer__portal theme-${theme}`}
+            portalClassName="dialog-renderer__portal"
             shouldCloseOnOverlayClick={false}
           >
             {'ABOUT' === dialog.type ? (

--- a/lib/dialogs/import/dropzone/style.scss
+++ b/lib/dialogs/import/dropzone/style.scss
@@ -93,7 +93,7 @@
   text-overflow: ellipsis;
 }
 
-.theme-dark {
+body[data-theme='dark'] {
   .importer-dropzone.theme-color-border {
     border-color: $studio-gray-50;
     color: $studio-gray-30;

--- a/lib/dialogs/import/source-importer/executor/style.scss
+++ b/lib/dialogs/import/source-importer/executor/style.scss
@@ -70,7 +70,7 @@
   }
 }
 
-.theme-dark {
+body[data-theme='dark'] {
   .source-importer-executor {
     .source-importer-executor__options {
       label {

--- a/lib/dialogs/import/source-importer/style.scss
+++ b/lib/dialogs/import/source-importer/style.scss
@@ -69,7 +69,7 @@
   }
 }
 
-.theme-dark {
+body[data-theme='dark'] {
   .source-importer {
     p {
       color: $studio-white;

--- a/lib/dialogs/keybindings/style.scss
+++ b/lib/dialogs/keybindings/style.scss
@@ -28,15 +28,15 @@
     text-align: center;
     display: inline-block;
     box-shadow: 0 1px 1px gray;
-
-    .theme-dark & {
-      border: 1px solid white;
-    }
-
-    .theme-light & {
-      border: 1px solid black;
-    }
   }
+}
+
+body[data-theme='light'] .keybindings kbd {
+  border: 1px solid black;
+}
+
+body[data-theme='dark'] .keybindings kbd {
+  border: 1px solid white;
 }
 
 .keybindings__key-item {

--- a/lib/dialogs/unsynchronized/style.scss
+++ b/lib/dialogs/unsynchronized/style.scss
@@ -82,7 +82,7 @@
   }
 }
 
-.theme-dark .logoutConfirmation .dialog {
+body[data-theme='dark'] .logoutConfirmation .dialog {
   .change-list {
     border-color: $studio-gray-80;
   }

--- a/lib/email-verification/index.tsx
+++ b/lib/email-verification/index.tsx
@@ -122,10 +122,7 @@ const EmailVerification: FunctionComponent<Props> = ({
       onRequestClose={dismiss}
       contentLabel="Confirm your email"
       overlayClassName="email-verification__overlay"
-      portalClassName={classNames(
-        'email-verification__portal',
-        'theme-' + theme
-      )}
+      portalClassName={classNames('email-verification__portal')}
     >
       {accountVerification === 'pending'
         ? displayEmailRequested

--- a/lib/email-verification/style.scss
+++ b/lib/email-verification/style.scss
@@ -77,7 +77,7 @@
   word-break: break-all;
 }
 
-.theme-dark {
+body[data-theme='dark'] {
   .email-verification__button-row .button-borderless {
     color: $studio-simplenote-blue-20;
   }

--- a/lib/error-boundary/index.tsx
+++ b/lib/error-boundary/index.tsx
@@ -100,7 +100,7 @@ const ErrorBoundaryWithSentry: FunctionComponent<ErrorBoundaryWithSentryProps> =
   theme,
 }) => {
   return (
-    <div className={`theme-${theme}`}>
+    <div>
       {isDevConfig || !allowAnalytics ? (
         <ErrorBoundary>{children}</ErrorBoundary>
       ) : (

--- a/lib/logging-out.tsx
+++ b/lib/logging-out.tsx
@@ -4,14 +4,17 @@ import { render } from 'react-dom';
 import '../scss/style.scss';
 
 class LoggingOut extends Component {
-  render() {
-    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
-      .matches
-      ? 'dark'
-      : 'light';
+  systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
 
+  componentDidMount() {
+    document.body.dataset.theme = this.systemTheme;
+  }
+
+  render() {
     return (
-      <div className={`app theme-${systemTheme}`}>
+      <div className="app">
         <div
           style={{
             fontSize: '18px',

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -59,7 +59,7 @@
   border-top: none;
 }
 
-.theme-dark {
+body[data-theme='dark'] {
   .navigation-bar-item {
     &.is-selected button {
       color: $studio-white;

--- a/lib/note-actions/style.scss
+++ b/lib/note-actions/style.scss
@@ -33,7 +33,7 @@
     height: 28px;
     cursor: pointer;
 
-    button {
+    button.button-borderless {
       padding: 0;
       font-weight: normal;
       color: inherit;
@@ -83,7 +83,7 @@
   }
 }
 
-.theme-dark {
+body[data-theme='dark'] {
   .spinner__circle {
     color: $studio-gray-50;
   }

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -214,7 +214,7 @@
   }
 }
 
-.theme-dark .note-detail-markdown p > code {
+body[data-theme='dark'] .note-detail-markdown p > code {
   background-color: $studio-gray-70;
 }
 

--- a/lib/note-info/index.tsx
+++ b/lib/note-info/index.tsx
@@ -42,7 +42,7 @@ export class NoteInfo extends Component<Props> {
         isOpen
         onRequestClose={onModalClose}
         overlayClassName="dialog-renderer__overlay"
-        portalClassName={`dialog-renderer__portal theme-${theme}`}
+        portalClassName="dialog-renderer__portal"
         shouldCloseOnOverlayClick={false}
       >
         <div className="note-info-panel note-info-stats theme-color-border theme-color-fg-dim">

--- a/lib/note-info/style.scss
+++ b/lib/note-info/style.scss
@@ -101,7 +101,7 @@
   }
 }
 
-.theme-dark {
+body[data-theme='dark'] {
   .note-info {
     .reference-link {
       &:hover {

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -92,7 +92,7 @@
   }
 }
 
-.theme-dark {
+body[data-theme='dark'] {
   .note-list-placeholder {
     .no-notes-icon,
     .no-notes-message {
@@ -227,7 +227,7 @@
       fill: $studio-gray-20;
     }
 
-    .theme-dark &.is-offline svg {
+    body[data-theme='dark'] &.is-offline svg {
       fill: $studio-gray-70;
     }
   }

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -23,7 +23,7 @@
   margin-top: -11px;
 }
 
-.theme-dark .note-toolbar-wrapper .offline-badge {
+body[data-theme='dark'] .note-toolbar-wrapper .offline-badge {
   border: solid 1px $studio-gray-80;
   box-shadow: 0 2px 4px 0 rgba(255, 255, 255, 0.02);
   color: $studio-gray-50;

--- a/lib/tag-list/index.tsx
+++ b/lib/tag-list/index.tsx
@@ -62,7 +62,6 @@ const SortableTag = SortableElement(
         `tag-list-item`,
         `theme-color-border`,
         `theme-color-fg`,
-        `theme-${theme}`,
         {
           'is-selected': isSelected,
         }

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -18,6 +18,10 @@
   border-bottom: 1px solid;
 }
 
+body .tag-list-item {
+  z-index: 2;
+}
+
 .tag-list {
   display: flex;
   flex-direction: column;
@@ -112,7 +116,7 @@ input.tag-list-input {
   margin-right: 8px;
 }
 
-.theme-dark {
+body[data-theme='dark'] {
   .icon-button {
     &.button-reorder {
       color: $studio-gray-50;
@@ -129,7 +133,7 @@ input.tag-list-input {
   }
 }
 
-.theme-light {
+body[data-theme='light'] {
   .icon-button {
     &.button-trash {
       color: $studio-simplenote-blue-20;

--- a/lib/tag-suggestions/style.scss
+++ b/lib/tag-suggestions/style.scss
@@ -28,13 +28,13 @@
   }
 }
 
-.theme-light {
+body[data-theme='light'] {
   .tag-suggestion {
     border-color: $studio-gray-5;
   }
 }
 
-.theme-dark {
+body[data-theme='dark'] {
   .tag-suggestion {
     border-color: $studio-gray-80;
   }

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -118,7 +118,7 @@ optgroup {
   }
 }
 
-.theme-dark .search-match {
+body[data-theme='dark'] .search-match {
   background-color: rgba($studio-simplenote-blue-50, 0.4);
   color: $studio-white;
 }

--- a/scss/print.scss
+++ b/scss/print.scss
@@ -3,7 +3,7 @@
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
 
-  .theme-dark .theme-color-bg {
+  body[data-theme='dark'] .theme-color-bg {
     background-color: $studio-white;
   }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -123,7 +123,7 @@ span[dir='ltr'] {
   }
 }
 
-.theme-light {
+body[data-theme='light'] {
   background-color: $studio-white;
   color: $studio-gray-50;
 
@@ -157,7 +157,7 @@ span[dir='ltr'] {
   border-color: $studio-gray-5;
 }
 
-.theme-dark {
+body[data-theme='dark'] {
   background-color: $studio-gray-90;
   color: $studio-gray-20;
 


### PR DESCRIPTION
### Fix

This works to update the way we set the theme being used in the app.
The current method has been to set a class such as `theme-light` or `theme-dark` in a number of places, the main one a couple of elements below the `#root` div of the app.

This had the added effect of not reaching modals opened as they were as part of the `body` element. This meant each modal had to have the class added as well.

This approach adds a data attribute to the `body` element such as `data-theme="dark"` or `data-theme="light"` instead. 

There should be no user-facing changes here.

### Test

1. In light and dark mode ensure that colors appear as they should.
2. Pay special attention to modals and dialogs opened. 

### Release

- Updated the method of setting the theme selection.
