### PR TITLE
Bump CI toolkit to version 5.7.0 to leverage new Windows AMI

### DIFF
--- a/.buildkite/commands/package_windows.ps1
+++ b/.buildkite/commands/package_windows.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-& "prepare_windows_host_for_app_distribution.ps1" # via CI toolkit Buildkite plugin
+& "setup_windows_code_signing.ps1" # via CI toolkit Buildkite plugin
 
 # First try to get the env var from the process environment
 $windowsCertPassword = [System.Environment]::GetEnvironmentVariable('WINDOWS_CODE_SIGNING_CERT_PASSWORD', [System.EnvironmentVariableTarget]::Process)

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
-CI_TOOLKIT_PLUGIN_VERSION='5.1.2'
+CI_TOOLKIT_PLUGIN_VERSION='5.7.0'
 NVM_PLUGIN_VERSION='0.6.0'
 
 export IMAGE_ID="$XCODE_VERSION"


### PR DESCRIPTION
These changes make sure we can make the most of the new Windows CI.

See https://linear.app/a8c/issue/AINFRA-1472