### PR TITLE
Update App Layout and Note Revisions components to use CSS variables for colors

### DIFF
--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -124,17 +124,14 @@ export class AppLayout extends Component<Props> {
           <aside
             aria-hidden={hiddenByRevisions}
             aria-label="Notes list"
-            className="app-layout__source-column theme-color-bg theme-color-fg"
+            className="app-layout__source-column"
           >
             <MenuBar />
             <SearchField />
             <NoteList />
           </aside>
           {editorVisible && (
-            <main
-              aria-label="Note editor"
-              className="app-layout__note-column theme-color-bg theme-color-fg theme-color-border"
-            >
+            <main aria-label="Note editor" className="app-layout__note-column">
               <NoteToolbar aria-hidden={hiddenByRevisions} />
               {showRevisions ? (
                 <NoteRevisions

--- a/lib/app-layout/style.scss
+++ b/lib/app-layout/style.scss
@@ -134,7 +134,7 @@
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
-  border-left: 1px solid;
+  border-left: 1px solid var(--secondary-color);
 
   @media only screen and (max-width: $single-column) {
     position: absolute;

--- a/lib/note-revisions/style.scss
+++ b/lib/note-revisions/style.scss
@@ -1,4 +1,5 @@
 .note-revisions {
+  background-color: var(--background-color);
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;


### PR DESCRIPTION
### Fix

This is a continuation of moving to CSS variables for colors within the app.
This updates the App Layout and Note Revisions components.

### Test

- Smoke test in light and dark mode
- Compare between production and this branch
- Ensure the main layout of the app still appears the same
- Open note history
- Ensure the main content still appears the same 

### Release

- Updated the App Layout and Note Revision components to use CSS variables for colors
