### PR TITLE
Update version to 2.13.0-beta2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplenote",
-  "version": "2.13.0-beta1",
+  "version": "2.13.0-beta2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "support@simplenote.com"
   },
   "productName": "Simplenote",
-  "version": "2.13.0-beta1",
+  "version": "2.13.0-beta2",
   "main": "desktop/index.js",
   "license": "GPL-2.0",
   "homepage": "https://simplenote.com",


### PR DESCRIPTION
I made a mistake in https://github.com/Automattic/simplenote-electron/pull/2923 and generated the `package-lock.json` file with my global node version instead of the one in `.nvmrc`. I've since addressed the issue as part of the PR, but haven't published a new beta.

@mokagio I'll wait for your approval before I tag the new beta, just in case I am still missing something.