### PR TITLE
Update tag hash algorithm to make it consistent with other platforms

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,10 @@
 
 ## [v2.23.1]
 
+### Fixes
+
+- Fixed inconsistent tag encoding of special characters that led to duplicate tags across platforms [#3017](https://github.com/Automattic/simplenote-electron/pull/3017)
+
 ### Other Changes
 
 - Updated dependencies [#3286](https://github.com/Automattic/simplenote-electron/pull/3286)

--- a/lib/tag-field/index.tsx
+++ b/lib/tag-field/index.tsx
@@ -8,7 +8,11 @@ import EmailToolTip from '../tag-email-tooltip';
 import TagChip from '../components/tag-chip';
 import TagInput from '../tag-input';
 import classNames from 'classnames';
-import { tagHashOf } from '../utils/tag-hash';
+import {
+  isTagInputKey,
+  tagHashOf,
+  MAX_TAG_HASH_LENGTH,
+} from '../utils/tag-hash';
 import { noteCanonicalTags } from '../state/selectors';
 
 import type * as S from '../state';
@@ -201,6 +205,14 @@ export class TagField extends Component<Props, OwnState> {
   onKeyDown = (e: React.KeyboardEvent) => {
     if (this.state.showEmailTooltip) {
       this.hideEmailTooltip();
+    }
+
+    if (
+      tagHashOf(this.state.tagInput as T.TagName).length >
+        MAX_TAG_HASH_LENGTH &&
+      isTagInputKey(e.which)
+    ) {
+      e.preventDefault();
     }
 
     return this.interceptKeys(e);

--- a/lib/tag-field/index.tsx
+++ b/lib/tag-field/index.tsx
@@ -8,11 +8,7 @@ import EmailToolTip from '../tag-email-tooltip';
 import TagChip from '../components/tag-chip';
 import TagInput from '../tag-input';
 import classNames from 'classnames';
-import {
-  isTagInputKey,
-  tagHashOf,
-  MAX_TAG_HASH_LENGTH,
-} from '../utils/tag-hash';
+import { tagHashOf, MAX_TAG_HASH_LENGTH } from '../utils/tag-hash';
 import { noteCanonicalTags } from '../state/selectors';
 
 import type * as S from '../state';
@@ -210,7 +206,7 @@ export class TagField extends Component<Props, OwnState> {
     if (
       tagHashOf(this.state.tagInput as T.TagName).length >
         MAX_TAG_HASH_LENGTH &&
-      isTagInputKey(e.which)
+      String.fromCharCode(e.which).match(/([^,\s])/g)
     ) {
       e.preventDefault();
     }

--- a/lib/tag-input/index.tsx
+++ b/lib/tag-input/index.tsx
@@ -8,6 +8,8 @@ import React, {
 import { connect } from 'react-redux';
 import { get, identity, invoke, noop } from 'lodash';
 
+import { tagHashOf, MAX_TAG_HASH_LENGTH } from '../utils/tag-hash';
+
 import type * as S from '../state';
 import type * as T from '../types';
 
@@ -223,8 +225,12 @@ export class TagInput extends Component<Props> {
 
     // Convert spaces/commans to submitted tags
     const tags = clipboardText.split(/\s|,|\n/);
-    const submittedTags = tags.slice(0, tags.length - 1);
-    const [pendingTag] = tags.slice(tags.length - 1);
+    const filteredTags = tags.filter(
+      (tag) => tagHashOf(tag).length <= MAX_TAG_HASH_LENGTH
+    );
+    const submittedTags = filteredTags.slice(0, filteredTags.length - 1);
+    const [pendingTag] = filteredTags.slice(filteredTags.length - 1);
+
     submittedTags.filter(Boolean).forEach(this.props.onSelect);
     this.onInput(pendingTag, { moveCaretToEndOfValue: true });
 

--- a/lib/tag-input/index.tsx
+++ b/lib/tag-input/index.tsx
@@ -223,7 +223,7 @@ export class TagInput extends Component<Props> {
       clipboardText = window.clipboardData.getData('Text'); // IE11
     }
 
-    // Convert spaces/commans to submitted tags
+    // Convert spaces/commas to submitted tags
     const tags = clipboardText.split(/\s|,|\n/);
     const filteredTags = tags.filter(
       (tag) => tagHashOf(tag).length <= MAX_TAG_HASH_LENGTH

--- a/lib/tag-list/input.tsx
+++ b/lib/tag-list/input.tsx
@@ -46,7 +46,6 @@ export const TagListInput: FunctionComponent<Props> = ({
       tagHashOf(enteredTagName).length >= MAX_TAG_HASH_LENGTH &&
       isTagInputKey(event.which)
     ) {
-      console.log('key: ' + event.which);
       event.preventDefault();
     }
   };

--- a/lib/tag-list/input.tsx
+++ b/lib/tag-list/input.tsx
@@ -6,6 +6,11 @@ import actions from '../state/actions';
 
 import type * as S from '../state';
 import type * as T from '../types';
+import {
+  isTagInputKey,
+  tagHashOf,
+  MAX_TAG_HASH_LENGTH,
+} from '../utils/tag-hash';
 
 type OwnProps = {
   editable: boolean;
@@ -35,9 +40,24 @@ export const TagListInput: FunctionComponent<Props> = ({
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTagName(event.target.value.replace(/[\s,]/g, ''));
   };
+
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    if (
+      tagHashOf(enteredTagName).length >= MAX_TAG_HASH_LENGTH &&
+      isTagInputKey(event.which)
+    ) {
+      console.log('key: ' + event.which);
+      event.preventDefault();
+    }
+  };
+
   const onDone = (event: React.FocusEvent<HTMLInputElement>) => {
     const newTagName = event.target?.value.trim() as T.TagName;
 
+    if (tagHashOf(newTagName).length > MAX_TAG_HASH_LENGTH) {
+      setTagName(tagName);
+      return;
+    }
     if (newTagName && newTagName !== tagName) {
       renameTag(tagName, newTagName);
     } else {
@@ -57,6 +77,7 @@ export const TagListInput: FunctionComponent<Props> = ({
       onChange={onChange}
       onBlur={onDone}
       spellCheck={false}
+      onKeyDown={onKeyDown}
     />
   ) : (
     <button className={classes} onClick={onClick}>

--- a/lib/tag-list/input.tsx
+++ b/lib/tag-list/input.tsx
@@ -6,11 +6,7 @@ import actions from '../state/actions';
 
 import type * as S from '../state';
 import type * as T from '../types';
-import {
-  isTagInputKey,
-  tagHashOf,
-  MAX_TAG_HASH_LENGTH,
-} from '../utils/tag-hash';
+import { tagHashOf, MAX_TAG_HASH_LENGTH } from '../utils/tag-hash';
 
 type OwnProps = {
   editable: boolean;
@@ -44,7 +40,7 @@ export const TagListInput: FunctionComponent<Props> = ({
   const onKeyDown = (event: React.KeyboardEvent) => {
     if (
       tagHashOf(enteredTagName).length >= MAX_TAG_HASH_LENGTH &&
-      isTagInputKey(event.which)
+      String.fromCharCode(event.which).match(/([^,\s])/g)
     ) {
       event.preventDefault();
     }

--- a/lib/utils/tag-hash.ts
+++ b/lib/utils/tag-hash.ts
@@ -1,12 +1,14 @@
 import type * as T from '../types';
 
+export const MAX_TAG_HASH_LENGTH = 256;
+
 export const tagHashOf = (tagName: T.TagName): T.TagHash => {
   const normalized = tagName.normalize('NFC');
   const lowercased = normalized.toLocaleLowerCase('en-US');
   const encoded = encodeURIComponent(lowercased);
 
   return encoded.replace(
-    /[!'()*]/g,
+    /[!'()*\-_~.]/g,
     (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase()
   ) as T.TagHash;
 };
@@ -30,4 +32,28 @@ export const withoutTag = (tags: T.TagName[], tag: T.TagName): T.TagName[] => {
   }
 
   return tags;
+};
+
+export const isTagInputKey = (key: number) => {
+  // Check if a key will add to an input based on keycodes from https://keycode.info
+  if (key >= 48 && key <= 90) {
+    return true;
+  }
+  if (key >= 160 && key <= 165) {
+    return true;
+  }
+  if (key >= 170 && key <= 171) {
+    return true;
+  }
+  if (key >= 186 && key <= 194) {
+    return true;
+  }
+  if (key >= 219 && key <= 223) {
+    return true;
+  }
+  if (key >= 225 && key <= 226) {
+    return true;
+  }
+
+  return false;
 };

--- a/lib/utils/tag-hash.ts
+++ b/lib/utils/tag-hash.ts
@@ -33,27 +33,3 @@ export const withoutTag = (tags: T.TagName[], tag: T.TagName): T.TagName[] => {
 
   return tags;
 };
-
-export const isTagInputKey = (key: number) => {
-  // Check if a key will add to an input based on keycodes from https://keycode.info
-  if (key >= 48 && key <= 90) {
-    return true;
-  }
-  if (key >= 160 && key <= 165) {
-    return true;
-  }
-  if (key >= 170 && key <= 171) {
-    return true;
-  }
-  if (key >= 186 && key <= 194) {
-    return true;
-  }
-  if (key >= 219 && key <= 223) {
-    return true;
-  }
-  if (key >= 225 && key <= 226) {
-    return true;
-  }
-
-  return false;
-};


### PR DESCRIPTION
Commandeering this PR! --Kat

### Fix

There were a few characters that were not being encoded in the tag hash algorithm which were being encoded on other platforms. This causes inconsistency and duplicate tags when working across different platforms.

This will fix #3279 and might fix some of our longer-standing issues with duplicate tags. However it will not clean up any preexisting tags with special characters that were improperly encoded.

### Test

Follow testing directions on #3279, i.e. it's best to create a tag with special characters on a different platform and then add it to a note here. You can also create a tag here and then log into Simperium to confirm it is being properly escaped:

![Screenshot 2025-01-23 at 07 06 29](https://github.com/user-attachments/assets/1e5fda21-2163-42a7-9873-b2e430920b45)


### Release

Release notes were updated with:

`- Fixed inconsistent tag encoding of special characters that led to duplicate tags across platforms [#3017](https://github.com/Automattic/simplenote-electron/pull/3017)
`