### PR TITLE
Importer: Supporting ZIP Imports

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,6 +6,10 @@
 
 - Fixed paste not working in context menu and enabled it in browsers [#3316](https://github.com/Automattic/simplenote-electron/pull/3316)
 
+### Other Changes
+
+- Implemented support for importing ZIP files (https://github.com/Automattic/simplenote-electron/pull/3328)
+
 ## [v2.23.2]
 
 ### Other Changes

--- a/lib/dialogs/import/importers.ts
+++ b/lib/dialogs/import/importers.ts
@@ -7,7 +7,7 @@ type Importer = {
 
 const simplenoteImporter: Importer = {
   name: 'simplenote',
-  fileTypes: ['json'],
+  fileTypes: ['json', 'zip'],
 };
 
 const evernoteImporter: Importer = {
@@ -47,6 +47,9 @@ export const forFilename = (file: String): Importer => {
 
   switch (fileExtension) {
     case 'json':
+      return simplenoteImporter;
+
+    case 'zip':
       return simplenoteImporter;
 
     case 'enex':

--- a/lib/dialogs/import/index.tsx
+++ b/lib/dialogs/import/index.tsx
@@ -23,11 +23,13 @@ class ImportDialog extends Component<Props> {
     const { closeDialog } = this.props;
     const { importStarted } = this.state;
     const source = {
-      acceptedTypes: isElectron ? '.txt,.md,.json,.enex' : '.txt,.md,.json',
+      acceptedTypes: isElectron
+        ? '.txt,.md,.json,.zip,.enex'
+        : '.txt,.md,.zip,.json',
       title: `Select the notes you'd like to import.`,
       instructions: isElectron
-        ? 'Accepted file formats: Simplenote (JSON), Text (TXT, MD) and Evernote (ENEX).'
-        : 'Accepted file formats: Simplenote (JSON) and Text (TXT, MD).',
+        ? 'Accepted file formats: Simplenote (JSON, ZIP), Text (TXT, MD) and Evernote (ENEX).'
+        : 'Accepted file formats: Simplenote (JSON, ZIP) and Text (TXT, MD).',
       multiple: true,
     };
 

--- a/lib/utils/import/simplenote/index.ts
+++ b/lib/utils/import/simplenote/index.ts
@@ -31,10 +31,10 @@ class SimplenoteImporter extends EventEmitter {
       return;
     }
 
-    // if (endsWith(fileName, '.json')) {
-    //   this.processJsonFile(file);
-    //   return;
-    // }
+    if (endsWith(fileName, '.json')) {
+      this.processJsonFile(file);
+      return;
+    }
 
     if (endsWith(fileName, '.zip')) {
       this.processZipFile(file);
@@ -43,7 +43,7 @@ class SimplenoteImporter extends EventEmitter {
     this.emit('status', 'error', 'File must be a .json or .zip file.');
   };
 
-  processJsonFile = (file, coreImporter) => {
+  processJsonFile = (file) => {
     const coreImporter = new CoreImporter(this.addNote);
     const fileReader = new FileReader();
 

--- a/lib/utils/import/simplenote/index.ts
+++ b/lib/utils/import/simplenote/index.ts
@@ -72,6 +72,16 @@ class SimplenoteImporter extends EventEmitter {
       return;
     }
 
+    if (!dataObj.activeNotes || !Array.isArray(dataObj.activeNotes)) {
+      this.emit('status', 'error', 'Invalid Simplenote JSON format.');
+      return;
+    }
+
+    if (!dataObj.trashedNotes || !Array.isArray(dataObj.trashedNotes)) {
+      this.emit('status', 'error', 'Invalid Simplenote JSON format.');
+      return;
+    }
+
     const noteCount = dataObj.activeNotes.length + dataObj.trashedNotes.length;
     const processedNotes = {
       activeNotes: convertModificationDates(dataObj.activeNotes),

--- a/lib/utils/import/simplenote/index.ts
+++ b/lib/utils/import/simplenote/index.ts
@@ -72,16 +72,6 @@ class SimplenoteImporter extends EventEmitter {
       return;
     }
 
-    if (!dataObj.activeNotes || !Array.isArray(dataObj.activeNotes)) {
-      this.emit('status', 'error', 'Invalid Simplenote JSON format.');
-      return;
-    }
-
-    if (!dataObj.trashedNotes || !Array.isArray(dataObj.trashedNotes)) {
-      this.emit('status', 'error', 'Invalid Simplenote JSON format.');
-      return;
-    }
-
     const noteCount = dataObj.activeNotes.length + dataObj.trashedNotes.length;
     const processedNotes = {
       activeNotes: convertModificationDates(dataObj.activeNotes),

--- a/lib/utils/import/simplenote/index.ts
+++ b/lib/utils/import/simplenote/index.ts
@@ -72,6 +72,11 @@ class SimplenoteImporter extends EventEmitter {
       return;
     }
 
+    if (!dataObj.activeNotes || !Array.isArray(dataObj.activeNotes)) {
+      this.emit('status', 'error', 'Invalid Simplenote JSON format.');
+      return;
+    }
+
     const noteCount = dataObj.activeNotes.length + dataObj.trashedNotes.length;
     const processedNotes = {
       activeNotes: convertModificationDates(dataObj.activeNotes),

--- a/lib/utils/import/simplenote/index.ts
+++ b/lib/utils/import/simplenote/index.ts
@@ -107,17 +107,17 @@ class SimplenoteImporter extends EventEmitter {
         .then(({ default: JSZip }) => JSZip.loadAsync(fileContent))
         .then((zip) => {
           // Look for JSON files in the ZIP
-          const jsonFiles = Object.keys(zip.files).filter((filename) =>
-            filename.toLowerCase().endsWith('.json')
+          const jsonFileEntry = Object.entries(zip.files).find(
+            ([path]) => path.toLowerCase() === 'source/notes.json'
           );
 
-          if (jsonFiles.length === 0) {
+          if (!jsonFileEntry) {
             this.emit('status', 'error', 'No JSON files found in ZIP archive.');
             return;
           }
 
           // Process the first JSON file found
-          const jsonFile = zip.files[jsonFiles[0]];
+          const jsonFile = jsonFileEntry[1];
           return jsonFile.async('text');
         })
         .then((jsonContent) => {

--- a/lib/utils/import/simplenote/test.ts
+++ b/lib/utils/import/simplenote/test.ts
@@ -92,6 +92,20 @@ describe('SimplenoteImporter', () => {
       expect(mockFileReader.readAsArrayBuffer).toHaveBeenCalledWith(zipFile);
     });
 
+    it('should handle missing activeNotes in JSON from ZIP', () => {
+      const incompleteJsonContent = JSON.stringify({
+        trashedNotes: [],
+      });
+
+      importer.parseAndImportJson(incompleteJsonContent);
+
+      expect(importer.emit).toHaveBeenCalledWith(
+        'status',
+        'error',
+        'Invalid Simplenote JSON format.'
+      );
+    });
+
     it('should correctly identify and process JSON files in ZIP', () => {
       // Test that the file type detection works correctly for ZIP files
       const zipFile = new File(['zip-content'], 'export.zip', {

--- a/lib/utils/import/simplenote/test.ts
+++ b/lib/utils/import/simplenote/test.ts
@@ -62,12 +62,12 @@ describe('SimplenoteImporter', () => {
       expect(importer.processZipFile).toHaveBeenCalledWith(zipFile);
     });
 
-    it('should emit error when ZIP file is empty in processZipFile', () => {
+    it('should emit error when ZIP file is empty in importNotes', () => {
       const zipFile = new File([''], 'test.zip', { type: 'application/zip' });
       const mockFileReader = new FileReader();
       (FileReader as any).mockImplementation(() => mockFileReader);
 
-      importer.processZipFile(zipFile);
+      importer.importNotes([zipFile]);
 
       mockFileReader.result = null;
       mockFileReader.onload({ target: { result: null } });
@@ -77,19 +77,6 @@ describe('SimplenoteImporter', () => {
         'error',
         'File was empty.'
       );
-    });
-
-    it('should call readAsArrayBuffer for ZIP files', () => {
-      const zipFile = new File(['content'], 'test.zip', {
-        type: 'application/zip',
-      });
-      const mockFileReader = new FileReader();
-      mockFileReader.readAsArrayBuffer = jest.fn();
-      (FileReader as any).mockImplementation(() => mockFileReader);
-
-      importer.processZipFile(zipFile);
-
-      expect(mockFileReader.readAsArrayBuffer).toHaveBeenCalledWith(zipFile);
     });
 
     it('should handle missing activeNotes in JSON from ZIP', () => {

--- a/lib/utils/import/simplenote/test.ts
+++ b/lib/utils/import/simplenote/test.ts
@@ -79,12 +79,23 @@ describe('SimplenoteImporter', () => {
       );
     });
 
-    it('should handle missing activeNotes in JSON from ZIP', () => {
+    it('should handle missing activeNotes in JSON', () => {
       const incompleteJsonContent = JSON.stringify({
         trashedNotes: [],
       });
 
-      importer.parseAndImportJson(incompleteJsonContent);
+      const jsonFile = new File([incompleteJsonContent], 'notes.json', {
+        type: 'application/json',
+      });
+
+      const mockFileReader = new FileReader();
+      (FileReader as any).mockImplementation(() => mockFileReader);
+
+      importer.importNotes([jsonFile]);
+
+      // Simulate the FileReader onload event with the incomplete JSON content
+      mockFileReader.result = incompleteJsonContent;
+      mockFileReader.onload({ target: { result: incompleteJsonContent } });
 
       expect(importer.emit).toHaveBeenCalledWith(
         'status',

--- a/lib/utils/import/simplenote/test.ts
+++ b/lib/utils/import/simplenote/test.ts
@@ -92,34 +92,6 @@ describe('SimplenoteImporter', () => {
       expect(mockFileReader.readAsArrayBuffer).toHaveBeenCalledWith(zipFile);
     });
 
-    it('should handle missing activeNotes in JSON from ZIP', () => {
-      const incompleteJsonContent = JSON.stringify({
-        trashedNotes: [],
-      });
-
-      importer.parseAndImportJson(incompleteJsonContent);
-
-      expect(importer.emit).toHaveBeenCalledWith(
-        'status',
-        'error',
-        'Invalid Simplenote JSON format.'
-      );
-    });
-
-    it('should handle missing trashedNotes in JSON from ZIP', () => {
-      const incompleteJsonContent = JSON.stringify({
-        activeNotes: [],
-      });
-
-      importer.parseAndImportJson(incompleteJsonContent);
-
-      expect(importer.emit).toHaveBeenCalledWith(
-        'status',
-        'error',
-        'Invalid Simplenote JSON format.'
-      );
-    });
-
     it('should correctly identify and process JSON files in ZIP', () => {
       // Test that the file type detection works correctly for ZIP files
       const zipFile = new File(['zip-content'], 'export.zip', {


### PR DESCRIPTION
### Fix
In this PR we're enhancing the Importer, so that users can import the `zip` files, exactly the way they've exported them.


### Test
1. Export your notes (zip) at Simplenote.com, any test account would work!
2. Setup Simplenote Electron secrets in your system (DM me if anything!)
3. Run `npm run dev`
4. Open `http://localhost:4000/`
5. Log into your account
6. Open `Settings > Tools > Import Notes`

- [ ] Verify you see a reference to Simplenote Zip files
- [ ] Verify you can import your notes!
- [ ] Verify the Unit Tests are green (`npm test`)


### Release
`RELEASE-NOTES.md` was updated with:

> Implemented support for importing ZIP files (https://github.com/Automattic/simplenote-electron/pull/3328)
