### PR TITLE
Fix: Notarize build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ references:
       command: |
         source $HOME/.nvm/nvm.sh
         nvm use
-        npm install --force
+        npm install --legacy-peer-deps
   npm_restore_cache: &npm_restore_cache
     restore_cache:
       name: Restore npm cache
@@ -200,7 +200,7 @@ jobs:
       - run:
           name: Npm install
           command: |
-            npm install --force
+            npm install --legacy-peer-deps
       - run:
           name: Build windows
           command: |
@@ -244,7 +244,7 @@ jobs:
       - run:
           name: Npm install
           command: |
-            npm install --force
+            npm install --legacy-peer-deps
       - run:
           name: Build windows
           command: |

--- a/Makefile
+++ b/Makefile
@@ -140,11 +140,11 @@ package-linux: build-if-changed
 install: node_modules
 
 node_modules/%:
-	@npm install $(notdir $@)
+	@npm install $(notdir $@) --legacy-peer-deps
 
 node_modules: package.json
 	@npm prune
-	@npm install
+	@npm install --legacy-peer-deps
 	@touch node_modules
 
 

--- a/after_sign_hook.js
+++ b/after_sign_hook.js
@@ -7,11 +7,6 @@ module.exports = async function (params) {
     return;
   }
 
-  if (!process.env.CIRCLE_TAG || process.env.CIRCLE_TAG.length === 0) {
-    console.log('Not on a tag. Skipping notarization'); // eslint-disable-line no-console
-    return;
-  }
-
   // Same appId in electron-builder.
   let appId = 'com.automattic.simplenote';
 
@@ -29,7 +24,7 @@ module.exports = async function (params) {
   console.log(`Notarizing ${appId} found at ${appPath}`); // eslint-disable-line no-console
 
   try {
-    const electron_notarize = require('electron-notarize');
+    const electron_notarize = require('@electron/notarize');
     await electron_notarize.notarize({
       appBundleId: appId,
       appPath: appPath,


### PR DESCRIPTION
Import the correct package to notarize build, use `--legacy-peer-deps` everywhere, notarize even when not on a tag