### PR TITLE
Updated navigation bar and tag list components to use css variables for colors

### DIFF
--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -95,8 +95,8 @@ export class NavigationBar extends Component<Props> {
           onDeactivate: this.handleFocusTrapDeactivate,
         }}
       >
-        <div className="navigation-bar theme-color-bg theme-color-fg theme-color-border">
-          <div className="navigation-bar__folders theme-color-border">
+        <div className="navigation-bar">
+          <div className="navigation-bar__folders">
             <NavigationBarItem
               icon={<NotesIcon />}
               isSelected={this.isSelected({ selectedRow: 'all' })}
@@ -115,11 +115,11 @@ export class NavigationBar extends Component<Props> {
               onClick={onSettings}
             />
           </div>
-          <div className="navigation-bar__tags theme-color-border">
+          <div className="navigation-bar__tags">
             {(tagCount && (
               <>
                 <TagList />
-                <div className="navigation-bar__folders navigation-bar__untagged theme-color-border">
+                <div className="navigation-bar__folders navigation-bar__untagged">
                   <NavigationBarItem
                     icon={<UntaggedNotesIcon />}
                     isSelected={this.isSelected({ selectedRow: 'untagged' })}
@@ -131,7 +131,7 @@ export class NavigationBar extends Component<Props> {
             )) ||
               null}
           </div>
-          <div className="navigation-bar__tools theme-color-border">
+          <div className="navigation-bar__tools">
             <div className="navigation-bar__server-connection">
               <ConnectionStatus />
             </div>
@@ -139,7 +139,7 @@ export class NavigationBar extends Component<Props> {
           <div className="navigation-bar__footer">
             <button
               type="button"
-              className="navigation-bar__footer-item theme-color-fg-dim"
+              className="navigation-bar__footer-item"
               onClick={this.props.showKeyboardShortcuts}
             >
               Keyboard Shortcuts
@@ -148,14 +148,14 @@ export class NavigationBar extends Component<Props> {
           <div className="navigation-bar__footer">
             <button
               type="button"
-              className="navigation-bar__footer-item theme-color-fg-dim"
+              className="navigation-bar__footer-item"
               onClick={this.onHelpClicked}
             >
               Help &amp; Support
             </button>
             <button
               type="button"
-              className="navigation-bar__footer-item theme-color-fg-dim"
+              className="navigation-bar__footer-item"
               onClick={onAbout}
             >
               About

--- a/lib/navigation-bar/item/index.tsx
+++ b/lib/navigation-bar/item/index.tsx
@@ -11,11 +11,10 @@ export const NavigationBarItem = ({
   const classes = classNames('navigation-bar-item', {
     'is-selected': isSelected,
   });
-  const buttonClasses = classNames('button', 'theme-color-fg');
 
   return (
     <div className={classes}>
-      <button type="button" className={buttonClasses} onClick={onClick}>
+      <button type="button" className="button" onClick={onClick}>
         <span className="navigation-bar-item__icon">{icon}</span>
         {label}
       </button>

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -6,8 +6,9 @@
 
   .button {
     border: 0;
-    border-top: 1px solid;
+    border-top: 1px solid var(--secondary-color);
     border-radius: 0;
+    color: var(--primary-color);
     font-size: 16px;
     font-weight: 400;
     height: 44px;

--- a/lib/navigation-bar/item/style.scss
+++ b/lib/navigation-bar/item/style.scss
@@ -59,15 +59,3 @@
 .navigation-bar-item.is-selected + .navigation-bar-item .button {
   border-top: none;
 }
-
-body[data-theme='dark'] {
-  .navigation-bar-item {
-    &.is-selected button {
-      color: var(--primary-color);
-    }
-
-    &:hover:not(.is-selected) {
-      background: var(--secondary-color);
-    }
-  }
-}

--- a/lib/navigation-bar/style.scss
+++ b/lib/navigation-bar/style.scss
@@ -1,4 +1,5 @@
 .navigation-bar {
+  background-color: var(--background-color);
   display: flex;
   flex-direction: column;
   position: absolute;
@@ -7,7 +8,7 @@
   padding-top: $toolbar-height;
   width: $navigation-bar-width;
   height: 100%;
-  border-right: 1px solid;
+  border-right: 1px solid var(--secondary-color);
   z-index: 2;
   transition: transform 200ms ease-in-out;
 }
@@ -16,7 +17,7 @@
   display: flex;
   flex: none;
   flex-direction: column;
-  border-bottom: 1px solid;
+  border-bottom: 1px solid var(--secondary-color);
 }
 
 .navigation-bar__tags {
@@ -30,16 +31,17 @@
 }
 
 .navigation-bar__untagged {
-  border-top: 1px solid;
+  border-top: 1px solid var(--secondary-color);
 }
 
 .navigation-bar__tools {
   flex: 1 0 auto;
   padding: 10px 0;
-  border-top: 1px solid;
+  border-top: 1px solid var(--secondary-color);
 }
 
 .navigation-bar__footer {
+  color: var(--foreground-color);
   display: flex;
   flex: none;
   justify-content: flex-start;
@@ -48,6 +50,7 @@
 }
 
 .navigation-bar__server-connection {
+  color: var(--foreground-color);
   display: flex;
   flex: none;
   justify-content: flex-start;

--- a/lib/tag-list/index.tsx
+++ b/lib/tag-list/index.tsx
@@ -58,14 +58,9 @@ const SortableTag = SortableElement(
   }) => (
     <li
       key={tagHash}
-      className={classNames(
-        `tag-list-item`,
-        `theme-color-border`,
-        `theme-color-fg`,
-        {
-          'is-selected': isSelected,
-        }
-      )}
+      className={classNames(`tag-list-item`, {
+        'is-selected': isSelected,
+      })}
       data-tag-name={tag.name}
     >
       <TagListInput
@@ -80,7 +75,7 @@ const SortableTag = SortableElement(
         </button>
       )}
       {editingActive && allowReordering && (
-        <button className="icon-button button-reorder theme-color-fg-dim">
+        <button className="icon-button button-reorder">
           <TagHandle />
         </button>
       )}
@@ -163,8 +158,8 @@ export class TagList extends Component<Props> {
 
     return (
       <div className={classes}>
-        <div className="tag-list-title theme-color-border">
-          <h2 className="theme-color-fg">Tags</h2>
+        <div className="tag-list-title">
+          <h2>Tags</h2>
           {sortedTags.length > 0 && (
             <button
               className="tag-list-edit-toggle button button-borderless"

--- a/lib/tag-list/input.tsx
+++ b/lib/tag-list/input.tsx
@@ -44,7 +44,7 @@ export const TagListInput: FunctionComponent<Props> = ({
       setTagName(tagName);
     }
   };
-  const classes = classNames('tag-list-input', 'theme-color-fg', {
+  const classes = classNames('tag-list-input', {
     'is-selected': isSelected,
   });
 

--- a/lib/tag-list/style.scss
+++ b/lib/tag-list/style.scss
@@ -19,7 +19,7 @@
 }
 
 .tag-list-item:not(:last-child) {
-  border-bottom: 1px solid;
+  border-bottom: 1px solid var(--secondary-color);
 }
 
 body .tag-list-item {
@@ -38,15 +38,17 @@ body .tag-list-item {
     justify-content: space-between;
     align-items: center;
     padding: 0 17px 13px;
-    border-bottom: 1px solid;
+    border-bottom: 1px solid var(--secondary-color);
 
     h2 {
+      color: var(--primary-color);
       font-size: 16px;
       font-weight: 400;
       margin: 0;
     }
 
     button {
+      color: var(--accent-color);
       font-size: 14px;
       font-weight: 400;
       padding: 0 2px 0;
@@ -80,6 +82,7 @@ body .tag-list-item {
 }
 
 .tag-list-input {
+  color: var(--primary-color);
   flex: 1 1 auto;
   display: block;
   width: 50px;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -74,6 +74,7 @@ body[data-theme='dark'] {
   --secondary-accent-color: #50575e; // $studio-gray-60
   // highlight-color = $studio-simplenote-blue-50 with 40% opacity
   --highlight-color: rgba(51, 97, 204, 0.4);
+  --secondary-highlight-color: #2c3338; // $studio-gray-80
   --search-highlight-color: #3361cc; // $studio-simplenote-blue-50
   --search-selection-color: #deb100; // $studio-yellow-30
   --placeholder-color: #a7aaad; // $studio-gray-20


### PR DESCRIPTION
### Fix

This is a continuation of moving to CSS variables for colors within the app.
This updates the Navigation Bar and Tag List components.

### Test

- Smoke test in light and dark mode
- Click the menu icon in the upper left to open the navigation bar
- Compare between production and this branch
- Ensure the navigation bar panel looks the same
- Click the edit button in the tag list
- Ensure the icons still look the same

### Release

- Updated the Navigation Bar and Tag List components to use CSS variables for colors