### PR TITLE
Update the new note icon to the new design

### DIFF
--- a/lib/icons/new-note.tsx
+++ b/lib/icons/new-note.tsx
@@ -8,7 +8,7 @@ export default function NewNoteIcon() {
       viewBox="0 0 24 24"
     >
       <rect x="0" fill="none" width="24" height="24" />
-      <path d="M17 21H5c-1.105 0-2-0.895-2-2V7c0-1.105 0.895-2 2-2h7v2H5v12h12v-7h2v7C19 20.105 18.105 21 17 21zM7 10h8v2H7V10zM7 14h8v2H7V14zM22 5h-3V2h-2v3h-3v2h3v3h2V7h3V5z" />
+      <path d="M9.707 12.879L19.59 3 21 4.41l-9.879 9.883L9 15 9.707 12.879zM18 18H6V6h7V4H6.002C4.896 4 4 4.896 4 6.002v11.996C4 19.104 4.896 20 6.002 20h11.996C19.104 20 20 19.104 20 17.998V11h-2V18z" />
     </svg>
   );
 }


### PR DESCRIPTION
### Fix

We have a new version of the new note icon, this updates to use it.

Before:
<img width="594" alt="Screen Shot 2021-06-25 at 10 05 31 AM" src="https://user-images.githubusercontent.com/1326294/123429348-3d4d7400-d59d-11eb-871f-d35dfe8bb005.png">
<img width="578" alt="Screen Shot 2021-06-25 at 10 05 16 AM" src="https://user-images.githubusercontent.com/1326294/123429361-41799180-d59d-11eb-9e6a-8d483b40b162.png">

After:
<img width="553" alt="Screen Shot 2021-06-25 at 10 04 12 AM" src="https://user-images.githubusercontent.com/1326294/123429386-48080900-d59d-11eb-85c8-f78b7d6ddbd2.png">
<img width="572" alt="Screen Shot 2021-06-25 at 10 03 55 AM" src="https://user-images.githubusercontent.com/1326294/123429396-4b9b9000-d59d-11eb-80fa-d9484355ec11.png">

### Test

1. Test in both light and dark mode
2. Open Simplenote
3. Ensure the new icon is showing to add a new note

### Release

- Updated the new note icon to the new design
