### PR TITLE
Fix WPCC redirect

### DIFF
--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -543,7 +543,7 @@ export class Auth extends Component<Props> {
 
   onSubmitCode = (event: React.FormEvent) => {
     event.preventDefault();
-    this.setState({ authState: 'login-requested' });
+    // this.setState({ authStatus: 'login-requested' });
     this.setState({
       passwordErrorMessage: '',
     });

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -34,7 +34,6 @@ type Props = OwnProps;
 
 export class Auth extends Component<Props> {
   state = {
-    authState: '',
     isCreatingAccount: false,
     passwordErrorMessage: null,
     onLine: window.navigator.onLine,
@@ -543,7 +542,6 @@ export class Auth extends Component<Props> {
 
   onSubmitCode = (event: React.FormEvent) => {
     event.preventDefault();
-    // this.setState({ authStatus: 'login-requested' });
     this.setState({
       passwordErrorMessage: '',
     });
@@ -564,8 +562,8 @@ export class Auth extends Component<Props> {
 
   onWPLogin = () => {
     const redirectUrl = encodeURIComponent(config.wpcc_redirect_url);
-    this.setState({ authState: `app-${cryptoRandomString(20)}` });
-    const authUrl = `https://public-api.wordpress.com/oauth2/authorize?client_id=${config.wpcc_client_id}&redirect_uri=${redirectUrl}&response_type=code&scope=global&state=${this.state.authState}`;
+    const savedAuthState = `app-${cryptoRandomString(20)}`;
+    const authUrl = `https://public-api.wordpress.com/oauth2/authorize?client_id=${config.wpcc_client_id}&redirect_uri=${redirectUrl}&response_type=code&scope=global&state=${savedAuthState}`;
 
     window.electron.send('wpLogin', authUrl);
 
@@ -593,12 +591,10 @@ export class Auth extends Component<Props> {
             'Please confirm your account with the confirmation email before signing in to Simplenote.'
           );
         default:
-          console.log(errorCode);
           return this.authError('An error was encountered while signing in.');
       }
 
-      if (authState !== this.state.authState) {
-        console.log(['authState mismatch: ', authState, this.state.authState]);
+      if (authState !== savedAuthState) {
         return;
       }
       this.props.tokenLogin(userEmail, simperiumToken);

--- a/lib/auth/index.tsx
+++ b/lib/auth/index.tsx
@@ -593,10 +593,12 @@ export class Auth extends Component<Props> {
             'Please confirm your account with the confirmation email before signing in to Simplenote.'
           );
         default:
+          console.log(errorCode);
           return this.authError('An error was encountered while signing in.');
       }
 
       if (authState !== this.state.authState) {
+        console.log(['authState mismatch: ', authState, this.state.authState]);
         return;
       }
       this.props.tokenLogin(userEmail, simperiumToken);


### PR DESCRIPTION
### Fix

Fixes #3278 

A bit of a typo / copypasta was introduced in #3246 that caused the auth state (checksum) to be overwritten before the request was handled and verified. If we keep it as a locally-scoped `const` rather than a state variable, authentication works again.

### Test

1. n.b. Make sure you are logged out of app.simplenote.com, or it won't redirect back to the app
1. Download the build artifact from this PR
2. Sign in via WordPress.com
3. Approve the request and login should succeed

### Release

`RELEASE-NOTES.md` was updated with:
> Fix WordPress.com login on the Electron builds

