### PR TITLE
Update the revision selector and slider components to use css variables for colors

### DIFF
--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -1,6 +1,7 @@
 .slider {
   @extend %smart-focus-outline;
 
+  background-color: var(--background-color);
   cursor: pointer;
   width: 100%;
   max-width: $max-content-width;
@@ -66,78 +67,38 @@
   }
 }
 
-body[data-theme='dark'] {
-  .slider {
-    // Track
-    &::-webkit-slider-runnable-track {
-      background: var(--primary-slider-color);
-    }
-    &::-moz-range-track {
-      background: var(--primary-slider-color);
-    }
-    &::-ms-track {
-      border-color: var(--primary-slider-color);
-    }
-    &::-ms-fill-lower {
-      background: var(--secondary-slider-color);
-    }
-    &::-ms-fill-upper {
-      background: var(--secondary-slider-color);
-    }
-
-    // Thumb
-    &::-webkit-slider-thumb {
-      border-color: var(--primary-slider-color);
-      background: var(--secondary-slider-color);
-      box-shadow: 0 1px 3px 0 var(--overlay-color);
-    }
-    &::-moz-range-thumb {
-      background: var(--secondary-slider-color);
-      border-color: var(--primary-slider-color);
-      box-shadow: 0 1px 3px 0 var(--overlay-color);
-    }
-    &::-ms-thumb {
-      border-color: var(--primary-slider-color);
-      background: var(--secondary-slider-color);
-      box-shadow: 0 1px 3px 0 var(--overlay-color);
-    }
+.slider {
+  // Track
+  &::-webkit-slider-runnable-track {
+    background: var(--primary-slider-color);
   }
-}
+  &::-moz-range-track {
+    background: var(--primary-slider-color);
+  }
+  &::-ms-track {
+    border-color: var(--primary-slider-color);
+  }
+  &::-ms-fill-lower {
+    background: var(--secondary-slider-color);
+  }
+  &::-ms-fill-upper {
+    background: var(--secondary-slider-color);
+  }
 
-body[data-theme='light'] {
-  .slider {
-    // Track
-    &::-webkit-slider-runnable-track {
-      background: var(--primary-slider-color);
-    }
-    &::-moz-range-track {
-      background: var(--primary-slider-color);
-    }
-    &::-ms-track {
-      border-color: var(--primary-slider-color);
-    }
-    &::-ms-fill-lower {
-      background: var(--secondary-slider-color);
-    }
-    &::-ms-fill-upper {
-      background: var(--secondary-slider-color);
-    }
-
-    // Thumb
-    &::-webkit-slider-thumb {
-      border-color: var(--primary-slider-color);
-      background: var(--secondary-slider-color);
-      box-shadow: 0 1px 3px 0 var(--overlay-color);
-    }
-    &::-moz-range-thumb {
-      background: var(--secondary-slider-color);
-      border-color: var(--primary-slider-color);
-      box-shadow: 0 1px 3px 0 var(--overlay-color);
-    }
-    &::-ms-thumb {
-      border-color: var(--primary-slider-color);
-      background: var(--secondary-slider-color);
-      box-shadow: 0 1px 3px 0 var(--overlay-color);
-    }
+  // Thumb
+  &::-webkit-slider-thumb {
+    border-color: var(--primary-slider-color);
+    background: var(--secondary-slider-color);
+    box-shadow: 0 1px 3px 0 var(--overlay-color);
+  }
+  &::-moz-range-thumb {
+    background: var(--secondary-slider-color);
+    border-color: var(--primary-slider-color);
+    box-shadow: 0 1px 3px 0 var(--overlay-color);
+  }
+  &::-ms-thumb {
+    border-color: var(--primary-slider-color);
+    background: var(--secondary-slider-color);
+    box-shadow: 0 1px 3px 0 var(--overlay-color);
   }
 }

--- a/lib/components/slider/style.scss
+++ b/lib/components/slider/style.scss
@@ -10,73 +10,20 @@
 
   // Track
   &::-webkit-slider-runnable-track {
+    background: var(--primary-slider-color);
     height: 4px;
     border-radius: 2px;
   }
   &::-moz-range-track {
+    background: var(--primary-slider-color);
     height: 3px;
     border-radius: 2px;
   }
   &::-ms-track {
+    border-color: var(--primary-slider-color);
     height: 3px;
     border-width: 7px 0;
     color: transparent;
-  }
-
-  // Thumb
-  &::-webkit-slider-thumb {
-    width: 15px;
-    height: 15px;
-    border-radius: 50%;
-    border: 2px solid;
-    appearance: none;
-    transition: 0.15s ease-in-out;
-    transform: translateY(calc(-50% + 2px));
-
-    &:active {
-      transform: translateY(calc(-50% + 2px)) scale(1.15);
-    }
-  }
-  &::-moz-range-thumb {
-    height: 15px;
-    width: 15px;
-    border-radius: 50%;
-    border: 1px solid;
-    appearance: none;
-    transition: 0.15s ease-in-out;
-
-    &:active {
-      transform: scale(1.15);
-    }
-  }
-  &::-ms-thumb {
-    width: 15px;
-    height: 15px;
-    border-radius: 50%;
-    border: 2px solid;
-    appearance: none;
-    transition: 0.15s ease-in-out;
-
-    &:active {
-      transform: scale(1.15);
-    }
-  }
-
-  &::-ms-tooltip {
-    display: none;
-  }
-}
-
-.slider {
-  // Track
-  &::-webkit-slider-runnable-track {
-    background: var(--primary-slider-color);
-  }
-  &::-moz-range-track {
-    background: var(--primary-slider-color);
-  }
-  &::-ms-track {
-    border-color: var(--primary-slider-color);
   }
   &::-ms-fill-lower {
     background: var(--secondary-slider-color);
@@ -87,18 +34,50 @@
 
   // Thumb
   &::-webkit-slider-thumb {
-    border-color: var(--primary-slider-color);
     background: var(--secondary-slider-color);
     box-shadow: 0 1px 3px 0 var(--overlay-color);
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    border: 2px solid var(--primary-slider-color);
+    appearance: none;
+    transition: 0.15s ease-in-out;
+    transform: translateY(calc(-50% + 2px));
+
+    &:active {
+      transform: translateY(calc(-50% + 2px)) scale(1.15);
+    }
   }
   &::-moz-range-thumb {
     background: var(--secondary-slider-color);
-    border-color: var(--primary-slider-color);
     box-shadow: 0 1px 3px 0 var(--overlay-color);
+    height: 15px;
+    width: 15px;
+    border-radius: 50%;
+    border: 1px solid var(--primary-slider-color);
+    appearance: none;
+    transition: 0.15s ease-in-out;
+
+    &:active {
+      transform: scale(1.15);
+    }
   }
   &::-ms-thumb {
-    border-color: var(--primary-slider-color);
     background: var(--secondary-slider-color);
     box-shadow: 0 1px 3px 0 var(--overlay-color);
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    border: 2px solid var(--primary-slider-color);
+    appearance: none;
+    transition: 0.15s ease-in-out;
+
+    &:active {
+      transform: scale(1.15);
+    }
+  }
+
+  &::-ms-tooltip {
+    display: none;
   }
 }

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -105,12 +105,9 @@ export class RevisionSelector extends Component<Props> {
       'MMM d, yyyy h:mm a'
     );
 
-    const mainClasses = classNames(
-      'revision-selector theme-color-border theme-color-fg theme-color-bg',
-      {
-        'is-visible': isViewingRevisions,
-      }
-    );
+    const mainClasses = classNames('revision-selector', {
+      'is-visible': isViewingRevisions,
+    });
 
     return (
       <FocusTrap

--- a/lib/revision-selector/style.scss
+++ b/lib/revision-selector/style.scss
@@ -1,5 +1,7 @@
 .revision-selector {
-  border-top: 1px solid;
+  background-color: var(--background-color);
+  border-top: 1px solid var(--secondary-color);
+  color: var(--primary-color);
   height: 178px;
   padding: 19px 20px 20px;
   position: relative;


### PR DESCRIPTION
### Fix

This is a continuation of moving to CSS variables for colors within the app.
This updates the Revision Selector and Slider components.

### Test

- Smoke test in light and dark mode
- Open the history for a note
- Compare between production and this branch

### Release

- Updated the Revision Selector and Slider components to use CSS variables for colors