### PR TITLE
Fix javascript error on log out

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -103,7 +103,9 @@ module.exports = function main() {
       Menu.setApplicationMenu(
         Menu.buildFromTemplate(createMenuTemplate(args), mainWindow)
       );
-      nativeTheme.themeSource = settings.theme;
+      if ('theme' in settings) {
+        nativeTheme.themeSource = settings.theme;
+      }
     });
 
     ipcMain.on('clearCookies', function () {


### PR DESCRIPTION
### Fix

Fixes #2888

When setting the Electron `nativeTheme` with the theme selected in the Simplenote settings it can cause a JavaScript error if the theme setting isn't present, such as when logging out of the app.

This checks to ensure the theme setting is set before updating the Electron `nativeTheme` setting.

### Test

1. Ensure you are logged in
2. Log out.
3. Ensure no error appears.

### Release
NA