### PR TITLE
10 seconds delay for the non-user-initiated checks

### DIFF
--- a/desktop/updater/auto-updater/index.js
+++ b/desktop/updater/auto-updater/index.js
@@ -27,7 +27,8 @@ class AutoUpdater extends Updater {
   // Check and download in the background, and only notify the user if
   // an update exists and has completed downloading.
   ping() {
-    autoUpdater.checkForUpdates();
+    // introduce a slight delay for the non-user-initiated checks
+    setTimeout(() => autoUpdater.checkForUpdates(), 10 * 1000);
   }
 
   // For user-initiated checks.


### PR DESCRIPTION
### Fix
Upon the program launch the user is instantly presented with a modal box, informing of a new app version.
For a smoother UX, delay the new version check by 10 seconds.

A graceful delay has a positive effect of reducing the resource contention for the application and for the user.

### Test
1. Make sure a new version of the program is available for distribution. (e.g. Version 2.12.0)
2. Close and then re-launch the program.
3. The "new version available" modal box should appear with a 10 seconds delay.

### Release
Checking for a new program version is delayed by 10 seconds on program launch.
