### PR TITLE
Fix search scrollbar highlights

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -125,6 +125,10 @@ class NoteContentEditor extends Component<Props> {
   contentDiv = createRef<HTMLDivElement>();
   decorations: string[] = [];
   matchesInNote: [] = [];
+  overviewRuler = {
+    color: '#3361cc',
+    position: Editor.OverviewRulerLane.Full,
+  };
 
   state: OwnState = {
     content: '',
@@ -443,10 +447,7 @@ class NoteContentEditor extends Component<Props> {
           matches.push({
             options: {
               inlineClassName: 'search-decoration',
-              overviewRuler: {
-                color: '#3361cc',
-                position: Editor.OverviewRulerLane.Full,
-              },
+              overviewRuler: this.overviewRuler,
             },
             range: {
               startLineNumber: start.lineNumber,
@@ -1137,12 +1138,18 @@ class NoteContentEditor extends Component<Props> {
       if (match.range === range) {
         decoration = {
           range: match.range,
-          options: { inlineClassName: 'selected-search' },
+          options: {
+            inlineClassName: 'selected-search',
+            overviewRuler: this.overviewRuler,
+          },
         };
       } else {
         decoration = {
           range: match.range,
-          options: { inlineClassName: 'search-decoration' },
+          options: {
+            inlineClassName: 'search-decoration',
+            overviewRuler: this.overviewRuler,
+          },
         };
       }
       newDecorations.push(decoration);


### PR DESCRIPTION
### Fix

Fixes #2903 

After a previous fix with the search highlighting, I broke the search scrollbar highlights showing where in the note search matches were when traversing through search results.

This fixes that issue by ensuring it appears even when going through search results.

<details>
<summary>Before</summary>
<img width="1457" alt="Screen Shot 2021-05-18 at 9 01 52 AM" src="https://user-images.githubusercontent.com/1326294/118647464-bd6f0580-b7b7-11eb-8811-54e5b6acbc19.png">
</details>
<details>
<summary>After</summary>
<img width="1462" alt="Screen Shot 2021-05-18 at 9 01 11 AM" src="https://user-images.githubusercontent.com/1326294/118647491-c2cc5000-b7b7-11eb-8c2f-0c930119a476.png">
</details>

### Test

1. Search for a term.
2. Ensure the scrollbar search highlight bar shows lines where matches are.
3. Toggle through search results using arrows at the bottom or `CtrlOrCmd+G`.
4. Ensure the scrollbar search highlight bar still shows.

### Release

- Fixed search scrollbar highlights so it always shows search matches while in the editor.