### PR TITLE
Experiment with overriding the menu with css.

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1243,6 +1243,7 @@ class NoteContentEditor extends Component<Props> {
               selectionHighlight: false,
               suggestOnTriggerCharacters: true,
               unusualLineTerminators: 'auto',
+              useShadowDOM: false,
               wordWrap: 'bounded',
               wordWrapColumn: 400,
               wrappingStrategy: isSafari ? 'simple' : 'advanced',

--- a/lib/note-editor/style.scss
+++ b/lib/note-editor/style.scss
@@ -5,4 +5,23 @@
   user-select: text;
   padding-top: 40px;
   background-color: var(--background-color);
+
+  // Hack: this hides the "Command Pallette" menu item
+  .monaco-menu .monaco-action-bar .actions-container li:last-of-type {
+    display: none;
+  }
+
+  // Monaco overrides, accessible through `useShadowDOM:false` setting
+  .monaco-menu-container {
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.2);
+
+    .monaco-menu {
+      background-color: #3c3c3c;
+      color: #fff;
+
+      li:hover:not(.disabled) {
+        background-color: var(--tertiary-accent-color);
+      }
+    }
+  }
 }

--- a/lib/note-editor/style.scss
+++ b/lib/note-editor/style.scss
@@ -6,7 +6,7 @@
   padding-top: 40px;
   background-color: var(--background-color);
 
-  // Hack: this hides the "Command Pallette" menu item
+  // Hack: this hides the "Command Palette" menu item
   .monaco-menu .monaco-action-bar .actions-container li:last-of-type {
     display: none;
   }


### PR DESCRIPTION
Enables the `useShadowDOM` flag, and tweaks the menu with CSS to add styling and remove the last menu item.

<img width="321" alt="Screenshot 2024-04-18 at 4 54 47 PM" src="https://github.com/Automattic/simplenote-electron/assets/789137/d5c69cd2-3914-4695-8279-27cb53e77f2d">

**To Test**
* Right-click on web and electron in light and dark mode.
* The "Command Palette" menu should be gone.
* The menu should look nice and work :)