### PR TITLE
Update the search field and tag suggestion components to use CSS variables for colors

### DIFF
--- a/lib/search-field/style.scss
+++ b/lib/search-field/style.scss
@@ -9,13 +9,14 @@
   background-color: var(--background-color);
 
   input {
-    width: 100%;
-    min-width: 0; // Firefox
-    border: 0;
     appearance: none;
-    font-size: 16px;
-    text-overflow: ellipsis !important;
     background-color: var(--background-color);
+    border: 0;
+    color: var(--primary-color);
+    font-size: 16px;
+    min-width: 0; // Firefox
+    text-overflow: ellipsis !important;
+    width: 100%;
 
     &:focus {
       outline: none;

--- a/lib/tag-suggestions/style.scss
+++ b/lib/tag-suggestions/style.scss
@@ -16,11 +16,12 @@
     }
 
     .tag-suggestion {
+      border-color: var(--secondary-color);
+      color: var(--primary-color);
       font-size: 16px;
       margin-left: 28px;
       overflow-x: hidden;
       text-overflow: ellipsis;
-      border-color: var(--secondary-color);
     }
   }
 


### PR DESCRIPTION
### Fix

This is a continuation of moving to CSS variables for colors within the app.
This updates the Search Field and Tag Suggestion components.

### Test

- Smoke test in light and dark mode
- Perform a search 
- Ensure the search field component looks the same
- Ensure the tag suggestion component looks the same

### Release

 - Updated the Search Field and Tag Suggestion components to use CSS variables for colors
