### PR TITLE
Save note scroll position and restore when returning to note

### DIFF
--- a/lib/boot.ts
+++ b/lib/boot.ts
@@ -17,6 +17,7 @@ const clearStorage = (): Promise<void> =>
     localStorage.removeItem('localQueue:preferences');
     localStorage.removeItem('localQueue:tag');
     localStorage.removeItem('stored_user');
+    localStorage.removeItem('note_positions');
     window.electron?.send('appStateUpdate', {});
 
     const settings = localStorage.getItem('simpleNote');

--- a/lib/boot.ts
+++ b/lib/boot.ts
@@ -17,7 +17,7 @@ const clearStorage = (): Promise<void> =>
     localStorage.removeItem('localQueue:preferences');
     localStorage.removeItem('localQueue:tag');
     localStorage.removeItem('stored_user');
-    localStorage.removeItem('note_positions');
+    sessionStorage.clear();
     window.electron?.send('appStateUpdate', {});
 
     const settings = localStorage.getItem('simpleNote');

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -220,12 +220,10 @@ class NoteContentEditor extends Component<Props> {
   }
 
   componentWillUnmount() {
-    const { noteId } = this.props;
-    const position = {
+    setNotePosition(this.props.noteId, {
       line: this.editor?.getPosition()?.lineNumber ?? 0,
       scroll: this.editor?.getScrollTop() ?? 0,
-    };
-    setNotePosition(noteId, position);
+    });
 
     if (this.bootTimer) {
       clearTimeout(this.bootTimer);

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -205,9 +205,63 @@ class NoteContentEditor extends Component<Props> {
       } while ((node = node.next));
     };
     removeById(contextMenuLinks, removableIds);
+
+    const notePositions = localStorage.getItem('note_positions');
+    let currentSavedPositions: any;
+    if (notePositions) {
+      try {
+        currentSavedPositions = JSON.parse(notePositions);
+      } catch (e) {
+        // pass - we only care if we can successfully do this,
+        //        not if we fail to do it
+      }
+    } else {
+      currentSavedPositions = {};
+    }
+
+    this.editor?.revealLineInCenter(currentSavedPositions[noteId].line);
+    window.setTimeout(() => {
+      this.editor?.setScrollPosition({
+        scrollTop: currentSavedPositions[noteId].scroll,
+      });
+    }, 200);
+
+    // const currentState = currentSavedPositions[noteId].state ?? {};
+    // if (currentState) {
+    //   this.editor?.restoreViewState(currentState);
+    //   window.setTimeout(() => {
+    //     this.editor?.setScrollPosition({
+    //       scrollTop: currentSavedPositions[noteId].scroll,
+    //     });
+    //   }, 200);
+    // }
   }
 
   componentWillUnmount() {
+    const notePositions = localStorage.getItem('note_positions');
+    let currentSavedPositions;
+    if (notePositions) {
+      try {
+        currentSavedPositions = JSON.parse(notePositions);
+      } catch (e) {
+        // pass - we only care if we can successfully do this,
+        //        not if we fail to do it
+      }
+    } else {
+      currentSavedPositions = {};
+    }
+
+    const { noteId } = this.props;
+    currentSavedPositions[noteId] = {
+      //state: this.editor?.saveViewState(),
+      line: this.editor?.getPosition()?.lineNumber,
+      scroll: this.editor?.getScrollTop(),
+    };
+    localStorage.setItem(
+      'note_positions',
+      JSON.stringify(currentSavedPositions)
+    );
+
     if (this.bootTimer) {
       clearTimeout(this.bootTimer);
     }

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -19,6 +19,7 @@ import actions from './state/actions';
 import * as selectors from './state/selectors';
 import { getTerms } from './utils/filter-notes';
 import { noteTitleAndPreview } from './utils/note-utils';
+import { getNotePosition, setNotePosition } from './utils/note-scroll-position';
 import { isMac, isSafari } from './utils/platform';
 import {
   withCheckboxCharacters,
@@ -206,61 +207,25 @@ class NoteContentEditor extends Component<Props> {
     };
     removeById(contextMenuLinks, removableIds);
 
-    const notePositions = localStorage.getItem('note_positions');
-    let currentSavedPositions: any;
-    if (notePositions) {
-      try {
-        currentSavedPositions = JSON.parse(notePositions);
-      } catch (e) {
-        // pass - we only care if we can successfully do this,
-        //        not if we fail to do it
-      }
-    } else {
-      currentSavedPositions = {};
+    const position = getNotePosition(noteId);
+
+    if (position) {
+      this.editor?.revealLineInCenter(position.line);
+      window.setTimeout(() => {
+        this.editor?.setScrollPosition({
+          scrollTop: position.scroll,
+        });
+      }, 200);
     }
-
-    this.editor?.revealLineInCenter(currentSavedPositions[noteId].line);
-    window.setTimeout(() => {
-      this.editor?.setScrollPosition({
-        scrollTop: currentSavedPositions[noteId].scroll,
-      });
-    }, 200);
-
-    // const currentState = currentSavedPositions[noteId].state ?? {};
-    // if (currentState) {
-    //   this.editor?.restoreViewState(currentState);
-    //   window.setTimeout(() => {
-    //     this.editor?.setScrollPosition({
-    //       scrollTop: currentSavedPositions[noteId].scroll,
-    //     });
-    //   }, 200);
-    // }
   }
 
   componentWillUnmount() {
-    const notePositions = localStorage.getItem('note_positions');
-    let currentSavedPositions;
-    if (notePositions) {
-      try {
-        currentSavedPositions = JSON.parse(notePositions);
-      } catch (e) {
-        // pass - we only care if we can successfully do this,
-        //        not if we fail to do it
-      }
-    } else {
-      currentSavedPositions = {};
-    }
-
     const { noteId } = this.props;
-    currentSavedPositions[noteId] = {
-      //state: this.editor?.saveViewState(),
-      line: this.editor?.getPosition()?.lineNumber,
-      scroll: this.editor?.getScrollTop(),
+    const position = {
+      line: this.editor?.getPosition()?.lineNumber ?? 0,
+      scroll: this.editor?.getScrollTop() ?? 0,
     };
-    localStorage.setItem(
-      'note_positions',
-      JSON.stringify(currentSavedPositions)
-    );
+    setNotePosition(noteId, position);
 
     if (this.bootTimer) {
       clearTimeout(this.bootTimer);

--- a/lib/utils/note-scroll-position.ts
+++ b/lib/utils/note-scroll-position.ts
@@ -13,7 +13,7 @@ export const setNotePosition = (noteId: string, position: notePosition) => {
   const positions = getAllPositions();
   if (positions) {
     positions[noteId] = position;
-    localStorage.setItem('note_positions', JSON.stringify(positions));
+    sessionStorage.setItem('note_positions', JSON.stringify(positions));
   }
 };
 
@@ -26,10 +26,8 @@ export const getNotePosition = (noteId: string): notePosition | '' => {
   }
 };
 
-export const removeNotePostion = (noteId: string) => {};
-
 const getAllPositions = (): notePositions | '' => {
-  const notePositions = localStorage.getItem('note_positions');
+  const notePositions = sessionStorage.getItem('note_positions');
   let currentSavedPositions: notePositions;
   if (notePositions) {
     try {
@@ -38,6 +36,8 @@ const getAllPositions = (): notePositions | '' => {
     } catch (e) {
       return '';
     }
+  } else {
+    currentSavedPositions = {};
   }
-  return '';
+  return currentSavedPositions;
 };

--- a/lib/utils/note-scroll-position.ts
+++ b/lib/utils/note-scroll-position.ts
@@ -1,15 +1,8 @@
-export type notePosition =
-  | {
-      scroll: number;
-      line: number;
-    }
-  | undefined;
-
 export type notePositions = {
-  [key: string]: notePosition;
+  [key: string]: number;
 };
 
-export const setNotePosition = (noteId: string, position: notePosition) => {
+export const setNotePosition = (noteId: string, position: number) => {
   const positions = getAllPositions();
   if (positions) {
     positions[noteId] = position;
@@ -17,16 +10,20 @@ export const setNotePosition = (noteId: string, position: notePosition) => {
   }
 };
 
-export const getNotePosition = (noteId: string): notePosition | '' => {
+export const getNotePosition = (noteId: string): number => {
   const positions = getAllPositions();
   if (positions) {
     return positions[noteId];
   } else {
-    return '';
+    return 0;
   }
 };
 
-const getAllPositions = (): notePositions | '' => {
+export const clearNotePositions = () => {
+  sessionStorage.removeItem('note_positions');
+};
+
+const getAllPositions = (): notePositions => {
   const notePositions = sessionStorage.getItem('note_positions');
   let currentSavedPositions: notePositions;
   if (notePositions) {
@@ -34,7 +31,7 @@ const getAllPositions = (): notePositions | '' => {
       currentSavedPositions = JSON.parse(notePositions);
       return currentSavedPositions;
     } catch (e) {
-      return '';
+      return {};
     }
   } else {
     currentSavedPositions = {};

--- a/lib/utils/note-scroll-position.ts
+++ b/lib/utils/note-scroll-position.ts
@@ -1,0 +1,43 @@
+export type notePosition =
+  | {
+      scroll: number;
+      line: number;
+    }
+  | undefined;
+
+export type notePositions = {
+  [key: string]: notePosition;
+};
+
+export const setNotePosition = (noteId: string, position: notePosition) => {
+  const positions = getAllPositions();
+  if (positions) {
+    positions[noteId] = position;
+    localStorage.setItem('note_positions', JSON.stringify(positions));
+  }
+};
+
+export const getNotePosition = (noteId: string): notePosition | '' => {
+  const positions = getAllPositions();
+  if (positions) {
+    return positions[noteId];
+  } else {
+    return '';
+  }
+};
+
+export const removeNotePostion = (noteId: string) => {};
+
+const getAllPositions = (): notePositions | '' => {
+  const notePositions = localStorage.getItem('note_positions');
+  let currentSavedPositions: notePositions;
+  if (notePositions) {
+    try {
+      currentSavedPositions = JSON.parse(notePositions);
+      return currentSavedPositions;
+    } catch (e) {
+      return '';
+    }
+  }
+  return '';
+};


### PR DESCRIPTION
### Fix

This will help fix #2951 and help fix #2861

Currently, if you have a longer note that needs to be scrolled when you leave the note and come back the scroll position is set back to the top. This includes if you are returning from a Markdown preview, or even if you change a setting that causes the editor to re-render.

This saves the line and scroll position of a note when you leave and then restores it when you come back. This is only saved for the current session. 

### Test

1. Open a note which needs to be scrolled
2. Scroll to a point in the note
3. Leave the note
4. Open the note again and ensure you are taken to the same spot in the note

### Release

- Updated to save the scroll position of a note so you can be restored when the note is viewed again
