### PR TITLE
Add support to handle unverified accounts at login

### DIFF
--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -17,6 +17,7 @@ type OwnProps = {
   hasInsecurePassword: boolean;
   hasInvalidCredentials: boolean;
   hasLoginError: boolean;
+  hasUnverifiedAccount: boolean;
   login: (username: string, password: string) => any;
   requestSignup: (username: string) => any;
   tokenLogin: (username: string, token: string) => any;
@@ -153,6 +154,27 @@ export class Auth extends Component<Props> {
               </a>
               . Passwords must be between 8 and 64 characters long and may not
               include your email address, new lines, or tabs.
+            </p>
+          )}
+          {this.props.hasUnverifiedAccount && (
+            <p
+              className="login__auth-message is-error"
+              data-error-name="verification-required"
+            >
+              Account verification required. You must verify your email before
+              logging in to your account.
+              <a
+                className="login__reset"
+                href={
+                  'https://app.simplenote.com/account/verify-email/' +
+                  btoa(get(this.usernameInput, 'value'))
+                }
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={this.onForgot}
+              >
+                Send Verification Email
+              </a>{' '}
             </p>
           )}
           {this.props.hasCompromisedPassword && (

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -25,7 +25,8 @@ type State = {
     | 'submitting'
     | 'insecure-password'
     | 'invalid-credentials'
-    | 'unknown-error';
+    | 'unknown-error'
+    | 'verification-required';
   emailSentTo: string;
   showAbout: boolean;
 };
@@ -105,6 +106,8 @@ class AppWithoutAuth extends Component<Props, State> {
             this.setState({ authStatus: 'invalid-credentials' });
           } else if ('compromised password' === message) {
             this.setState({ authStatus: 'compromised-password' });
+          } else if ('verification required' === message) {
+            this.setState({ authStatus: 'verification-required' });
           } else {
             this.setState({ authStatus: 'unknown-error' });
           }
@@ -161,6 +164,9 @@ class AppWithoutAuth extends Component<Props, State> {
             }
             hasInvalidCredentials={
               this.state.authStatus === 'invalid-credentials'
+            }
+            hasUnverifiedAccount={
+              this.state.authStatus === 'verification-required'
             }
             hasLoginError={this.state.authStatus === 'unknown-error'}
             login={this.authenticate}

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -103,6 +103,9 @@ class AppWithoutAuth extends Component<Props, State> {
             'invalid login' === message ||
             message.startsWith('unknown username:')
           ) {
+            // We check for compromised password before verified account as if the password is
+            // compromised it will require a password reset. During that process unverified
+            // accounts will be verified as it requires an email to the account address
             this.setState({ authStatus: 'invalid-credentials' });
           } else if ('compromised password' === message) {
             this.setState({ authStatus: 'compromised-password' });


### PR DESCRIPTION
### Fix

This will add support to show an error message with a link to start verification of account email when logging in with an unverified account.

### Todo

- [x] Get clarification on error message copy

### Test

This is rather hard to test currently to see the new error message as changes to the API endpoint haven't been made to show the error yet.

We can ensure that login still works as expected that you can log in with a valid email and password, and you can't log in with an invalid one.

In order to test this, I had to set up Charles Proxy and use it to intercept the API call and change the response text to be `verification required`

### Release

- Added support for handling failed logins due to having an unverified account email
