### PR TITLE
Update: Clear tracks data when logging out

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v2.23.0]
+
+### Fixes
+
+- Properly clear analytics cookies on logout [#3269](https://github.com/Automattic/simplenote-electron/pull/3269)
+
 ## [v2.22.2]
 
 ### Enhancements

--- a/lib/boot.ts
+++ b/lib/boot.ts
@@ -16,20 +16,10 @@ const clearStorage = (): Promise<void> =>
     localStorage.removeItem('localQueue:note');
     localStorage.removeItem('localQueue:preferences');
     localStorage.removeItem('localQueue:tag');
+    localStorage.removeItem('simpleNote');
     localStorage.removeItem('stored_user');
     sessionStorage.clear();
     window.electron?.send('appStateUpdate', {});
-
-    const settings = localStorage.getItem('simpleNote');
-    if (settings) {
-      try {
-        const { accountName, ...otherSettings } = JSON.parse(settings);
-        localStorage.setItem('simpleNote', JSON.stringify(otherSettings));
-      } catch (e) {
-        // pass - we only care if we can successfully do this,
-        //        not if we fail to do it
-      }
-    }
 
     Promise.all([
       new Promise((resolve) => {

--- a/lib/state/analytics/middleware.ts
+++ b/lib/state/analytics/middleware.ts
@@ -100,6 +100,7 @@ export const middleware: S.Middleware = (store) => {
         break;
       case 'LOGOUT':
         record('user_signed_out');
+        analytics.clearedIdentity();
         break;
       case 'OPEN_NOTE':
         record('list_note_opened');


### PR DESCRIPTION
### Fix

Fixes this issue about the `tk` cookie sticking around: https://hackerone.com/reports/2793499

Will close https://github.com/Automattic/simplenote-gae/issues/644

### Test

1. Log in and have analytics enabled (if it was disabled, you might want to log out and log back in to make sure the cookie gets set)
2. Log out
3. Verify that the `tk_id` cookie no longer has the signed-in email address

### Release

<!--
**_(Required)_** Add a concise statement to `RELEASE-NOTES.md` if the changes should be included in release notes. Include details about updating the notes in this section. For example:

> `RELEASE-NOTES.md` was updated with:
>
> > Added markdown support

If the changes should not be included in release notes, add a statement to this section. For example:

> These changes do not require release notes.
-->
