### PR TITLE
Update importer dialog to use css variables for colors

### DIFF
--- a/lib/dialogs/import/dropzone/index.tsx
+++ b/lib/dialogs/import/dropzone/index.tsx
@@ -111,7 +111,7 @@ function ImporterDropzone({
       {...getRootProps()}
       className={classnames(
         { 'is-accepted': acceptedFile },
-        'importer-dropzone theme-color-border'
+        'importer-dropzone'
       )}
     >
       <input {...getInputProps()} />

--- a/lib/dialogs/import/dropzone/style.scss
+++ b/lib/dialogs/import/dropzone/style.scss
@@ -5,8 +5,7 @@
   justify-content: center;
   align-items: center;
   padding: 16px;
-  border-width: 2px;
-  border-style: dashed;
+  border: 2px dashed var(--disabled-text-color);
   transition: padding 0.2s ease-out, background 0.2s ease-out;
   text-align: center;
   color: var(--foreground-color);
@@ -82,7 +81,7 @@
     margin-top: 8px;
 
     span {
-      color: var(--primary-branding-color);
+      color: var(--accent-color);
     }
   }
 }
@@ -91,37 +90,4 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-}
-
-body[data-theme='dark'] {
-  .importer-dropzone.theme-color-border {
-    border-color: var(--tertiary-color);
-    color: var(--foreground-color);
-  }
-  .importer-dropzone {
-    .drop-instructions {
-      span {
-        color: var(--accent-color);
-      }
-    }
-    &.is-accepted {
-      ul {
-        border-color: var(--secondary-color);
-      }
-
-      li {
-        color: var(--primary-color);
-      }
-
-      svg {
-        fill: var(--foreground-color);
-      }
-
-      .error-message {
-        li {
-          color: var(--foreground-color);
-        }
-      }
-    }
-  }
 }

--- a/lib/dialogs/import/source-importer/executor/index.tsx
+++ b/lib/dialogs/import/source-importer/executor/index.tsx
@@ -115,7 +115,7 @@ class ImportExecutor extends Component<Props> {
               disabled={locked}
             />
           </label>
-          {hint && <p className="theme-color-fg-dim">{hint}</p>}
+          {hint && <p className="hint">{hint}</p>}
         </section>
         <TransitionFadeInOut shouldMount={Boolean(errorMessage)}>
           <div role="alert" className="source-importer-executor__error">

--- a/lib/dialogs/import/source-importer/executor/style.scss
+++ b/lib/dialogs/import/source-importer/executor/style.scss
@@ -22,6 +22,7 @@
   flex: 1 0 auto;
 
   .panel-title {
+    color: var(--foreground-color);
     text-transform: none;
     font-weight: normal;
     font-size: 14px;
@@ -38,6 +39,7 @@
   }
 
   .enable-markdown {
+    color: var(--primary-color);
     flex: 1 1 auto;
     line-height: 28px;
   }
@@ -67,15 +69,5 @@
     font-size: 14px;
     border: 0;
     font-weight: 400;
-  }
-}
-
-body[data-theme='dark'] {
-  .source-importer-executor {
-    .source-importer-executor__options {
-      label {
-        border-color: var(--secondary-color);
-      }
-    }
   }
 }


### PR DESCRIPTION
### Fix

This is a continuation of moving to CSS variables for colors within the app.
This updates the Import Dialog components. 

### Test

- Smoke test in light and dark mode
- Compare between production and this branch
- Open the note importer
- Ensure it still looks the same
- Go through the process of importing notes
- Ensure everything still appears the same

### Release

- Updated the Importer dialog components to use CSS variables for colors
