### PR TITLE
Fix: Paste issues in the context menu

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v2.23.3]
+
+### Fixes
+
+- Fixed paste not working in context menu and enabled it in browsers [#3316](https://github.com/Automattic/simplenote-electron/pull/3316)
+
 ## [v2.23.2]
 
 ### Other Changes

--- a/lib/boot-without-auth.tsx
+++ b/lib/boot-without-auth.tsx
@@ -54,10 +54,10 @@ class AppWithoutAuth extends Component<Props, State> {
     window.electron?.receive('appCommand', this.onAppCommand);
     document.body.dataset.theme = this.systemTheme;
 
-    window.electron?.receive('tokenLogin', (url) => {
+    window.electron?.receive('tokenLogin', (url: string) => {
       const { searchParams } = new URL(url);
       const simperiumToken = searchParams.get('token');
-      const email = atob(searchParams.get('email'));
+      const email = atob(searchParams.get('email') || '');
       this.tokenLogin(email, simperiumToken);
     });
   }

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -715,7 +715,6 @@ class NoteContentEditor extends Component<Props> {
       keybindingContext: 'allowBrowserKeybinding',
       contextMenuGroupId: '1_modification',
       contextMenuOrder: 2,
-      // precondition: 'undo',
       run: () => {
         editor.trigger('contextMenu', 'undo', null);
       },
@@ -731,7 +730,6 @@ class NoteContentEditor extends Component<Props> {
       keybindingContext: 'allowBrowserKeybinding',
       contextMenuGroupId: '1_modification',
       contextMenuOrder: 3,
-      // precondition: 'redo',
       run: () => {
         editor.trigger('contextMenu', 'redo', null);
       },
@@ -742,17 +740,17 @@ class NoteContentEditor extends Component<Props> {
       {
         keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyX,
         command: 'editor.action.clipboardCutAction',
-        when: 'allowBrowserKeybinding',
+        when: 'allowBrowserKeybinding && editorTextFocus',
       },
       {
         keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyC,
         command: 'editor.action.clipboardCopyAction',
-        when: 'allowBrowserKeybinding',
+        when: 'allowBrowserKeybinding && editorTextFocus',
       },
       {
         keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV,
         command: 'editor.action.clipboardPasteAction',
-        when: 'allowBrowserKeybinding',
+        when: 'allowBrowserKeybinding && editorTextFocus',
       },
     ]);
 
@@ -771,7 +769,7 @@ class NoteContentEditor extends Component<Props> {
       contextMenuGroupId: '9_cutcopypaste',
       contextMenuOrder: 4,
       keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyA],
-      keybindingContext: 'allowBrowserKeybinding',
+      keybindingContext: 'allowBrowserKeybinding && editorTextFocus',
       run: () => {
         const range = editor.getModel()?.getFullModelRange();
         range && editor.setSelection(range);
@@ -785,7 +783,7 @@ class NoteContentEditor extends Component<Props> {
         monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyC,
         monaco.KeyMod.WinCtrl | monaco.KeyMod.Shift | monaco.KeyCode.KeyC,
       ],
-      keybindingContext: 'allowBrowserKeybinding',
+      keybindingContext: 'allowBrowserKeybinding && editorTextFocus',
       contextMenuGroupId: '10_checklist',
       contextMenuOrder: 1,
       run: this.insertOrRemoveCheckboxes,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -688,12 +688,6 @@ class NoteContentEditor extends Component<Props> {
       'editor.action.selectHighlights',
     ];
 
-    // let Electron menus trigger these on the Mac
-    // this breaks the shortcuts on Win/Linux -- not sure why
-    if (window.electron && isMac) {
-      shortcutsToDisable.push('undo', 'redo', 'editor.action.selectAll');
-    }
-
     shortcutsToDisable.forEach(function (action) {
       monaco.editor.addKeybindingRule({
         keybinding: 0,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -650,11 +650,8 @@ class NoteContentEditor extends Component<Props> {
 
     /* remove unwanted context menu items */
     // see https://github.com/Microsoft/monaco-editor/issues/1058#issuecomment-468681208
-    const removableIds = [
+    const idsToRemove = [
       'editor.action.changeAll',
-      'editor.action.clipboardCutAction',
-      'editor.action.clipboardCopyAction',
-      'editor.action.clipboardPasteAction',
       'editor.action.quickCommand',
     ];
 
@@ -669,8 +666,8 @@ class NoteContentEditor extends Component<Props> {
     contextmenu._getMenuActions = function (...args) {
       const items = realMethod.apply(contextmenu, args);
 
-      return items.filter(function (item) {
-        return !removableIds.includes(item.id);
+      return items.filter(function (item: Editor.IActionDescriptor) {
+        return !idsToRemove.includes(item.id);
       });
     };
 
@@ -690,6 +687,7 @@ class NoteContentEditor extends Component<Props> {
       'editor.action.nextMatchFindAction',
       'editor.action.selectHighlights',
     ];
+
     // let Electron menus trigger these on the Mac
     // this breaks the shortcuts on Win/Linux -- not sure why
     if (window.electron && isMac) {
@@ -739,35 +737,24 @@ class NoteContentEditor extends Component<Props> {
       },
     });
 
-    // add a new Cut and Copy that show keyboard shortcuts
-    // Cut and Copy don't show keybindings
-    // @see https://github.com/microsoft/monaco-editor/issues/2882
-    editor.addAction({
-      id: 'context_cut',
-      label: 'Cut',
-      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyX],
-      keybindingContext: 'allowBrowserKeybinding',
-      contextMenuGroupId: '9_cutcopypaste',
-      contextMenuOrder: 1,
-      run: () => {
-        editor.trigger('contextMenu', 'editor.action.clipboardCutAction', null);
+    // re-add keybindings for cut/copy/paste so they show labels
+    monaco.editor.addKeybindingRules([
+      {
+        keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyX,
+        command: 'editor.action.clipboardCutAction',
+        when: 'allowBrowserKeybinding',
       },
-    });
-    editor.addAction({
-      id: 'context_copy',
-      label: 'Copy',
-      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyC],
-      keybindingContext: 'allowBrowserKeybinding',
-      contextMenuGroupId: '9_cutcopypaste',
-      contextMenuOrder: 2,
-      run: () => {
-        editor.trigger(
-          'contextMenu',
-          'editor.action.clipboardCopyAction',
-          null
-        );
+      {
+        keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyC,
+        command: 'editor.action.clipboardCopyAction',
+        when: 'allowBrowserKeybinding',
       },
-    });
+      {
+        keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV,
+        command: 'editor.action.clipboardPasteAction',
+        when: 'allowBrowserKeybinding',
+      },
+    ]);
 
     // cancel selection that bubbles up to clear any search terms
     editor.addAction({
@@ -777,21 +764,6 @@ class NoteContentEditor extends Component<Props> {
       keybindingContext: '!suggestWidgetVisible',
       run: this.cancelSelectionOrSearch,
     });
-
-    /* paste doesn't work in the browser due to security issues */
-    if (window.electron) {
-      editor.addAction({
-        id: 'paste',
-        label: 'Paste',
-        contextMenuGroupId: '9_cutcopypaste',
-        contextMenuOrder: 3,
-        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV],
-        keybindingContext: 'allowBrowserKeybinding',
-        run: () => {
-          document.execCommand('paste');
-        },
-      });
-    }
 
     editor.addAction({
       id: 'select_all',


### PR DESCRIPTION
### Fix

Will fix #3315 
Will fix #2994

Monaco/VSCode [now support](https://github.com/microsoft/vscode/issues/82604) paste in the browser.

We do still need to re-add the keybindings if we want labels for the keybindings. See: https://github.com/microsoft/monaco-editor/issues/2882#issuecomment-2101997854

### Test

This needs testing in multiple browsers and platforms (browser and Electron).

1. Right click should show Cut/Copy/Paste with labels appropriate to the platform (cmd key / ctrl key)
2. Cut/Copy/Paste should work from context menu
3. Should also work from keyboard shortcuts
4. Should also wrok from top-level Edit menu

### Release

`RELEASE-NOTES.md` was updated with:
> Fixed paste not working in context menu and enabled it in browsers
