### PR TITLE
Fix the results bar bar text from always being plural

### DIFF
--- a/lib/search-results-bar/index.tsx
+++ b/lib/search-results-bar/index.tsx
@@ -41,7 +41,9 @@ const SearchResultsBar: FunctionComponent<Props> = ({
   return (
     <div className="search-results">
       <div>
-        {index === null ? `${total} Results` : `${index + 1} of ${total}`}
+        {index === null
+          ? `${total} ${total > 1 ? 'Results' : 'Result'}`
+          : `${index + 1} of ${total}`}
       </div>
       <span className="search-results-next">
         <IconButton


### PR DESCRIPTION
### Fix

Fixes #2887

Currently, if there is only one search result the search results bar at the bottom says "1 Results" instead of "1 Result".

This checks and displays the plural version only if there is more than one search result.

Before:
![Screen Shot 2021-05-04 at 8 20 48 AM](https://user-images.githubusercontent.com/1326294/116996352-a9081480-acb1-11eb-9a32-6a62d6d0acc1.png)

After:
![Screen Shot 2021-05-04 at 8 19 27 AM](https://user-images.githubusercontent.com/1326294/116996276-8b3aaf80-acb1-11eb-913d-01046ed18688.png)


### Test

1.  Have a note that contains a keyword only once
2. Search for this keyword
3. Select this note
4. Ensure the search results bar at the bottom says "1 Result"
5. Search for a keyword with more than one result
6. Ensure the search results bar at the bottom says "Results" in plural now.


### Release

- Fixed search results bar to only use the plural Results if there is more than one matching keyword.
