### PR TITLE
Update top components in app to use css variables for colors

### DIFF
--- a/lib/menu-bar/index.tsx
+++ b/lib/menu-bar/index.tsx
@@ -64,7 +64,7 @@ export const MenuBar: FunctionComponent<Props> = ({
   const CmdOrCtrl = isMac ? 'Cmd' : 'Ctrl';
 
   return (
-    <div className="menu-bar theme-color-border">
+    <div className="menu-bar">
       <IconButton
         icon={<MenuIcon />}
         onClick={toggleNavigation}

--- a/lib/menu-bar/style.scss
+++ b/lib/menu-bar/style.scss
@@ -6,6 +6,7 @@
   justify-content: space-between;
   align-items: center;
   flex: 0 0 auto;
+  background-color: var(--background-color);
 
   .notes-title {
     font-size: 16px;
@@ -13,6 +14,7 @@
     flex: 0 1 auto;
     overflow: hidden;
     text-overflow: ellipsis;
+    color: var(--primary-color);
   }
 
   .icon-button {

--- a/lib/note-editor/index.tsx
+++ b/lib/note-editor/index.tsx
@@ -133,7 +133,7 @@ export class NoteEditor extends Component<Props> {
     const isTrashed = !!note.deleted;
 
     return (
-      <div className="note-editor theme-color-bg theme-color-fg">
+      <div className="note-editor">
         {editMode || !note.systemTags.includes('markdown') ? (
           <NoteDetail
             storeFocusEditor={this.storeFocusEditor}

--- a/lib/note-editor/style.scss
+++ b/lib/note-editor/style.scss
@@ -4,4 +4,5 @@
   flex: 1 0 auto;
   user-select: text;
   padding-top: 40px;
+  background-color: var(--background-color);
 }

--- a/lib/note-toolbar/index.tsx
+++ b/lib/note-toolbar/index.tsx
@@ -42,10 +42,7 @@ export class NoteToolbar extends Component<Props> {
   render() {
     const { 'aria-hidden': ariaHidden, note } = this.props;
     return (
-      <div
-        aria-hidden={ariaHidden}
-        className="note-toolbar-wrapper theme-color-border"
-      >
+      <div aria-hidden={ariaHidden} className="note-toolbar-wrapper">
         {note?.deleted ? this.renderTrashed() : this.renderNormal()}
       </div>
     );
@@ -63,11 +60,11 @@ export class NoteToolbar extends Component<Props> {
     } = this.props;
 
     return !note ? (
-      <div className="note-toolbar-placeholder theme-color-border" />
+      <div className="note-toolbar-placeholder" />
     ) : (
       <div aria-label="note actions" role="toolbar" className="note-toolbar">
         <div className="note-toolbar__column-left">
-          <div className="note-toolbar__button new-note-toolbar__button-sidebar theme-color-border">
+          <div className="note-toolbar__button new-note-toolbar__button-sidebar">
             <IconButton
               icon={<NewNoteIcon />}
               onClick={() => newNote()}

--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -4,6 +4,7 @@
   flex: none;
   height: $toolbar-height;
   border-bottom: 1px solid var(--secondary-color);
+  background-color: var(--background-color);
 }
 
 .note-toolbar-wrapper .offline-badge {

--- a/lib/search-field/index.tsx
+++ b/lib/search-field/index.tsx
@@ -75,7 +75,7 @@ export class SearchField extends Component<Props> {
     const hasQuery = searchQuery.length > 0;
 
     return (
-      <div className="search-field theme-color-fg theme-color-border">
+      <div className="search-field">
         <button
           aria-label="Focus search field"
           onClick={this.props.focusSearchField}

--- a/lib/search-field/style.scss
+++ b/lib/search-field/style.scss
@@ -4,8 +4,9 @@
   align-items: center;
   width: 100%;
   padding: 6px 5px 5px 14px;
-  border-bottom: 1px solid;
+  border-bottom: 1px solid var(--secondary-color);
   height: $toolbar-height;
+  background-color: var(--background-color);
 
   input {
     width: 100%;
@@ -14,6 +15,7 @@
     appearance: none;
     font-size: 16px;
     text-overflow: ellipsis !important;
+    background-color: var(--background-color);
 
     &:focus {
       outline: none;


### PR DESCRIPTION
### Fix

This is a continuation of moving to CSS variables for colors within the app.
This updates the components which physically make up the top of the app which are:
- Note toolbar
- Menu bar
- Note editor
- Search field

### Test

1. Smoke test in light and dark mode
2. Ensure those components (basically the very top of the app) still appear the same

### Release

- Updated the Note toolbar, Menu bar, Note editor, and Search field components to use CSS variables for colors
