### PR TITLE
Update the note preview and note detail components to use css variables for colors

### DIFF
--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -166,7 +166,7 @@ export const NotePreview: FunctionComponent<Props> = ({
       <div className="note-detail note-detail-preview">
         <div
           ref={previewNode}
-          className="note-detail-markdown theme-color-bg theme-color-fg note-preview"
+          className="note-detail-markdown note-preview"
           data-markdown-root
         >
           {!showRenderedView && withCheckboxCharacters(note?.content ?? '')}

--- a/lib/note-detail/style.scss
+++ b/lib/note-detail/style.scss
@@ -57,7 +57,7 @@
   border: 0;
   line-height: 1.5em;
   font-size: 16px;
-  color: var(--foreground-color);
+  color: var(--primary-color);
   background: var(--background-color);
   resize: none;
   -webkit-tap-highlight-color: transparent;
@@ -213,10 +213,6 @@
     border-radius: 3px;
     box-shadow: inset 0 0 0 #959da5;
   }
-}
-
-body[data-theme='dark'] .note-detail-markdown p > code {
-  background-color: var(--secondary-color);
 }
 
 .monaco-editor.monaco-editor .detected-link {


### PR DESCRIPTION
### Fix

This is a continuation of moving to CSS variables for colors within the app.
This updates the Note Preview and Note Detail components.

### Test

- Smoke test in light and dark mode
- Open a markdown test note [Example Content](https://gist.githubusercontent.com/sandymcfadden/d08e182d2206bcacaf9998724a95cc8d/raw/c0078c7fdfc0337412f377c57ae84452080043ad/simplenote-markdown-test.md)
- Compare between production and this branch
- View preview of the note
- Ensure the preview is still the same


### Release

- Updated the Note Preview and Note Detail components to use CSS variables for colors