### PR TITLE
Add handling of 429 HTTP errors on authentication

### DIFF
--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -17,6 +17,7 @@ type OwnProps = {
   hasInsecurePassword: boolean;
   hasInvalidCredentials: boolean;
   hasLoginError: boolean;
+  hasTooManyRequests: boolean;
   hasUnverifiedAccount: boolean;
   login: (username: string, password: string) => any;
   requestSignup: (username: string) => any;
@@ -198,6 +199,14 @@ export class Auth extends Component<Props> {
                 update your password
               </a>{' '}
               before being able to log in again.
+            </p>
+          )}
+          {this.props.hasTooManyRequests && (
+            <p
+              className="login__auth-message is-error"
+              data-error-name="too-many-requests"
+            >
+              Too many log in attempts. Try again later.
             </p>
           )}
           {(this.props.hasInvalidCredentials || this.props.hasLoginError) && (

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -26,7 +26,8 @@ type State = {
     | 'insecure-password'
     | 'invalid-credentials'
     | 'unknown-error'
-    | 'verification-required';
+    | 'verification-required'
+    | 'too-many-requests';
   emailSentTo: string;
   showAbout: boolean;
 };
@@ -111,6 +112,8 @@ class AppWithoutAuth extends Component<Props, State> {
             this.setState({ authStatus: 'compromised-password' });
           } else if ('verification required' === message) {
             this.setState({ authStatus: 'verification-required' });
+          } else if ('too many requests' === message) {
+            this.setState({ authStatus: 'too-many-requests' });
           } else {
             this.setState({ authStatus: 'unknown-error' });
           }
@@ -171,6 +174,7 @@ class AppWithoutAuth extends Component<Props, State> {
             hasUnverifiedAccount={
               this.state.authStatus === 'verification-required'
             }
+            hasTooManyRequests={this.state.authStatus === 'too-many-requests'}
             hasLoginError={this.state.authStatus === 'unknown-error'}
             login={this.authenticate}
             tokenLogin={this.tokenLogin}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18691,8 +18691,9 @@
       "dev": true
     },
     "simperium": {
-      "version": "github:Automattic/node-simperium#e5474ed3b9629eb55e3f2464bc849675eeaebd24",
-      "from": "github:Automattic/node-simperium#e5474ed3b9629eb55e3f2464bc849675eeaebd24",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/simperium/-/simperium-1.1.4.tgz",
+      "integrity": "sha512-f3Xe5BUU8/Hy93eBiALRFyKk1gD6S8gBPYUmSsbibyhRyLRajlailsLAqao8Z0dEOf1eC67zglxTTJYd5QG7zQ==",
       "requires": {
         "@babel/polyfill": "7.7.0",
         "events": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18691,8 +18691,8 @@
       "dev": true
     },
     "simperium": {
-      "version": "github:Automattic/node-simperium#1c727522cd33e116b11f0929e485adfc5496ec49",
-      "from": "github:Automattic/node-simperium#1c727522cd33e116b11f0929e485adfc5496ec49",
+      "version": "github:Automattic/node-simperium#e5474ed3b9629eb55e3f2464bc849675eeaebd24",
+      "from": "github:Automattic/node-simperium#e5474ed3b9629eb55e3f2464bc849675eeaebd24",
       "requires": {
         "@babel/polyfill": "7.7.0",
         "events": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8752,9 +8752,9 @@
       }
     },
     "ext": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.5.0.tgz",
-      "integrity": "sha512-+ONcYoWj/SoQwUofMr94aGu05Ou4FepKi7N7b+O8T4jVfyIsZQV1/xeS8jpaBzF0csAk0KLXoHCxU7cKYZjo1Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
       "requires": {
         "type": "^2.5.0"
       },
@@ -18691,9 +18691,8 @@
       "dev": true
     },
     "simperium": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/simperium/-/simperium-1.1.3.tgz",
-      "integrity": "sha512-fp6djg0JGCnTC80yiPNbsSTKsJA0WeBXQdClFuCFAp1KFUHWU8Fnyg7Cx4Zio14F1TW4IYSsCNBYZdffD4gUcw==",
+      "version": "github:Automattic/node-simperium#1c727522cd33e116b11f0929e485adfc5496ec49",
+      "from": "github:Automattic/node-simperium#1c727522cd33e116b11f0929e485adfc5496ec49",
       "requires": {
         "@babel/polyfill": "7.7.0",
         "events": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "sax": "1.2.4",
     "semver": "7.3.2",
     "showdown": "1.9.1",
-    "simperium": "github:Automattic/node-simperium#e5474ed3b9629eb55e3f2464bc849675eeaebd24",
+    "simperium": "1.1.4",
     "string-replace-to-array": "1.0.3",
     "turndown": "6.0.0",
     "unorm": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "sax": "1.2.4",
     "semver": "7.3.2",
     "showdown": "1.9.1",
-    "simperium": "1.1.3",
+    "simperium": "github:Automattic/node-simperium#1c727522cd33e116b11f0929e485adfc5496ec49",
     "string-replace-to-array": "1.0.3",
     "turndown": "6.0.0",
     "unorm": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "sax": "1.2.4",
     "semver": "7.3.2",
     "showdown": "1.9.1",
-    "simperium": "github:Automattic/node-simperium#1c727522cd33e116b11f0929e485adfc5496ec49",
+    "simperium": "github:Automattic/node-simperium#e5474ed3b9629eb55e3f2464bc849675eeaebd24",
     "string-replace-to-array": "1.0.3",
     "turndown": "6.0.0",
     "unorm": "1.6.0",


### PR DESCRIPTION
### Fix

There are times when rate limiting will be applied when trying to login multiple times unsuccessfully causing future login attempts to fail as well. Currently, there is no way to show this in the app leaving things confusing if you get rate limited. This updates to handle that error case when logging in.

To do this it also includes an update to the Simperium dependency. It is right now a temporary package for testing.

<img width="491" alt="Screen Shot 2021-09-30 at 1 01 12 PM" src="https://user-images.githubusercontent.com/1326294/135490549-6d72506a-00fd-4474-8d97-735203c74e1b.png">


### Test

In addition to the steps below, please ensure that syncing, publishing, and other features work as expected.

1. Attempt to log in with valid credentials and ensure login is successful
2. Attempt to log in with a compromised password and ensure it is unsuccessful
3. Attempt to log in with an unverified account and ensure it is unsuccessful
4. Attempt to log in multiple more times with invalid credentials.
5. Ensure you are not able to log in and get the appropriate error message "Too many log in attempts. Try again later."

### Release

- Updated to handle too many login attempts during authentication
