### PR TITLE
Add Magic link login

### DIFF
--- a/desktop/app.js
+++ b/desktop/app.js
@@ -84,6 +84,7 @@ module.exports = function main() {
         contextIsolation: true,
         nodeIntegration: false,
         preload: path.join(__dirname, './preload.js'),
+        webSecurity: false,
       },
     });
 

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -84,7 +84,7 @@ module.exports = function main() {
         contextIsolation: true,
         nodeIntegration: false,
         preload: path.join(__dirname, './preload.js'),
-        webSecurity: false,
+        webSecurity: !isDev,
       },
     });
 

--- a/desktop/app.js
+++ b/desktop/app.js
@@ -84,7 +84,6 @@ module.exports = function main() {
         contextIsolation: true,
         nodeIntegration: false,
         preload: path.join(__dirname, './preload.js'),
-        webSecurity: !isDev,
       },
     });
 

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -15,7 +15,7 @@ const validChannels = [
   'wpLogin',
 ];
 
-contextBridge.exposeInMainWorld('electron', {
+export const electronAPI = {
   confirmLogout: (changes) => {
     const response = remote.dialog.showMessageBoxSync({
       type: 'warning',
@@ -61,4 +61,6 @@ contextBridge.exposeInMainWorld('electron', {
   },
   isMac: process.platform === 'darwin',
   isLinux: process.platform === 'linux',
-});
+};
+
+contextBridge.exposeInMainWorld('electron', electronAPI);

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -15,7 +15,7 @@ const validChannels = [
   'wpLogin',
 ];
 
-export const electronAPI = {
+const electronAPI = {
   confirmLogout: (changes) => {
     const response = remote.dialog.showMessageBoxSync({
       type: 'warning',
@@ -64,3 +64,7 @@ export const electronAPI = {
 };
 
 contextBridge.exposeInMainWorld('electron', electronAPI);
+
+module.exports = {
+  electronAPI: electronAPI,
+};

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -177,6 +177,7 @@ export class Auth extends Component<Props> {
                 className="account-requested__code"
                 placeholder="Code"
                 maxLength={6}
+                autoFocus
                 ref={(ref) => (this.codeInput = ref)}
               ></input>
               <button className="button button-primary" type="submit">

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -38,6 +38,7 @@ export class Auth extends Component<Props> {
     passwordErrorMessage: null,
     onLine: window.navigator.onLine,
     usePassword: false,
+    emailForPasswordForm: null,
   };
 
   componentDidMount() {
@@ -48,6 +49,15 @@ export class Auth extends Component<Props> {
   componentWillUnmount() {
     window.removeEventListener('online', this.setConnectivity, false);
     window.removeEventListener('offline', this.setConnectivity, false);
+  }
+
+  componentDidUpdate() {
+    // Add the email to the username/password form if it was set
+    if (this.state.usePassword && this.state.emailForPasswordForm) {
+      this.usernameInput.value = this.state.emailForPasswordForm;
+      this.setState({ emailForPasswordForm: null });
+      this.passwordInput.focus();
+    }
   }
 
   setConnectivity = () => this.setState({ onLine: window.navigator.onLine });
@@ -503,6 +513,7 @@ export class Auth extends Component<Props> {
       }
       this.setState({ passwordErrorMessage: null });
       this.props.login(username, password);
+      return;
     }
 
     // default: magic link login
@@ -599,7 +610,8 @@ export class Auth extends Component<Props> {
     this.props.resetErrors();
     this.setState({
       passwordErrorMessage: '',
+      emailForPasswordForm: this.props.emailSentTo,
+      usePassword: !this.state.usePassword,
     });
-    this.setState({ usePassword: !this.state.usePassword });
   };
 }

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -357,8 +357,6 @@ export class Auth extends Component<Props> {
 
           {usePassword && (
             <Fragment>
-              {/* <span className="or">Or</span>
-              <span className="or-line"></span> */}
               <a
                 className="login__forgot"
                 href="#"

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -75,7 +75,12 @@ export class Auth extends Component<Props> {
 
     const signUpText = 'Sign up';
     const logInText = 'Log in';
-    const buttonLabel = isCreatingAccount ? signUpText : logInText;
+    const headerLabel = isCreatingAccount ? signUpText : logInText;
+    const buttonLabel = isCreatingAccount
+      ? signUpText
+      : !isCreatingAccount && !usePassword
+        ? 'Log in with email'
+        : logInText;
     const wpccLabel =
       (isCreatingAccount ? signUpText : logInText) + ' with WordPress.com';
     const helpLinkLabel = isCreatingAccount ? logInText : signUpText;
@@ -209,7 +214,7 @@ export class Auth extends Component<Props> {
         {isElectron && isMac && <div className="login__draggable-area" />}
         <SimplenoteLogo />
         <form className="login__form" onSubmit={this.onSubmit}>
-          <h1>{buttonLabel}</h1>
+          <h1>{headerLabel}</h1>
           {!this.state.onLine && (
             <p className="login__auth-message is-error">Offline</p>
           )}

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -20,6 +20,8 @@ type OwnProps = {
   hasUnverifiedAccount: boolean;
   login: (username: string, password: string) => any;
   loginRequested: boolean;
+  isCompletingLogin: boolean;
+  hasCodeError: boolean;
   requestLogin: (username: string) => any;
   completeLogin: (username: string, code: string) => any;
   requestSignup: (username: string) => any;
@@ -131,7 +133,11 @@ export class Auth extends Component<Props> {
       );
     }
 
-    if (this.props.loginRequested) {
+    if (
+      this.props.loginRequested ||
+      this.props.isCompletingLogin ||
+      this.props.hasCodeError
+    ) {
       return (
         <div className={mainClasses}>
           {isElectron && isMac && <div className="login__draggable-area" />}
@@ -143,9 +149,11 @@ export class Auth extends Component<Props> {
                 <strong>{this.props.emailSentTo}</strong>. The code will be
                 valid for a few minutes.
               </p>
-              {passwordErrorMessage && (
+              {(passwordErrorMessage || this.props.hasCodeError) && (
                 <p className="login__auth-message is-error">
-                  {passwordErrorMessage}
+                  {passwordErrorMessage
+                    ? passwordErrorMessage
+                    : 'Could not log in. Check the code and try again.'}
                 </p>
               )}
               <input
@@ -156,7 +164,11 @@ export class Auth extends Component<Props> {
                 ref={(ref) => (this.codeInput = ref)}
               ></input>
               <button className="button button-primary" type="submit">
-                Log in
+                {this.props.isCompletingLogin ? (
+                  <Spinner isWhite={true} size={20} thickness={5} />
+                ) : (
+                  'Log in'
+                )}
               </button>
               <Fragment>
                 <div className="or-section">

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import classNames from 'classnames';
 import cryptoRandomString from '../utils/crypto-random-string';
 import { get } from 'lodash';
+import { isDev } from '../../desktop/env';
 import MailIcon from '../icons/mail';
 import SimplenoteLogo from '../icons/simplenote';
 import Spinner from '../components/spinner';
@@ -37,7 +38,7 @@ export class Auth extends Component<Props> {
     isCreatingAccount: false,
     passwordErrorMessage: null,
     onLine: window.navigator.onLine,
-    usePassword: false,
+    usePassword: isDev, // Magic link login doesn't work in dev mode
     emailForPasswordForm: null,
   };
 

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -422,7 +422,7 @@ export class Auth extends Component<Props> {
     this.props.resetErrors();
   };
 
-  onSubmit = (event: MouseEvent) => {
+  onSubmit = (event: React.FormEvent) => {
     event.preventDefault();
 
     // clear any existing error messages on submit
@@ -489,7 +489,7 @@ export class Auth extends Component<Props> {
 
     window.electron.send('wpLogin', authUrl);
 
-    window.electron.receive('wpLogin', (url) => {
+    window.electron.receive('wpLogin', (url: string) => {
       const { searchParams } = new URL(url);
 
       const errorCode = searchParams.get('error')
@@ -529,7 +529,7 @@ export class Auth extends Component<Props> {
     });
   };
 
-  onForgot = (event: MouseEvent) => {
+  onForgot = (event: React.MouseEvent) => {
     event.preventDefault();
     window.open(
       (event.currentTarget as HTMLAnchorElement).href,
@@ -538,7 +538,7 @@ export class Auth extends Component<Props> {
     );
   };
 
-  toggleSignUp = (event: Event) => {
+  toggleSignUp = (event: React.MouseEvent) => {
     event.preventDefault();
     this.props.resetErrors();
     this.setState({
@@ -546,7 +546,7 @@ export class Auth extends Component<Props> {
     });
     this.setState({ isCreatingAccount: !this.state.isCreatingAccount });
   };
-  togglePassword = (event: Event) => {
+  togglePassword = (event: React.MouseEvent) => {
     event.preventDefault();
     this.props.resetErrors();
     this.setState({

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -531,7 +531,7 @@ export class Auth extends Component<Props> {
     const alphanumericRegex = /^[a-zA-Z0-9]{6}$/;
     if (!alphanumericRegex.test(code)) {
       this.setState({
-        passwordErrorMessage: 'Code must be 6 alphanumeric characters.',
+        passwordErrorMessage: 'Code must be 6 characters.',
       });
       return;
     }

--- a/lib/auth/style.scss
+++ b/lib/auth/style.scss
@@ -4,6 +4,7 @@
 
 body {
   background-color: var(--background-color);
+  color: var(--primary-color);
 }
 
 .login.is-electron {
@@ -162,18 +163,36 @@ body {
   }
 }
 
-.accountRequested {
+.account-requested {
   font-size: 16px;
   line-height: 22px;
   text-align: center;
   width: 320px;
+  .button {
+    width: 95%;
+  }
+
+  .or-section {
+    display: block;
+    min-height: 40px;
+    margin-top: 16px;
+  }
 
   svg.icon-mail {
     color: var(--foreground-color);
     width: 60px;
     height: 60px;
   }
-  .accountRequested__footer {
+
+  .account-requested__code {
+    margin: 16px auto;
+  }
+
+  .account-requested__password-button {
+    margin-bottom: 16px;
+  }
+
+  .account-requested__footer {
     font-size: 14px;
     line-height: 20px;
   }

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -9,8 +9,6 @@ import classNames from 'classnames';
 import AboutDialog from './dialogs/about';
 import ErrorBoundary from './error-boundary';
 
-import { IpcMainEvent, IpcMessageEvent } from 'electron';
-
 import '../scss/style.scss';
 
 type Props = {
@@ -68,13 +66,13 @@ class AppWithoutAuth extends Component<Props, State> {
     this.props.onAuth(token, username);
   }
 
-  onAppCommand = (event: IpcMainEvent) => {
+  onAppCommand = (event: Electron.IpcRendererEvent) => {
     if ('showDialog' === event.action && 'ABOUT' === event.dialog) {
       this.setState({ showAbout: true });
     }
   };
 
-  onDismissDialog = (event: Event) => {
+  onDismissDialog = (event: React.MouseEvent) => {
     this.setState({ showAbout: false });
   };
 
@@ -179,7 +177,7 @@ class AppWithoutAuth extends Component<Props, State> {
   };
 
   tokenLogin = (username: string, token: string) => {
-    this.login(token, username, false);
+    this.login(token, username);
   };
 
   render() {

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -133,7 +133,10 @@ class AppWithoutAuth extends Component<Props, State> {
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ username: username }),
+            body: JSON.stringify({
+              username: username,
+              request_source: 'electron',
+            }),
           }
         );
         if (response.ok) {

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -147,6 +147,48 @@ class AppWithoutAuth extends Component<Props, State> {
     });
   };
 
+  completeLogin = (email: string, code: string) => {
+    const username = email.trim().toLowerCase();
+    if (!username) {
+      return;
+    }
+
+    const upperCaseCode = code.trim().toUpperCase();
+    if (!upperCaseCode) {
+      return;
+    }
+
+    console.log(`Username: ${username}, Code: ${upperCaseCode}`);
+
+    this.setState({ authStatus: 'submitting' }, async () => {
+      try {
+        const response = await fetch(
+          'https://app.simplenote.com/account/complete-login',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              username: username,
+              auth_code: upperCaseCode,
+            }),
+          }
+        );
+        if (response.ok) {
+          // Set token and LOGIN!
+          console.log('Logging in via email');
+          const data = await response.json();
+          const syncToken = data.sync_token;
+          console.log('Sync token!', syncToken);
+          this.login(syncToken, username);
+        } else {
+          this.setState({ authStatus: 'unknown-error' });
+        }
+      } catch {
+        this.setState({ authStatus: 'unknown-error' });
+      }
+    });
+  };
+
   requestSignup = (email: string) => {
     const username = email.trim().toLowerCase();
     if (!username) {
@@ -209,6 +251,7 @@ class AppWithoutAuth extends Component<Props, State> {
               this.setState({ authStatus: 'unsubmitted', emailSentTo: '' })
             }
             requestLogin={this.requestLogin}
+            completeLogin={this.completeLogin}
             requestSignup={this.requestSignup}
           />
           {this.state.showAbout && (

--- a/lib/dialogs/about/index.tsx
+++ b/lib/dialogs/about/index.tsx
@@ -8,7 +8,7 @@ import Dialog from '../../dialog';
 const appVersion = config.version; // eslint-disable-line no-undef
 
 type OwnProps = {
-  closeDialog: () => any;
+  closeDialog: () => void;
 };
 
 type Props = OwnProps;

--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -1,7 +1,7 @@
 import { TKQItem, TracksAPI } from './analytics/types';
 import { compose } from 'redux';
 
-import { IpcMainEvent } from 'electron';
+import { electronAPI } from './preload';
 
 import * as S from './state';
 
@@ -21,36 +21,7 @@ declare global {
   interface Window {
     __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: typeof compose;
     analyticsEnabled: boolean;
-    electron: {
-      confirmLogout(changes: string): 'logout' | 'reconsider' | 'export';
-      isMac: boolean;
-      isLinux: boolean;
-      receive(command: 'appCommand', callback: (event: IpcMainEvent) => any);
-      receive(command: 'editorCommand', callback: (event: IpcMainEvent) => any);
-      receive(
-        command: 'noteImportChannel',
-        callback: (event: IpcMainEvent) => any
-      );
-      receive(command: 'tokenLogin', callback: (event: IpcMainEvent) => any);
-      receive(command: 'wpLogin', callback: (event: IpcMainEvent) => any);
-      removeListener(command: 'appCommand');
-      removeListener(command: 'editorCommand');
-      removeListener(command: 'noteImportChannel');
-      removeListener(command: 'tokenLogin');
-      send(
-        command: 'appStateUpdate',
-        args: {
-          settings: S.State['settings'];
-          editMode: boolean;
-        }
-      );
-      send(command: 'clearCookies'): void;
-      send(command: 'importNotes', filePath: string);
-      send(command: 'reallyCloseWindow'): void;
-      send(command: 'reload');
-      send(command: 'setAutoHideMenuBar', newValue: boolean);
-      send(command: 'wpLogin', url: string);
-    };
+    electron: typeof electronAPI;
     location: Location;
     testEvents: (string | [string, ...any[]])[];
     _tkq: TKQItem[] & { a: unknown };

--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -1,6 +1,8 @@
 import { TKQItem, TracksAPI } from './analytics/types';
 import { compose } from 'redux';
 
+import { IpcMainEvent } from 'electron';
+
 import * as S from './state';
 
 declare global {
@@ -23,13 +25,18 @@ declare global {
       confirmLogout(changes: string): 'logout' | 'reconsider' | 'export';
       isMac: boolean;
       isLinux: boolean;
-      receive(command: 'appCommand', callback: (event: any) => any);
-      receive(command: 'editorCommand', callback: (event: any) => any);
-      receive(command: 'noteImportChannel', callback: (event: any) => any);
-      receive(command: 'tokenLogin', callback: (event: any) => any);
-      receive(command: 'wpLogin', callback: (event: any) => any);
+      receive(command: 'appCommand', callback: (event: IpcMainEvent) => any);
+      receive(command: 'editorCommand', callback: (event: IpcMainEvent) => any);
+      receive(
+        command: 'noteImportChannel',
+        callback: (event: IpcMainEvent) => any
+      );
+      receive(command: 'tokenLogin', callback: (event: IpcMainEvent) => any);
+      receive(command: 'wpLogin', callback: (event: IpcMainEvent) => any);
+      removeListener(command: 'appCommand');
       removeListener(command: 'editorCommand');
       removeListener(command: 'noteImportChannel');
+      removeListener(command: 'tokenLogin');
       send(
         command: 'appStateUpdate',
         args: {

--- a/lib/logging-out.tsx
+++ b/lib/logging-out.tsx
@@ -18,11 +18,8 @@ class LoggingOut extends Component {
         <div
           style={{
             fontSize: '18px',
-            margin: 'auto',
-            position: 'absolute',
-            top: '50%',
-            left: '50%',
-            transform: '-50% -50%',
+            alignSelf: 'center',
+            margin: '0 auto',
           }}
         >
           Logging out…


### PR DESCRIPTION
### Fix

Adds the option to login via a link or code to the Electron apps.

<img width="1026" alt="Screenshot 2024-08-27 at 12 17 37 PM" src="https://github.com/user-attachments/assets/9a1736f6-9be4-4288-a7b8-e80502c5fcf4">

<img width="1016" alt="Screenshot 2024-08-27 at 12 20 00 PM" src="https://github.com/user-attachments/assets/84c14042-9874-49eb-b4b3-569d308c4097">


### Test
1. You should download a build from this PR to test with. (In the build artifacts)
2. Enter a valid account email.
3. You should get the code or link via email
4. Entering the code should work (Clicking the link was tested on the GAE PR already)
5. Try ALL the other things on the sign in form: password entry, creating an account, etc. Should still work!

### Release

Added the option to log in via "magic" link or code.