### PR TITLE
Add system theme for Windows and Mac Electron builds

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -7,6 +7,7 @@ const {
   shell,
   Menu,
   session,
+  nativeTheme,
 } = require('electron');
 
 const path = require('path');
@@ -102,6 +103,18 @@ module.exports = function main() {
       Menu.setApplicationMenu(
         Menu.buildFromTemplate(createMenuTemplate(args), mainWindow)
       );
+    });
+
+    mainWindow.webContents.send('appCommand', {
+      action: 'systemTheme',
+      theme: nativeTheme.shouldUseDarkColors ? 'dark' : 'light',
+    });
+
+    nativeTheme.on('updated', () => {
+      mainWindow.webContents.send('appCommand', {
+        action: 'systemTheme',
+        theme: nativeTheme.shouldUseDarkColors ? 'dark' : 'light',
+      });
     });
 
     ipcMain.on('clearCookies', function () {

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -103,6 +103,7 @@ module.exports = function main() {
       Menu.setApplicationMenu(
         Menu.buildFromTemplate(createMenuTemplate(args), mainWindow)
       );
+      nativeTheme.themeSource = settings.theme;
     });
 
     mainWindow.webContents.send('appCommand', {

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -106,18 +106,6 @@ module.exports = function main() {
       nativeTheme.themeSource = settings.theme;
     });
 
-    // mainWindow.webContents.send('appCommand', {
-    //   action: 'systemTheme',
-    //   theme: nativeTheme.shouldUseDarkColors ? 'dark' : 'light',
-    // });
-
-    // nativeTheme.on('updated', () => {
-    //   mainWindow.webContents.send('appCommand', {
-    //     action: 'systemTheme',
-    //     theme: nativeTheme.shouldUseDarkColors ? 'dark' : 'light',
-    //   });
-    // });
-
     ipcMain.on('clearCookies', function () {
       // Removes any cookies stored in the app. We're particularly interested in
       // removing the WordPress.com cookies that may have been set during sign in.

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -106,17 +106,17 @@ module.exports = function main() {
       nativeTheme.themeSource = settings.theme;
     });
 
-    mainWindow.webContents.send('appCommand', {
-      action: 'systemTheme',
-      theme: nativeTheme.shouldUseDarkColors ? 'dark' : 'light',
-    });
+    // mainWindow.webContents.send('appCommand', {
+    //   action: 'systemTheme',
+    //   theme: nativeTheme.shouldUseDarkColors ? 'dark' : 'light',
+    // });
 
-    nativeTheme.on('updated', () => {
-      mainWindow.webContents.send('appCommand', {
-        action: 'systemTheme',
-        theme: nativeTheme.shouldUseDarkColors ? 'dark' : 'light',
-      });
-    });
+    // nativeTheme.on('updated', () => {
+    //   mainWindow.webContents.send('appCommand', {
+    //     action: 'systemTheme',
+    //     theme: nativeTheme.shouldUseDarkColors ? 'dark' : 'light',
+    //   });
+    // });
 
     ipcMain.on('clearCookies', function () {
       // Removes any cookies stored in the app. We're particularly interested in

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -5,6 +5,32 @@ const buildViewMenu = (settings, isAuthenticated) => {
   settings = settings || {};
   isAuthenticated = isAuthenticated || false;
 
+  const themeSubMenu = platform.isLinux()
+    ? [
+        {
+          label: '&Light',
+          id: 'light',
+        },
+        {
+          label: '&Dark',
+          id: 'dark',
+        },
+      ]
+    : [
+        {
+          label: '&System',
+          id: 'system',
+        },
+        {
+          label: '&Light',
+          id: 'light',
+        },
+        {
+          label: '&Dark',
+          id: 'dark',
+        },
+      ];
+
   const menu = {
     label: '&View',
     submenu: [
@@ -107,20 +133,7 @@ const buildViewMenu = (settings, isAuthenticated) => {
       {
         label: 'T&heme',
         visible: isAuthenticated,
-        submenu: [
-          {
-            label: '&System',
-            id: 'system',
-          },
-          {
-            label: '&Light',
-            id: 'light',
-          },
-          {
-            label: '&Dark',
-            id: 'dark',
-          },
-        ].map(
+        submenu: themeSubMenu.map(
           buildRadioGroup({
             action: 'activateTheme',
             propName: 'theme',

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -5,31 +5,21 @@ const buildViewMenu = (settings, isAuthenticated) => {
   settings = settings || {};
   isAuthenticated = isAuthenticated || false;
 
-  const themeSubMenu = platform.isLinux()
-    ? [
-        {
-          label: '&Light',
-          id: 'light',
-        },
-        {
-          label: '&Dark',
-          id: 'dark',
-        },
-      ]
-    : [
-        {
-          label: '&System',
-          id: 'system',
-        },
-        {
-          label: '&Light',
-          id: 'light',
-        },
-        {
-          label: '&Dark',
-          id: 'dark',
-        },
-      ];
+  const themeSubMenu = [];
+  if (!platform.isLinux()) {
+    themeSubMenu.push({
+      label: '&System',
+      id: 'system',
+    });
+  }
+  themeSubMenu.push({
+    label: '&Light',
+    id: 'light',
+  });
+  themeSubMenu.push({
+    label: '&Dark',
+    id: 'dark',
+  });
 
   const menu = {
     label: '&View',

--- a/desktop/menus/view-menu.js
+++ b/desktop/menus/view-menu.js
@@ -109,6 +109,10 @@ const buildViewMenu = (settings, isAuthenticated) => {
         visible: isAuthenticated,
         submenu: [
           {
+            label: '&System',
+            id: 'system',
+          },
+          {
             label: '&Light',
             id: 'light',
           },

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -60,4 +60,5 @@ contextBridge.exposeInMainWorld('electron', {
     }
   },
   isMac: process.platform === 'darwin',
+  isLinux: process.platform === 'linux',
 });

--- a/lib/dialogs/settings/panels/display.tsx
+++ b/lib/dialogs/settings/panels/display.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment, FunctionComponent } from 'react';
 import { connect } from 'react-redux';
 
-import { isElectron, isMac } from '../../../utils/platform';
+import { isElectron, isLinux, isMac } from '../../../utils/platform';
 import RadioGroup from '../../radio-settings-group';
 import SettingsGroup, { Item } from '../../settings-group';
 import ToggleGroup from '../../toggle-settings-group';
@@ -131,7 +131,7 @@ const DisplayPanel: FunctionComponent<Props> = (props) => (
       onChange={props.setActiveTheme}
       renderer={RadioGroup}
     >
-      <Item title="System" slug="system" />
+      {!isLinux && <Item title="System" slug="system" />}
       <Item title="Light" slug="light" />
       <Item title="Dark" slug="dark" />
     </SettingsGroup>

--- a/lib/dialogs/settings/panels/display.tsx
+++ b/lib/dialogs/settings/panels/display.tsx
@@ -131,9 +131,7 @@ const DisplayPanel: FunctionComponent<Props> = (props) => (
       onChange={props.setActiveTheme}
       renderer={RadioGroup}
     >
-      {navigator.userAgent.toLowerCase().indexOf(' electron/') === -1 && (
-        <Item title="System" slug="system" />
-      )}
+      <Item title="System" slug="system" />
       <Item title="Light" slug="light" />
       <Item title="Dark" slug="dark" />
     </SettingsGroup>

--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -10,6 +10,7 @@ declare global {
     electron: {
       confirmLogout(changes: string): 'logout' | 'reconsider' | 'export';
       isMac: boolean;
+      isLinux: boolean;
       receive(command: 'appCommand', callback: (event: any) => any);
       receive(command: 'editorCommand', callback: (event: any) => any);
       receive(command: 'noteImportChannel', callback: (event: any) => any);

--- a/lib/state/electron/middleware.ts
+++ b/lib/state/electron/middleware.ts
@@ -15,8 +15,13 @@ export const middleware: S.Middleware = ({ dispatch, getState }) => {
       dispatch(actions.ui.showAlternateLoginPrompt(tokenEmail));
     }
   });
+
   window.electron.receive('appCommand', (command) => {
     switch (command.action) {
+      case 'systemTheme':
+        dispatch({ type: 'SYSTEM_THEME_UPDATE', prefers: command.theme });
+        return;
+
       case 'closeWindow':
         dispatch(actions.ui.closeWindow());
         return;

--- a/lib/state/electron/middleware.ts
+++ b/lib/state/electron/middleware.ts
@@ -15,13 +15,8 @@ export const middleware: S.Middleware = ({ dispatch, getState }) => {
       dispatch(actions.ui.showAlternateLoginPrompt(tokenEmail));
     }
   });
-
   window.electron.receive('appCommand', (command) => {
     switch (command.action) {
-      case 'systemTheme':
-        dispatch({ type: 'SYSTEM_THEME_UPDATE', prefers: command.theme });
-        return;
-
       case 'closeWindow':
         dispatch(actions.ui.closeWindow());
         return;

--- a/lib/utils/platform.ts
+++ b/lib/utils/platform.ts
@@ -10,3 +10,7 @@ export const CmdOrCtrl = isElectron && isMac ? 'Cmd' : 'Ctrl';
 export const isSafari = /^((?!chrome|android).)*safari/i.test(
   window.navigator.userAgent
 );
+
+export const isLinux = isElectron
+  ? window?.electron?.isLinux
+  : navigator.appVersion.indexOf('Linux') !== -1;


### PR DESCRIPTION
### Fix

Picked up from PR #2135

Currently in our Electron builds we don't offer a system theme that responds to the OSs color preference but is available in the web app.

This enables it for both Windows and Mac builds. There appears to be a bug in Electron or Chromium on Linux that the app doesn't respond properly to changing the color preferences so it still won't work there. Possibly this will get resolved in Electron 13 due to come out May 25, 2021.

It also updates so that the system menu for Windows updates to be choice of theme in Simplenote itself. So if you specifically choose Light the menu will be light, same for dark, overriding the system color preference. 

This semi addresses issues #2134 and #1799 as they will both be resolved for Mac and Windows, but still not working on the Linux builds. 

Related issues: 
- https://github.com/electron/electron/issues/28887
- https://github.com/electron/electron/issues/25925

Windows Screen Recording
https://user-images.githubusercontent.com/1326294/116714765-76f26c00-a9ac-11eb-979c-c08ad8aeebf5.mov


### Test
Needs testing on Mac, Windows, and Linux

1. Open Simplenote
2. Ensure on Windows and Mac under the view menu and theme there is a System option
3. Ensure on Linux there is no System option showing for the theme.
4. Ensure option shows under Settings > Display as well for both Windows and Mac, but not Linux
5. Choose System theme on Windows or Mac.
6. Change color preference on the operating system.
7. Ensure Simplenote updates to match.
8. Set either light or dark theme.
9. Change color preferences on the operating system.
10. Ensure Simplenote does not change and stays with your app settings.
11. On Linux ensure you can still switch between Light and Dark themes properly.

### Release

- Added system theme for Mac and Windows Electron apps.
