### PR TITLE
Remove unused hint from importer

### DIFF
--- a/lib/dialogs/import/source-importer/executor/index.tsx
+++ b/lib/dialogs/import/source-importer/executor/index.tsx
@@ -19,9 +19,6 @@ type OwnProps = {
   locked: boolean;
   onClose: Function;
   onStart: Function;
-  source: {
-    optionsHint: string;
-  };
 };
 
 type DispatchProps = {
@@ -91,7 +88,6 @@ class ImportExecutor extends Component<Props> {
 
   render() {
     const { endValue, locked, onClose } = this.props;
-    const { optionsHint: hint } = this.props.source;
     const {
       errorMessage,
       finalNoteCount,
@@ -115,7 +111,6 @@ class ImportExecutor extends Component<Props> {
               disabled={locked}
             />
           </label>
-          {hint && <p className="hint">{hint}</p>}
         </section>
         <TransitionFadeInOut shouldMount={Boolean(errorMessage)}>
           <div role="alert" className="source-importer-executor__error">

--- a/lib/dialogs/import/source-importer/index.tsx
+++ b/lib/dialogs/import/source-importer/index.tsx
@@ -23,7 +23,7 @@ class SourceImporter extends React.Component {
   };
 
   render() {
-    const { buckets, onClose, onStart, locked = false, source } = this.props;
+    const { buckets, onClose, onStart, locked = false } = this.props;
     const { acceptedTypes, instructions, title } = this.props.source;
     const { acceptedFiles } = this.state;
 
@@ -66,7 +66,6 @@ class SourceImporter extends React.Component {
             locked={locked}
             onClose={onClose}
             onStart={onStart}
-            source={source}
           />
         </TransitionFadeInOut>
       </div>


### PR DESCRIPTION
### Fix

This removes an unused hint option that was included in the importer dialogs. It came to light in [this comment](https://github.com/Automattic/simplenote-electron/pull/3023#discussion_r716749274).

### Test

- Attempt to import some notes
- Ensure the import works as expected

### Release

- Removed unused hint option in the importer dialog
