### PR TITLE
Meta: Update RELEASE NOTES instructions in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,13 @@
 ### Fix
+
 <!--
-**_(Required)_** Add a concise description of what you fixed. If this is related 
+**_(Required)_** Add a concise description of what you fixed. If this is related
 to an issue, add a link to it. If applicable, add screenshots, animations, or
 videos to help illustrate the fix.
 -->
 
 ### Test
+
 <!--
 **_(Required)_** List the steps to test the behavior. For example:
 > 1. Go to...
@@ -19,8 +21,12 @@ videos to help illustrate the fix.
 
 ### Release
 
-<!--
-**_(Required)_** If the changes should be included in release notes, add a
-concise statement below describing the change. For example:
-Fixed crash that occurred when opening the navigation sidebar.
--->
+**_(Required)_** Add a concise statement to `RELEASE-NOTES.md` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
+
+> `RELEASE-NOTES.txt` was updated in d3adb3ef with:
+>
+> > Added markdown support
+
+If the changes should not be included in release notes, add a statement to this section. For example:
+
+> These changes do not require release notes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,12 +21,14 @@ videos to help illustrate the fix.
 
 ### Release
 
+<!--
 **_(Required)_** Add a concise statement to `RELEASE-NOTES.md` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
 
-> `RELEASE-NOTES.txt` was updated in d3adb3ef with:
+> `RELEASE-NOTES.md` was updated with:
 >
 > > Added markdown support
 
 If the changes should not be included in release notes, add a statement to this section. For example:
 
 > These changes do not require release notes.
+-->


### PR DESCRIPTION
### Fix

This updates the RELEASE NOTES section of the PR template to copy [the one used in the simplenote-android repo](https://raw.githubusercontent.com/Automattic/simplenote-android/trunk/.github/PULL_REQUEST_TEMPLATE.md), because I just opened a PR over there and I liked it. I feel our current one creates some confusion by leaving it ambiguous when the release notes themselves will be updated, and that is currently an extra manual step in the release cycle.

In other words **this represents a slight change to our process for generating release notes**; rather than collating them all and doing a separate commit for release notes when we cut a new beta, this will keep release notes updates with the relevant PRs. Hopefully it won't become annoying if we don't know what version a PR will land in and have to move things around, but we can iterate on it.

FYI for @mokagio particularly!