### PR TITLE
Use HTTPS protocol over HTTP for  links

### DIFF
--- a/lib/navigation-bar/index.tsx
+++ b/lib/navigation-bar/index.tsx
@@ -57,7 +57,7 @@ export class NavigationBar extends Component<Props> {
     }
   };
 
-  onHelpClicked = () => viewExternalUrl('http://simplenote.com/help');
+  onHelpClicked = () => viewExternalUrl('https://simplenote.com/help');
 
   onSelectTrash = () => {
     this.props.selectTrash();

--- a/lib/note-actions/index.tsx
+++ b/lib/note-actions/index.tsx
@@ -62,7 +62,7 @@ export class NoteActions extends Component<Props> {
   };
 
   getPublishURL = (url: string | undefined) => {
-    return isEmpty(url) ? null : `http://simp.ly/p/${url}`;
+    return isEmpty(url) ? null : `https://simp.ly/p/${url}`;
   };
 
   render() {

--- a/lib/utils/export/README.md
+++ b/lib/utils/export/README.md
@@ -13,39 +13,37 @@ This archive contains each note as its own file with a generated filename and th
 
 ```json
 {
-  "activeNotes": [ {
-    "id": "some-auto-generated-id",
-    "content": "Simplenote is so simple! I love it.",
-    "creationDate": "2016-11-18T23:28:42.957Z",
-    "lastModified": "2016-12-22T21:59:36.623Z"
-  }, {
-    "id": "some-auto-generated-id-that-is-unique",
-    "content": "This note can be accessed from a secret URL",
-    "creationDate": "2016-07-02T07:24:22.699Z",
-    "lastModified": "2016-11-29T16:55:49.890Z",
-    "publicURL": "http://simp.ly/p/short-url-string"
-  }, {
-    "id": "some-auto-generated-id-again",
-    "content": "Sharing is caring",
-    "creationDate": "2016-10-01T08:40:33.968Z",
-    "lastModified": "2016-10-30T01:57:56.050Z",
-    "tags": [
-      "reminders",
-      "people"
-    ],
-    "collaboratorEmails": [
-      "prince@example.com",
-      "pauper@example.com"
-    ]
-  } ],
-  "trashedNotes": [ {
-    "id": "some-different-auto-generated-id",
-    "content": "This note is no longer relevant",
-    "creationDate": "2015-11-18T10:13:42.138Z",
-    "lastModified": "2016-01-13T14:03:33.583Z",
-    "tags": [
-      "the departed"
-    ]
-  } ]
+  "activeNotes": [
+    {
+      "id": "some-auto-generated-id",
+      "content": "Simplenote is so simple! I love it.",
+      "creationDate": "2016-11-18T23:28:42.957Z",
+      "lastModified": "2016-12-22T21:59:36.623Z"
+    },
+    {
+      "id": "some-auto-generated-id-that-is-unique",
+      "content": "This note can be accessed from a secret URL",
+      "creationDate": "2016-07-02T07:24:22.699Z",
+      "lastModified": "2016-11-29T16:55:49.890Z",
+      "publicURL": "https://simp.ly/p/short-url-string"
+    },
+    {
+      "id": "some-auto-generated-id-again",
+      "content": "Sharing is caring",
+      "creationDate": "2016-10-01T08:40:33.968Z",
+      "lastModified": "2016-10-30T01:57:56.050Z",
+      "tags": ["reminders", "people"],
+      "collaboratorEmails": ["prince@example.com", "pauper@example.com"]
+    }
+  ],
+  "trashedNotes": [
+    {
+      "id": "some-different-auto-generated-id",
+      "content": "This note is no longer relevant",
+      "creationDate": "2015-11-18T10:13:42.138Z",
+      "lastModified": "2016-01-13T14:03:33.583Z",
+      "tags": ["the departed"]
+    }
+  ]
 }
 ```

--- a/lib/utils/export/export-notes.ts
+++ b/lib/utils/export/export-notes.ts
@@ -27,7 +27,7 @@ const exportNotes = (notes: Map<T.EntityId, T.Note>) => {
       tags.length && { tags },
       note.systemTags.includes('published') &&
         note?.publishURL && {
-          publicURL: `http://simp.ly/p/${note.publishURL}`,
+          publicURL: `https://simp.ly/p/${note.publishURL}`,
         },
       note.systemTags.includes('shared') &&
         collaboratorEmails.length && { collaboratorEmails }


### PR DESCRIPTION
### Fix

Generate public note url with HTTPS instead of unsecured HTTP protocol
Use HTTPS for external help link

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1. Create a note
2. Publish the note
3. Copy the url : it starts with `http://simp.ly`

### Release

Generate public note url with HTTPS instead of unsecured HTTP protocol
