### PR TITLE
Update: Indentation woes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v2.23.3]
+
+### Fixes
+
+- Remove hanging indent support due to its detrimental effect on word-wrapped list items [#3302](https://github.com/Automattic/simplenote-electron/pull/3302)
+
 ## [v2.23.2]
 
 ### Other Changes

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -1286,7 +1286,7 @@ class NoteContentEditor extends Component<Props> {
               unusualLineTerminators: 'auto',
               wordWrap: 'bounded',
               wordWrapColumn: 400,
-              wrappingIndent: 'none',
+              wrappingIndent: 'same',
               wrappingStrategy: 'advanced',
             }}
             value={content}


### PR DESCRIPTION
### Fix

In #3216, I changed Monaco's `wrappingIndent` to `none` in order to address a request to support hanging indents on paragraphs. Unfortunately this also removes the indentation from lists, making lists less readable.

Some further research in https://github.com/Automattic/simplenote-electron/issues/3053#issuecomment-2696467125 but basically I think we were better off with the default of `same`. There's no way to indent paragraphs, sadly, as even a single space gets matched by the word wrapping algorithm (which is not affected by the settings for detecting indentation settings, tab size, etc.).

Monaco/VS Code does not support these things I've thought of as workarounds:
- Different word wrap settings for lists and paragraphs
- Using CSS to apply styling to only the first line
- Different word wrap settings for different languages
- Using the tokenizer to adjust the indent size
- Language settings for indent/outdent applying to the word wrapping indent

Here are some relevant upstream issues: https://github.com/microsoft/monaco-editor/issues/3914, https://github.com/microsoft/vscode/issues/219680, https://github.com/microsoft/vscode/issues/169804, https://github.com/microsoft/vscode/issues/164267

Anyhow, this PR represents a partial revert of #3216, as maybe the least terrible of the available options. I think that `indent` is a deal-breaker due to representing a serious departure from expectations for long-form writing, whereas a hanging indent on paragraphs is more of a "nice to have" for that use-case. Meanwhile for lists, `none` is pretty bad, probably(?) worse than the weird behavior of indenting entire paragraphs that we get with `same`.

Which is a complicated way of saying that `same` is optimal for lists with word-wrapping, `none` is optimal for paragraphs, and we can't switch our strategy depending on which it is we have, so we have to pick a side.

Other considerations:
- An initial indent gets perceived by the Markdown preview renderer as an indication of a code block. List items that aren't indented, and their nested children, are safe -- but indented list items that don't have an un-indented parent are not.
- The native apps apparently support an initial indent on paragraphs, which then indents the entire paragraph when viewed on web/desktop.

## Screenshots

Here are the three options and their trade-offs.

![Screenshot 2025-03-04 at 01 03 09](https://github.com/user-attachments/assets/4363f39b-e1ea-4a42-aa28-45a4f0342e24)

![Screenshot 2025-03-04 at 01 34 39](https://github.com/user-attachments/assets/44396112-5739-4aa1-88e4-817672344334)

![Screenshot 2025-03-04 at 02 26 31](https://github.com/user-attachments/assets/0e69291d-08f6-485b-801b-22b291856bf6)


### Release

Release notes updated with:

> Remove hanging indent support due to its detrimental effect on word-wrapped list items.

n.b. I've added this to a new minor version, 2.23.3, but it could arguably be a hotfix for 2.23.2.