### PR TITLE
Update the note info compontent to use css variables for colors

### DIFF
--- a/lib/note-info/index.tsx
+++ b/lib/note-info/index.tsx
@@ -37,7 +37,7 @@ export class NoteInfo extends Component<Props> {
     return (
       <Modal
         key="note-info-modal"
-        className="dialog-renderer__content note-info theme-color-border theme-color-bg theme-color-fg dialog"
+        className="dialog-renderer__content note-info dialog"
         contentLabel="Document"
         isOpen
         onRequestClose={onModalClose}
@@ -45,9 +45,9 @@ export class NoteInfo extends Component<Props> {
         portalClassName="dialog-renderer__portal"
         shouldCloseOnOverlayClick={false}
       >
-        <div className="note-info-panel note-info-stats theme-color-border theme-color-fg-dim">
-          <div className="note-info-header theme-color-border">
-            <h2 className="panel-title theme-color-fg">Document</h2>
+        <div className="note-info-panel note-info-stats">
+          <div className="note-info-header">
+            <h2 className="panel-title">Document</h2>
             <button
               type="button"
               aria-label="Close note info"
@@ -59,8 +59,8 @@ export class NoteInfo extends Component<Props> {
           </div>
           <p className="note-info-item">
             <span className="note-info-item-text">
-              <span className="note-info-name theme-color-fg">Last synced</span>
-              <span className="note-info-detail theme-color-fg-dim">
+              <span className="note-info-name">Last synced</span>
+              <span className="note-info-detail">
                 <LastSyncTime noteId={noteId} />
               </span>
             </span>
@@ -68,8 +68,8 @@ export class NoteInfo extends Component<Props> {
           {modificationDate && (
             <p className="note-info-item">
               <span className="note-info-item-text">
-                <span className="note-info-name theme-color-fg">Modified</span>
-                <span className="note-info-detail theme-color-fg-dim">
+                <span className="note-info-name">Modified</span>
+                <span className="note-info-detail">
                   <time dateTime={new Date(modificationDate).toISOString()}>
                     {new Date(modificationDate).toLocaleString([], {
                       year: 'numeric',
@@ -85,8 +85,8 @@ export class NoteInfo extends Component<Props> {
           )}
           <p className="note-info-item">
             <span className="note-info-item-text">
-              <span className="note-info-name theme-color-fg">Created</span>
-              <span className="note-info-detail theme-color-fg-dim">
+              <span className="note-info-name">Created</span>
+              <span className="note-info-detail">
                 <time dateTime={new Date(creationDate).toISOString()}>
                   {new Date(creationDate).toLocaleString([], {
                     year: 'numeric',
@@ -101,16 +101,16 @@ export class NoteInfo extends Component<Props> {
           </p>
           <p className="note-info-item">
             <span className="note-info-item-text">
-              <span className="note-info-name theme-color-fg">Words</span>
-              <span className="note-info-detail theme-color-fg-dim">
+              <span className="note-info-name">Words</span>
+              <span className="note-info-detail">
                 {wordCount(note.content)}
               </span>
             </span>
           </p>
           <p className="note-info-item">
             <span className="note-info-item-text">
-              <span className="note-info-name theme-color-fg">Characters</span>
-              <span className="note-info-detail theme-color-fg-dim">
+              <span className="note-info-name">Characters</span>
+              <span className="note-info-detail">
                 {characterCount(note.content)}
               </span>
             </span>

--- a/lib/note-info/reference.tsx
+++ b/lib/note-info/reference.tsx
@@ -39,10 +39,8 @@ export const Reference: FunctionComponent<Props> = ({
 
   return (
     <button className="reference-link" onClick={openNote}>
-      <span className="reference-title note-info-name theme-color-fg">
-        {reference.title}
-      </span>
-      <span className="theme-color-fg-dim">
+      <span className="reference-title note-info-name">{reference.title}</span>
+      <span>
         {reference.count} Reference{reference.count > 1 ? 's' : ''}
         {reference.modificationDate && ', last modified '}
         {reference.modificationDate && (

--- a/lib/note-info/references.tsx
+++ b/lib/note-info/references.tsx
@@ -20,9 +20,9 @@ export const References: FunctionComponent<Props> = ({ references }) => {
   }
 
   return (
-    <div className="note-references note-info-panel note-info-internal-link theme-color-border">
+    <div className="note-references note-info-panel note-info-internal-link">
       <div className="note-info-item">
-        <div className="note-info-name theme-color-fg-dim">Referenced In</div>
+        <div className="note-info-name">Referenced In</div>
         {references.map((noteId) => (
           <Reference noteId={noteId} key={noteId} />
         ))}

--- a/lib/note-info/style.scss
+++ b/lib/note-info/style.scss
@@ -1,4 +1,5 @@
 .note-info {
+  color: var(--primary-color);
   display: flex;
   flex-direction: column;
   width: 360px;
@@ -7,7 +8,7 @@
 
   .note-info-panel {
     flex: 0 0 auto;
-    border-bottom: 1px solid;
+    border-bottom: 1px solid var(--secondary-color);
     padding-bottom: 8px;
 
     &:last-child {
@@ -17,7 +18,7 @@
 
   .note-info-header {
     display: flex;
-    border-bottom: 1px solid;
+    border-bottom: 1px solid var(--secondary-color);
     padding: 12px 8px 12px 16px;
     margin-bottom: 8px;
     flex-direction: row;
@@ -43,6 +44,7 @@
     height: 28px;
 
     .note-info-detail {
+      color: var(--foreground-color);
       float: right;
       padding-right: 16px;
     }
@@ -60,6 +62,7 @@
     padding-bottom: 0;
 
     div.note-info-name {
+      color: var(--foreground-color);
       height: 28px;
       padding-left: 16px;
       line-height: 28px;
@@ -82,6 +85,7 @@
     padding-right: 16px;
 
     span {
+      color: var(--foreground-color);
       display: block;
       margin: 0;
       font-size: 13px;
@@ -92,21 +96,12 @@
     }
 
     .reference-title {
+      color: var(--primary-color);
       font-weight: 500;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
       font-size: 14px;
-    }
-  }
-}
-
-body[data-theme='dark'] {
-  .note-info {
-    .reference-link {
-      &:hover {
-        background-color: var(--secondary-color);
-      }
     }
   }
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -74,6 +74,7 @@ body[data-theme='dark'] {
   --secondary-accent-color: #50575e; // $studio-gray-60
   // highlight-color = $studio-simplenote-blue-50 with 40% opacity
   --highlight-color: rgba(51, 97, 204, 0.4);
+  --secondary-highlight-color: #2c3338; // $studio-gray-80
   --search-highlight-color: #3361cc; // $studio-simplenote-blue-50
   --search-selection-color: #deb100; // $studio-yellow-30
   --placeholder-color: #a7aaad; // $studio-gray-20


### PR DESCRIPTION
### Fix

This is a continuation of moving to CSS variables for colors within the app.
This updates the Note Info components.

### Test

- Smoke test in light and dark mode
- Have a note with references pointing to it
- Open the Note Info panel using the (i) icon in the upper right
- Compare between production and this branch
- Ensure the note info panel looks the same

### Release

- Updated the Note Info components to use CSS variables for colors