### PR TITLE
Fix new note button separator color in focus mode

### DIFF
--- a/lib/note-toolbar/style.scss
+++ b/lib/note-toolbar/style.scss
@@ -109,7 +109,7 @@ body[data-theme='dark'] .note-toolbar-wrapper .offline-badge {
 }
 
 .new-note-toolbar__button-sidebar {
-  border-right: 1px solid;
+  border-right: 1px solid var(--secondary-color);
   display: none;
   height: $toolbar-height;
   line-height: $toolbar-height;


### PR DESCRIPTION
### Fix

The color of the separator line between the new note button and focus mode button, while in focus mode, was not being set correctly. This ensures it is set to the right color

**Before**
<img width="135" alt="Screen Shot 2021-09-10 at 9 53 11 AM" src="https://user-images.githubusercontent.com/1326294/132856304-1b6c6465-ac96-4394-a8c4-84a46d69878b.png">
<img width="124" alt="Screen Shot 2021-09-10 at 9 53 28 AM" src="https://user-images.githubusercontent.com/1326294/132856324-c7584016-ca79-4fd7-b1ed-c0699cd45583.png">

**After**
<img width="117" alt="Screen Shot 2021-09-10 at 9 53 51 AM" src="https://user-images.githubusercontent.com/1326294/132856356-05c147b1-4205-4334-9298-0257c16a0b16.png">
<img width="122" alt="Screen Shot 2021-09-10 at 9 53 39 AM" src="https://user-images.githubusercontent.com/1326294/132856374-5f4b714f-931f-457e-bfaf-f650d3e0982b.png">


### Test

- Smoke test in light and dark mode
- Switch to focus mode
- Ensure the separator color matches other border colors

### Release

- Fixed the new note button separator color while in focus mode
