### PR TITLE
Fix the font color used for the login screen titles

### DIFF
--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -26,6 +26,7 @@
   }
 
   h1 {
+    color: var(--primary-color);
     font-size: 36px;
     font-weight: 600;
     margin: 0 0 16px;


### PR DESCRIPTION
### Fix

The color used for the headings on the Login/Signup page in light mode was incorrect. This updates to resolve that.

Before:
<img width="488" alt="Screen Shot 2021-07-02 at 1 21 05 PM" src="https://user-images.githubusercontent.com/1326294/124303079-62f7f180-db38-11eb-8bad-26ff06df0bbc.png">

After:
<img width="507" alt="Screen Shot 2021-07-02 at 1 20 51 PM" src="https://user-images.githubusercontent.com/1326294/124303088-67bca580-db38-11eb-96e6-ee18c044ca55.png">


### Test

1. Test in light mode
2. Ensure the title "Log in" and "Sign up" have the darker color

### Release

- Fixed the color used for headings on the login and sign up pages
