### PR TITLE
Update Dark mode colors to use to css variables

### DIFF
--- a/lib/alternate-login-prompt/style.scss
+++ b/lib/alternate-login-prompt/style.scss
@@ -73,6 +73,6 @@
 
 body[data-theme='dark'] {
   .alternate-login__button-row .button-borderless {
-    color: $studio-simplenote-blue-20;
+    color: var(--accent-color);
   }
 }

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -67,7 +67,7 @@
 
   input:read-only,
   input:disabled {
-    border-color: var(--readonly-input-bg-color);
+    border-color: var(--readonly-input-highlight-color);
     background-color: var(--readonly-input-color);
   }
 
@@ -214,7 +214,7 @@ body[data-theme='dark'] .login {
 
     &:read-only,
     &:disabled {
-      border-color: var(--readonly-input-bg-color);
+      border-color: var(--readonly-input-highlight-color);
       background-color: var(--readonly-input-color);
     }
 

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -202,7 +202,7 @@ body[data-theme='dark'] .login {
   }
 
   .or {
-    background: $studio-gray-90;
+    background: var(--background-color);
     color: $studio-gray-20;
   }
   .or-line {

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -194,7 +194,7 @@ body[data-theme='dark'] .login {
   .login__signup a,
   .login__auth-message a,
   .terms a {
-    color: $studio-simplenote-blue-20;
+    color: var(--accent-color);
   }
 
   .login__auth-message.is-error {
@@ -226,8 +226,8 @@ body[data-theme='dark'] .login {
     }
 
     &:focus {
-      border-color: $studio-simplenote-blue-20;
-      box-shadow: 0 0 0 1px $studio-simplenote-blue-20;
+      border-color: var(--accent-color);
+      box-shadow: 0 0 0 1px var(--accent-color);
     }
   }
 }

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -210,7 +210,7 @@ body[data-theme='dark'] .login {
   }
 
   svg.icon-mail {
-    color: $studio-gray-30;
+    color: var(--foreground-color);
   }
   input {
     border-color: var(--foreground-color);

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -91,7 +91,7 @@
   }
 
   a.login__forgot {
-    color: var(--foreground-color);
+    color: var(--accent-color);
     text-decoration: none;
   }
 
@@ -178,9 +178,6 @@ body[data-theme='dark'] .login {
   h1 {
     color: var(--primary-color);
   }
-  a.login__forgot {
-    color: var(--foreground-color);
-  }
 
   .login__forgot,
   .login__signup,
@@ -190,7 +187,8 @@ body[data-theme='dark'] .login {
 
   .login__signup a,
   .login__auth-message a,
-  .terms a {
+  .terms a,
+  .login__forgot {
     color: var(--accent-color);
   }
 

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -182,13 +182,13 @@ body[data-theme='dark'] .login {
     color: $studio-white;
   }
   a.login__forgot {
-    color: $studio-gray-20;
+    color: var(--foreground-color);
   }
 
   .login__forgot,
   .login__signup,
   .terms {
-    color: $studio-gray-20;
+    color: var(--foreground-color);
   }
 
   .login__signup a,
@@ -203,7 +203,7 @@ body[data-theme='dark'] .login {
 
   .or {
     background: var(--background-color);
-    color: $studio-gray-20;
+    color: var(--foreground-color);
   }
   .or-line {
     border-color: var(--primary-color);

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -179,7 +179,7 @@
 
 body[data-theme='dark'] .login {
   h1 {
-    color: $studio-white;
+    color: var(--primary-color);
   }
   a.login__forgot {
     color: var(--foreground-color);

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -38,7 +38,8 @@
     max-width: 347px;
     text-align: center;
     width: 90%;
-    .is-error {
+
+    &.is-error {
       color: var(--tertiary-highlight-color);
     }
   }
@@ -64,14 +65,10 @@
     font-weight: 400;
   }
 
+  input:read-only,
   input:disabled {
-    border-color: var(--secondary-color);
-    color: var(--tertiary-color);
-  }
-
-  input:read-only {
-    border-color: var(--secondary-accent-color);
-    background-color: rgba(0, 0, 0, 0.05);
+    border-color: var(--readonly-input-bg-color);
+    background-color: var(--readonly-input-color);
   }
 
   input:focus {
@@ -198,7 +195,7 @@ body[data-theme='dark'] .login {
   }
 
   .login__auth-message.is-error {
-    color: $studio-red-20;
+    color: var(--tertiary-highlight-color);
   }
 
   .or {
@@ -215,14 +212,10 @@ body[data-theme='dark'] .login {
   input {
     border-color: var(--secondary-accent-color);
 
+    &:read-only,
     &:disabled {
-      color: var(--foreground-color);
-      border-color: $studio-gray-70;
-    }
-
-    &:read-only {
-      border-color: var(--foreground-color);
-      background-color: rgba(255, 255, 255, 0.07);
+      border-color: var(--readonly-input-bg-color);
+      background-color: var(--readonly-input-color);
     }
 
     &:focus {

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -213,7 +213,7 @@ body[data-theme='dark'] .login {
     color: var(--foreground-color);
   }
   input {
-    border-color: var(--foreground-color);
+    border-color: var(--secondary-accent-color);
 
     &:disabled {
       color: var(--foreground-color);

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -143,7 +143,7 @@
     background-color: var(--wordpress-color);
     border-radius: 4px;
     box-sizing: border-box;
-    color: var(--background-color);
+    color: var(--primary-button-fg-color);
     display: block;
     font-size: 16px;
     font-weight: 500;

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -85,9 +85,9 @@
   }
 
   button[type='submit'] {
-    background-color: var(--accent-color);
+    background-color: var(--primary-button-bg-color);
     border: none;
-    color: var(--background-color);
+    color: var(--primary-button-fg-color);
     font-weight: 500;
     margin: 16px auto 8px;
     padding: 0 15px 2px;

--- a/lib/components/progress-bar/style.scss
+++ b/lib/components/progress-bar/style.scss
@@ -3,7 +3,7 @@
     background-color: var(--secondary-color);
   }
   @at-root body[data-theme='dark'] & {
-    background-color: $studio-gray-80;
+    background-color: var(--secondary-color);
   }
 }
 

--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -79,26 +79,26 @@ body[data-theme='dark'] {
       border-color: $studio-gray-50;
     }
     &::-ms-fill-lower {
-      background: $studio-white;
+      background: var(--primary-color);
     }
     &::-ms-fill-upper {
-      background: $studio-white;
+      background: var(--primary-color);
     }
 
     // Thumb
     &::-webkit-slider-thumb {
       border-color: $studio-gray-5;
-      background: $studio-white;
+      background: var(--primary-color);
       box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
     }
     &::-moz-range-thumb {
-      background: $studio-white;
+      background: var(--primary-color);
       border-color: $studio-gray-5;
       box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
     }
     &::-ms-thumb {
       border-color: $studio-gray-5;
-      background: $studio-white;
+      background: var(--primary-color);
       box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
     }
   }

--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -70,13 +70,13 @@ body[data-theme='dark'] {
   .slider {
     // Track
     &::-webkit-slider-runnable-track {
-      background: $studio-gray-50;
+      background: var(--tertiary-color);
     }
     &::-moz-range-track {
-      background: $studio-gray-50;
+      background: var(--tertiary-color);
     }
     &::-ms-track {
-      border-color: $studio-gray-50;
+      border-color: var(--tertiary-color);
     }
     &::-ms-fill-lower {
       background: var(--primary-color);

--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -70,35 +70,35 @@ body[data-theme='dark'] {
   .slider {
     // Track
     &::-webkit-slider-runnable-track {
-      background: var(--tertiary-color);
+      background: var(--primary-slider-color);
     }
     &::-moz-range-track {
-      background: var(--tertiary-color);
+      background: var(--primary-slider-color);
     }
     &::-ms-track {
-      border-color: var(--tertiary-color);
+      border-color: var(--primary-slider-color);
     }
     &::-ms-fill-lower {
-      background: var(--primary-color);
+      background: var(--secondary-slider-color);
     }
     &::-ms-fill-upper {
-      background: var(--primary-color);
+      background: var(--secondary-slider-color);
     }
 
     // Thumb
     &::-webkit-slider-thumb {
-      border-color: $studio-gray-5;
-      background: var(--primary-color);
+      border-color: var(--primary-slider-color);
+      background: var(--secondary-slider-color);
       box-shadow: 0 1px 3px 0 var(--overlay-color);
     }
     &::-moz-range-thumb {
-      background: var(--primary-color);
-      border-color: $studio-gray-5;
+      background: var(--secondary-slider-color);
+      border-color: var(--primary-slider-color);
       box-shadow: 0 1px 3px 0 var(--overlay-color);
     }
     &::-ms-thumb {
-      border-color: $studio-gray-5;
-      background: var(--primary-color);
+      border-color: var(--primary-slider-color);
+      background: var(--secondary-slider-color);
       box-shadow: 0 1px 3px 0 var(--overlay-color);
     }
   }
@@ -108,35 +108,35 @@ body[data-theme='light'] {
   .slider {
     // Track
     &::-webkit-slider-runnable-track {
-      background: var(--secondary-color);
+      background: var(--primary-slider-color);
     }
     &::-moz-range-track {
-      background: var(--secondary-color);
+      background: var(--primary-slider-color);
     }
     &::-ms-track {
-      border-color: var(--secondary-color);
+      border-color: var(--primary-slider-color);
     }
     &::-ms-fill-lower {
-      background: var(--background-color);
+      background: var(--secondary-slider-color);
     }
     &::-ms-fill-upper {
-      background: var(--background-color);
+      background: var(--secondary-slider-color);
     }
 
     // Thumb
     &::-webkit-slider-thumb {
-      border-color: var(--secondary-color);
-      background: var(--background-color);
+      border-color: var(--primary-slider-color);
+      background: var(--secondary-slider-color);
       box-shadow: 0 1px 3px 0 var(--overlay-color);
     }
     &::-moz-range-thumb {
-      background: var(--background-color);
-      border-color: var(--secondary-color);
+      background: var(--secondary-slider-color);
+      border-color: var(--primary-slider-color);
       box-shadow: 0 1px 3px 0 var(--overlay-color);
     }
     &::-ms-thumb {
-      border-color: var(--secondary-color);
-      background: var(--background-color);
+      border-color: var(--primary-slider-color);
+      background: var(--secondary-slider-color);
       box-shadow: 0 1px 3px 0 var(--overlay-color);
     }
   }

--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -89,17 +89,17 @@ body[data-theme='dark'] {
     &::-webkit-slider-thumb {
       border-color: $studio-gray-5;
       background: var(--primary-color);
-      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
+      box-shadow: 0 1px 3px 0 var(--overlay-color);
     }
     &::-moz-range-thumb {
       background: var(--primary-color);
       border-color: $studio-gray-5;
-      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
+      box-shadow: 0 1px 3px 0 var(--overlay-color);
     }
     &::-ms-thumb {
       border-color: $studio-gray-5;
       background: var(--primary-color);
-      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
+      box-shadow: 0 1px 3px 0 var(--overlay-color);
     }
   }
 }

--- a/lib/components/spinner/style.scss
+++ b/lib/components/spinner/style.scss
@@ -3,7 +3,7 @@
     color: var(--secondary-color);
   }
   @at-root body[data-theme='dark'] & {
-    color: $studio-gray-80;
+    color: var(--secondary-color);
   }
 
   &.is-white {

--- a/lib/components/tab-panels/style.scss
+++ b/lib/components/tab-panels/style.scss
@@ -35,8 +35,8 @@ body[data-theme='light'] .tab-panels__tab-list li.is-active {
 }
 
 body[data-theme='dark'] .tab-panels__tab-list li.is-active {
-  color: $studio-simplenote-blue-20;
-  border-bottom-color: $studio-simplenote-blue-20;
+  color: var(--accent-color);
+  border-bottom-color: var(--accent-color);
 }
 
 .tab-panels__panel {

--- a/lib/components/tag-chip/style.scss
+++ b/lib/components/tag-chip/style.scss
@@ -5,7 +5,7 @@
   border-radius: 16px;
   line-height: 1.25em;
   white-space: nowrap;
-  background: var(--secondary-color);
+  background: var(--primary-tag-chip-color);
   text-decoration: none;
   font-size: 14px;
   position: relative;
@@ -23,7 +23,7 @@
   }
 
   &.deleted {
-    background: $studio-red-5;
+    background: var(--secondary-tag-chip-color);
   }
 
   .remove-tag-icon {
@@ -51,16 +51,16 @@
 
 body[data-theme='dark'] {
   .tag-chip {
-    background: $studio-gray-70;
+    background: var(--primary-tag-chip-color);
     color: var(--primary-color);
 
     &.deleted {
-      background: $studio-red-70;
+      background: var(--secondary-tag-chip-color);
     }
   }
 
   .remove-tag-icon {
     background-color: var(--foreground-color);
-    color: $studio-black;
+    color: var(--background-color);
   }
 }

--- a/lib/components/tag-chip/style.scss
+++ b/lib/components/tag-chip/style.scss
@@ -60,7 +60,7 @@ body[data-theme='dark'] {
   }
 
   .remove-tag-icon {
-    background-color: $studio-gray-30;
+    background-color: var(--foreground-color);
     color: $studio-black;
   }
 }

--- a/lib/components/tag-chip/style.scss
+++ b/lib/components/tag-chip/style.scss
@@ -52,7 +52,7 @@
 body[data-theme='dark'] {
   .tag-chip {
     background: $studio-gray-70;
-    color: $studio-white;
+    color: var(--primary-color);
 
     &.deleted {
       background: $studio-red-70;

--- a/lib/controls/toggle/style.scss
+++ b/lib/controls/toggle/style.scss
@@ -64,7 +64,7 @@ $toggle-control-knob-size: $toggle-control-height - $toggle-control-knob-margin 
     display: block;
     width: $toggle-control-knob-size;
     height: $toggle-control-knob-size;
-    background: var(--background-color);
+    background: var(--primary-button-fg-color);
     border-radius: $toggle-control-height * 0.5;
     transform: translate(
       $toggle-control-knob-margin,

--- a/lib/controls/toggle/style.scss
+++ b/lib/controls/toggle/style.scss
@@ -51,7 +51,7 @@ $toggle-control-knob-size: $toggle-control-height - $toggle-control-knob-margin 
   }
 
   .toggle-control-unchecked-color {
-    background: var(--secondary-accent-color);
+    background: var(--inactive-controls-color);
   }
 
   .toggle-control-checked-color {

--- a/lib/dialogs/about/style.scss
+++ b/lib/dialogs/about/style.scss
@@ -5,10 +5,11 @@
     max-height: calc(100vh - 2rem);
 
     // For overriding theme settings.
-    // TODO: Improve theme management so this isn't necessary
+    // TODO: Improve theme management so this isn't neccessary
 
     --accent-color: #3361cc; // $studio-simplenote-blue-50
     --background-color: #fff; // $studio-white
+
     background: var(--accent-color) !important;
     color: var(--background-color) !important;
     a {

--- a/lib/dialogs/about/style.scss
+++ b/lib/dialogs/about/style.scss
@@ -7,6 +7,8 @@
     // For overriding theme settings.
     // TODO: Improve theme management so this isn't necessary
 
+    --accent-color: #3361cc; // $studio-simplenote-blue-50
+    --background-color: #fff; // $studio-white
     background: var(--accent-color) !important;
     color: var(--background-color) !important;
     a {

--- a/lib/dialogs/import/dropzone/style.scss
+++ b/lib/dialogs/import/dropzone/style.scss
@@ -101,7 +101,7 @@ body[data-theme='dark'] {
   .importer-dropzone {
     .drop-instructions {
       span {
-        color: $studio-simplenote-blue-20;
+        color: var(--accent-color);
       }
     }
     &.is-accepted {

--- a/lib/dialogs/import/dropzone/style.scss
+++ b/lib/dialogs/import/dropzone/style.scss
@@ -95,7 +95,7 @@
 
 body[data-theme='dark'] {
   .importer-dropzone.theme-color-border {
-    border-color: $studio-gray-50;
+    border-color: var(--tertiary-color);
     color: $studio-gray-30;
   }
   .importer-dropzone {

--- a/lib/dialogs/import/dropzone/style.scss
+++ b/lib/dialogs/import/dropzone/style.scss
@@ -82,7 +82,7 @@
     margin-top: 8px;
 
     span {
-      color: $studio-simplenote-blue;
+      color: var(--primary-branding-color);
     }
   }
 }

--- a/lib/dialogs/import/dropzone/style.scss
+++ b/lib/dialogs/import/dropzone/style.scss
@@ -110,7 +110,7 @@ body[data-theme='dark'] {
       }
 
       li {
-        color: $studio-white;
+        color: var(--primary-color);
       }
 
       svg {

--- a/lib/dialogs/import/dropzone/style.scss
+++ b/lib/dialogs/import/dropzone/style.scss
@@ -106,7 +106,7 @@ body[data-theme='dark'] {
     }
     &.is-accepted {
       ul {
-        border-color: $studio-gray-80;
+        border-color: var(--secondary-color);
       }
 
       li {

--- a/lib/dialogs/import/dropzone/style.scss
+++ b/lib/dialogs/import/dropzone/style.scss
@@ -96,7 +96,7 @@
 body[data-theme='dark'] {
   .importer-dropzone.theme-color-border {
     border-color: var(--tertiary-color);
-    color: $studio-gray-30;
+    color: var(--foreground-color);
   }
   .importer-dropzone {
     .drop-instructions {
@@ -114,12 +114,12 @@ body[data-theme='dark'] {
       }
 
       svg {
-        fill: $studio-gray-30;
+        fill: var(--foreground-color);
       }
 
       .error-message {
         li {
-          color: $studio-gray-30;
+          color: var(--foreground-color);
         }
       }
     }

--- a/lib/dialogs/import/source-importer/executor/style.scss
+++ b/lib/dialogs/import/source-importer/executor/style.scss
@@ -74,7 +74,7 @@ body[data-theme='dark'] {
   .source-importer-executor {
     .source-importer-executor__options {
       label {
-        border-color: $studio-gray-80;
+        border-color: var(--secondary-color);
       }
     }
   }

--- a/lib/dialogs/import/source-importer/style.scss
+++ b/lib/dialogs/import/source-importer/style.scss
@@ -75,7 +75,7 @@ body[data-theme='dark'] {
       color: var(--primary-color);
     }
     button.disabled {
-      background-color: $studio-gray-50;
+      background-color: var(--tertiary-color);
       color: var(--primary-color);
     }
   }

--- a/lib/dialogs/import/source-importer/style.scss
+++ b/lib/dialogs/import/source-importer/style.scss
@@ -72,11 +72,11 @@
 body[data-theme='dark'] {
   .source-importer {
     p {
-      color: $studio-white;
+      color: var(--primary-color);
     }
     button.disabled {
       background-color: $studio-gray-50;
-      color: $studio-white;
+      color: var(--primary-color);
     }
   }
 }

--- a/lib/dialogs/unsynchronized/style.scss
+++ b/lib/dialogs/unsynchronized/style.scss
@@ -88,6 +88,6 @@ body[data-theme='dark'] .logoutConfirmation .dialog {
   }
 
   .export-unsynchronized {
-    color: $studio-simplenote-blue-20;
+    color: var(--accent-color);
   }
 }

--- a/lib/dialogs/unsynchronized/style.scss
+++ b/lib/dialogs/unsynchronized/style.scss
@@ -84,7 +84,7 @@
 
 body[data-theme='dark'] .logoutConfirmation .dialog {
   .change-list {
-    border-color: $studio-gray-80;
+    border-color: var(--secondary-color);
   }
 
   .export-unsynchronized {

--- a/lib/email-verification/style.scss
+++ b/lib/email-verification/style.scss
@@ -79,6 +79,6 @@
 
 body[data-theme='dark'] {
   .email-verification__button-row .button-borderless {
-    color: $studio-simplenote-blue-20;
+    color: var(--accent-color);
   }
 }

--- a/lib/icons/style.scss
+++ b/lib/icons/style.scss
@@ -11,7 +11,7 @@ svg[class^='icon-'][class$='-small'] {
 
 // Color for the Simplenote logo
 .logo path {
-  fill: var(--accent-color);
+  fill: var(--primary-branding-color);
 }
 .logo circle {
   fill: var(--background-color);

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -62,7 +62,7 @@
 body[data-theme='dark'] {
   .navigation-bar-item {
     &.is-selected button {
-      color: $studio-white;
+      color: var(--primary-color);
     }
 
     &:hover:not(.is-selected) {

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -66,7 +66,7 @@ body[data-theme='dark'] {
     }
 
     &:hover:not(.is-selected) {
-      background: $studio-gray-80;
+      background: var(--secondary-color);
     }
   }
 }

--- a/lib/note-actions/style.scss
+++ b/lib/note-actions/style.scss
@@ -96,7 +96,7 @@ body[data-theme='dark'] {
   }
 
   .note-actions-item:hover {
-    background-color: $studio-gray-80;
+    background-color: var(--secondary-color);
   }
 
   .note-actions-item-control .checkbox-control .checkbox-control-base,

--- a/lib/note-actions/style.scss
+++ b/lib/note-actions/style.scss
@@ -75,7 +75,7 @@
   }
 
   .spinner__circle {
-    color: $studio-gray-30;
+    color: var(--tertiary-accent-color);
   }
 }
 
@@ -102,7 +102,7 @@ body[data-theme='dark'] {
   .note-actions-item-control .checkbox-control .checkbox-control-base,
   .note-actions-item-control .checkbox-control .checkbox-control-checked {
     background-position: 0 -18px;
-    fill: $studio-gray-30;
+    fill: var(--foreground-color);
   }
 
   .note-actions-item-control .checkbox-control .checkbox-control-checked {

--- a/lib/note-actions/style.scss
+++ b/lib/note-actions/style.scss
@@ -81,7 +81,7 @@
 
 body[data-theme='dark'] {
   .spinner__circle {
-    color: $studio-gray-50;
+    color: var(--tertiary-color);
   }
   .note-actions.theme-color-bg {
     background-color: var(--background-color);
@@ -92,7 +92,7 @@ body[data-theme='dark'] {
   }
 
   .note-actions-item-disabled {
-    color: $studio-gray-50;
+    color: var(--tertiary-color);
   }
 
   .note-actions-item:hover {

--- a/lib/note-actions/style.scss
+++ b/lib/note-actions/style.scss
@@ -88,7 +88,7 @@ body[data-theme='dark'] {
   }
 
   .note-actions-trash {
-    color: $studio-red-30;
+    color: var(--tertiary-highlight-color);
   }
 
   .note-actions-item-disabled {

--- a/lib/note-actions/style.scss
+++ b/lib/note-actions/style.scss
@@ -84,7 +84,7 @@ body[data-theme='dark'] {
     color: $studio-gray-50;
   }
   .note-actions.theme-color-bg {
-    background-color: $studio-gray-90;
+    background-color: var(--background-color);
   }
 
   .note-actions-trash {

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -215,7 +215,7 @@
 }
 
 body[data-theme='dark'] .note-detail-markdown p > code {
-  background-color: $studio-gray-70;
+  background-color: var(--secondary-color);
 }
 
 .monaco-editor.monaco-editor .detected-link {

--- a/lib/note-info/style.scss
+++ b/lib/note-info/style.scss
@@ -105,7 +105,7 @@ body[data-theme='dark'] {
   .note-info {
     .reference-link {
       &:hover {
-        background-color: $studio-gray-80;
+        background-color: var(--secondary-color);
       }
     }
   }

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -96,7 +96,7 @@ body[data-theme='dark'] {
   .note-list-placeholder {
     .no-notes-icon,
     .no-notes-message {
-      color: $studio-gray-30;
+      color: var(--foreground-color);
     }
 
     button {

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -228,7 +228,7 @@ body[data-theme='dark'] {
     }
 
     body[data-theme='dark'] &.is-offline svg {
-      fill: $studio-gray-70;
+      fill: var(--tertiary-color);
     }
   }
 

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -100,12 +100,12 @@ body[data-theme='dark'] {
     }
 
     button {
-      color: $studio-simplenote-blue-20;
+      color: var(--accent-color);
     }
   }
 
   .note-list .search-match {
-    color: $studio-simplenote-blue-20;
+    color: var(--accent-color);
   }
 }
 

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -20,7 +20,7 @@
 }
 
 body[data-theme='dark'] .note-toolbar-wrapper .offline-badge {
-  border: solid 1px $studio-gray-80;
+  border: solid 1px var(--secondary-color);
   box-shadow: 0 2px 4px 0 rgba(255, 255, 255, 0.02);
   color: $studio-gray-50;
 }

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -22,7 +22,7 @@
 body[data-theme='dark'] .note-toolbar-wrapper .offline-badge {
   border: solid 1px var(--secondary-color);
   box-shadow: 0 2px 4px 0 rgba(255, 255, 255, 0.02);
-  color: $studio-gray-50;
+  color: var(--tertiary-color);
 }
 
 .note-toolbar {

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -64,8 +64,8 @@
   }
 
   .button-secondary {
-    background: var(--foreground-color);
-    color: var(--background-color);
+    background: var(--secondary-button-bg-color);
+    color: var(--primary-button-fg-color);
     margin-right: 10px;
 
     &:active {

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -119,7 +119,7 @@ input.tag-list-input {
 body[data-theme='dark'] {
   .icon-button {
     &.button-reorder {
-      color: $studio-gray-50;
+      color: var(--tertiary-color);
     }
     &.button-trash {
       color: $studio-simplenote-blue-20;

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -122,7 +122,7 @@ body[data-theme='dark'] {
       color: var(--tertiary-color);
     }
     &.button-trash {
-      color: $studio-simplenote-blue-20;
+      color: var(--accent-color);
     }
   }
 

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -128,7 +128,7 @@ body[data-theme='dark'] {
 
   .tag-list-item {
     &:hover {
-      background-color: $studio-gray-80;
+      background-color: var(--secondary-color);
     }
   }
 }

--- a/lib/tag-suggestions/style.scss
+++ b/lib/tag-suggestions/style.scss
@@ -36,6 +36,6 @@ body[data-theme='light'] {
 
 body[data-theme='dark'] {
   .tag-suggestion {
-    border-color: $studio-gray-80;
+    border-color: var(--secondary-color);
   }
 }

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -90,6 +90,6 @@ optgroup {
 }
 
 body[data-theme='dark'] .search-match {
-  background-color: rgba($studio-simplenote-blue-50, 0.4);
+  background-color: var(--highlight-color);
   color: var(--primary-color);
 }

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -86,7 +86,7 @@ optgroup {
 }
 
 .MuiTooltip-tooltip.icon-button__tooltip {
-  background-color: $studio-gray-50;
+  background-color: var(--tertiary-color);
 }
 
 body[data-theme='dark'] .search-match {

--- a/scss/_general.scss
+++ b/scss/_general.scss
@@ -91,5 +91,5 @@ optgroup {
 
 body[data-theme='dark'] .search-match {
   background-color: rgba($studio-simplenote-blue-50, 0.4);
-  color: $studio-white;
+  color: var(--primary-color);
 }

--- a/scss/_scrollbar.scss
+++ b/scss/_scrollbar.scss
@@ -9,7 +9,7 @@
 }
 
 ::-webkit-scrollbar-thumb {
-  background: $studio-gray-10;
+  background: var(--secondary-color);
   border-radius: 100px;
   border: 4px solid var(--background-color);
   min-height: 24px;

--- a/scss/_scrollbar.scss
+++ b/scss/_scrollbar.scss
@@ -19,12 +19,12 @@
   background-color: var(--foreground-color);
 }
 ::-webkit-scrollbar-thumb:active {
-  background: $studio-gray-30;
+  background: var(--tertiary-accent-color);
   border-radius: 100px;
 }
 
 // Styles for Firefox not a lot of options we are able to set for custom scrollbars
 body {
   scrollbar-width: thin;
-  scrollbar-color: $studio-gray-30 transparent;
+  scrollbar-color: var(--tertiary-accent-color) transparent;
 }

--- a/scss/_scrollbar.scss
+++ b/scss/_scrollbar.scss
@@ -16,7 +16,7 @@
 }
 // hover effect for scrollbar 'thumb'
 ::-webkit-scrollbar-thumb:hover {
-  background-color: $studio-gray-20;
+  background-color: var(--foreground-color);
 }
 ::-webkit-scrollbar-thumb:active {
   background: $studio-gray-30;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -51,4 +51,5 @@ body[data-theme='dark'] {
   --primary-color: #fff; // $studio-white
   --secondary-color: #2c3338; // $studio-gray-80
   --tertiary-color: #646970; // $studio-gray-50
+  --accent-color: #84a4f0; // $studio-simplenote-blue-20
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -43,6 +43,8 @@ body[data-theme='light'] {
   --wordpress-color: #006088; // $studio-wordpress-blue-50
   --active-controls-color: #1ed15a; // $studio-green-20
   --warning-highlight-color: #faa754; // $studio-orange-20
+  --primary-button-bg-color: #3361cc; // $studio-simplenote-blue-50
+  --primary-button-fg-color: #fff; // $studio-white
 }
 
 body[data-theme='dark'] {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -56,6 +56,8 @@ body[data-theme='light'] {
   --readonly-input-highlight-color: #c3c4c7; // $studio-gray-10
   --primary-slider-color: #dcdcde; // $studio-gray-5
   --secondary-slider-color: #fff; // $studio-white
+  --primary-tag-chip-color: #dcdcde; // $studio-gray-5
+  --secondary-tag-chip-color: #facfd2; // $studio-red-5
 }
 
 body[data-theme='dark'] {
@@ -78,4 +80,6 @@ body[data-theme='dark'] {
   --readonly-input-highlight-color: #8c8f94; // $studio-gray-30
   --primary-slider-color: #646970; // $studio-gray-50
   --secondary-slider-color: #fff; // $studio-white
+  --primary-tag-chip-color: #3c434a; // $studio-gray-70
+  --secondary-tag-chip-color: #8a2424; // $studio-red-70
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -54,6 +54,8 @@ body[data-theme='light'] {
   // readonly-input-color = $studio-black with 0.05 opacity
   --readonly-input-color: rgba(0, 0, 0, 0.05);
   --readonly-input-highlight-color: #c3c4c7; // $studio-gray-10
+  --primary-slider-color: #dcdcde; // $studio-gray-5
+  --secondary-slider-color: #fff; // $studio-white
 }
 
 body[data-theme='dark'] {
@@ -74,4 +76,6 @@ body[data-theme='dark'] {
   // readonly-input-color = $studio-white with 0.07 opacity
   --readonly-input-color: rgba(255, 255, 255, 0.07);
   --readonly-input-highlight-color: #8c8f94; // $studio-gray-30
+  --primary-slider-color: #646970; // $studio-gray-50
+  --secondary-slider-color: #fff; // $studio-white
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -49,4 +49,5 @@ body[data-theme='dark'] {
   --background-color: #1d2327; // $studio-gray-90
   --foreground-color: #a7aaad; // $studio-gray-20
   --primary-color: #fff; // $studio-white
+  --secondary-color: #2c3338; // $studio-gray-80
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -45,6 +45,7 @@ body[data-theme='light'] {
   --active-controls-color: #1ed15a; // $studio-green-20
   --warning-highlight-color: #faa754; // $studio-orange-20
   --primary-button-bg-color: #3361cc; // $studio-simplenote-blue-50
+  --secondary-button-bg-color: #646970; // $studio-gray-50
   --primary-button-fg-color: #fff; // $studio-white
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -74,7 +74,7 @@ body[data-theme='dark'] {
   --search-selection-color: #deb100; // $studio-yellow-30
   --placeholder-color: #646970; // $studio-gray-50
   --primary-button-bg-color: #3361cc; // $studio-simplenote-blue-50
-  --tertiary-highlight-color: #ff8085; // $studio-red-20
+  --tertiary-highlight-color: #d63638; // $studio-red-50
   // readonly-input-color = $studio-white with 0.07 opacity
   --readonly-input-color: rgba(255, 255, 255, 0.07);
   --readonly-input-highlight-color: #8c8f94; // $studio-gray-30

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -52,4 +52,7 @@ body[data-theme='dark'] {
   --secondary-color: #2c3338; // $studio-gray-80
   --tertiary-color: #646970; // $studio-gray-50
   --accent-color: #84a4f0; // $studio-simplenote-blue-20
+  // --secondary-accent-color: #c3c4c7; // $studio-gray-10
+  // --highlight-color = $studio-simplenote-blue-50 with 40% opacity
+  --highlight-color: rgba(51, 97, 204, 0.4);
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -51,6 +51,9 @@ body[data-theme='light'] {
   --primary-button-fg-color: #fff; // $studio-white
   --primary-branding-color: #3361cc; // $studio-simplenote-blue-50
   --placeholder-color: #646970; // $studio-gray-50
+  // readonly-input-color = $studio-black with 0.05 opacity
+  --readonly-input-color: rgba(0, 0, 0, 0.05);
+  --readonly-input-bg-color: #c3c4c7; // $studio-gray-10
 }
 
 body[data-theme='dark'] {
@@ -67,4 +70,8 @@ body[data-theme='dark'] {
   --search-selection-color: #deb100; // $studio-yellow-30
   --placeholder-color: #646970; // $studio-gray-50
   --primary-button-bg-color: #3361cc; // $studio-simplenote-blue-50
+  --tertiary-highlight-color: #ff8085; // $studio-red-20
+  // readonly-input-color = $studio-white with 0.07 opacity
+  --readonly-input-color: rgba(255, 255, 255, 0.07);
+  --readonly-input-bg-color: #8c8f94; // $studio-gray-30
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -58,6 +58,7 @@ body[data-theme='light'] {
   --secondary-slider-color: #fff; // $studio-white
   --primary-tag-chip-color: #dcdcde; // $studio-gray-5
   --secondary-tag-chip-color: #facfd2; // $studio-red-5
+  --settings-fg-color: #2c3338; // $studio-gray-80
 }
 
 body[data-theme='dark'] {
@@ -82,4 +83,5 @@ body[data-theme='dark'] {
   --secondary-slider-color: #fff; // $studio-white
   --primary-tag-chip-color: #3c434a; // $studio-gray-70
   --secondary-tag-chip-color: #8a2424; // $studio-red-70
+  --settings-fg-color: #dcdcde; // $studio-gray-5
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -44,11 +44,13 @@ body[data-theme='light'] {
   --search-highlight-color: #ced9f2; // $studio-simplenote-blue-5
   --wordpress-color: #006088; // $studio-wordpress-blue-50
   --active-controls-color: #1ed15a; // $studio-green-20
+  --inactive-controls-color: #c3c4c7; // $studio-gray-10
   --warning-highlight-color: #faa754; // $studio-orange-20
   --primary-button-bg-color: #3361cc; // $studio-simplenote-blue-50
   --secondary-button-bg-color: #646970; // $studio-gray-50
   --primary-button-fg-color: #fff; // $studio-white
   --primary-branding-color: #3361cc; // $studio-simplenote-blue-50
+  --placeholder-color: #646970; // $studio-gray-50
 }
 
 body[data-theme='dark'] {
@@ -58,8 +60,11 @@ body[data-theme='dark'] {
   --secondary-color: #2c3338; // $studio-gray-80
   --tertiary-color: #646970; // $studio-gray-50
   --accent-color: #84a4f0; // $studio-simplenote-blue-20
+  --secondary-accent-color: #50575e; // $studio-gray-60
   // highlight-color = $studio-simplenote-blue-50 with 40% opacity
   --highlight-color: rgba(51, 97, 204, 0.4);
   --search-highlight-color: #3361cc; // $studio-simplenote-blue-50
   --search-selection-color: #deb100; // $studio-yellow-30
+  --placeholder-color: #646970; // $studio-gray-50
+  --primary-button-bg-color: #3361cc; // $studio-simplenote-blue-50
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -41,6 +41,7 @@ body[data-theme='light'] {
   --tertiary-highlight-color: #d63638; // $studio-red-50
   --overlay-color: rgba(0, 0, 0, 0.2); // black with 20% opacity
   --search-selection-color: #f0c930; // $studio-yellow-20
+  --search-highlight-color: #ced9f2; // $studio-simplenote-blue-5
   --wordpress-color: #006088; // $studio-wordpress-blue-50
   --active-controls-color: #1ed15a; // $studio-green-20
   --warning-highlight-color: #faa754; // $studio-orange-20
@@ -59,4 +60,5 @@ body[data-theme='dark'] {
   // --secondary-accent-color: #c3c4c7; // $studio-gray-10
   // --highlight-color = $studio-simplenote-blue-50 with 40% opacity
   --highlight-color: rgba(51, 97, 204, 0.4);
+  --search-highlight-color: #3361cc; // $studio-simplenote-blue-50
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -47,4 +47,5 @@ body[data-theme='light'] {
 
 body[data-theme='dark'] {
   --background-color: #1d2327; // $studio-gray-90
+  --foreground-color: #a7aaad; // $studio-gray-20
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -44,3 +44,7 @@ body[data-theme='light'] {
   --active-controls-color: #1ed15a; // $studio-green-20
   --warning-highlight-color: #faa754; // $studio-orange-20
 }
+
+body[data-theme='dark'] {
+  --background-color: #1d2327; // $studio-gray-90
+}

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -53,7 +53,7 @@ body[data-theme='light'] {
   --placeholder-color: #646970; // $studio-gray-50
   // readonly-input-color = $studio-black with 0.05 opacity
   --readonly-input-color: rgba(0, 0, 0, 0.05);
-  --readonly-input-bg-color: #c3c4c7; // $studio-gray-10
+  --readonly-input-highlight-color: #c3c4c7; // $studio-gray-10
 }
 
 body[data-theme='dark'] {
@@ -73,5 +73,5 @@ body[data-theme='dark'] {
   --tertiary-highlight-color: #ff8085; // $studio-red-20
   // readonly-input-color = $studio-white with 0.07 opacity
   --readonly-input-color: rgba(255, 255, 255, 0.07);
-  --readonly-input-bg-color: #8c8f94; // $studio-gray-30
+  --readonly-input-highlight-color: #8c8f94; // $studio-gray-30
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -48,6 +48,7 @@ body[data-theme='light'] {
   --primary-button-bg-color: #3361cc; // $studio-simplenote-blue-50
   --secondary-button-bg-color: #646970; // $studio-gray-50
   --primary-button-fg-color: #fff; // $studio-white
+  --primary-branding-color: #3361cc; // $studio-simplenote-blue-50
 }
 
 body[data-theme='dark'] {
@@ -57,8 +58,7 @@ body[data-theme='dark'] {
   --secondary-color: #2c3338; // $studio-gray-80
   --tertiary-color: #646970; // $studio-gray-50
   --accent-color: #84a4f0; // $studio-simplenote-blue-20
-  // --secondary-accent-color: #c3c4c7; // $studio-gray-10
-  // --highlight-color = $studio-simplenote-blue-50 with 40% opacity
+  // highlight-color = $studio-simplenote-blue-50 with 40% opacity
   --highlight-color: rgba(51, 97, 204, 0.4);
   --search-highlight-color: #3361cc; // $studio-simplenote-blue-50
   --search-selection-color: #deb100; // $studio-yellow-30

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -73,7 +73,7 @@ body[data-theme='dark'] {
   --highlight-color: rgba(51, 97, 204, 0.4);
   --search-highlight-color: #3361cc; // $studio-simplenote-blue-50
   --search-selection-color: #deb100; // $studio-yellow-30
-  --placeholder-color: #646970; // $studio-gray-50
+  --placeholder-color: #a7aaad; // $studio-gray-20
   --primary-button-bg-color: #3361cc; // $studio-simplenote-blue-50
   --tertiary-highlight-color: #d63638; // $studio-red-50
   // readonly-input-color = $studio-white with 0.07 opacity

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -75,7 +75,7 @@ body[data-theme='dark'] {
   --search-selection-color: #deb100; // $studio-yellow-30
   --placeholder-color: #a7aaad; // $studio-gray-20
   --primary-button-bg-color: #3361cc; // $studio-simplenote-blue-50
-  --tertiary-highlight-color: #d63638; // $studio-red-50
+  --tertiary-highlight-color: #ff8085; // $studio-red-20
   // readonly-input-color = $studio-white with 0.07 opacity
   --readonly-input-color: rgba(255, 255, 255, 0.07);
   --readonly-input-highlight-color: #8c8f94; // $studio-gray-30

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -61,4 +61,5 @@ body[data-theme='dark'] {
   // --highlight-color = $studio-simplenote-blue-50 with 40% opacity
   --highlight-color: rgba(51, 97, 204, 0.4);
   --search-highlight-color: #3361cc; // $studio-simplenote-blue-50
+  --search-selection-color: #deb100; // $studio-yellow-30
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -50,4 +50,5 @@ body[data-theme='dark'] {
   --foreground-color: #a7aaad; // $studio-gray-20
   --primary-color: #fff; // $studio-white
   --secondary-color: #2c3338; // $studio-gray-80
+  --tertiary-color: #646970; // $studio-gray-50
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -35,6 +35,7 @@ body[data-theme='light'] {
   --tertiary-color: #a7aaad; // $studio-gray-20
   --accent-color: #3361cc; // $studio-simplenote-blue-50
   --secondary-accent-color: #c3c4c7; // $studio-gray-10
+  --tertiary-accent-color: #8c8f94; // $studio-gray-30
   --highlight-color: #ced9f2; // $studio-simplenote-blue-5
   --secondary-highlight-color: #f6f7f7; // $studio-gray-0;
   --tertiary-highlight-color: #d63638; // $studio-red-50
@@ -49,7 +50,7 @@ body[data-theme='light'] {
 
 body[data-theme='dark'] {
   --background-color: #1d2327; // $studio-gray-90
-  --foreground-color: #a7aaad; // $studio-gray-20
+  --foreground-color: #8c8f94; // $studio-gray-30
   --primary-color: #fff; // $studio-white
   --secondary-color: #2c3338; // $studio-gray-80
   --tertiary-color: #646970; // $studio-gray-50

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -48,4 +48,5 @@ body[data-theme='light'] {
 body[data-theme='dark'] {
   --background-color: #1d2327; // $studio-gray-90
   --foreground-color: #a7aaad; // $studio-gray-20
+  --primary-color: #fff; // $studio-white
 }

--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -29,10 +29,10 @@ button {
   transition: $anim-fast;
   -webkit-tap-highlight-color: transparent;
   background: transparent;
-  border-color: $studio-gray-30;
+  border-color: var(--tertiary-accent-color);
   border-style: solid;
   border-width: 2px;
-  color: $studio-gray-30;
+  color: var(--tertiary-accent-color);
   font-size: 14px;
   line-height: 1.5;
   font-weight: $bold;

--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -41,8 +41,8 @@ button {
 
   &:active,
   &.active {
-    background: var(--accent-color);
-    color: var(--background-color);
+    background: var(--primary-button-bg-color);
+    color: var(--primary-button-fg-color);
   }
   &[disabled],
   &:disabled {
@@ -52,8 +52,8 @@ button {
 
 // Primary buttons. Solid buttons.
 .button-primary {
-  background: var(--accent-color);
-  color: var(--background-color);
+  background: var(--primary-button-bg-color);
+  color: var(--primary-button-fg-color);
 }
 
 // Compact buttons. Use to make buttons smaller.

--- a/scss/inputs.scss
+++ b/scss/inputs.scss
@@ -11,7 +11,7 @@ input {
   -webkit-tap-highlight-color: transparent;
 
   &::placeholder {
-    color: var(--foreground-color);
+    color: var(--placeholder-color);
     opacity: 1;
   }
 

--- a/scss/print.scss
+++ b/scss/print.scss
@@ -4,7 +4,7 @@
   }
 
   body[data-theme='dark'] .theme-color-bg {
-    background-color: $studio-white;
+    background-color: var(--primary-color);
   }
 
   .app-layout__note-column {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -91,7 +91,7 @@ span[dir='ltr'] {
     border: 3px solid gray;
   }
   .search-decoration {
-    background-color: var(--highlight-color);
+    background-color: var(--search-highlight-color);
   }
   .selected-search {
     background-color: var(--search-selection-color);
@@ -258,7 +258,7 @@ body[data-theme='dark'] {
   }
 
   .search-decoration {
-    background-color: $studio-simplenote-blue-50;
+    background-color: var(--search-highlight-color);
   }
   .selected-search {
     background-color: $studio-yellow-30;

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -158,14 +158,14 @@ body[data-theme='light'] {
 }
 
 body[data-theme='dark'] {
-  background-color: $studio-gray-90;
+  background-color: var(--background-color);
   color: $studio-gray-20;
 
   .theme-color-bg {
-    background-color: $studio-gray-90;
+    background-color: var(--background-color);
   }
   .theme-color-bg-lighter {
-    background-color: $studio-gray-90;
+    background-color: var(--background-color);
   }
   .theme-color-fg {
     color: $studio-white;
@@ -184,7 +184,7 @@ body[data-theme='dark'] {
     border-color: $studio-gray-50;
   }
   ::-webkit-scrollbar-thumb:hover {
-    background-color: $studio-gray-90;
+    background-color: var(--background-color);
   }
   ::-webkit-scrollbar-thumb:active {
     background-color: $studio-gray-50;
@@ -262,7 +262,7 @@ body[data-theme='dark'] {
   }
   .selected-search {
     background-color: $studio-yellow-30;
-    color: $studio-gray-90;
+    color: var(--background-color);
   }
 
   .settings-group p {
@@ -339,7 +339,7 @@ body[data-theme='dark'] {
   .search-results {
     color: $studio-gray-10;
     border-color: $studio-gray-80;
-    background-color: $studio-gray-90;
+    background-color: var(--background-color);
 
     button svg {
       fill: $studio-simplenote-blue-20;

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -176,11 +176,11 @@ body[data-theme='dark'] {
   .theme-color-border,
   &.theme-color-border,
   .button {
-    border-color: $studio-gray-80;
+    border-color: var(--secondary-color);
   }
 
   ::-webkit-scrollbar-thumb {
-    background-color: $studio-gray-80;
+    background-color: var(--secondary-color);
     border-color: $studio-gray-50;
   }
   ::-webkit-scrollbar-thumb:hover {
@@ -225,7 +225,7 @@ body[data-theme='dark'] {
   }
 
   .checkbox-control-base {
-    border-color: $studio-gray-80;
+    border-color: var(--secondary-color);
   }
 
   .navigation-bar-item {
@@ -305,7 +305,7 @@ body[data-theme='dark'] {
 
     .note-list-item:not(.note-list-item-selected) {
       &:hover {
-        background: $studio-gray-80;
+        background: var(--secondary-color);
       }
     }
   }
@@ -314,15 +314,15 @@ body[data-theme='dark'] {
     @import '../node_modules/highlight.js/scss/solarized-dark.scss';
 
     hr {
-      border-color: $studio-gray-80;
+      border-color: var(--secondary-color);
     }
 
     blockquote {
-      border-color: $studio-gray-80;
+      border-color: var(--secondary-color);
     }
 
     pre {
-      border-color: $studio-gray-80;
+      border-color: var(--secondary-color);
     }
 
     table {
@@ -331,14 +331,14 @@ body[data-theme='dark'] {
         border-color: $studio-gray-50;
       }
       tr:nth-child(2n) {
-        background-color: $studio-gray-80;
+        background-color: var(--secondary-color);
       }
     }
   }
 
   .search-results {
     color: $studio-gray-10;
-    border-color: $studio-gray-80;
+    border-color: var(--secondary-color);
     background-color: var(--background-color);
 
     button svg {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -168,7 +168,7 @@ body[data-theme='dark'] {
     background-color: var(--background-color);
   }
   .theme-color-fg {
-    color: $studio-white;
+    color: var(--primary-color);
   }
   .theme-color-fg-dim {
     color: $studio-gray-30;
@@ -206,11 +206,11 @@ body[data-theme='dark'] {
     color: $studio-gray-30;
   }
   a.button {
-    color: $studio-white;
+    color: var(--primary-color);
   }
 
   input {
-    color: $studio-white;
+    color: var(--primary-color);
   }
 
   input,
@@ -230,7 +230,7 @@ body[data-theme='dark'] {
 
   .navigation-bar-item {
     button {
-      color: $studio-white;
+      color: var(--primary-color);
     }
     svg[class^='icon-'] {
       fill: $studio-gray-30;
@@ -242,10 +242,10 @@ body[data-theme='dark'] {
     background-color: rgba($studio-simplenote-blue-50, 0.4);
 
     svg[class^='icon-'] {
-      fill: $studio-white;
+      fill: var(--primary-color);
     }
     button {
-      color: $studio-white;
+      color: var(--primary-color);
     }
   }
 
@@ -279,7 +279,7 @@ body[data-theme='dark'] {
       .note-list-item-excerpt,
       .note-list-item-published-icon,
       .note-list-item-pending-changes {
-        color: $studio-white;
+        color: var(--primary-color);
       }
       .note-list-item-pending-changes {
         &.is-offline svg {
@@ -287,7 +287,7 @@ body[data-theme='dark'] {
         }
       }
       &.note-list-item-pinned .note-list-item-pinner {
-        color: $studio-white;
+        color: var(--primary-color);
       }
     }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -261,7 +261,7 @@ body[data-theme='dark'] {
   }
 
   .settings-group p {
-    color: var(--primary-color);
+    color: var(--settings-fg-color);
   }
 
   .note-list-header {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -181,13 +181,13 @@ body[data-theme='dark'] {
 
   ::-webkit-scrollbar-thumb {
     background-color: var(--secondary-color);
-    border-color: $studio-gray-50;
+    border-color: var(--tertiary-color);
   }
   ::-webkit-scrollbar-thumb:hover {
     background-color: var(--background-color);
   }
   ::-webkit-scrollbar-thumb:active {
-    background-color: $studio-gray-50;
+    background-color: var(--tertiary-color);
   }
 
   .button-borderless {
@@ -196,7 +196,7 @@ body[data-theme='dark'] {
     &[disabled],
     &:disabled {
       svg[class^='icon-'] {
-        fill: $studio-gray-50;
+        fill: var(--tertiary-color);
       }
     }
   }
@@ -328,7 +328,7 @@ body[data-theme='dark'] {
     table {
       th,
       td {
-        border-color: $studio-gray-50;
+        border-color: var(--tertiary-color);
       }
       tr:nth-child(2n) {
         background-color: var(--secondary-color);

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -261,7 +261,7 @@ body[data-theme='dark'] {
     background-color: var(--search-highlight-color);
   }
   .selected-search {
-    background-color: $studio-yellow-30;
+    background-color: var(--search-selection-color);
     color: var(--background-color);
   }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -215,13 +215,8 @@ body[data-theme='dark'] {
 
   input,
   textarea {
-    border-color: $studio-gray-70;
+    border-color: var(--secondary-accent-color);
     background-color: transparent;
-  }
-
-  .transparent-input::placeholder,
-  input::placeholder {
-    color: var(--foreground-color);
   }
 
   .checkbox-control-base {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -171,7 +171,7 @@ body[data-theme='dark'] {
     color: var(--primary-color);
   }
   .theme-color-fg-dim {
-    color: $studio-gray-30;
+    color: var(--foreground-color);
   }
   .theme-color-border,
   &.theme-color-border,
@@ -203,7 +203,7 @@ body[data-theme='dark'] {
 
   .icon-button,
   a {
-    color: $studio-gray-30;
+    color: var(--foreground-color);
   }
   a.button {
     color: var(--primary-color);
@@ -221,7 +221,7 @@ body[data-theme='dark'] {
 
   .transparent-input::placeholder,
   input::placeholder {
-    color: $studio-gray-30;
+    color: var(--foreground-color);
   }
 
   .checkbox-control-base {
@@ -233,7 +233,7 @@ body[data-theme='dark'] {
       color: var(--primary-color);
     }
     svg[class^='icon-'] {
-      fill: $studio-gray-30;
+      fill: var(--foreground-color);
     }
   }
 
@@ -270,7 +270,7 @@ body[data-theme='dark'] {
   }
 
   .note-list-header {
-    color: $studio-gray-30;
+    color: var(--foreground-color);
   }
 
   .note-list {
@@ -283,7 +283,7 @@ body[data-theme='dark'] {
       }
       .note-list-item-pending-changes {
         &.is-offline svg {
-          fill: $studio-gray-30;
+          fill: var(--foreground-color);
         }
       }
       &.note-list-item-pinned .note-list-item-pinner {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -239,7 +239,7 @@ body[data-theme='dark'] {
 
   .navigation-bar-item.is-selected,
   .tag-list-item.is-selected {
-    background-color: rgba($studio-simplenote-blue-50, 0.4);
+    background-color: var(--highlight-color);
 
     svg[class^='icon-'] {
       fill: var(--primary-color);
@@ -275,7 +275,7 @@ body[data-theme='dark'] {
 
   .note-list {
     .note-list-item-selected {
-      background: rgba($studio-simplenote-blue-50, 0.4);
+      background: var(--highlight-color);
       .note-list-item-excerpt,
       .note-list-item-published-icon,
       .note-list-item-pending-changes {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -159,7 +159,7 @@ body[data-theme='light'] {
 
 body[data-theme='dark'] {
   background-color: var(--background-color);
-  color: $studio-gray-20;
+  color: var(--foreground-color);
 
   .theme-color-bg {
     background-color: var(--background-color);
@@ -253,7 +253,7 @@ body[data-theme='dark'] {
     background: transparent;
 
     &::placeholder {
-      color: $studio-gray-20;
+      color: var(--foreground-color);
     }
   }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -266,7 +266,7 @@ body[data-theme='dark'] {
   }
 
   .settings-group p {
-    color: $studio-gray-5;
+    color: var(--primary-color);
   }
 
   .note-list-header {
@@ -337,7 +337,7 @@ body[data-theme='dark'] {
   }
 
   .search-results {
-    color: $studio-gray-10;
+    color: var(--primary-color);
     border-color: var(--secondary-color);
     background-color: var(--background-color);
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -191,7 +191,7 @@ body[data-theme='dark'] {
   }
 
   .button-borderless {
-    color: $studio-simplenote-blue-20;
+    color: var(--accent-color);
 
     &[disabled],
     &:disabled {
@@ -293,7 +293,7 @@ body[data-theme='dark'] {
 
     .note-list-item-pinned:not(.note-list-item-selected) {
       .note-list-item-pinner {
-        color: $studio-simplenote-blue-20;
+        color: var(--accent-color);
       }
     }
 
@@ -342,7 +342,7 @@ body[data-theme='dark'] {
     background-color: var(--background-color);
 
     button svg {
-      fill: $studio-simplenote-blue-20;
+      fill: var(--accent-color);
     }
   }
 }


### PR DESCRIPTION
### Fix

This is a continuation of previous work to update the CSS to use variables for colors.
This moves all colors for dark mode to use CSS variables instead. 

There should be no user impact or any noticeable changes. It's an intermediate step to simplifying the CSS used throughout the app. 

### Test

1. Smoke test in dark mode
2. Ensure that everything looks good

### Release

- Update colors in dark mode to use CSS variables
