### PR TITLE
Updated note action component to use css variables for colors

### DIFF
--- a/lib/note-actions/index.tsx
+++ b/lib/note-actions/index.tsx
@@ -78,11 +78,8 @@ export class NoteActions extends Component<Props> {
           onDeactivate: this.handleFocusTrapDeactivate,
         }}
       >
-        <div
-          className="note-actions theme-color-bg theme-color-fg theme-color-border"
-          ref={this.containerRef}
-        >
-          <div className="note-actions-panel theme-color-border">
+        <div className="note-actions" ref={this.containerRef}>
+          <div className="note-actions-panel">
             <label
               className="note-actions-item"
               htmlFor="note-actions-pin-checkbox"
@@ -147,7 +144,7 @@ export class NoteActions extends Component<Props> {
               </div>
             )}
           </div>
-          <div className="note-actions-panel note-actions-public-link theme-color-border">
+          <div className="note-actions-panel note-actions-public-link">
             <label
               className="note-actions-item"
               htmlFor="note-actions-publish-checkbox"
@@ -187,7 +184,7 @@ export class NoteActions extends Component<Props> {
               )}
             </div>
           </div>
-          <div className="note-actions-panel theme-color-border">
+          <div className="note-actions-panel">
             <div className="note-actions-item">
               <button
                 className="button button-borderless"
@@ -197,7 +194,7 @@ export class NoteActions extends Component<Props> {
               </button>
             </div>
           </div>
-          <div className="note-actions-panel theme-color-border">
+          <div className="note-actions-panel">
             <div className="note-actions-item note-actions-trash">
               <button
                 className="button button-borderless"

--- a/lib/note-actions/style.scss
+++ b/lib/note-actions/style.scss
@@ -80,15 +80,3 @@
     color: var(--disabled-text-color);
   }
 }
-
-body[data-theme='dark'] {
-  .note-actions-item-control .checkbox-control .checkbox-control-base,
-  .note-actions-item-control .checkbox-control .checkbox-control-checked {
-    background-position: 0 -18px;
-    fill: var(--foreground-color);
-  }
-
-  .note-actions-item-control .checkbox-control .checkbox-control-checked {
-    background-position: -18px -18px;
-  }
-}

--- a/lib/note-actions/style.scss
+++ b/lib/note-actions/style.scss
@@ -1,11 +1,13 @@
 .note-actions {
+  background-color: var(--background-color);
   width: 200px;
   position: absolute;
   right: 16px;
   top: $toolbar-height + 16px;
-  border: 1px solid;
+  border: 1px solid var(--secondary-color);
   border-radius: 6px;
   box-shadow: 0 3px 6px 0 var(--overlay-color);
+  color: var(--primary-color);
   display: flex;
   flex-direction: column;
   overflow: auto;
@@ -14,7 +16,7 @@
 
   .note-actions-panel {
     flex: none;
-    border-bottom: 1px solid;
+    border-bottom: 1px solid var(--secondary-color);
     padding: 4px 0;
 
     &:last-child {
@@ -38,12 +40,12 @@
     }
 
     &:hover {
-      background-color: var(--secondary-highlight-color);
+      background-color: var(--alternative-highlight-color);
     }
   }
 
   .note-actions-item-disabled {
-    color: var(--secondary-color);
+    color: var(--disabled-text-color);
     &:hover {
       background-color: transparent;
     }
@@ -74,31 +76,12 @@
     }
   }
 
-  .spinner__circle {
-    color: var(--tertiary-accent-color);
+  svg .spinner__circle {
+    color: var(--disabled-text-color);
   }
 }
 
 body[data-theme='dark'] {
-  .spinner__circle {
-    color: var(--tertiary-color);
-  }
-  .note-actions.theme-color-bg {
-    background-color: var(--background-color);
-  }
-
-  .note-actions-trash {
-    color: var(--tertiary-highlight-color);
-  }
-
-  .note-actions-item-disabled {
-    color: var(--tertiary-color);
-  }
-
-  .note-actions-item:hover {
-    background-color: var(--secondary-color);
-  }
-
   .note-actions-item-control .checkbox-control .checkbox-control-base,
   .note-actions-item-control .checkbox-control .checkbox-control-checked {
     background-position: 0 -18px;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -61,6 +61,7 @@ body[data-theme='light'] {
   --secondary-tag-chip-color: #facfd2; // $studio-red-5
   --settings-fg-color: #2c3338; // $studio-gray-80
   --alternative-highlight-color: #f6f7f7; // $studio-gray-0;
+  --disabled-text-color: #dcdcde; // $studio-gray-5
 }
 
 body[data-theme='dark'] {
@@ -87,4 +88,5 @@ body[data-theme='dark'] {
   --secondary-tag-chip-color: #8a2424; // $studio-red-70
   --settings-fg-color: #dcdcde; // $studio-gray-5
   --alternative-highlight-color: #2c3338; // $studio-gray-80
+  --disabled-text-color: #646970; // $studio-gray-50
 }


### PR DESCRIPTION
### Fix

This is a continuation of moving to CSS variables for colors within the app.
This updates the Note Action component.

~Note: The checkboxes used in this component and elsewhere will need to be updated separately still to allow changing colors more easily. Tracked in https://github.com/Automattic/simplenote-electron/issues/3000~

### Test

- Smoke test in light and dark mode
- Click the note action icon in the upper right
- Ensure the open panel looks the same
- Toggle publish ensure spinner and copy still appear the same

Release

- Updated the Note Action components to use CSS variables for colors