### PR TITLE
Fix: Prevent preview from crashing on email address

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,6 +6,7 @@
 
 - Adjusted word wrap borders in Safari to match other browsers [#3191](https://github.com/Automattic/simplenote-electron/pull/3191)
 - Fixed an issue that caused the right-click menu to vanish immediately in Safari [#3192](https://github.com/Automattic/simplenote-electron/pull/3192)
+- Fixed a bug where an email address in a note would cause the preview to be blank [#3205](https://github.com/Automattic/simplenote-electron/pull/3205)
 
 ### Other Changes
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,7 +83,7 @@ module.exports = () => {
     },
     plugins: [
       new NodePolyfillPlugin({
-        includeAliases: ['path', 'process', 'stream', 'util'],
+        includeAliases: ['Buffer', 'path', 'process', 'stream', 'util'],
       }),
       new HtmlWebpackPlugin({
         'build-platform': process.platform,


### PR DESCRIPTION
### Fix

This PR fixes #3200. The crash was a missing polyfill for `Buffer` that was only causing a runtime crash when the `isemail` code ran.

### Test

1. Create a Markdown note with an email address in it
2. Preview the note
3. Verify the note displays correctly

### Release

Fixed a bug where an email address in a note would cause the preview to be blank.
