### PR TITLE
[codex] Add Cmd+K global search shortcut

### DIFF
--- a/desktop/menus/edit-menu.js
+++ b/desktop/menus/edit-menu.js
@@ -54,6 +54,11 @@ const buildEditMenu = (settings, isAuthenticated, editMode) => {
         accelerator: 'CommandOrControl+Shift+S',
       },
       {
+        label: 'Search Notes…',
+        click: appCommandSender({ action: 'focusSearchField' }),
+        accelerator: 'CommandOrControl+K',
+      },
+      {
         label: '&Find in Note',
         click: appCommandSender({ action: 'focusSearchField' }),
         accelerator: 'CommandOrControl+F',

--- a/lib/app.tsx
+++ b/lib/app.tsx
@@ -158,7 +158,8 @@ class AppComponent extends Component<Props> {
 
     if (
       (cmdOrCtrl && shiftKey && 's' === key) ||
-      (cmdOrCtrl && !shiftKey && 'f' === key)
+      (cmdOrCtrl && !shiftKey && 'f' === key) ||
+      (cmdOrCtrl && !shiftKey && 'k' === key)
     ) {
       this.props.focusSearchField();
 

--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -62,6 +62,9 @@ export class AboutDialog extends Component<DispatchProps> {
                   </Keys>
                 </li>
                 <li>
+                  <Keys keys={[CmdOrCtrl, 'K']}>Focus search field</Keys>
+                </li>
+                <li>
                   <Keys keys={[CmdOrCtrl, 'G']}>
                     Jump to next match in note
                   </Keys>


### PR DESCRIPTION
## Summary

Adds `Cmd+K` / `Ctrl+K` as another way to focus the existing global search field.

Changes:
- Handles `Cmd/Ctrl+K` in the existing browser capture-phase search shortcut handler.
- Adds an Electron Edit menu accelerator that dispatches the same `focusSearchField` action.
- Documents the shortcut in the keyboard shortcuts dialog.

Linear: https://linear.app/a8c/issue/SIMPL-48/add-cmdk-ctrlk-as-an-alias-for-global-search

## Testing

- `npx eslint lib/app.tsx desktop/menus/edit-menu.js lib/dialogs/keybindings/index.tsx`

Note: targeted lint passes with one existing `no-shadow` warning in `lib/dialogs/keybindings/index.tsx`.
