### PR TITLE
Add support to handle compromised password at login

### DIFF
--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -13,6 +13,7 @@ type OwnProps = {
   accountCreationRequested: boolean;
   authPending: boolean;
   emailSentTo: string;
+  hasCompromisedPassword: boolean;
   hasInsecurePassword: boolean;
   hasInvalidCredentials: boolean;
   hasLoginError: boolean;
@@ -152,6 +153,28 @@ export class Auth extends Component<Props> {
               </a>
               . Passwords must be between 8 and 64 characters long and may not
               include your email address, new lines, or tabs.
+            </p>
+          )}
+          {this.props.hasCompromisedPassword && (
+            <p
+              className="login__auth-message is-error"
+              data-error-name="invalid-login"
+            >
+              This password has appeared in a data breach, which puts your
+              account at high risk of compromise. Please
+              <a
+                className="login__reset"
+                href={
+                  'https://app.simplenote.com/reset/?email=' +
+                  encodeURIComponent(get(this.usernameInput, 'value'))
+                }
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={this.onForgot}
+              >
+                reset
+              </a>{' '}
+              your password.
             </p>
           )}
           {this.props.hasInvalidCredentials ||

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -158,7 +158,7 @@ export class Auth extends Component<Props> {
           {this.props.hasCompromisedPassword && (
             <p
               className="login__auth-message is-error"
-              data-error-name="invalid-login"
+              data-error-name="compromised-password"
             >
               This password has appeared in a data breach, which puts your
               account at high risk of compromise. Please
@@ -177,15 +177,14 @@ export class Auth extends Component<Props> {
               your password.
             </p>
           )}
-          {this.props.hasInvalidCredentials ||
-            (this.props.hasLoginError && (
-              <p
-                className="login__auth-message is-error"
-                data-error-name="invalid-login"
-              >
-                {errorMessage}
-              </p>
-            ))}
+          {(this.props.hasInvalidCredentials || this.props.hasLoginError) && (
+            <p
+              className="login__auth-message is-error"
+              data-error-name="invalid-login"
+            >
+              {errorMessage}
+            </p>
+          )}
           {passwordErrorMessage && (
             <p className="login__auth-message is-error">
               {passwordErrorMessage}

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -99,12 +99,12 @@ class AppWithoutAuth extends Component<Props, State> {
         .catch((error: unknown) => {
           const message = error?.underlyingError.message ?? '';
           if (
-            'invalid password' === message ||
+            'invalid login' === message ||
             message.startsWith('unknown username:')
           ) {
             this.setState({ authStatus: 'invalid-credentials' });
           } else if ('compromised password' === message) {
-            +this.setState({ authStatus: 'compromised-password' });
+            this.setState({ authStatus: 'compromised-password' });
           } else {
             this.setState({ authStatus: 'unknown-error' });
           }

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -20,6 +20,7 @@ type Props = {
 type State = {
   authStatus:
     | 'account-creation-requested'
+    | 'compromised-password'
     | 'unsubmitted'
     | 'submitting'
     | 'insecure-password'
@@ -96,11 +97,14 @@ class AppWithoutAuth extends Component<Props, State> {
           this.login(user.access_token, username, false);
         })
         .catch((error: unknown) => {
+          const message = error?.underlyingError.message ?? '';
           if (
-            'invalid password' === error?.message ||
-            error?.message.startsWith('unknown username:')
+            'invalid password' === message ||
+            message.startsWith('unknown username:')
           ) {
             this.setState({ authStatus: 'invalid-credentials' });
+          } else if ('compromised password' === message) {
+            +this.setState({ authStatus: 'compromised-password' });
           } else {
             this.setState({ authStatus: 'unknown-error' });
           }
@@ -152,6 +156,9 @@ class AppWithoutAuth extends Component<Props, State> {
             authPending={this.state.authStatus === 'submitting'}
             emailSentTo={this.state.emailSentTo}
             hasInsecurePassword={this.state.authStatus === 'insecure-password'}
+            hasCompromisedPassword={
+              this.state.authStatus === 'compromised-password'
+            }
             hasInvalidCredentials={
               this.state.authStatus === 'invalid-credentials'
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8760,9 +8760,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
+          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
         }
       }
     },
@@ -18691,9 +18691,9 @@
       "dev": true
     },
     "simperium": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/simperium/-/simperium-1.1.0.tgz",
-      "integrity": "sha512-xBjZSgM6bLE8SmXEXbL18iUO+V7DfT1s1pnGZVChhBsiLgeISXTZZa5tN+1u6rijAoSajWTbl855JT5umX0RQQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/simperium/-/simperium-1.1.2.tgz",
+      "integrity": "sha512-6cJ/BfZEXXvdcW26/ag92wf7OXNewcibzdyK7gX4WSfSA0bG3v3gbQZkga6qgfl9mciBYNT3ABpLBDmUm4xllw==",
       "requires": {
         "@babel/polyfill": "7.7.0",
         "events": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "sax": "1.2.4",
     "semver": "7.3.2",
     "showdown": "1.9.1",
-    "simperium": "1.1.0",
+    "simperium": "1.1.2",
     "string-replace-to-array": "1.0.3",
     "turndown": "6.0.0",
     "unorm": "1.6.0",


### PR DESCRIPTION
### Fix

This will add support to show an error message and prompt to reset the password if the given password has been found in known data breaches and is therefore not secure. It required updating the `node-simperium` dependency to do that as well.

### Testing

This is rather hard to test currently to see the new error message as changes to the API endpoint haven't been made to show the error yet.

We can ensure that login still works as expected that you can log in with a valid email and password, and you can't log in with an invalid one.

In order to test this, I had to set up Charles Proxy and use it to intercept the API call and change the response text to be `compromised password` 


### Release

- Add support for handling passwords found in known data breaches. 
