### PR TITLE
Update CircleCI xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
 
   mac:
     macos:
-      xcode: '10.0.0'
+      xcode: '12.5.1'
     shell: /bin/bash --login
     working_directory: /Users/distiller/simplenote
     steps:


### PR DESCRIPTION
### Fix

The Xcode image version we were using in CircleCI has been deprecated and removed. This caused builds to fail as the Mac build could not be completed.
This updates the Xcode image to the [latest stable version](https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions).

### Test

- Download the built Mac artifact and ensure it installs and works as expected

### Release

- [Internal] Updated the Xcode version for CircleCI to a newer supported version