### PR TITLE
Update: Disable sticky scroll option

### DIFF
--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1277,6 +1277,7 @@ class NoteContentEditor extends Component<Props> {
               scrollBeyondLastLine: false,
               selectionHighlight: false,
               showFoldingControls: 'never',
+              stickyScroll: { enabled: false },
               suggestOnTriggerCharacters: true,
               unicodeHighlight: {
                 ambiguousCharacters: false,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -129,12 +129,17 @@ module.exports = () => {
       }),
       new MonacoWebpackPlugin({
         languages: [],
+        // don't include features we disable. these generally correspond to the options
+        // passed to editor initialization in note-content-editor.tsx
+        // @see https://github.com/microsoft/monaco-editor/blob/main/webpack-plugin/README.md#options
         features: [
           '!bracketMatching',
           '!codeAction',
           '!codelens',
-          '!colorDetector',
+          '!colorPicker',
           '!comment',
+          '!diffEditor',
+          '!diffEditorBreadcrumbs',
           '!folding',
           '!gotoError',
           '!gotoLine',
@@ -144,12 +149,15 @@ module.exports = () => {
           '!multicursor',
           '!parameterHints',
           '!quickCommand',
+          '!quickHelp',
           '!quickOutline',
           '!referenceSearch',
           '!rename',
-          '!snippets',
+          '!snippet',
+          '!stickyScroll',
           '!suggest',
           '!toggleHighContrast',
+          '!unicodeHighlighter',
         ],
       }),
       new webpack.DefinePlugin({


### PR DESCRIPTION
### Fix

Potential fix for #3250. Also removes this, and some unused features, from the package.

This is a hotfix for 2.22.2 release.

(I updated the list of possible features by importing metadata and logging it to console, as recommended in the linked README.)

### Release

Disabled "sticky scrolling" option ([#3254](https://github.com/Automattic/simplenote-electron/pull/3254))