### PR TITLE
Update tag field / input to use css variables for colors

### DIFF
--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -5,6 +5,7 @@
   flex-direction: column;
   flex: 1 1 auto;
   padding-top: 0;
+  background-color: var(--background-color);
 }
 
 .note-detail {

--- a/lib/tag-field/style.scss
+++ b/lib/tag-field/style.scss
@@ -8,6 +8,7 @@
   overflow: auto;
   max-height: calc(2.5 * 1.75em + 16px); // about 2.5 rows
   padding: 8px 12px;
+  background-color: var(--background-color);
 
   &:focus {
     outline: none;

--- a/lib/tag-input/index.tsx
+++ b/lib/tag-input/index.tsx
@@ -280,10 +280,7 @@ export class TagInput extends Component<Props> {
         }}
       >
         {shouldShowPlaceholder && (
-          <span
-            aria-hidden
-            className="tag-input__placeholder theme-color-fg-dim"
-          >
+          <span aria-hidden className="tag-input__placeholder">
             Add tag…
           </span>
         )}

--- a/lib/tag-input/style.scss
+++ b/lib/tag-input/style.scss
@@ -5,6 +5,7 @@
   flex: 1 0 auto;
   overflow: visible;
   min-height: 26px;
+  color: var(--primary-color);
 
   input {
     width: 100%;
@@ -22,6 +23,7 @@
   display: block;
   background: transparent;
   user-select: none;
+  color: var(--placeholder-color);
 }
 
 .tag-input__entry {

--- a/lib/tag-suggestions/index.tsx
+++ b/lib/tag-suggestions/index.tsx
@@ -42,7 +42,7 @@ export class TagSuggestions extends Component<Props> {
         {filteredTags.length > 0 && (
           <div className="tag-suggestions">
             <div className="note-list-header">Search by Tag</div>
-            <ul className="tag-suggestions-list theme-color-border">
+            <ul className="tag-suggestions-list">
               {filteredTags.map((tagId) => {
                 const tagName =
                   tagId === 'untagged' ? 'untagged' : tags.get(tagId)!.name;

--- a/lib/tag-suggestions/style.scss
+++ b/lib/tag-suggestions/style.scss
@@ -20,22 +20,11 @@
       margin-left: 28px;
       overflow-x: hidden;
       text-overflow: ellipsis;
+      border-color: var(--secondary-color);
     }
   }
 
   .tag-suggestion-row:last-child .tag-suggestion {
     border-bottom: none;
-  }
-}
-
-body[data-theme='light'] {
-  .tag-suggestion {
-    border-color: var(--secondary-color);
-  }
-}
-
-body[data-theme='dark'] {
-  .tag-suggestion {
-    border-color: var(--secondary-color);
   }
 }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -123,221 +123,221 @@ span[dir='ltr'] {
   }
 }
 
-body[data-theme='light'] {
-  background-color: var(--background-color);
-  color: var(--foreground-color);
+// body[data-theme='light'] {
+//   background-color: var(--background-color);
+//   color: var(--foreground-color);
 
-  .theme-color-bg {
-    background-color: var(--background-color);
-  }
-  .theme-color-bg-lighter {
-    background-color: var(--background-color);
-  }
-  .theme-color-fg {
-    color: var(--primary-color);
-  }
-  .theme-color-fg-dim {
-    color: var(--foreground-color);
-  }
-  .theme-color-border,
-  &.theme-color-border,
-  .button {
-    border-color: var(--secondary-color);
-  }
-  .button-borderless {
-    color: var(--accent-color);
-  }
+//   .theme-color-bg {
+//     background-color: var(--background-color);
+//   }
+//   .theme-color-bg-lighter {
+//     background-color: var(--background-color);
+//   }
+//   .theme-color-fg {
+//     color: var(--primary-color);
+//   }
+//   .theme-color-fg-dim {
+//     color: var(--foreground-color);
+//   }
+//   .theme-color-border,
+//   &.theme-color-border,
+//   .button {
+//     border-color: var(--secondary-color);
+//   }
+//   .button-borderless {
+//     color: var(--accent-color);
+//   }
 
-  .note-list-item-pinned .note-list-item-pinner {
-    color: var(--accent-color);
-  }
-}
+//   .note-list-item-pinned .note-list-item-pinner {
+//     color: var(--accent-color);
+//   }
+// }
 
-.theme-light.theme-color-border {
-  border-color: var(--secondary-color);
-}
+// .theme-light.theme-color-border {
+//   border-color: var(--secondary-color);
+// }
 
-body[data-theme='dark'] {
-  background-color: var(--background-color);
-  color: var(--foreground-color);
+// body[data-theme='dark'] {
+//   background-color: var(--background-color);
+//   color: var(--foreground-color);
 
-  .theme-color-bg {
-    background-color: var(--background-color);
-  }
-  .theme-color-bg-lighter {
-    background-color: var(--background-color);
-  }
-  .theme-color-fg {
-    color: var(--primary-color);
-  }
-  .theme-color-fg-dim {
-    color: var(--foreground-color);
-  }
-  .theme-color-border,
-  &.theme-color-border,
-  .button {
-    border-color: var(--secondary-color);
-  }
+//   .theme-color-bg {
+//     background-color: var(--background-color);
+//   }
+//   .theme-color-bg-lighter {
+//     background-color: var(--background-color);
+//   }
+//   .theme-color-fg {
+//     color: var(--primary-color);
+//   }
+//   .theme-color-fg-dim {
+//     color: var(--foreground-color);
+//   }
+//   .theme-color-border,
+//   &.theme-color-border,
+//   .button {
+//     border-color: var(--secondary-color);
+//   }
 
-  ::-webkit-scrollbar-thumb {
-    background-color: var(--secondary-color);
-    border-color: var(--tertiary-color);
-  }
-  ::-webkit-scrollbar-thumb:hover {
-    background-color: var(--background-color);
-  }
-  ::-webkit-scrollbar-thumb:active {
-    background-color: var(--tertiary-color);
-  }
+//   ::-webkit-scrollbar-thumb {
+//     background-color: var(--secondary-color);
+//     border-color: var(--tertiary-color);
+//   }
+//   ::-webkit-scrollbar-thumb:hover {
+//     background-color: var(--background-color);
+//   }
+//   ::-webkit-scrollbar-thumb:active {
+//     background-color: var(--tertiary-color);
+//   }
 
-  .button-borderless {
-    color: var(--accent-color);
+//   .button-borderless {
+//     color: var(--accent-color);
 
-    &[disabled],
-    &:disabled {
-      svg[class^='icon-'] {
-        fill: var(--tertiary-color);
-      }
-    }
-  }
+//     &[disabled],
+//     &:disabled {
+//       svg[class^='icon-'] {
+//         fill: var(--tertiary-color);
+//       }
+//     }
+//   }
 
-  .icon-button,
-  a {
-    color: var(--foreground-color);
-  }
-  a.button {
-    color: var(--primary-color);
-  }
+//   .icon-button,
+//   a {
+//     color: var(--foreground-color);
+//   }
+//   a.button {
+//     color: var(--primary-color);
+//   }
 
-  input {
-    color: var(--primary-color);
-  }
+//   input {
+//     color: var(--primary-color);
+//   }
 
-  input,
-  textarea {
-    border-color: var(--secondary-accent-color);
-    background-color: transparent;
-  }
+//   input,
+//   textarea {
+//     border-color: var(--secondary-accent-color);
+//     background-color: transparent;
+//   }
 
-  .checkbox-control-base {
-    border-color: var(--secondary-color);
-  }
+//   .checkbox-control-base {
+//     border-color: var(--secondary-color);
+//   }
 
-  .navigation-bar-item {
-    button {
-      color: var(--primary-color);
-    }
-    svg[class^='icon-'] {
-      fill: var(--foreground-color);
-    }
-  }
+//   .navigation-bar-item {
+//     button {
+//       color: var(--primary-color);
+//     }
+//     svg[class^='icon-'] {
+//       fill: var(--foreground-color);
+//     }
+//   }
 
-  .navigation-bar-item.is-selected,
-  .tag-list-item.is-selected {
-    background-color: var(--highlight-color);
+//   .navigation-bar-item.is-selected,
+//   .tag-list-item.is-selected {
+//     background-color: var(--highlight-color);
 
-    svg[class^='icon-'] {
-      fill: var(--primary-color);
-    }
-    button {
-      color: var(--primary-color);
-    }
-  }
+//     svg[class^='icon-'] {
+//       fill: var(--primary-color);
+//     }
+//     button {
+//       color: var(--primary-color);
+//     }
+//   }
 
-  .tag-field input {
-    background: transparent;
+//   .tag-field input {
+//     background: transparent;
 
-    &::placeholder {
-      color: var(--foreground-color);
-    }
-  }
+//     &::placeholder {
+//       color: var(--foreground-color);
+//     }
+//   }
 
-  .search-decoration {
-    background-color: var(--search-highlight-color);
-  }
-  .selected-search {
-    background-color: var(--search-selection-color);
-    color: var(--background-color);
-  }
+//   .search-decoration {
+//     background-color: var(--search-highlight-color);
+//   }
+//   .selected-search {
+//     background-color: var(--search-selection-color);
+//     color: var(--background-color);
+//   }
 
-  .settings-group p {
-    color: var(--settings-fg-color);
-  }
+//   .settings-group p {
+//     color: var(--settings-fg-color);
+//   }
 
-  .note-list-header {
-    color: var(--foreground-color);
-  }
+//   .note-list-header {
+//     color: var(--foreground-color);
+//   }
 
-  .note-list {
-    .note-list-item-selected {
-      background: var(--highlight-color);
-      .note-list-item-excerpt,
-      .note-list-item-published-icon,
-      .note-list-item-pending-changes {
-        color: var(--primary-color);
-      }
-      .note-list-item-pending-changes {
-        &.is-offline svg {
-          fill: var(--foreground-color);
-        }
-      }
-      &.note-list-item-pinned .note-list-item-pinner {
-        color: var(--primary-color);
-      }
-    }
+//   .note-list {
+//     .note-list-item-selected {
+//       background: var(--highlight-color);
+//       .note-list-item-excerpt,
+//       .note-list-item-published-icon,
+//       .note-list-item-pending-changes {
+//         color: var(--primary-color);
+//       }
+//       .note-list-item-pending-changes {
+//         &.is-offline svg {
+//           fill: var(--foreground-color);
+//         }
+//       }
+//       &.note-list-item-pinned .note-list-item-pinner {
+//         color: var(--primary-color);
+//       }
+//     }
 
-    .note-list-item-pinned:not(.note-list-item-selected) {
-      .note-list-item-pinner {
-        color: var(--accent-color);
-      }
-    }
+//     .note-list-item-pinned:not(.note-list-item-selected) {
+//       .note-list-item-pinner {
+//         color: var(--accent-color);
+//       }
+//     }
 
-    .note-list-item:not(.note-list-item-pinned):hover {
-      .note-list-item-pinner {
-        color: rgba(255, 255, 255, 0.4);
-      }
-    }
+//     .note-list-item:not(.note-list-item-pinned):hover {
+//       .note-list-item-pinner {
+//         color: rgba(255, 255, 255, 0.4);
+//       }
+//     }
 
-    .note-list-item:not(.note-list-item-selected) {
-      &:hover {
-        background: var(--secondary-color);
-      }
-    }
-  }
+//     .note-list-item:not(.note-list-item-selected) {
+//       &:hover {
+//         background: var(--secondary-color);
+//       }
+//     }
+//   }
 
-  .note-detail-markdown {
-    @import '../node_modules/highlight.js/scss/solarized-dark.scss';
+//   .note-detail-markdown {
+//     @import '../node_modules/highlight.js/scss/solarized-dark.scss';
 
-    hr {
-      border-color: var(--secondary-color);
-    }
+//     hr {
+//       border-color: var(--secondary-color);
+//     }
 
-    blockquote {
-      border-color: var(--secondary-color);
-    }
+//     blockquote {
+//       border-color: var(--secondary-color);
+//     }
 
-    pre {
-      border-color: var(--secondary-color);
-    }
+//     pre {
+//       border-color: var(--secondary-color);
+//     }
 
-    table {
-      th,
-      td {
-        border-color: var(--tertiary-color);
-      }
-      tr:nth-child(2n) {
-        background-color: var(--secondary-color);
-      }
-    }
-  }
+//     table {
+//       th,
+//       td {
+//         border-color: var(--tertiary-color);
+//       }
+//       tr:nth-child(2n) {
+//         background-color: var(--secondary-color);
+//       }
+//     }
+//   }
 
-  .search-results {
-    color: var(--primary-color);
-    border-color: var(--secondary-color);
-    background-color: var(--background-color);
+//   .search-results {
+//     color: var(--primary-color);
+//     border-color: var(--secondary-color);
+//     background-color: var(--background-color);
 
-    button svg {
-      fill: var(--accent-color);
-    }
-  }
-}
+//     button svg {
+//       fill: var(--accent-color);
+//     }
+//   }
+// }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -123,221 +123,221 @@ span[dir='ltr'] {
   }
 }
 
-// body[data-theme='light'] {
-//   background-color: var(--background-color);
-//   color: var(--foreground-color);
+body[data-theme='light'] {
+  background-color: var(--background-color);
+  color: var(--foreground-color);
 
-//   .theme-color-bg {
-//     background-color: var(--background-color);
-//   }
-//   .theme-color-bg-lighter {
-//     background-color: var(--background-color);
-//   }
-//   .theme-color-fg {
-//     color: var(--primary-color);
-//   }
-//   .theme-color-fg-dim {
-//     color: var(--foreground-color);
-//   }
-//   .theme-color-border,
-//   &.theme-color-border,
-//   .button {
-//     border-color: var(--secondary-color);
-//   }
-//   .button-borderless {
-//     color: var(--accent-color);
-//   }
+  .theme-color-bg {
+    background-color: var(--background-color);
+  }
+  .theme-color-bg-lighter {
+    background-color: var(--background-color);
+  }
+  .theme-color-fg {
+    color: var(--primary-color);
+  }
+  .theme-color-fg-dim {
+    color: var(--foreground-color);
+  }
+  .theme-color-border,
+  &.theme-color-border,
+  .button {
+    border-color: var(--secondary-color);
+  }
+  .button-borderless {
+    color: var(--accent-color);
+  }
 
-//   .note-list-item-pinned .note-list-item-pinner {
-//     color: var(--accent-color);
-//   }
-// }
+  .note-list-item-pinned .note-list-item-pinner {
+    color: var(--accent-color);
+  }
+}
 
-// .theme-light.theme-color-border {
-//   border-color: var(--secondary-color);
-// }
+.theme-light.theme-color-border {
+  border-color: var(--secondary-color);
+}
 
-// body[data-theme='dark'] {
-//   background-color: var(--background-color);
-//   color: var(--foreground-color);
+body[data-theme='dark'] {
+  background-color: var(--background-color);
+  color: var(--foreground-color);
 
-//   .theme-color-bg {
-//     background-color: var(--background-color);
-//   }
-//   .theme-color-bg-lighter {
-//     background-color: var(--background-color);
-//   }
-//   .theme-color-fg {
-//     color: var(--primary-color);
-//   }
-//   .theme-color-fg-dim {
-//     color: var(--foreground-color);
-//   }
-//   .theme-color-border,
-//   &.theme-color-border,
-//   .button {
-//     border-color: var(--secondary-color);
-//   }
+  .theme-color-bg {
+    background-color: var(--background-color);
+  }
+  .theme-color-bg-lighter {
+    background-color: var(--background-color);
+  }
+  .theme-color-fg {
+    color: var(--primary-color);
+  }
+  .theme-color-fg-dim {
+    color: var(--foreground-color);
+  }
+  .theme-color-border,
+  &.theme-color-border,
+  .button {
+    border-color: var(--secondary-color);
+  }
 
-//   ::-webkit-scrollbar-thumb {
-//     background-color: var(--secondary-color);
-//     border-color: var(--tertiary-color);
-//   }
-//   ::-webkit-scrollbar-thumb:hover {
-//     background-color: var(--background-color);
-//   }
-//   ::-webkit-scrollbar-thumb:active {
-//     background-color: var(--tertiary-color);
-//   }
+  ::-webkit-scrollbar-thumb {
+    background-color: var(--secondary-color);
+    border-color: var(--tertiary-color);
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: var(--background-color);
+  }
+  ::-webkit-scrollbar-thumb:active {
+    background-color: var(--tertiary-color);
+  }
 
-//   .button-borderless {
-//     color: var(--accent-color);
+  .button-borderless {
+    color: var(--accent-color);
 
-//     &[disabled],
-//     &:disabled {
-//       svg[class^='icon-'] {
-//         fill: var(--tertiary-color);
-//       }
-//     }
-//   }
+    &[disabled],
+    &:disabled {
+      svg[class^='icon-'] {
+        fill: var(--tertiary-color);
+      }
+    }
+  }
 
-//   .icon-button,
-//   a {
-//     color: var(--foreground-color);
-//   }
-//   a.button {
-//     color: var(--primary-color);
-//   }
+  .icon-button,
+  a {
+    color: var(--foreground-color);
+  }
+  a.button {
+    color: var(--primary-color);
+  }
 
-//   input {
-//     color: var(--primary-color);
-//   }
+  input {
+    color: var(--primary-color);
+  }
 
-//   input,
-//   textarea {
-//     border-color: var(--secondary-accent-color);
-//     background-color: transparent;
-//   }
+  input,
+  textarea {
+    border-color: var(--secondary-accent-color);
+    background-color: transparent;
+  }
 
-//   .checkbox-control-base {
-//     border-color: var(--secondary-color);
-//   }
+  .checkbox-control-base {
+    border-color: var(--secondary-color);
+  }
 
-//   .navigation-bar-item {
-//     button {
-//       color: var(--primary-color);
-//     }
-//     svg[class^='icon-'] {
-//       fill: var(--foreground-color);
-//     }
-//   }
+  .navigation-bar-item {
+    button {
+      color: var(--primary-color);
+    }
+    svg[class^='icon-'] {
+      fill: var(--foreground-color);
+    }
+  }
 
-//   .navigation-bar-item.is-selected,
-//   .tag-list-item.is-selected {
-//     background-color: var(--highlight-color);
+  .navigation-bar-item.is-selected,
+  .tag-list-item.is-selected {
+    background-color: var(--highlight-color);
 
-//     svg[class^='icon-'] {
-//       fill: var(--primary-color);
-//     }
-//     button {
-//       color: var(--primary-color);
-//     }
-//   }
+    svg[class^='icon-'] {
+      fill: var(--primary-color);
+    }
+    button {
+      color: var(--primary-color);
+    }
+  }
 
-//   .tag-field input {
-//     background: transparent;
+  .tag-field input {
+    background: transparent;
 
-//     &::placeholder {
-//       color: var(--foreground-color);
-//     }
-//   }
+    &::placeholder {
+      color: var(--foreground-color);
+    }
+  }
 
-//   .search-decoration {
-//     background-color: var(--search-highlight-color);
-//   }
-//   .selected-search {
-//     background-color: var(--search-selection-color);
-//     color: var(--background-color);
-//   }
+  .search-decoration {
+    background-color: var(--search-highlight-color);
+  }
+  .selected-search {
+    background-color: var(--search-selection-color);
+    color: var(--background-color);
+  }
 
-//   .settings-group p {
-//     color: var(--settings-fg-color);
-//   }
+  .settings-group p {
+    color: var(--settings-fg-color);
+  }
 
-//   .note-list-header {
-//     color: var(--foreground-color);
-//   }
+  .note-list-header {
+    color: var(--foreground-color);
+  }
 
-//   .note-list {
-//     .note-list-item-selected {
-//       background: var(--highlight-color);
-//       .note-list-item-excerpt,
-//       .note-list-item-published-icon,
-//       .note-list-item-pending-changes {
-//         color: var(--primary-color);
-//       }
-//       .note-list-item-pending-changes {
-//         &.is-offline svg {
-//           fill: var(--foreground-color);
-//         }
-//       }
-//       &.note-list-item-pinned .note-list-item-pinner {
-//         color: var(--primary-color);
-//       }
-//     }
+  .note-list {
+    .note-list-item-selected {
+      background: var(--highlight-color);
+      .note-list-item-excerpt,
+      .note-list-item-published-icon,
+      .note-list-item-pending-changes {
+        color: var(--primary-color);
+      }
+      .note-list-item-pending-changes {
+        &.is-offline svg {
+          fill: var(--foreground-color);
+        }
+      }
+      &.note-list-item-pinned .note-list-item-pinner {
+        color: var(--primary-color);
+      }
+    }
 
-//     .note-list-item-pinned:not(.note-list-item-selected) {
-//       .note-list-item-pinner {
-//         color: var(--accent-color);
-//       }
-//     }
+    .note-list-item-pinned:not(.note-list-item-selected) {
+      .note-list-item-pinner {
+        color: var(--accent-color);
+      }
+    }
 
-//     .note-list-item:not(.note-list-item-pinned):hover {
-//       .note-list-item-pinner {
-//         color: rgba(255, 255, 255, 0.4);
-//       }
-//     }
+    .note-list-item:not(.note-list-item-pinned):hover {
+      .note-list-item-pinner {
+        color: rgba(255, 255, 255, 0.4);
+      }
+    }
 
-//     .note-list-item:not(.note-list-item-selected) {
-//       &:hover {
-//         background: var(--secondary-color);
-//       }
-//     }
-//   }
+    .note-list-item:not(.note-list-item-selected) {
+      &:hover {
+        background: var(--secondary-color);
+      }
+    }
+  }
 
-//   .note-detail-markdown {
-//     @import '../node_modules/highlight.js/scss/solarized-dark.scss';
+  .note-detail-markdown {
+    @import '../node_modules/highlight.js/scss/solarized-dark.scss';
 
-//     hr {
-//       border-color: var(--secondary-color);
-//     }
+    hr {
+      border-color: var(--secondary-color);
+    }
 
-//     blockquote {
-//       border-color: var(--secondary-color);
-//     }
+    blockquote {
+      border-color: var(--secondary-color);
+    }
 
-//     pre {
-//       border-color: var(--secondary-color);
-//     }
+    pre {
+      border-color: var(--secondary-color);
+    }
 
-//     table {
-//       th,
-//       td {
-//         border-color: var(--tertiary-color);
-//       }
-//       tr:nth-child(2n) {
-//         background-color: var(--secondary-color);
-//       }
-//     }
-//   }
+    table {
+      th,
+      td {
+        border-color: var(--tertiary-color);
+      }
+      tr:nth-child(2n) {
+        background-color: var(--secondary-color);
+      }
+    }
+  }
 
-//   .search-results {
-//     color: var(--primary-color);
-//     border-color: var(--secondary-color);
-//     background-color: var(--background-color);
+  .search-results {
+    color: var(--primary-color);
+    border-color: var(--secondary-color);
+    background-color: var(--background-color);
 
-//     button svg {
-//       fill: var(--accent-color);
-//     }
-//   }
-// }
+    button svg {
+      fill: var(--accent-color);
+    }
+  }
+}


### PR DESCRIPTION
### Fix

This is a continuation of moving to CSS variables for colors within the app.
This updates the tag field and related components to use the variables instead of classes. The components updated are:

- Note Detail
- Tag Field
- Tag Input
- Tag Suggestion

### Test

1. Smoke test in light and dark mode
2. Ensure these components still appear the same.

### Release

- Updated the Note Detail, Tag Field, Tag Input, and Tag Suggestion components to use CSS variables for colors
