### PR TITLE
Remove `gconf2` dependency

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -110,8 +110,7 @@
     }
   ],
   "deb": {
-    "compression": "gz",
-    "depends": ["gconf2"]
+    "compression": "gz"
   },
   "afterSign": "./after_sign_hook.js",
   "afterAllArtifactBuild": "./after_sign_hook.js"


### PR DESCRIPTION
### Fix

This is an attempt to fix the issue reported by users who cannot install Simplenote on various Linux systems because the `gconf2` dependency cannot be satisfied, https://github.com/Automattic/simplenote-electron/issues/3241

The [`electron-builder` docs](https://www.electron.build/configuration/linux.html) mention that `gconf2` can give issues if one wants to support [KDE](https://kde.org/).

> If need to support KDE, `gconf2` and `gconf-service` should be removed as it’s no longer used [by GNOME](https://packages.debian.org/bullseye/gconf2).

Moreover, [the `gconf2` entry in the Debian packages repository](https://packages.debian.org/bullseye/gconf2) states:

> This package is for legacy applications and no longer used by GNOME.

Given the above, this PR is an attempt to see what the app would do without the dependency. My guess is that everything should run fine in most modern systems, because all information points to `gconf2` not being in use there.

### Test

To test this we'll need to download the artifacts from CI and try to install them on Linux distros. If it works on our end, it might be good to reach out to the users in #3241 and see how they go.

