### PR TITLE
Fix: Markdown preview renders hanging indents as code blocks

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1248,7 +1248,6 @@ class NoteContentEditor extends Component<Props> {
               // @ts-ignore, @see https://github.com/microsoft/monaco-editor/issues/3829
               'bracketPairColorization.enabled': false,
               codeLens: false,
-              detectIndentation: false,
               folding: false,
               fontFamily:
                 '"Simplenote Tasks", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
@@ -1279,7 +1278,6 @@ class NoteContentEditor extends Component<Props> {
               selectionHighlight: false,
               showFoldingControls: 'never',
               suggestOnTriggerCharacters: true,
-              tabSize: 3 /* 4 spaces is considered the beginning of a code block */,
               unicodeHighlight: {
                 ambiguousCharacters: false,
                 invisibleCharacters: false,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1248,6 +1248,7 @@ class NoteContentEditor extends Component<Props> {
               // @ts-ignore, @see https://github.com/microsoft/monaco-editor/issues/3829
               'bracketPairColorization.enabled': false,
               codeLens: false,
+              detectIndentation: false,
               folding: false,
               fontFamily:
                 '"Simplenote Tasks", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',
@@ -1278,6 +1279,7 @@ class NoteContentEditor extends Component<Props> {
               selectionHighlight: false,
               showFoldingControls: 'never',
               suggestOnTriggerCharacters: true,
+              tabSize: 3 /* 4 spaces is considered the beginning of a code block */,
               unicodeHighlight: {
                 ambiguousCharacters: false,
                 invisibleCharacters: false,

--- a/lib/utils/render-note-to-html.ts
+++ b/lib/utils/render-note-to-html.ts
@@ -21,13 +21,11 @@ export const renderNoteToHtml = (content: string) => {
         extensions: ['enableCheckboxes', 'removeLineBreaks'],
       });
       markdownConverter.setFlavor('github');
-      markdownConverter.setOption('ghMentions', false);
-      markdownConverter.setOption('literalMidWordUnderscores', true);
       markdownConverter.setOption('simpleLineBreaks', false); // override GFM
+      markdownConverter.setOption('ghMentions', false);
       markdownConverter.setOption('smoothLivePreview', true);
-      markdownConverter.setOption('splitAdjacentBlockquotes', true);
-      markdownConverter.setOption('strikethrough', true); // ~~strikethrough~~
       markdownConverter.setOption('tables', true); // table syntax
+      markdownConverter.setOption('strikethrough', true); // ~~strikethrough~~
 
       let transformedContent = content.replace(
         /([ \t\u2000-\u200a]*)\u2022(\s)/gm,

--- a/lib/utils/render-note-to-html.ts
+++ b/lib/utils/render-note-to-html.ts
@@ -21,16 +21,28 @@ export const renderNoteToHtml = (content: string) => {
         extensions: ['enableCheckboxes', 'removeLineBreaks'],
       });
       markdownConverter.setFlavor('github');
-      markdownConverter.setOption('simpleLineBreaks', false); // override GFM
       markdownConverter.setOption('ghMentions', false);
+      markdownConverter.setOption('literalMidWordUnderscores', true);
+      markdownConverter.setOption('simpleLineBreaks', false); // override GFM
       markdownConverter.setOption('smoothLivePreview', true);
-      markdownConverter.setOption('tables', true); // table syntax
+      markdownConverter.setOption('splitAdjacentBlockquotes', true);
       markdownConverter.setOption('strikethrough', true); // ~~strikethrough~~
+      markdownConverter.setOption('tables', true); // table syntax
 
-      const transformedContent = content.replace(
+      let transformedContent = content.replace(
         /([ \t\u2000-\u200a]*)\u2022(\s)/gm,
         '$1-$2'
       ); // normalized bullets
+
+      // remove tab indentation on paragraphs
+      // TODO this is very naive and fragile and will break in a lot of cases, such as:
+      // - different size indentations
+      // - paragraphs that begin with a number or a list character
+      // - list characters other than - and *
+      transformedContent = content.replace(
+        /\n {4}(([^-*\d]))/g,
+        '\n&nbsp;&nbsp;&nbsp;$1'
+      );
 
       return sanitizeHtml(markdownConverter.makeHtml(transformedContent));
     }


### PR DESCRIPTION
### Fix

A tab (four spaces) at the beginning of a paragraph is parsed as a code block. This is an issue that other Markdown text editors have encountered (Obsidian, for example, has many complaints, e.g. [#](https://forum.obsidian.md/t/break-markdown-option-to-change-default-tab-indent-behavior-do-not-create-code-block/8741/14)).

Naturally showdown does not have an option to disable these style codeblocks, despite the fact that we also have Github-style "code fence" support (three backticks). As others [have done](https://github.com/showdownjs/showdown/issues/646), I experimented with a naive regex replace that removes four spaces at the beginning of a line and uses three instead, but there are a lot of edge cases with list indentation that probably aren't handled. I also experimented with adjusting the editor's options around tab sizes, but due to the auto detect (and the fact that we're probably going to get four-space-indentations from clients or from existing saved notes) this seems like a nonstarter.

I think if we cleaned up this regex to catch more of the edge cases, it might be a good idea to add this.

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1.
2.
3.

### Release

Don't render indented paragraphs as code blocks
