### PR TITLE
Make search global

### DIFF
--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -74,9 +74,6 @@ export class SearchField extends Component<Props> {
     const { openedTag, searchQuery } = this.props;
     const hasQuery = searchQuery.length > 0;
 
-    const description =
-      'Search ' + (openedTag ? 'notes in ' + openedTag : 'notes and tags');
-
     return (
       <div className="search-field theme-color-fg theme-color-border">
         <button
@@ -89,7 +86,7 @@ export class SearchField extends Component<Props> {
         <input
           ref={this.inputField}
           type="search"
-          placeholder={description}
+          placeholder="Search notes and tags"
           onChange={this.update}
           onKeyUp={this.interceptEsc}
           value={searchQuery}

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -86,7 +86,7 @@ export class SearchField extends Component<Props> {
         <input
           ref={this.inputField}
           type="search"
-          placeholder="Search notes and tags"
+          placeholder="Search all notes and tags"
           onChange={this.update}
           onKeyUp={this.interceptEsc}
           value={searchQuery}

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -233,7 +233,12 @@ export const middleware: S.Middleware = (store) => {
       }
 
       const openedTagHash = collection.type === 'tag' && t(collection.tagName);
-      if (openedTagHash && !note.tags.has(openedTagHash)) {
+      if (
+        searchTerms.length === 0 &&
+        searchTags.size === 0 &&
+        openedTagHash &&
+        !note.tags.has(openedTagHash)
+      ) {
         continue;
       }
 


### PR DESCRIPTION
### Fix

Fixes #2626
This updates the way search is handled if there is an opened tag to match the other platforms.
Currently, if there is a tag selected the search is restricted to that tag. 
This updates so that whenever a search is placed it is for all notes. Searches can still be restricted to tags using the syntax `tag:recipe` in the search field.

<details>
<summary>Before</summary>
<img width="581" alt="Screen Shot 2021-04-28 at 2 28 03 PM" src="https://user-images.githubusercontent.com/1326294/116447564-8350ba80-a82e-11eb-9cda-3acfd40be30c.png">
<img width="598" alt="Screen Shot 2021-04-28 at 2 27 51 PM" src="https://user-images.githubusercontent.com/1326294/116447569-83e95100-a82e-11eb-8ee2-6ebc3b595929.png">
<img width="606" alt="Screen Shot 2021-04-28 at 2 27 35 PM" src="https://user-images.githubusercontent.com/1326294/116447573-83e95100-a82e-11eb-8809-ead9a6249866.png">
<img width="536" alt="Screen Shot 2021-04-28 at 2 27 26 PM" src="https://user-images.githubusercontent.com/1326294/116447574-8481e780-a82e-11eb-87d4-8c5c08b0bf92.png">
<img width="541" alt="Screen Shot 2021-04-28 at 2 26 57 PM" src="https://user-images.githubusercontent.com/1326294/116447576-8481e780-a82e-11eb-846b-d48fd51c5104.png">

</details>
<details>
<summary>After</summary>
<img width="569" alt="Screen Shot 2021-04-28 at 2 31 23 PM" src="https://user-images.githubusercontent.com/1326294/116447608-8f3c7c80-a82e-11eb-8570-ca6cbef6d264.png">
<img width="602" alt="Screen Shot 2021-04-28 at 2 31 04 PM" src="https://user-images.githubusercontent.com/1326294/116447610-8fd51300-a82e-11eb-83ae-7b58cf285dd2.png">
<img width="595" alt="Screen Shot 2021-04-28 at 2 30 32 PM" src="https://user-images.githubusercontent.com/1326294/116447613-906da980-a82e-11eb-9d07-330554931bd4.png">
<img width="640" alt="Screen Shot 2021-04-28 at 2 30 10 PM" src="https://user-images.githubusercontent.com/1326294/116447615-906da980-a82e-11eb-9821-5380764da96b.png">
<img width="606" alt="Screen Shot 2021-04-28 at 2 29 55 PM" src="https://user-images.githubusercontent.com/1326294/116447616-91064000-a82e-11eb-95a2-ad094dee84c0.png">

</details>

### Test

1. Select a tag
2. Ensure only notes with that tag are displayed
3. Perform a search
4. Ensure any note matching shows

### Release

- Updated search so that all notes are searched even if there is a currently selected tag.
