### PR TITLE
Update: react-monaco-editor and the hooks issue

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -186,20 +186,6 @@ class NoteContentEditor extends Component<Props> {
 
   componentDidMount() {
     const { noteId } = this.props;
-    // this.bootTimer = setTimeout(() => {
-    //   if (noteId === this.props.noteId) {
-    //     this.setState({
-    //       editor: 'full',
-    //       content: withCheckboxCharacters(this.props.note.content),
-    //     });
-    //     const position = getNotePosition(noteId);
-    //     if (position) {
-    //       this.editor?.setScrollPosition({
-    //         scrollTop: position,
-    //       });
-    //     }
-    //   }
-    // }, SPEED_DELAY);
     window.addEventListener('resize', clearNotePositions);
     window.addEventListener('toggleChecklist', this.handleChecklist, true);
     this.toggleShortcuts(true);
@@ -615,12 +601,12 @@ class NoteContentEditor extends Component<Props> {
     this.props.storeHasFocus(this.hasFocus);
 
     this.bootTimer = setTimeout(() => {
-        const position = getNotePosition(this.props.noteId);
-        if (position) {
-          this.editor?.setScrollPosition({
-            scrollTop: position,
-          });
-        }
+      const position = getNotePosition(this.props.noteId);
+      if (position) {
+        this.editor?.setScrollPosition({
+          scrollTop: position,
+        });
+      }
     }, SPEED_DELAY);
 
     monaco.languages.registerLinkProvider('plaintext', {

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -186,23 +186,20 @@ class NoteContentEditor extends Component<Props> {
 
   componentDidMount() {
     const { noteId } = this.props;
-    this.bootTimer = setTimeout(() => {
-      if (noteId === this.props.noteId) {
-        this.setState({
-          editor: 'full',
-          content: withCheckboxCharacters(this.props.note.content),
-        });
-        const position = getNotePosition(noteId);
-        if (position) {
-          this.editor?.setScrollPosition({
-            scrollTop: position,
-          });
-        }
-      }
-    }, SPEED_DELAY);
-    this.focusEditor();
-    this.props.storeFocusEditor(this.focusEditor);
-    this.props.storeHasFocus(this.hasFocus);
+    // this.bootTimer = setTimeout(() => {
+    //   if (noteId === this.props.noteId) {
+    //     this.setState({
+    //       editor: 'full',
+    //       content: withCheckboxCharacters(this.props.note.content),
+    //     });
+    //     const position = getNotePosition(noteId);
+    //     if (position) {
+    //       this.editor?.setScrollPosition({
+    //         scrollTop: position,
+    //       });
+    //     }
+    //   }
+    // }, SPEED_DELAY);
     window.addEventListener('resize', clearNotePositions);
     window.addEventListener('toggleChecklist', this.handleChecklist, true);
     this.toggleShortcuts(true);
@@ -612,6 +609,19 @@ class NoteContentEditor extends Component<Props> {
 
   editorReady: EditorDidMount = (editor, monaco) => {
     this.editor = editor;
+
+    this.focusEditor();
+    this.props.storeFocusEditor(this.focusEditor);
+    this.props.storeHasFocus(this.hasFocus);
+
+    this.bootTimer = setTimeout(() => {
+        const position = getNotePosition(this.props.noteId);
+        if (position) {
+          this.editor?.setScrollPosition({
+            scrollTop: position,
+          });
+        }
+    }, SPEED_DELAY);
 
     monaco.languages.registerLinkProvider('plaintext', {
       provideLinks: (model) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "react-dom": "17.0.2",
         "react-dropzone": "11.7.1",
         "react-modal": "3.16.1",
-        "react-monaco-editor": "0.50.1",
+        "react-monaco-editor": "0.55.0",
         "react-overlays": "5.2.1",
         "react-redux": "8.1.3",
         "react-sortable-hoc": "2.0.0",
@@ -16872,16 +16872,16 @@
       }
     },
     "node_modules/react-monaco-editor": {
-      "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/react-monaco-editor/-/react-monaco-editor-0.50.1.tgz",
-      "integrity": "sha512-qvYdJhQdkPIrPDMxCrEl0T2x9TfBB+aUbrpFv69FwoTybeyfAjxgJ219MYSsgn3c/g06BgyLX4ENrXM4niZ9ag==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/react-monaco-editor/-/react-monaco-editor-0.55.0.tgz",
+      "integrity": "sha512-GdEP0Q3Rn1dczfKEEyY08Nes5plWwIYU4sWRBQO0+jsQWQsKMHKCC6+hPRwR7G/4aA3V/iU9jSmWPzVJYMVFSQ==",
       "dependencies": {
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
-        "@types/react": ">=17 <= 18",
-        "monaco-editor": "^0.34.0",
-        "react": ">=17 <= 18"
+        "@types/react": ">=16 <= 18",
+        "monaco-editor": "^0.44.0",
+        "react": ">=16 <= 18"
       }
     },
     "node_modules/react-onclickoutside": {

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "react-dom": "17.0.2",
     "react-dropzone": "11.7.1",
     "react-modal": "3.16.1",
-    "react-monaco-editor": "0.50.1",
+    "react-monaco-editor": "0.55.0",
     "react-overlays": "5.2.1",
     "react-redux": "8.1.3",
     "react-sortable-hoc": "2.0.0",


### PR DESCRIPTION
### Fix

In the course of the multiple upgrades in #3183, we noticed that the editor sometimes failed to focus the text area on load or on creating a new note. I eventually traced this to the version bump of `monaco-react-editor`, specifically the [refactor to use hooks](https://github.com/react-monaco-editor/react-monaco-editor/issues/660), which was included in versions higher than 0.50.1.

After some experimentation I reordered the code in such a way that it seems to work (moving the initialization from `componentDidMount` into `editorReady`), but I'm a little worried about this change, because the existing codebase is written with a Redux (action dispatch) architecture that largely predates React hooks, and I'm not sure whether it might introduce unintended side effects. I'm also not sure if we still need to use a boot timer, or if this refactor incidentally solves that.

The discussion at the above-referenced issue does not contain any real workarounds nor is there an update to the component that reverts or fixes the behavior, which is somewhat concerning. However a quick search for alternatives to `react-monaco-editor` didn't unearth any viable options (the other major package is written to load the editor from a CDN on load to avoid configuration, which is definitely a choice).

### Test

Since this change affects the loading order of the editor component, we need to make sure it doesn't have any unintended side effects, so smoke-test all the things: switching notes, creating a new note, syncing changes, etc.

### Release

Fixed a bug causing the text area not to be focused on load or on new note creation.