### PR TITLE
fix: no button outline

### DIFF
--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -9,6 +9,7 @@ button {
   font-size: 14px;
   appearance: none;
   vertical-align: baseline;
+  outline: none !important;
 
   svg {
     cursor: pointer;


### PR DESCRIPTION
### Fix
<!--
**_(Required)_** Add a concise description of what you fixed. If this is related 
to an issue, add a link to it. If applicable, add screenshots, animations, or
videos to help illustrate the fix.
-->

Button outline looks bad, not sure why it's added:

https://github.com/user-attachments/assets/88a754f3-93cd-46e9-b0f9-9a314b787c69

### Test
<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1. Click the note entry
2. No button outline

https://github.com/user-attachments/assets/593540ce-f71a-483b-9ca7-b2ee8bb627f8

### Release

<!--
**_(Required)_** If the changes should be included in release notes, add a
concise statement below describing the change. For example:
Fixed crash that occurred when opening the navigation sidebar.
-->

Removed button outline.
