### PR TITLE
Fix the font stack outside of the editor

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,5 +1,5 @@
-$sans: -apple-system, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell',
-  'Helvetica Neue', sans-serif;
+$sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+  sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 $bold: 600;
 $light: 300;
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,5 +1,6 @@
-$sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
-  sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+$sans: -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Helvetica',
+  'Arial', 'sans-serif', 'Apple Color Emoji', 'Segoe UI Emoji',
+  'Segoe UI Symbol';
 $bold: 600;
 $light: 300;
 


### PR DESCRIPTION
### Fix

Fix the font stack to add in BlinkMacSystemFont. This was included in the font stack for the editor, but not the rest of the app.

This adds it in.

### Test
1. Ensure the font used in the editor matches font used in the rest of the app.

### Release

- Fixed font stack used so the font is consistent everywhere
