### PR TITLE
Add default title bar space for Mac Electron

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -66,7 +66,6 @@ module.exports = function main() {
       height: mainWindowState.height,
       minWidth: 370,
       minHeight: 520,
-      titleBarStyle: 'hidden',
       show: false,
       webPreferences: {
         contextIsolation: true,

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -204,7 +204,6 @@ class AppComponent extends Component<Props> {
     const mainClasses = classNames('simplenote-app', {
       'navigation-open': showNavigation,
       'is-electron': isElectron,
-      'is-macos': isElectron && isMac,
     });
 
     return (

--- a/lib/navigation-bar/style.scss
+++ b/lib/navigation-bar/style.scss
@@ -12,10 +12,6 @@
   transition: transform 200ms ease-in-out;
 }
 
-.is-macos .navigation-bar {
-  padding-top: $toolbar-height + 26px;
-}
-
 .navigation-bar__folders {
   display: flex;
   flex: none;

--- a/lib/note-actions/style.scss
+++ b/lib/note-actions/style.scss
@@ -1,7 +1,3 @@
-.is-macos .note-actions {
-  top: $toolbar-height + 16px + 26px;
-}
-
 .note-actions {
   width: 200px;
   position: absolute;

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -19,10 +19,6 @@
   width: 64px;
 }
 
-.is-electron.is-macos .note-toolbar-wrapper .offline-badge {
-  margin-top: -11px;
-}
-
 body[data-theme='dark'] .note-toolbar-wrapper .offline-badge {
   border: solid 1px $studio-gray-80;
   box-shadow: 0 2px 4px 0 rgba(255, 255, 255, 0.02);

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -62,39 +62,6 @@ optgroup {
   height: 100%;
 }
 
-.is-macos {
-  .note-toolbar-wrapper {
-    box-sizing: border-box;
-    -webkit-app-region: drag;
-    padding: 40px 0 30px;
-  }
-
-  .new-note-toolbar__button-sidebar {
-    border-right: 0;
-    padding-right: 0;
-  }
-
-  .menu-bar {
-    padding: 40px 15px 30px;
-    box-sizing: border-box;
-    -webkit-app-region: drag;
-  }
-
-  .note-toolbar-placeholder {
-    height: 71px;
-    -webkit-app-region: drag;
-  }
-
-  .note-info {
-    padding-top: 10px;
-  }
-
-  .button,
-  .search-field {
-    -webkit-app-region: no-drag;
-  }
-}
-
 .login__draggable-area {
   height: 100px;
   position: absolute;


### PR DESCRIPTION
### Fix

Previously we had been adding specific styles to different components for only Mac Electron app to prevent things from overlapping the window buttons.

This removes those and instead enables the default title bar.

<details>
<summary>Screenshots</summary>
<img width="1190" alt="Screen Shot 2021-05-04 at 1 55 54 PM" src="https://user-images.githubusercontent.com/1326294/117040804-a7097a00-ace0-11eb-9132-4cfda96dc90a.png">
<img width="1182" alt="Screen Shot 2021-05-04 at 1 55 40 PM" src="https://user-images.githubusercontent.com/1326294/117040806-a83aa700-ace0-11eb-9725-f62541bc5b28.png">

</details>

### Test

1. Run Mac Electron app.
2. Ensure bar appears at the top with the app below it as usual.

### Release

- Added default title bar to Mac Electron app
