### PR TITLE
Fix monaco recursion error

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -411,10 +411,11 @@ class NoteContentEditor extends Component<Props> {
     this.props.storeNumberOfMatchesInNote(this.matchesInNote.length);
     const titleDecoration = this.getTitleDecoration() ?? [];
 
-    this.decorations = this.editor.deltaDecorations(this.decorations, [
-      ...this.matchesInNote,
-      ...titleDecoration,
-    ]);
+    const decorationsCollection = this.editor?.getModel()?.decorations;
+    this.decorations = decorationsCollection?.changeDecorations(
+      this.decorations,
+      [...this.matchesInNote, ...titleDecoration]
+    );
   };
 
   getTitleDecoration = () => {
@@ -1175,7 +1176,8 @@ class NoteContentEditor extends Component<Props> {
       newDecorations.push(decoration);
     });
 
-    this.decorations = this.editor.deltaDecorations(
+    const decorationsCollection = this.editor?.getModel()?.decorations;
+    this.decorations = decorationsCollection?.changeDecorations(
       this.decorations,
       newDecorations
     );


### PR DESCRIPTION
### Fix
The latest Monaco was not happy with a recursive call: `Invoking deltaDecorations recursively could lead to leaking decorations.` I've replaced it with `changeDecorations` which I think is the same thing under the hood 🤷. But it removes the error :)

### Test
1. On web or electron, edit a task list. You should not see any errors about the recursion.
2. In electron only, press cmd+g to search notes, press it again a few times. It should work and no recursion errors should be in the console.
