### PR TITLE
Update compromised password login message

### DIFF
--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -183,7 +183,8 @@ export class Auth extends Component<Props> {
               data-error-name="compromised-password"
             >
               This password has appeared in a data breach, which puts your
-              account at high risk of compromise. Please
+              account at high risk of compromise. To protect your data, you'll
+              need to{' '}
               <a
                 className="login__reset"
                 href={
@@ -194,9 +195,9 @@ export class Auth extends Component<Props> {
                 rel="noopener noreferrer"
                 onClick={this.onForgot}
               >
-                reset
+                update your password
               </a>{' '}
-              your password.
+              before being able to log in again.
             </p>
           )}
           {(this.props.hasInvalidCredentials || this.props.hasLoginError) && (

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -183,8 +183,8 @@ export class Auth extends Component<Props> {
               data-error-name="compromised-password"
             >
               This password has appeared in a data breach, which puts your
-              account at high risk of compromise. To protect your data, you'll
-              need to{' '}
+              account at high risk of compromise. To protect your data,
+              you&apos;ll need to
               <a
                 className="login__reset"
                 href={


### PR DESCRIPTION
### Fix

Fixes #3012 

This updates the error message displayed when attempting to log in with a password that is known to be compromised. It will match the copy provided in #3012. 

>This password has appeared in a data breach, which puts your account at high risk of compromise. To protect your data, you'll need to update your password before being able to log in again.

<img width="491" alt="Screen Shot 2021-09-23 at 7 49 36 PM" src="https://user-images.githubusercontent.com/1326294/134593947-e4cc03f7-6f79-45bd-8c70-8413aee105fc.png">


### Test

- Attempt to log in with an account using a known compromised password
- Ensure the message matches the above copy

### Release

- Updated the message that is shown when attempting to log in with a known compromised password
