### PR TITLE
Update: use `simplenote:user_id` instead of `wpcom:user_id` for Tracks

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,6 +6,7 @@
 
 - Updated styles, sass, style linting [#3294](https://github.com/Automattic/simplenote-electron/pull/3294)
 - Upgraded dependencies [#3292](https://github.com/Automattic/simplenote-electron/pull/3292)
+- Updated the ID type used for analytics to avoid sending invalid WPCOM IDs [#3291](https://github.com/Automattic/simplenote-electron/pull/3291)
 
 ## [v2.23.1]
 

--- a/lib/analytics/tracks.ts
+++ b/lib/analytics/tracks.ts
@@ -139,7 +139,7 @@ function buildTracks() {
     }
     userId = loadWpcomIdentity();
     if (userId) {
-      userIdType = 'simplenote:user_id';
+      userIdType = 'wpcom:user_email';
     } else {
       userIdType = 'anon';
       userId = get(userAnonCookie);

--- a/lib/analytics/tracks.ts
+++ b/lib/analytics/tracks.ts
@@ -139,7 +139,7 @@ function buildTracks() {
     }
     userId = loadWpcomIdentity();
     if (userId) {
-      userIdType = 'wpcom:user_id';
+      userIdType = 'simplenote:user_id';
     } else {
       userIdType = 'anon';
       userId = get(userAnonCookie);
@@ -317,7 +317,7 @@ function buildTracks() {
     }
 
     userId = newUserId;
-    userIdType = 'wpcom:user_id';
+    userIdType = 'simplenote:user_id';
     set(userNameCookie, userId);
     const anonId = get(userAnonCookie);
     if (anonId) {

--- a/lib/analytics/tracks.ts
+++ b/lib/analytics/tracks.ts
@@ -106,16 +106,6 @@ function buildTracks() {
     setCookie(key, value, ttl);
   };
 
-  const loadWpcomIdentity = function () {
-    const wpcomCookie =
-      getCookie('wordpress') ||
-      getCookie('wordpress_sec') ||
-      getCookie('wordpress_loggedin');
-    if (wpcomCookie) {
-      return get(userNameCookie);
-    }
-  };
-
   const newAnonId = function () {
     const randomBytesLength = 18; // 18 * 4/3 = 24
     let randomBytes: number[] | Uint8Array = [];
@@ -131,23 +121,6 @@ function buildTracks() {
 
     // eslint-disable-next-line
     return btoa(String.fromCharCode.apply(String, randomBytes as number[]));
-  };
-
-  const loadIdentity = function () {
-    if (userId) {
-      return;
-    }
-    userId = loadWpcomIdentity();
-    if (userId) {
-      userIdType = 'wpcom:user_email';
-    } else {
-      userIdType = 'anon';
-      userId = get(userAnonCookie);
-      if (!userId) {
-        userId = newAnonId();
-        set(userAnonCookie, userId);
-      }
-    }
   };
 
   const getQueries = function () {
@@ -238,7 +211,6 @@ function buildTracks() {
   };
 
   const send = function (query: Query) {
-    loadIdentity();
     retryQueries();
     query._ui = userId;
     query._ut = userIdType;
@@ -334,7 +306,6 @@ function buildTracks() {
     userLogin = null;
     set(userNameCookie, '', -1);
     set(userAnonCookie, '', -1);
-    loadIdentity();
   };
 
   const setProperties = function (properties: Query) {


### PR DESCRIPTION
### Fix

Will close #3290.

After testing, @roundhill and I concluded that we only care about the Simplenote ID, and don't need to associate these accounts with WPCOM accounts. At any rate, the code path that attempts to load user information from the WPCOM login cookie never seems to be hit. So for consistency with the mobile apps (and the expectations of the Tracks API) this removes that code entirely and sends the Simplenote ID (email address) as the ID type `simplenote:user_id`.

### Release

`RELEASE-NOTES.md` was updated with:

> Updated the ID type used for analytics to avoid sending invalid WPCOM IDs