### PR TITLE
Mark a couple of release notes entries as "internal"

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,7 +6,7 @@
 
 - Added support for handling failed logins due to having an unverified account email [#2976](https://github.com/automattic/simplenote-electron/pull/2976)
 - [Internal] Added support for handling passwords found in known data breaches [#2972](https://github.com/automattic/simplenote-electron/pull/2972)
-- Updated Simperium library dependency to latest version [#2984](https://github.com/automattic/simplenote-electron/pull/2984)
+- [Internal] Updated Simperium library dependency to latest version [#2984](https://github.com/automattic/simplenote-electron/pull/2984)
 
 ## [v2.17.0]
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,7 +5,7 @@
 ### Enhancements
 
 - Added support for handling failed logins due to having an unverified account email [#2976](https://github.com/automattic/simplenote-electron/pull/2976)
-- Added support for handling passwords found in known data breaches [#2972](https://github.com/automattic/simplenote-electron/pull/2972)
+- [Internal] Added support for handling passwords found in known data breaches [#2972](https://github.com/automattic/simplenote-electron/pull/2972)
 - Updated Simperium library dependency to latest version [#2984](https://github.com/automattic/simplenote-electron/pull/2984)
 
 ## [v2.17.0]


### PR DESCRIPTION
A quick fix to address @belcherj (_welcome back from sabbatical_ 😊👋) request [here](https://github.com/Automattic/simplenote-electron/pull/2989#discussion_r702071406).

I committed each line individually so if only one was meant to be internal we can cherry-pick just that one.