### PR TITLE
Use latest Buildkite plugins

### DIFF
--- a/.buildkite/commands/package_windows.ps1
+++ b/.buildkite/commands/package_windows.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-& "prepare_windows_host_for_node.ps1"
+& "prepare_windows_host_for_app_distribution.ps1" # via CI toolkit Buildkite plugin
 
 # First try to get the env var from the process environment
 $windowsCertPassword = [System.Environment]::GetEnvironmentVariable('WINDOWS_CODE_SIGNING_CERT_PASSWORD', [System.EnvironmentVariableTarget]::Process)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,6 +73,7 @@ steps:
       queue: windows
     plugins:
       - $CI_TOOLKIT_PLUGIN
+      - $NVM_PLUGIN
     command: .buildkite/commands/package_windows.ps1
     env:
       CSC_FOR_PULL_REQUEST: true

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
-CI_TOOLKIT_PLUGIN_VERSION='mokagio/windows-utils'
+CI_TOOLKIT_PLUGIN_VERSION='5.0.0'
 NVM_PLUGIN_VERSION='0.3.0'
 
 export IMAGE_ID="$XCODE_VERSION"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -6,7 +6,7 @@
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
 CI_TOOLKIT_PLUGIN_VERSION='5.0.0'
-NVM_PLUGIN_VERSION='0.3.0'
+NVM_PLUGIN_VERSION='0.4.0'
 
 export IMAGE_ID="$XCODE_VERSION"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -6,7 +6,7 @@
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
 CI_TOOLKIT_PLUGIN_VERSION='5.0.0'
-NVM_PLUGIN_VERSION='0.4.0'
+NVM_PLUGIN_VERSION='0.5.0'
 
 export IMAGE_ID="$XCODE_VERSION"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"


### PR DESCRIPTION
### Fix

Use latest Buildkite plugins:

- CI toolkit v5 for better Windows support
- nvm v0.4.0 for better logs

### Test

See green CI for the Windows step in this PR:

<img width="1385" alt="image" src="https://github.com/user-attachments/assets/184084a9-ef02-481e-9985-b2b962a1798a" />

<!-- blue -->
> [!NOTE]  
> Looking at the logs made me realize we don't have Node.js modules caching in CI. Tracked in https://github.com/Automattic/simplenote-electron/issues/3301

### Release notes

N.A.