### PR TITLE
Fixes a bug where you had to use ⌘Q twice to quit the mac app.

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -28,6 +28,14 @@ module.exports = function main() {
   // be closed automatically when the JavaScript object is GCed.
   let mainWindow = null;
   let isAuthenticated;
+  let shouldQuit = false;
+
+  // Checks to see if the application was asked to quit instead of just close the window
+  // we then use this variable to check if we should quit the app.
+  // Important for MacOS so it will quit when pressing CMD+Q
+  app.on('before-quit', () => {
+    shouldQuit = true;
+  });
 
   app.on('will-finish-launching', function () {
     setTimeout(updater.ping.bind(updater), config.updater.delay);
@@ -186,9 +194,10 @@ module.exports = function main() {
     ipcMain.on('reallyCloseWindow', () => {
       // On OSX we potentially have an ipc listerner that does not have a mainWindow.
       mainWindow && mainWindow.destroy();
-      if (!platform.isOSX()) {
+      if (!platform.isOSX() || shouldQuit) {
         app.exit(0);
       }
+      shouldQuit = false;
     });
 
     // Emitted when the window is closed.


### PR DESCRIPTION
### Fix

Fixes #2676

In Mac OS there the expected behavior is that when you close the window of an app that it stays running and you can open it again from the dock. Then if you quit the app using ⌘Q it completely closes.

Currently in order to fully quit you need to press ⌘Q twice which is unexpected. This resolves that by allowing you to close the window and reopen it, but also quit the app as expected.

### Test

1. Open Mac app.
2. Close the window.
3. App should still be in the dock.
4. App should open again when you click it.
5. Quit the app with ⌘Q or using the context menu when clicking on the doc icon.
6. App should fully quit.

### Release

- Fixed a bug where the Mac app wouldn't quit on the first request.
