### PR TITLE
Fix up editor padding and Safari right-click behavior

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -977,7 +977,10 @@ class NoteContentEditor extends Component<Props> {
     });
 
     editor.onMouseDown((event: Editor.IEditorMouseEvent) => {
-      if((event.event.ctrlKey && event.event.leftButton) || event.event.rightButton) {
+      if (
+        (event.event.ctrlKey && event.event.leftButton) ||
+        event.event.rightButton
+      ) {
         // ignore right clicks and OSX trackpad right clicks (ctrl+click)
         return;
       }
@@ -1206,15 +1209,18 @@ class NoteContentEditor extends Component<Props> {
         onClick={(e: React.MouseEvent) => {
           // click was on the editor body, let the editor handle it
           const target = e.target as HTMLDivElement;
-          if(target.classList.contains('view-line') || target.classList.contains('view-lines')) {
+          if (
+            target.classList.contains('view-line') ||
+            target.classList.contains('view-lines')
+          ) {
             return;
           }
 
           // it was a fake (trackpad) right click, ignore it
-          if(e.ctrlKey) {
+          if (e.ctrlKey) {
             // TODO it would be nice if we could trigger the context menu from the left gutter :/
             return;
-         }
+          }
           this.focusEditor();
         }}
       >
@@ -1248,7 +1254,7 @@ class NoteContentEditor extends Component<Props> {
               hideCursorInOverviewRuler: true,
               fontSize: 16,
               guides: { indentation: false },
-              lineDecorationsWidth: editorPadding, /* hack for left padding */
+              lineDecorationsWidth: editorPadding /* hack for left padding */,
               lineHeight: 24,
               lineNumbers: 'off',
               links: true,
@@ -1257,7 +1263,7 @@ class NoteContentEditor extends Component<Props> {
               multiCursorLimit: 1,
               occurrencesHighlight: 'off',
               overviewRulerBorder: false,
-              padding: { 'top': 40, 'bottom': 0 },
+              padding: { top: 40, bottom: 0 },
               quickSuggestions: false,
               renderControlCharacters: false,
               renderLineHighlight: 'none',
@@ -1265,7 +1271,8 @@ class NoteContentEditor extends Component<Props> {
               scrollbar: {
                 horizontal: 'hidden',
                 useShadows: false,
-                verticalScrollbarSize: editorPadding, /* hack for right padding */
+                verticalScrollbarSize:
+                  editorPadding /* hack for right padding */,
               },
               scrollBeyondLastLine: false,
               selectionHighlight: false,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -977,6 +977,10 @@ class NoteContentEditor extends Component<Props> {
     });
 
     editor.onMouseDown((event: Editor.IEditorMouseEvent) => {
+      if((event.event.ctrlKey && event.event.leftButton) || event.event.rightButton) {
+        // ignore right clicks and OSX trackpad right clicks (ctrl+click)
+        return;
+      }
       const { editNote, noteId } = this.props;
       const { content } = this.state;
       const {
@@ -1199,7 +1203,20 @@ class NoteContentEditor extends Component<Props> {
         className={`note-content-editor-shell${
           overTodo ? ' cursor-pointer' : ''
         }`}
-        onClick={this.focusEditor}
+        onClick={(e: React.MouseEvent) => {
+          // click was on the editor body, let the editor handle it
+          const target = e.target as HTMLDivElement;
+          if(target.classList.contains('view-line') || target.classList.contains('view-lines')) {
+            return;
+          }
+
+          // it was a fake (trackpad) right click, ignore it
+          if(e.ctrlKey) {
+            // TODO it would be nice if we could trigger the context menu from the left gutter :/
+            return;
+         }
+          this.focusEditor();
+        }}
       >
         <div
           className={`note-content-plaintext${

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1231,7 +1231,7 @@ class NoteContentEditor extends Component<Props> {
               hideCursorInOverviewRuler: true,
               fontSize: 16,
               guides: { indentation: false },
-              lineDecorationsWidth: editorPadding,
+              lineDecorationsWidth: editorPadding, /* hack for left padding */
               lineHeight: 24,
               lineNumbers: 'off',
               links: true,
@@ -1240,15 +1240,19 @@ class NoteContentEditor extends Component<Props> {
               multiCursorLimit: 1,
               occurrencesHighlight: 'off',
               overviewRulerBorder: false,
+              padding: { 'top': 40, 'bottom': 0 },
               quickSuggestions: false,
+              renderControlCharacters: false,
               renderLineHighlight: 'none',
+              renderWhitespace: 'none',
               scrollbar: {
                 horizontal: 'hidden',
                 useShadows: false,
-                verticalScrollbarSize: editorPadding,
+                verticalScrollbarSize: editorPadding, /* hack for right padding */
               },
               scrollBeyondLastLine: false,
               selectionHighlight: false,
+              showFoldingControls: 'never',
               suggestOnTriggerCharacters: true,
               unicodeHighlight: {
                 ambiguousCharacters: false,

--- a/lib/note-editor/style.scss
+++ b/lib/note-editor/style.scss
@@ -3,6 +3,5 @@
   flex-direction: column;
   flex: 1 0 auto;
   user-select: text;
-  padding-top: 40px;
   background-color: var(--background-color);
 }


### PR DESCRIPTION
### Fix

When testing the context menu fixes, I noticed that I wasn't able to display the right-click menu in Safari, though it worked in Electron and other browsers. It would flicker for a moment and then vanish again.

I don't have a real mouse and use ctrl+tap on my trackpad to right click. It turns out that this does not create a "true" right click event, and was therefore being erroneously picked up by the click and mousedown handlers.

In the process of fixing this I found a few opportunities to clean up the padding, though there is sadly no official way to add left/right padding via Monaco. I also tested and fixed the word-wrap setting in Safari in a separate PR, #3191 .

### Test

In multiple browsers and on Electron:
* Click in various places on the editor and verify that it focuses the text editor.
* Right-click (with various mice if possible?) and verify that the context menu is shown appropriately.

n.b. We do not show the context menu after a right-click on the left gutter, because we are tricking Monaco into putting padding there by abusing the lineDecorationsWidth option.