### PR TITLE
Fix spacing on tag list edit buttons

### DIFF
--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -12,6 +12,10 @@
   &.is-selected {
     background-color: $studio-simplenote-blue-5;
   }
+
+  .icon-button:last-child {
+    margin-right: 10px;
+  }
 }
 
 .tag-list-item:not(:last-child) {
@@ -110,10 +114,6 @@ input.tag-list-input {
       outline: none;
     }
   }
-}
-
-.button-reorder {
-  margin-right: 8px;
 }
 
 body[data-theme='dark'] {


### PR DESCRIPTION
### Fix

Fixes #2891

Currently, if you set to sort tags alphabetically and then choose to edit your tag list, the trash icon is hard up to the right side of the list.
If you have it set to manually sort tags then the reorder handle has spacing on the right.

This makes it more consistent and adds the spacing in either situation.

Before:
<img width="258" alt="Screen Shot 2021-05-04 at 8 37 09 AM" src="https://user-images.githubusercontent.com/1326294/116997985-f08fa000-acb3-11eb-8678-7cb56c595a84.png">

After:
<img width="260" alt="Screen Shot 2021-05-04 at 8 36 46 AM" src="https://user-images.githubusercontent.com/1326294/116997992-f5ecea80-acb3-11eb-8fa6-fedd6451dd19.png">

### Test

1. Set tags to be sorted alphabetically
2. Open tag list.
3. Choose to edit tags.
4. Notice trash icon is spaced nicely from the right.
5. Set tags to be no longer sorted alphabetically.
6. Choose to edit tags.
7. Ensure spacing still looks correct.

### Release

- Fixed spacing issue on the trash tag button when set to sort tags alphabetically.
