### PR TITLE
Merge 2.10.0 beta 2 into develop

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [v2.10.0]
+
+### Enhancements
+
+- Removed the sort options bar from the note list and updated the sort options in the Settings [#2841](https://github.com/automattic/simplenote-electron/pull/2841)
+- Updated the design of the login/sign up form as well as clarifying the message shown when requesting an account [#2831](https://github.com/automattic/simplenote-electron/pull/2831)
+- Updated the styling of the search UI including the search highlighting [#2791](https://github.com/automattic/simplenote-electron/pull/2791)
+- Updated the note toolbar and note info sidebar to be two dialogs, one for note info, and one for note actions [#2622](https://github.com/automattic/simplenote-electron/pull/2622), [#2835](https://github.com/automattic/simplenote-electron/pull/2835), [#2843](https://github.com/automattic/simplenote-electron/pull/2843), [#2842](https://github.com/automattic/simplenote-electron/pull/2842)
+- Added scrolling to the list of unsynchronized notes in the warning dialog [#2816](https://github.com/automattic/simplenote-electron/pull/2816)
+
+### Fixes
+
+- Fixed extra line breaks issue when exporting notes [#2819](https://github.com/automattic/simplenote-electron/pull/2819)
+- Fixed displaying extra blank spaces in history screen [#2829](https://github.com/automattic/simplenote-electron/pull/2829)
+- Fixed to apply selected tag to a new note by default [#2556](https://github.com/automattic/simplenote-electron/pull/2556)
+- Fixed spacing on unsynced notes warning message [#2797](https://github.com/automattic/simplenote-electron/pull/2797)
+- Fixed cut off issue for dialogs when the window is too small [#2815](https://github.com/automattic/simplenote-electron/pull/2815), [#2834](https://github.com/automattic/simplenote-electron/pull/2834)
+- Fixed unnecessary separators in the Electron builds File and Edit menus when not yet logged in (props @Klauswk) [#2724](https://github.com/automattic/simplenote-electron/pull/2724)
+
 ## [v2.9.0]
 
 ### Enhancements

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,6 +18,7 @@
 - Fixed spacing on unsynced notes warning message [#2797](https://github.com/automattic/simplenote-electron/pull/2797)
 - Fixed cut off issue for dialogs when the window is too small [#2815](https://github.com/automattic/simplenote-electron/pull/2815), [#2834](https://github.com/automattic/simplenote-electron/pull/2834), [#2863](https://github.com/automattic/simplenote-electron/pull/2863)
 - Fixed unnecessary separators in the Electron builds File and Edit menus when not yet logged in (props @Klauswk) [#2724](https://github.com/automattic/simplenote-electron/pull/2724)
+- Fixed the clear search button so it does not appear unless there is a search term to clear [#2862](https://github.com/automattic/simplenote-electron/pull/2862)
 
 ## [v2.9.0]
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,7 +13,7 @@
 ### Fixes
 
 - Fixed extra line breaks issue when exporting notes [#2819](https://github.com/automattic/simplenote-electron/pull/2819)
-- Fixed displaying extra blank spaces in history screen [#2829](https://github.com/automattic/simplenote-electron/pull/2829)
+- Fixed displaying extra blank spaces in history screen [#2829](https://github.com/automattic/simplenote-electron/pull/2829), [#2867](https://github.com/automattic/simplenote-electron/pull/2867)
 - Fixed to apply selected tag to a new note by default [#2556](https://github.com/automattic/simplenote-electron/pull/2556)
 - Fixed spacing on unsynced notes warning message [#2797](https://github.com/automattic/simplenote-electron/pull/2797)
 - Fixed cut off issue for dialogs when the window is too small [#2815](https://github.com/automattic/simplenote-electron/pull/2815), [#2834](https://github.com/automattic/simplenote-electron/pull/2834)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -16,7 +16,7 @@
 - Fixed displaying extra blank spaces in history screen [#2829](https://github.com/automattic/simplenote-electron/pull/2829), [#2867](https://github.com/automattic/simplenote-electron/pull/2867)
 - Fixed to apply selected tag to a new note by default [#2556](https://github.com/automattic/simplenote-electron/pull/2556)
 - Fixed spacing on unsynced notes warning message [#2797](https://github.com/automattic/simplenote-electron/pull/2797)
-- Fixed cut off issue for dialogs when the window is too small [#2815](https://github.com/automattic/simplenote-electron/pull/2815), [#2834](https://github.com/automattic/simplenote-electron/pull/2834)
+- Fixed cut off issue for dialogs when the window is too small [#2815](https://github.com/automattic/simplenote-electron/pull/2815), [#2834](https://github.com/automattic/simplenote-electron/pull/2834), [#2863](https://github.com/automattic/simplenote-electron/pull/2863)
 - Fixed unnecessary separators in the Electron builds File and Edit menus when not yet logged in (props @Klauswk) [#2724](https://github.com/automattic/simplenote-electron/pull/2724)
 
 ## [v2.9.0]

--- a/lib/components/tab-panels/style.scss
+++ b/lib/components/tab-panels/style.scss
@@ -35,6 +35,7 @@
 }
 
 .tab-panels__panel {
+  height: 30.5em;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
 }

--- a/lib/dialogs/about/style.scss
+++ b/lib/dialogs/about/style.scss
@@ -2,6 +2,7 @@
   .dialog {
     position: relative;
     max-width: 472px;
+    max-height: calc(100vh - 2rem);
 
     // For overriding theme settings.
     // TODO: Improve theme management so this isn't necessary
@@ -15,6 +16,7 @@
 
   .dialog-content {
     padding: 30px 20px 20px;
+    max-height: calc(100vh - 2rem - 70px);
   }
 
   a {

--- a/lib/dialogs/keybindings/style.scss
+++ b/lib/dialogs/keybindings/style.scss
@@ -2,10 +2,12 @@
   .dialog {
     max-width: 500px;
     margin: auto;
+    max-height: calc(100vh - 2rem);
   }
 
   .dialog-content {
     padding: 10px 20px 20px;
+    max-height: calc(100vh - 2rem - 56px);
   }
 
   ul {

--- a/lib/dialogs/settings/style.scss
+++ b/lib/dialogs/settings/style.scss
@@ -1,6 +1,14 @@
 .settings {
   max-width: 630px;
 
+  &.dialog {
+    max-height: calc(100vh - 2rem);
+
+    .dialog-content {
+      max-height: calc(100vh - 2rem - 56px);
+    }
+  }
+
   input[type='radio'] {
     cursor: pointer;
   }

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -95,14 +95,15 @@ export class SearchField extends Component<Props> {
           value={searchQuery}
           spellCheck={false}
         />
-        <button
-          aria-label="Clear search"
-          className="icon-button"
-          hidden={!hasQuery}
-          onClick={this.clearQuery}
-        >
-          <SmallCrossIcon />
-        </button>
+        {hasQuery && (
+          <button
+            aria-label="Clear search"
+            className="icon-button"
+            onClick={this.clearQuery}
+          >
+            <SmallCrossIcon />
+          </button>
+        )}
       </div>
     );
   }

--- a/lib/utils/render-note-to-html.ts
+++ b/lib/utils/render-note-to-html.ts
@@ -6,12 +6,19 @@ const enableCheckboxes = {
   replace: '<input type="checkbox" ',
 };
 
+const removeLineBreaks = {
+  type: 'output',
+  regex: '>\n',
+  replace: '>',
+};
+
 export const renderNoteToHtml = (content: string) => {
   return import(/* webpackChunkName: 'showdown' */ 'showdown').then(
     ({ default: showdown }) => {
       showdown.extension('enableCheckboxes', enableCheckboxes);
+      showdown.extension('removeLineBreaks', removeLineBreaks);
       const markdownConverter = new showdown.Converter({
-        extensions: ['enableCheckboxes'],
+        extensions: ['enableCheckboxes', 'removeLineBreaks'],
       });
       markdownConverter.setFlavor('github');
       markdownConverter.setOption('simpleLineBreaks', false); // override GFM

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplenote",
-  "version": "2.10.0-beta1",
+  "version": "2.10.0-beta2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "support@simplenote.com"
   },
   "productName": "Simplenote",
-  "version": "2.10.0-beta1",
+  "version": "2.10.0-beta2",
   "main": "desktop/index.js",
   "license": "GPL-2.0",
   "homepage": "https://simplenote.com",


### PR DESCRIPTION
There were a few hotfixes which went into 2.10.0 beta 2, this moves them back into `develop`.
See: #2867, #2863, #2862, and #2876.