### PR TITLE
Add release notes for PR 3281

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fix WordPress.com login on the Electron builds [#3281](https://github.com/Automattic/simplenote-electron/pull/3281)
 - Properly clear analytics cookies on logout [#3269](https://github.com/Automattic/simplenote-electron/pull/3269)
 
 ## [v2.22.2]


### PR DESCRIPTION
### Fix

I apparently added the release note to the PR description for #3281 and committed the change locally, but didn't push it upstream. So here it is.

