### PR TITLE
Build using production `config.json` in Buildkite CI

### DIFF
--- a/.buildkite/commands/package_windows.ps1
+++ b/.buildkite/commands/package_windows.ps1
@@ -41,6 +41,9 @@ choco install make
 Write-Host "--- :npm: Installing dependencies"
 npm ci --legacy-peer-deps
 
+Write-Host "--- :lock_with_ink_pen: Decrypting secrets"
+make decrypt_conf_production
+
 Write-Host "--- :node: Building app"
 make build
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,8 +55,7 @@ steps:
       install_gems
       bundle exec fastlane configure_code_signing
       echo "--- Decrypt secrets"
-      # This comes from 'make decrypt_conf' which we cannot call because it's interactive
-      openssl aes-256-cbc -d -in ./resources/secrets/config.json.enc -out ./config-local.json -pbkdf2 -k $SECRETS_ENCRYPTION_KEY
+      make decrypt_conf_production
       bundle exec fastlane run configure_apply
       echo "--- Build"
       make build
@@ -96,8 +95,7 @@ steps:
       echo "--- Build"
       make build
       echo "--- Decrypt secrets"
-      # This comes from 'make decrypt_conf' which we cannot call because it's interactive
-      openssl aes-256-cbc -d -in ./resources/secrets/config.json.enc -out ./config.json -pbkdf2 -k $SECRETS_ENCRYPTION_KEY
+      make decrypt_conf_production
       echo "--- Package"
       make package-linux SKIP_BUILD=true
     env:

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ node_modules/%:
 	@npm install $(notdir $@) --legacy-peer-deps
 
 node_modules: package.json
-	@npm prune
+	@npm prune --legacy-peer-deps
 	@npm install --legacy-peer-deps
 	@touch node_modules
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ endif
 THIS_MAKEFILE_PATH := $(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
 THIS_DIR := $(shell cd $(dir $(THIS_MAKEFILE_PATH));pwd)
 
+CONF_FILE_ENCRYPTED=./resources/secrets/config.json.enc
+CONF_FILE_LOCAL=./config-local.json
+CONF_FILE=./config.json
+
 NPM ?= $(NODE) $(shell which npm)
 NPM_BIN = $(shell npm bin)
 
@@ -171,8 +175,8 @@ node_modules: package.json
 
 # Checks
 config.json:
-ifeq (,$(wildcard $(THIS_DIR)$/config.json))
-	$(error config.json not found. Required file, see docs)
+ifeq (,$(wildcard $(THIS_DIR)$/$CONF_FILE))
+	$(error $(CONF_FILE) not found. Required file, see docs)
 endif
 
 
@@ -198,9 +202,6 @@ lint-js:
 
 # encrypted config file
 .PHONY: _pwd_prompt decrypt_conf encrypt_conf
-
-CONF_FILE_ENCRYPTED=./resources/secrets/config.json.enc
-CONF_FILE_LOCAL=./config-local.json
 
 # 'private' task for echoing instructions
 _pwd_prompt:

--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,7 @@ lint-js:
 .PHONY: _pwd_prompt decrypt_conf encrypt_conf
 
 CONF_FILE_ENCRYPTED=./resources/secrets/config.json.enc
+CONF_FILE_LOCAL=./config-local.json
 
 # 'private' task for echoing instructions
 _pwd_prompt:
@@ -207,8 +208,8 @@ _pwd_prompt:
 
 # to create config for local development
 decrypt_conf: _pwd_prompt
-	openssl aes-256-cbc -d -in ${CONF_FILE_ENCRYPTED} -out ./config-local.json -pbkdf2
+	openssl aes-256-cbc -d -in ${CONF_FILE_ENCRYPTED} -out ${CONF_FILE_LOCAL} -pbkdf2
 
 # for updating the stored config with the local values
 encrypt_conf: _pwd_prompt
-	openssl aes-256-cbc -e -in config-local.json -out ${CONF_FILE_ENCRYPTED} -pbkdf2
+	openssl aes-256-cbc -e -in ${CONF_FILE_LOCAL} -out ${CONF_FILE_ENCRYPTED} -pbkdf2

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ ifeq ($(strip $(SECRETS_ENCRYPTION_KEY)),)
 	$(error Could not decode $(CONF_FILE) because SECRETS_ENCRYPTION_KEY is missing from environment.)
 else
 	@openssl aes-256-cbc -d -in $(CONF_FILE_ENCRYPTED) -out $(CONF_FILE) -pbkdf2 -k ${SECRETS_ENCRYPTION_KEY}
-	@echo "Succefully decoded $(CONF_FILE_ENCRYPTED) into $(CONF_FILE)."
+	@echo "Successfully decoded $(CONF_FILE_ENCRYPTED) into $(CONF_FILE)."
 endif
 else
 	@echo "Will not attempt to decode $(CONF_FILE_ENCRYPTED) because not running in production (NODE_ENV = $(NODE_ENV))."

--- a/Makefile
+++ b/Makefile
@@ -199,16 +199,16 @@ lint-js:
 # encrypted config file
 .PHONY: _pwd_prompt decrypt_conf encrypt_conf
 
-CONF_FILE=./resources/secrets/config.json.enc
+CONF_FILE_ENCRYPTED=./resources/secrets/config.json.enc
 
 # 'private' task for echoing instructions
 _pwd_prompt:
 	@echo "Check the secret store for Simplenote!"
 
-# to create config
+# to create config for local development
 decrypt_conf: _pwd_prompt
-	openssl aes-256-cbc -d -in ${CONF_FILE} -out ./config-local.json -pbkdf2
+	openssl aes-256-cbc -d -in ${CONF_FILE_ENCRYPTED} -out ./config-local.json -pbkdf2
 
-# for updating config
+# for updating the stored config with the local values
 encrypt_conf: _pwd_prompt
-	openssl aes-256-cbc -e -in config-local.json -out ${CONF_FILE} -pbkdf2
+	openssl aes-256-cbc -e -in config-local.json -out ${CONF_FILE_ENCRYPTED} -pbkdf2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplenote",
-  "version": "2.22.0-beta6",
+  "version": "2.22.0-beta7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simplenote",
-      "version": "2.22.0-beta6",
+      "version": "2.22.0-beta7",
       "license": "GPL-2.0",
       "dependencies": {
         "@automattic/color-studio": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "support@simplenote.com"
   },
   "productName": "Simplenote",
-  "version": "2.22.0-beta6",
+  "version": "2.22.0-beta7",
   "main": "desktop/index.js",
   "license": "GPL-2.0",
   "homepage": "https://simplenote.com",


### PR DESCRIPTION
Follows up on @codebykat 's comment in #3204 , https://github.com/Automattic/simplenote-electron/pull/3204/files#r1638753450

- Centralize logic to decrypt the prod config via `make`
- Run it in CI before building for all platforms

---

**WIP**: I know this will work in the Unix-based builds, but I don't know what the Windows one will do when asked to call `openssl`. 🍿 ...

**Update**: The Windows CI didn't sweat:

![image](https://github.com/Automattic/simplenote-electron/assets/1218433/e519acc5-ce44-49a4-94ed-7593c23bdf58)

**Update 2**: And the resulting `exe` is one I can successfully login with:

<img width="1030" alt="image" src="https://github.com/Automattic/simplenote-electron/assets/1218433/2d292a02-7bf8-4e64-a0bb-acdfbe71dda5">

