### PR TITLE
Create an app-config.json file in webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/**/*
+app-config.json
 config-local.json
 desktop-build/
 dist/

--- a/get-config.js
+++ b/get-config.js
@@ -1,7 +1,6 @@
 function readConfig() {
-  const configPath = './config-local';
   try {
-    const config = require(configPath);
+    const config = require('./app-config');
     if (typeof config === 'function') {
       throw new Error('Invalid config file. Config must be JSON.');
     }
@@ -9,7 +8,7 @@ function readConfig() {
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error(
-      `Could not load the required configuration file at ${configPath}.\n` +
+      `Could not load the required configuration file.\n` +
         'Please consult the project README.md for further information.'
     );
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,9 +86,6 @@ module.exports = () => {
       ],
     },
     resolve: {
-      fallback: {
-        './config-local': require.resolve('./config'), // fallback to config.json if config-local.json is missing
-      },
       extensions: ['.js', '.jsx', '.json', '.scss', '.css', '.ts', '.tsx'],
       modules: ['node_modules'],
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const autoprefixer = require('autoprefixer');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const getConfig = require('./get-config');
+const fs = require('fs');
 const spawnSync = require('child_process').spawnSync;
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
@@ -9,7 +10,17 @@ const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 
 // Object.assign(global, { WebSocket: require('ws') });
 
+function createAppConfig() {
+  const configPath = fs.existsSync('./config-local.json')
+    ? './config-local.json'
+    : './config.json';
+
+  const configData = fs.readFileSync(configPath, 'utf8');
+  fs.writeFileSync('app-config.json', configData, null, 2);
+}
+
 module.exports = () => {
+  createAppConfig();
   const isDevMode = process.env.NODE_ENV === 'development';
   const config = getConfig();
 


### PR DESCRIPTION
### Fix
This fixes #3228. It does not appear possible to do dynamic requires in webpack, so instead I'm proposing the app use an `app-config.json` file that gets created in the webpack build, using either the contents of `config-local.json` if it is present, otherwise it will use `config.json` using `fs` to detect if the file is present or not.

### Test
* `npm run dev`
* Verify that an `app-config.json` file was created properly. (Try deleting your `config-local.json` file if present, it should update to whatever is in `config.json`)
* The electron and web app should both load up without errors.
