### PR TITLE
Fix: Adjust word wrap strategy in Safari

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1214,7 +1214,7 @@ class NoteContentEditor extends Component<Props> {
               unusualLineTerminators: 'auto',
               wordWrap: 'bounded',
               wordWrapColumn: 400,
-              wrappingStrategy: isSafari ? 'simple' : 'advanced',
+              wrappingStrategy: 'advanced',
             }}
             value={content}
           />


### PR DESCRIPTION
### Fix

We initially set the word-wrap option in Safari to "simple" rather than "advanced" because we [noted performance issues](https://github.com/Automattic/simplenote-electron/pull/2297#pullrequestreview-474047898) with it. In some brief testing, it looks to me like the performance issues are now mitigated, so we can fix the line wrapping in Safari. Putting this in its own PR in case we do find that it causes issues.

Will fix #2805 

### Test

Open some long notes in Safari and verify that word wrap is no longer awkwardly early and also that it does not freeze the browser or cause long load times.