### PR TITLE
GitHub issue templates: add note that github issues are public

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -6,7 +6,7 @@ labels: bug
 assignees: ""
 ---
 
-<!-- IMPORTANT NOTE: Do not share any private information here. GitHub issues are public, including any information uploaded to this report. For assistance troubleshooting account-related questions, please contact us at support@simplenote.com. -->
+<!-- IMPORTANT NOTE: Do not share any private information here. GitHub issues are public, including any screenshots or files uploaded to this issue. For assistance troubleshooting account-related questions, please contact us at support@simplenote.com. -->
 
 <!-- Please, be as descriptive as possible.  Issues lacking detail, or for any other reason than to report a bug, may be closed without action. -->
 

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -6,6 +6,8 @@ labels: bug
 assignees: ""
 ---
 
+<!-- IMPORTANT NOTE: Do not share any private information here. GitHub issues are public, including any information uploaded to this report. For assistance troubleshooting account-related questions, please contact us at support@simplenote.com. -->
+
 <!-- Please, be as descriptive as possible.  Issues lacking detail, or for any other reason than to report a bug, may be closed without action. -->
 
 ### Expected

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -6,7 +6,7 @@ labels: feature request
 assignees: ""
 ---
 
-<!-- IMPORTANT NOTE: Do not share any private information here. GitHub issues are public, including any information uploaded to this report. For assistance troubleshooting account-related questions, please contact us at support@simplenote.com. -->
+<!-- IMPORTANT NOTE: Do not share any private information here. GitHub issues are public, including any screenshots or files uploaded to this issue. For assistance troubleshooting account-related questions, please contact us at support@simplenote.com. -->
 
 <!-- Please, be as descriptive as possible.  Issues lacking detail, or for any other reason than to request a feature, may be closed without action. -->
 

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -6,6 +6,8 @@ labels: feature request
 assignees: ""
 ---
 
+<!-- IMPORTANT NOTE: Do not share any private information here. GitHub issues are public, including any information uploaded to this report. For assistance troubleshooting account-related questions, please contact us at support@simplenote.com. -->
+
 <!-- Please, be as descriptive as possible.  Issues lacking detail, or for any other reason than to request a feature, may be closed without action. -->
 
 ### What


### PR DESCRIPTION
### Fix

Folks don't always realize information shared here is public. Maybe this will help.

