### PR TITLE
Fix: Disable the menu item to check for updates if the updater won't check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,6 @@ jobs:
       - persist_to_workspace:
           root: ~/simplenote
           paths: *app_cache_paths
-    resource_class: large
   test:
     docker:
       - image: cimg/node:18.19.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,7 @@ jobs:
       - persist_to_workspace:
           root: ~/simplenote
           paths: *app_cache_paths
+    resource_class: large
   test:
     docker:
       - image: cimg/node:18.19.1

--- a/desktop/menus/menu-items.js
+++ b/desktop/menus/menu-items.js
@@ -2,6 +2,7 @@ const { app } = require('electron');
 
 const { appCommandSender } = require('./utils');
 const updater = require('../updater');
+const { autoUpdater } = require('electron-updater');
 
 const about = {
   label: '&About ' + app.name,
@@ -13,6 +14,7 @@ const about = {
 
 const checkForUpdates = {
   label: '&Check for Updates…',
+  enabled: autoUpdater.isUpdaterActive(),
   click: updater.pingAndShowProgress.bind(updater),
 };
 


### PR DESCRIPTION
### Fix

If you "check for updates" on a non-packaged version of the app, it will immediately resolve the promise to `null` and log the message "Skip checkForUpdates because application is not packed and dev update config is not forced". However the current progress bar doesn't get an `onError` callback from that so it hangs indefinitely.

This PR uses the same function the updater uses to disable the option to check for updates if it won't work anyway.

Fixes #3213 (the underlying problem isn't what I initially thought it was)

### Test

1. On a packaged version of the app (see build artifacts), you should be able to check for updates from the menu
2. On a development version (e.g. from `npm run dev`), the menu option should be grayed out

### Release

Disable the menu item to check for updates in the development environment