### PR TITLE
Update the standard checkbox component to use individual SVG images

### DIFF
--- a/lib/controls/checkbox/index.tsx
+++ b/lib/controls/checkbox/index.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import classNames from 'classnames';
 
+import CheckedCheckbox from '../../icons/checkbox-checked';
+import UncheckedCheckbox from '../../icons/checkbox-unchecked';
+
 type OwnProps = React.HTMLProps<HTMLInputElement> & {
   className?: string;
   onChange: () => any;
@@ -26,23 +29,9 @@ function CheckboxControl({
           <span className="checkbox-control-checked" />
         </span>
       ) : checked ? (
-        <svg
-          className="checked"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-        >
-          <rect x="0" fill="none" width="24" height="24" />
-          <path d="M19 3H5A2 2 0 0 0 3 5V19a2 2 0 0 0 2 2H19a2 2 0 0 0 2-2V5A2 2 0 0 0 19 3ZM10.14 16.85 5.76 12.48l1.42-1.42 3 3 6.63-6.63 1.41 1.42Z" />
-        </svg>
+        <CheckedCheckbox />
       ) : (
-        <svg
-          className="unchecked"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-        >
-          <rect x="0" fill="none" width="24" height="24" />
-          <path d="M19 5h0V19H5V5H19m0-2H5A2 2 0 0 0 3 5V19a2 2 0 0 0 2 2H19a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2Z" />
-        </svg>
+        <UncheckedCheckbox />
       )}
     </span>
   );

--- a/lib/controls/checkbox/index.tsx
+++ b/lib/controls/checkbox/index.tsx
@@ -7,7 +7,12 @@ type OwnProps = React.HTMLProps<HTMLInputElement> & {
   isStandard?: boolean;
 };
 
-function CheckboxControl({ className, isStandard, ...props }: OwnProps) {
+function CheckboxControl({
+  className,
+  isStandard,
+  checked,
+  ...props
+}: OwnProps) {
   return (
     <span
       className={classNames('checkbox-control', [
@@ -15,10 +20,30 @@ function CheckboxControl({ className, isStandard, ...props }: OwnProps) {
         { 'checkbox-standard': isStandard },
       ])}
     >
-      <input type="checkbox" {...props} />
-      <span className="checkbox-control-base">
-        <span className="checkbox-control-checked" />
-      </span>
+      <input type="checkbox" {...props} checked={checked} />
+      {!isStandard ? (
+        <span className="checkbox-control-base">
+          <span className="checkbox-control-checked" />
+        </span>
+      ) : checked ? (
+        <svg
+          className="checked"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+        >
+          <rect x="0" fill="none" width="24" height="24" />
+          <path d="M19 3H5A2 2 0 0 0 3 5V19a2 2 0 0 0 2 2H19a2 2 0 0 0 2-2V5A2 2 0 0 0 19 3ZM10.14 16.85 5.76 12.48l1.42-1.42 3 3 6.63-6.63 1.41 1.42Z" />
+        </svg>
+      ) : (
+        <svg
+          className="unchecked"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+        >
+          <rect x="0" fill="none" width="24" height="24" />
+          <path d="M19 5h0V19H5V5H19m0-2H5A2 2 0 0 0 3 5V19a2 2 0 0 0 2 2H19a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2Z" />
+        </svg>
+      )}
     </span>
   );
 }

--- a/lib/controls/checkbox/style.scss
+++ b/lib/controls/checkbox/style.scss
@@ -1,5 +1,3 @@
-$checkbox-sprite: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0OCA0OCI+PHJlY3QgeD0iMCIgZmlsbD0ibm9uZSIgd2lkdGg9IjQ4IiBoZWlnaHQ9IjQ4Ii8+PHBhdGggZmlsbD0iIzY0Njk3MCIgZD0iTTE5IDVMMTkgNXYxNEg1VjVIMTlNMTkgM0g1QzMuODk1IDMgMyAzLjg5NSAzIDV2MTRjMCAxLjEwNSAwLjg5NSAyIDIgMmgxNGMxLjEwNSAwIDItMC44OTUgMi0yVjVDMjEgMy44OTUgMjAuMTA1IDMgMTkgM3pNNDMgM0gyOWMtMS4xMDUgMC0yIDAuODk1LTIgMnYxNGMwIDEuMTA1IDAuODk1IDIgMiAyaDE0YzEuMTA1IDAgMi0wLjg5NSAyLTJWNUM0NSAzLjg5NSA0NC4xMDUgMyA0MyAzek0zNC4xNCAxNi44NWwtNC4zOC00LjM3IDEuNDItMS40MiAzIDMgNi42My02LjYzIDEuNDEgMS40MkwzNC4xNCAxNi44NXoiLz48cGF0aCBmaWxsPSIjOGM4Zjk0IiBkPSJNMTkgMjlMMTkgMjl2MTRINVYyOUgxOU0xOSAyN0g1Yy0xLjEwNSAwLTIgMC44OTUtMiAydjE0YzAgMS4xMDUgMC44OTUgMiAyIDJoMTRjMS4xMDUgMCAyLTAuODk1IDItMlYyOUMyMSAyNy44OTUgMjAuMTA1IDI3IDE5IDI3ek00MyAyN0gyOWMtMS4xMDUgMC0yIDAuODk1LTIgMnYxNGMwIDEuMTA1IDAuODk1IDIgMiAyaDE0YzEuMTA1IDAgMi0wLjg5NSAyLTJWMjlDNDUgMjcuODk1IDQ0LjEwNSAyNyA0MyAyN3pNMzQuMTQgNDAuODVsLTQuMzgtNC4zNyAxLjQyLTEuNDIgMyAzIDYuNjMtNi42MyAxLjQxIDEuNDJMMzQuMTQgNDAuODV6Ii8+PC9zdmc+';
-
 .checkbox-control {
   -webkit-touch-callout: none;
   width: 16px;
@@ -66,21 +64,9 @@ $checkbox-sprite: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5
     width: 18px;
     height: 18px;
 
-    .checkbox-control-base,
-    .checkbox-control-checked {
-      background-image: url($checkbox-sprite);
-      background-repeat: no-repeat;
-      background-size: 36px 36px;
-      border-radius: 0;
-      border: 0;
+    svg {
+      vertical-align: top;
       fill: var(--foreground-color);
-    }
-    .checkbox-control-base {
-      background-position: 0 0;
-    }
-    .checkbox-control-checked {
-      background-color: transparent;
-      background-position: -18px 0;
     }
   }
 }

--- a/lib/icons/checkbox-checked.tsx
+++ b/lib/icons/checkbox-checked.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function CheckedCheckbox() {
+  return (
+    <svg
+      className="checked-checkbox"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+    >
+      <rect x="0" fill="none" width="24" height="24" />
+      <path d="M19 3H5A2 2 0 0 0 3 5V19a2 2 0 0 0 2 2H19a2 2 0 0 0 2-2V5A2 2 0 0 0 19 3ZM10.14 16.85 5.76 12.48l1.42-1.42 3 3 6.63-6.63 1.41 1.42Z" />
+    </svg>
+  );
+}

--- a/lib/icons/checkbox-unchecked.tsx
+++ b/lib/icons/checkbox-unchecked.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function UncheckedCheckbox() {
+  return (
+    <svg
+      className="unchecked-checkbox"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+    >
+      <rect x="0" fill="none" width="24" height="24" />
+      <path d="M19 5h0V19H5V5H19m0-2H5A2 2 0 0 0 3 5V19a2 2 0 0 0 2 2H19a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2Z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
### Fix

Fixes #3000 

The current implementation of the standard checkboxes uses an SVG sprite as background to display the correct color and state of a checkbox.

This makes it difficult to modify the color of the checkbox and could get hard to manage if adding more potential colors.

This updates the component to add the appropriate SVG image to the HTML. The color can then be set with CSS. 

<table>
<tr>
<td>
<img width="226" alt="Screen Shot 2021-09-10 at 8 45 30 PM" src="https://user-images.githubusercontent.com/1326294/133072918-585fb259-43cf-4d40-8635-e7afc57e0fca.png">
</td>
<td>
<img width="238" alt="Screen Shot 2021-09-10 at 8 45 44 PM" src="https://user-images.githubusercontent.com/1326294/133072923-2b18cd4c-452f-4873-af34-219f74382b39.png">
</td>
</tr>
</table>


### Test

- Smoke test in light and dark mode
- Ensure checkboxes in the Note Actions panel work and look as expected
- Ensure the checkbox in the Note History panel works and looks as expected

### Release

- Updated the standard checkbox to be easier to manage
