### PR TITLE
Add ability to search for tag:untagged to find all untagged notes

### DIFF
--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -217,18 +217,22 @@ export const middleware: S.Middleware = (store) => {
         continue;
       }
 
+      const showUntagged =
+        collection.type === 'untagged' ||
+        searchTags.has(t('untagged' as T.TagName));
+
+      if (showUntagged && note.tags.size) {
+        continue;
+      }
+
       let hasAllTags = true;
       for (const tagName of searchTags.values()) {
-        if (!note.tags.has(tagName)) {
+        if (tagName !== 'untagged' && !note.tags.has(tagName)) {
           hasAllTags = false;
           break;
         }
       }
       if (!hasAllTags) {
-        continue;
-      }
-
-      if (collection.type === 'untagged' && note.tags.size) {
         continue;
       }
 

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -43,20 +43,22 @@ export class TagSuggestions extends Component<Props> {
           <div className="tag-suggestions">
             <div className="note-list-header">Search by Tag</div>
             <ul className="tag-suggestions-list theme-color-border">
-              {filteredTags.map((tagId) => (
-                <li
-                  key={tagId}
-                  id={tagId}
-                  className="tag-suggestion-row"
-                  onClick={() =>
-                    this.updateSearch(`tag:${tags.get(tagId)!.name}`)
-                  }
-                >
-                  <div className="tag-suggestion" title={tags.get(tagId)!.name}>
-                    tag:{tags.get(tagId)!.name}
-                  </div>
-                </li>
-              ))}
+              {filteredTags.map((tagId) => {
+                const tagName =
+                  tagId === 'untagged' ? 'untagged' : tags.get(tagId)!.name;
+                return (
+                  <li
+                    key={tagId}
+                    id={tagId}
+                    className="tag-suggestion-row"
+                    onClick={() => this.updateSearch(`tag:${tagName}`)}
+                  >
+                    <div className="tag-suggestion" title={tagName}>
+                      tag:{tagName}
+                    </div>
+                  </li>
+                );
+              })}
             </ul>
           </div>
         )}
@@ -104,6 +106,12 @@ export const filterTags = (
   for (const tagHash of tags.keys()) {
     if (matcher(tagHash)) {
       filteredTags.push(tagHash);
+    }
+  }
+
+  if (!query.includes('tag:')) {
+    if (matcher(tagHashOf('untagged' as T.TagName))) {
+      filteredTags.push(tagHashOf('untagged' as T.TagName));
     }
   }
 

--- a/lib/tag-suggestions/test.tsx
+++ b/lib/tag-suggestions/test.tsx
@@ -102,20 +102,26 @@ it('matches with the tag: prefix (only prefixes)', () => {
 });
 
 it('falls-back to plain text matching if the tag: prefix is incomplete', () => {
-  expect(filterTags(animals, new Map(), 't')).toEqual(['bat', 'cat']);
-  expect(filterTags(animals, new Map(), 'ta')).toEqual([]);
-  expect(filterTags(animals, new Map(), 'tag')).toEqual([]);
+  expect(filterTags(animals, new Map(), 't')).toEqual([
+    'bat',
+    'cat',
+    'untagged',
+  ]);
+  expect(filterTags(animals, new Map(), 'ta')).toEqual(['untagged']);
+  expect(filterTags(animals, new Map(), 'tag')).toEqual(['untagged']);
   expect(filterTags(animals, new Map(), 'tag:')).toEqual([]);
+  expect(filterTags(animals, new Map(), 'do')).toEqual(['dog']);
+  expect(filterTags(animals, new Map(), 'dot')).toEqual([]);
 
   // matching first-letter takes precedence over lexical sort
   expect(filterTags(taggers, new Map(), 't')).toEqual(
-    ['tag', 'atag', 'atag:what?'].map(th)
+    ['tag', 'atag', 'atag:what?', 'untagged'].map(th)
   );
   expect(filterTags(taggers, new Map(), 'ta')).toEqual(
-    ['tag', 'atag', 'atag:what?'].map(th)
+    ['tag', 'atag', 'atag:what?', 'untagged'].map(th)
   );
   expect(filterTags(taggers, new Map(), 'tag')).toEqual(
-    ['tag', 'atag', 'atag:what?'].map(th)
+    ['tag', 'atag', 'atag:what?', 'untagged'].map(th)
   );
   expect(filterTags(taggers, new Map(), 'tag:')).toEqual(
     ['atag:what?'].map(th)


### PR DESCRIPTION
### Fix

Fixes #1644 

This adds the ability to use the tag search syntax to find all notes without any tags. You can now search with `tag:untagged`.

![Screen Capture on 2021-04-29 at 08-58-33](https://user-images.githubusercontent.com/1326294/116547465-4be31c00-a8c9-11eb-95fd-79bff6389d0f.gif)


### Test

1. Ensure you have some notes with no tags.
2. Search for `tag:untagged`.
3. Notice all untagged notes show in the note list.

### Release

- Added the option to search with `tag:untagged` to find notes without any tags.
