### PR TITLE
Implements collaboration deprecation notice

### DIFF
--- a/lib/dialogs/settings/style.scss
+++ b/lib/dialogs/settings/style.scss
@@ -84,3 +84,17 @@
     }
   }
 }
+
+.collab_notice {
+  color: var(--primary-button-fg-color);
+  background-color: var(--primary-branding-color);
+  text-align: center;
+  border-radius: 8px;
+  padding: 10px;
+  margin-bottom: 30px;
+}
+
+.collab_notice a {
+  color: var(--primary-button-fg-color);
+  text-decoration: none;
+}

--- a/lib/dialogs/share/index.tsx
+++ b/lib/dialogs/share/index.tsx
@@ -74,9 +74,12 @@ export class ShareDialog extends Component<Props> {
         <div className="tab-panels__panel">
           <div className="tab-panels__column">
             <div className="settings-group">
-              <p>
-                Add an email address of another Simplenote user to share a note.
-                You&apos;ll both be able to edit and view the note.
+              <p className="collab_notice">
+                <a href="https://simplenote.com/2024/05/01/collaboration-feature-retirement" target="_blank">
+                  Collaboration is retiring on July 1st, 2024.
+                  <br />
+                  For more details, click here.
+                </a>
               </p>
               <div className="settings-items">
                 <form


### PR DESCRIPTION
### Fix
<!--
**_(Required)_** Add a concise description of what you fixed. If this is related 
to an issue, add a link to it. If applicable, add screenshots, animations, or
videos to help illustrate the fix.
-->

### Test
1. Log into your account
2. Click on any note
3. Click on the top right `(...)` button
4. Click on `Collaborate`

- [ ] Verify the new Collaboration Deprecation Notice is presented

### Screenshots:

Light | Dark
-|-
<img width="400" src="https://github.com/Automattic/simplenote-electron/assets/1195260/2e45bc7e-9b0a-4413-b4ba-d55d9d18a7b4"> | <img width="400" src="https://github.com/Automattic/simplenote-electron/assets/1195260/20a6b68a-6e37-4725-90e2-724c81483a65">


### Release
Implements the new Collaboration Deprecation Notice