### PR TITLE
Fix Firefox web Ctrl+V paste regression

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v2.24.1]
+
+### Fixes
+
+- Fixed Firefox web paste to use the browser's native clipboard shortcuts and context menu [#3349](https://github.com/Automattic/simplenote-electron/pull/3349)
+
 ## [v2.24.0]
 
 ### New Features

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -26,7 +26,7 @@ import {
   getNotePosition,
   setNotePosition,
 } from './utils/note-scroll-position';
-import { isMac, isSafari } from './utils/platform';
+import { useMonacoPasteShortcut } from './utils/platform';
 import {
   withCheckboxCharacters,
   withCheckboxSyntax,
@@ -729,8 +729,9 @@ class NoteContentEditor extends Component<Props> {
       },
     });
 
-    // re-add keybindings for cut/copy/paste so they show labels
-    monaco.editor.addKeybindingRules([
+    // Firefox fails to resolve `editor.action.clipboardPasteAction` in web mode.
+    // Let the browser handle Ctrl+V natively there.
+    const clipboardKeybindingRules = [
       {
         keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyX,
         command: 'editor.action.clipboardCutAction',
@@ -741,12 +742,15 @@ class NoteContentEditor extends Component<Props> {
         command: 'editor.action.clipboardCopyAction',
         when: 'allowBrowserKeybinding && editorTextFocus',
       },
-      {
+    ];
+    if (useMonacoPasteShortcut) {
+      clipboardKeybindingRules.push({
         keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV,
         command: 'editor.action.clipboardPasteAction',
         when: 'allowBrowserKeybinding && editorTextFocus',
-      },
-    ]);
+      });
+    }
+    monaco.editor.addKeybindingRules(clipboardKeybindingRules);
 
     // cancel selection that bubbles up to clear any search terms
     editor.addAction({

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -729,8 +729,7 @@ class NoteContentEditor extends Component<Props> {
       },
     });
 
-    // Firefox fails to resolve `editor.action.clipboardPasteAction` in web mode.
-    // Let the browser handle Ctrl+V natively there.
+    // Firefox web is more reliable when the browser handles Ctrl+V natively.
     const clipboardKeybindingRules = [
       {
         keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyX,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -699,10 +699,8 @@ class NoteContentEditor extends Component<Props> {
 
     // disable editor keybindings for Electron since it is handled by editorCommand
     // doing it this way will always show the keyboard hint in the context menu!
-    editor.createContextKey(
-      'allowBrowserKeybinding',
-      window.electron ? false : true
-    );
+    const allowBrowserKeybinding = !window.electron;
+    editor.createContextKey('allowBrowserKeybinding', allowBrowserKeybinding);
 
     editor.addAction({
       id: 'context_undo',
@@ -731,7 +729,7 @@ class NoteContentEditor extends Component<Props> {
       },
     });
 
-    // Firefox web is more reliable when the browser handles Ctrl+V natively.
+    // Firefox web is more reliable when the browser handles clipboard UI natively.
     const clipboardKeybindingRules = [
       {
         keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyX,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -26,7 +26,7 @@ import {
   getNotePosition,
   setNotePosition,
 } from './utils/note-scroll-position';
-import { useMonacoPasteShortcut } from './utils/platform';
+import { useMonacoContextMenu, useMonacoPasteShortcut } from './utils/platform';
 import {
   withCheckboxCharacters,
   withCheckboxSyntax,
@@ -648,28 +648,30 @@ class NoteContentEditor extends Component<Props> {
       },
     });
 
-    /* remove unwanted context menu items */
-    // see https://github.com/Microsoft/monaco-editor/issues/1058#issuecomment-468681208
-    const idsToRemove = [
-      'editor.action.changeAll',
-      'editor.action.quickCommand',
-    ];
+    if (useMonacoContextMenu) {
+      /* remove unwanted context menu items */
+      // see https://github.com/Microsoft/monaco-editor/issues/1058#issuecomment-468681208
+      const idsToRemove = [
+        'editor.action.changeAll',
+        'editor.action.quickCommand',
+      ];
 
-    const contextmenu = this.editor.getContribution(
-      'editor.contrib.contextmenu'
-    );
+      const contextmenu = this.editor.getContribution(
+        'editor.contrib.contextmenu'
+      );
 
-    // @ts-ignore undocumented internals
-    const realMethod = contextmenu._getMenuActions;
+      // @ts-ignore undocumented internals
+      const realMethod = contextmenu._getMenuActions;
 
-    // @ts-ignore undocumented internals
-    contextmenu._getMenuActions = function (...args) {
-      const items = realMethod.apply(contextmenu, args);
+      // @ts-ignore undocumented internals
+      contextmenu._getMenuActions = function (...args) {
+        const items = realMethod.apply(contextmenu, args);
 
-      return items.filter(function (item: Editor.IActionDescriptor) {
-        return !idsToRemove.includes(item.id);
-      });
-    };
+        return items.filter(function (item: Editor.IActionDescriptor) {
+          return !idsToRemove.includes(item.id);
+        });
+      };
+    }
 
     // remove some default keybindings
     // @see https://github.com/microsoft/monaco-editor/issues/3623#issuecomment-1472578786
@@ -1215,6 +1217,7 @@ class NoteContentEditor extends Component<Props> {
               // @ts-ignore, @see https://github.com/microsoft/monaco-editor/issues/3829
               'bracketPairColorization.enabled': false,
               codeLens: false,
+              contextmenu: useMonacoContextMenu,
               folding: false,
               fontFamily:
                 '"Simplenote Tasks", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif',

--- a/lib/utils/platform.test.ts
+++ b/lib/utils/platform.test.ts
@@ -1,4 +1,5 @@
 import {
+  canUseMonacoContextMenu,
   canUseMonacoPasteShortcut,
   isFirefoxUserAgent,
   isSafariUserAgent,
@@ -63,6 +64,33 @@ describe('platform user-agent detection', () => {
   it('keeps Monaco paste shortcut enabled outside Firefox web mode', () => {
     expect(
       canUseMonacoPasteShortcut(
+        false,
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36'
+      )
+    ).toBe(true);
+  });
+
+  it('disables Monaco context menu in Firefox web mode', () => {
+    expect(
+      canUseMonacoContextMenu(
+        false,
+        'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0'
+      )
+    ).toBe(false);
+  });
+
+  it('keeps Monaco context menu enabled in Electron mode', () => {
+    expect(
+      canUseMonacoContextMenu(
+        true,
+        'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0'
+      )
+    ).toBe(true);
+  });
+
+  it('keeps Monaco context menu enabled outside Firefox web mode', () => {
+    expect(
+      canUseMonacoContextMenu(
         false,
         'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36'
       )

--- a/lib/utils/platform.test.ts
+++ b/lib/utils/platform.test.ts
@@ -5,95 +5,59 @@ import {
   isSafariUserAgent,
 } from './platform';
 
+const firefoxDesktopUserAgent =
+  'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0';
+
+const firefoxIosUserAgent =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/150.0 Mobile/15E148 Safari/605.1.15';
+
+const chromeDesktopUserAgent =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36';
+
+const safariDesktopUserAgent =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15';
+
 describe('platform user-agent detection', () => {
   it('detects Firefox user agents', () => {
-    expect(
-      isFirefoxUserAgent(
-        'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0'
-      )
-    ).toBe(true);
+    expect(isFirefoxUserAgent(firefoxDesktopUserAgent)).toBe(true);
   });
 
   it('detects Firefox for iOS user agents', () => {
-    expect(
-      isFirefoxUserAgent(
-        'Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/150.0 Mobile/15E148 Safari/605.1.15'
-      )
-    ).toBe(true);
+    expect(isFirefoxUserAgent(firefoxIosUserAgent)).toBe(true);
   });
 
   it('does not detect Chromium as Firefox', () => {
-    expect(
-      isFirefoxUserAgent(
-        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36'
-      )
-    ).toBe(false);
+    expect(isFirefoxUserAgent(chromeDesktopUserAgent)).toBe(false);
   });
 
   it('keeps Safari detection separate from Chromium', () => {
-    expect(
-      isSafariUserAgent(
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15'
-      )
-    ).toBe(true);
-    expect(
-      isSafariUserAgent(
-        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36'
-      )
-    ).toBe(false);
+    expect(isSafariUserAgent(safariDesktopUserAgent)).toBe(true);
+    expect(isSafariUserAgent(chromeDesktopUserAgent)).toBe(false);
   });
 
   it('disables Monaco paste shortcut in Firefox web mode', () => {
-    expect(
-      canUseMonacoPasteShortcut(
-        false,
-        'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0'
-      )
-    ).toBe(false);
+    expect(canUseMonacoPasteShortcut(false, firefoxDesktopUserAgent)).toBe(
+      false
+    );
   });
 
   it('keeps Monaco paste shortcut enabled in Electron mode', () => {
-    expect(
-      canUseMonacoPasteShortcut(
-        true,
-        'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0'
-      )
-    ).toBe(true);
+    expect(canUseMonacoPasteShortcut(true, firefoxDesktopUserAgent)).toBe(true);
   });
 
   it('keeps Monaco paste shortcut enabled outside Firefox web mode', () => {
-    expect(
-      canUseMonacoPasteShortcut(
-        false,
-        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36'
-      )
-    ).toBe(true);
+    expect(canUseMonacoPasteShortcut(false, chromeDesktopUserAgent)).toBe(true);
   });
 
   it('disables Monaco context menu in Firefox web mode', () => {
-    expect(
-      canUseMonacoContextMenu(
-        false,
-        'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0'
-      )
-    ).toBe(false);
+    expect(canUseMonacoContextMenu(false, firefoxDesktopUserAgent)).toBe(false);
   });
 
   it('keeps Monaco context menu enabled in Electron mode', () => {
-    expect(
-      canUseMonacoContextMenu(
-        true,
-        'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0'
-      )
-    ).toBe(true);
+    expect(canUseMonacoContextMenu(true, firefoxDesktopUserAgent)).toBe(true);
   });
 
   it('keeps Monaco context menu enabled outside Firefox web mode', () => {
-    expect(
-      canUseMonacoContextMenu(
-        false,
-        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36'
-      )
-    ).toBe(true);
+    expect(canUseMonacoContextMenu(false, chromeDesktopUserAgent)).toBe(true);
   });
 });

--- a/lib/utils/platform.test.ts
+++ b/lib/utils/platform.test.ts
@@ -1,0 +1,85 @@
+import {
+  canUseMonacoPasteShortcut,
+  isFirefoxUserAgent,
+  isSafariUserAgent,
+} from './platform';
+
+describe('platform user-agent detection', () => {
+  it('detects Firefox user agents', () => {
+    expect(
+      isFirefoxUserAgent(
+        'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0'
+      )
+    ).toBe(true);
+  });
+
+  it('detects Firefox for iOS user agents', () => {
+    expect(
+      isFirefoxUserAgent(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/150.0 Mobile/15E148 Safari/605.1.15'
+      )
+    ).toBe(true);
+  });
+
+  it('does not detect Chromium as Firefox', () => {
+    expect(
+      isFirefoxUserAgent(
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36'
+      )
+    ).toBe(false);
+  });
+
+  it('keeps Safari detection separate from Chromium', () => {
+    expect(
+      isSafariUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15'
+      )
+    ).toBe(true);
+    expect(
+      isSafariUserAgent(
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36'
+      )
+    ).toBe(false);
+  });
+
+  it('disables Monaco paste shortcut in Firefox web mode', () => {
+    expect(
+      canUseMonacoPasteShortcut(
+        false,
+        'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0',
+        true,
+        false
+      )
+    ).toBe(false);
+  });
+
+  it('keeps Monaco paste shortcut enabled in Electron mode', () => {
+    expect(
+      canUseMonacoPasteShortcut(
+        true,
+        'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0',
+        true,
+        false
+      )
+    ).toBe(true);
+  });
+
+  it('uses queryCommandSupported result when clipboard API is missing', () => {
+    expect(
+      canUseMonacoPasteShortcut(
+        false,
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36',
+        false,
+        true
+      )
+    ).toBe(true);
+    expect(
+      canUseMonacoPasteShortcut(
+        false,
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36',
+        false,
+        false
+      )
+    ).toBe(false);
+  });
+});

--- a/lib/utils/platform.test.ts
+++ b/lib/utils/platform.test.ts
@@ -46,9 +46,7 @@ describe('platform user-agent detection', () => {
     expect(
       canUseMonacoPasteShortcut(
         false,
-        'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0',
-        true,
-        false
+        'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0'
       )
     ).toBe(false);
   });
@@ -57,29 +55,17 @@ describe('platform user-agent detection', () => {
     expect(
       canUseMonacoPasteShortcut(
         true,
-        'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0',
-        true,
-        false
+        'Mozilla/5.0 (X11; Linux x86_64; rv:145.0) Gecko/20100101 Firefox/145.0'
       )
     ).toBe(true);
   });
 
-  it('uses queryCommandSupported result when clipboard API is missing', () => {
+  it('keeps Monaco paste shortcut enabled outside Firefox web mode', () => {
     expect(
       canUseMonacoPasteShortcut(
         false,
-        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36',
-        false,
-        true
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36'
       )
     ).toBe(true);
-    expect(
-      canUseMonacoPasteShortcut(
-        false,
-        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36',
-        false,
-        false
-      )
-    ).toBe(false);
   });
 });

--- a/lib/utils/platform.ts
+++ b/lib/utils/platform.ts
@@ -7,8 +7,39 @@ export const isMac = isElectron
 
 export const CmdOrCtrl = isElectron && isMac ? 'Cmd' : 'Ctrl';
 
-export const isSafari = /^((?!chrome|android).)*safari/i.test(
-  window.navigator.userAgent
+export const isSafariUserAgent = (userAgent: string) =>
+  /^((?!chrome|android).)*safari/i.test(userAgent);
+
+export const isFirefoxUserAgent = (userAgent: string) =>
+  /(firefox|fxios|librewolf|iceweasel)/i.test(userAgent);
+
+export const isSafari = isSafariUserAgent(window.navigator.userAgent);
+
+export const isFirefox = isFirefoxUserAgent(window.navigator.userAgent);
+
+export const canUseMonacoPasteShortcut = (
+  useElectron: boolean,
+  userAgent: string,
+  clipboardApiAvailable: boolean,
+  pasteCommandSupported: boolean
+) => {
+  if (useElectron) {
+    return true;
+  }
+
+  if (!clipboardApiAvailable || isFirefoxUserAgent(userAgent)) {
+    return pasteCommandSupported;
+  }
+
+  return true;
+};
+
+export const useMonacoPasteShortcut = canUseMonacoPasteShortcut(
+  isElectron,
+  window.navigator.userAgent,
+  typeof navigator.clipboard !== 'undefined',
+  typeof document.queryCommandSupported === 'function' &&
+    document.queryCommandSupported('paste')
 );
 
 export const isLinux = isElectron

--- a/lib/utils/platform.ts
+++ b/lib/utils/platform.ts
@@ -19,27 +19,12 @@ export const isFirefox = isFirefoxUserAgent(window.navigator.userAgent);
 
 export const canUseMonacoPasteShortcut = (
   useElectron: boolean,
-  userAgent: string,
-  clipboardApiAvailable: boolean,
-  pasteCommandSupported: boolean
-) => {
-  if (useElectron) {
-    return true;
-  }
-
-  if (!clipboardApiAvailable || isFirefoxUserAgent(userAgent)) {
-    return pasteCommandSupported;
-  }
-
-  return true;
-};
+  userAgent: string
+) => useElectron || !isFirefoxUserAgent(userAgent);
 
 export const useMonacoPasteShortcut = canUseMonacoPasteShortcut(
   isElectron,
-  window.navigator.userAgent,
-  typeof navigator.clipboard !== 'undefined',
-  typeof document.queryCommandSupported === 'function' &&
-    document.queryCommandSupported('paste')
+  window.navigator.userAgent
 );
 
 export const isLinux = isElectron

--- a/lib/utils/platform.ts
+++ b/lib/utils/platform.ts
@@ -17,17 +17,22 @@ export const isSafari = isSafariUserAgent(window.navigator.userAgent);
 
 export const isFirefox = isFirefoxUserAgent(window.navigator.userAgent);
 
-const canUseMonacoClipboardUi = (useElectron: boolean, userAgent: string) =>
-  useElectron || !isFirefoxUserAgent(userAgent);
+const shouldUseNativeBrowserClipboardUi = (
+  useElectron: boolean,
+  userAgent: string
+) => !useElectron && isFirefoxUserAgent(userAgent);
 
-export const canUseMonacoPasteShortcut = canUseMonacoClipboardUi;
+export const canUseMonacoPasteShortcut = (
+  useElectron: boolean,
+  userAgent: string
+) => !shouldUseNativeBrowserClipboardUi(useElectron, userAgent);
 
 export const useMonacoPasteShortcut = canUseMonacoPasteShortcut(
   isElectron,
   window.navigator.userAgent
 );
 
-export const canUseMonacoContextMenu = canUseMonacoClipboardUi;
+export const canUseMonacoContextMenu = canUseMonacoPasteShortcut;
 
 export const useMonacoContextMenu = canUseMonacoContextMenu(
   isElectron,

--- a/lib/utils/platform.ts
+++ b/lib/utils/platform.ts
@@ -17,12 +17,19 @@ export const isSafari = isSafariUserAgent(window.navigator.userAgent);
 
 export const isFirefox = isFirefoxUserAgent(window.navigator.userAgent);
 
-export const canUseMonacoPasteShortcut = (
-  useElectron: boolean,
-  userAgent: string
-) => useElectron || !isFirefoxUserAgent(userAgent);
+const canUseMonacoClipboardUi = (useElectron: boolean, userAgent: string) =>
+  useElectron || !isFirefoxUserAgent(userAgent);
+
+export const canUseMonacoPasteShortcut = canUseMonacoClipboardUi;
 
 export const useMonacoPasteShortcut = canUseMonacoPasteShortcut(
+  isElectron,
+  window.navigator.userAgent
+);
+
+export const canUseMonacoContextMenu = canUseMonacoClipboardUi;
+
+export const useMonacoContextMenu = canUseMonacoContextMenu(
   isElectron,
   window.navigator.userAgent
 );


### PR DESCRIPTION
### Fix

Fixes Firefox web paste regressions in the note editor (`#3329`).

After `#3316`, Simplenote re-added Monaco clipboard keybindings in the browser and continued using Monaco’s context menu there. In Firefox web mode, those Monaco clipboard paths are not reliable.

This PR keeps the existing Monaco clipboard behavior for Electron and non-Firefox browsers, but for Firefox web it now:
- skips the Monaco paste shortcut so Firefox handles `Ctrl+V` natively
- disables the Monaco editor context menu so Firefox uses its native clipboard context menu instead

That moves Firefox web back to the browser-native clipboard flow while keeping the current behavior elsewhere.

### Test

1. In Firefox web, focus the note editor and verify `Ctrl+V` pastes using the browser-native clipboard flow.
2. In Firefox web, right-click in the editor and verify the browser-native context menu is used instead of Monaco’s context menu.
3. In Chromium/Electron flows, verify cut/copy/paste shortcuts still work.
4. Run:
   - `npx eslint lib/note-content-editor.tsx lib/utils/platform.ts lib/utils/platform.test.ts`
   - `npx jest --config=./jest.config.js lib/utils/platform.test.ts`
   - `make build`

### Release

`RELEASE-NOTES.md` was updated with:

> Fixed Firefox web paste to use the browser's native clipboard shortcuts and context menu