### PR TITLE
Fixed app start up issue on Linux (Ubuntu)

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -39,7 +39,7 @@ module.exports = function main() {
 
   // Fixes rendering bug on Linux when sandbox === true (Electron 11.0)
   if (process.platform === 'linux') {
-    app.disableHardwareAcceleration();
+    app.commandLine.appendSwitch('disable-gpu-sandbox'); 
   }
 
   app.on('will-finish-launching', function () {


### PR DESCRIPTION
### Fix
App would not start on Ubuntu 22.04 because of GPU sandbox. This appears to be a problem with chromium and adding the flag --disable-gpu-sandbox fixes it. This fixes #3155 and #3149.

P.S. If you want me to add back the ```app.disableHardwareAcceleration();``` just let me know, but I assume that because the sandbox required that line it won't be necessary any more with the GPU sand box disabled. This assumption holds true on my machine but again if you want that line back just let me know.

### Test
1. Install on Ubuntu 22.04
2. Open app

### Release
Fixed but preventing start up on Ubuntu Linux systems.
