### PR TITLE
[codex] Add source-visible Markdown decorations

### DIFF
--- a/lib/markdown-decorations.test.ts
+++ b/lib/markdown-decorations.test.ts
@@ -36,9 +36,9 @@ describe('getMarkdownDecorations', () => {
     ]);
   });
 
-  it('decorates only the asterisk marker for supported unordered lists', () => {
+  it('decorates supported unordered list markers', () => {
     const decorations = getMarkdownDecorations(
-      modelFromLines(['* list item', '- out of scope'])
+      modelFromLines(['* list item', '- second item', '  + nested item'])
     );
 
     expect(decorations).toEqual([
@@ -48,6 +48,24 @@ describe('getMarkdownDecorations', () => {
           startColumn: 1,
           endLineNumber: 1,
           endColumn: 2,
+        },
+        options: { inlineClassName: 'md-list-marker' },
+      },
+      {
+        range: {
+          startLineNumber: 2,
+          startColumn: 1,
+          endLineNumber: 2,
+          endColumn: 2,
+        },
+        options: { inlineClassName: 'md-list-marker' },
+      },
+      {
+        range: {
+          startLineNumber: 3,
+          startColumn: 3,
+          endLineNumber: 3,
+          endColumn: 4,
         },
         options: { inlineClassName: 'md-list-marker' },
       },
@@ -144,9 +162,30 @@ describe('getMarkdownDecorations', () => {
     ]);
   });
 
+  it('decorates supported strikethrough spans', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines(['A ~~struck span~~ here'])
+    );
+
+    expect(decorations).toEqual([
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 3,
+          endLineNumber: 1,
+          endColumn: 18,
+        },
+        options: { inlineClassName: 'md-strikethrough' },
+      },
+    ]);
+  });
+
   it('does not decorate escaped markers or URL-like spans', () => {
     const decorations = getMarkdownDecorations(
-      modelFromLines(['Skip \\*escaped\\* and https://example.com/*path*'])
+      modelFromLines([
+        'Skip \\*escaped\\* and https://example.com/*path*',
+        'Skip \\~~escaped~~ and https://example.com/~~path~~',
+      ])
     );
 
     expect(decorations).toEqual([]);
@@ -154,7 +193,9 @@ describe('getMarkdownDecorations', () => {
 
   it('does not decorate whitespace-padded italic markers', () => {
     const decorations = getMarkdownDecorations(
-      modelFromLines(['Skip * padded* and *padded * and _ padded_'])
+      modelFromLines([
+        'Skip * padded* and *padded * and _ padded_ and ~~ nope~~',
+      ])
     );
 
     expect(decorations).toEqual([]);

--- a/lib/markdown-decorations.test.ts
+++ b/lib/markdown-decorations.test.ts
@@ -72,6 +72,51 @@ describe('getMarkdownDecorations', () => {
     ]);
   });
 
+  it('decorates double-asterisk spans as bold instead of italic', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines(['A **bold span** here'])
+    );
+
+    expect(decorations).toEqual([
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 3,
+          endLineNumber: 1,
+          endColumn: 16,
+        },
+        options: { inlineClassName: 'md-bold' },
+      },
+    ]);
+  });
+
+  it('decorates bold and italic spans independently', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines(['Use **bold** and *italic*'])
+    );
+
+    expect(decorations).toEqual([
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 5,
+          endLineNumber: 1,
+          endColumn: 13,
+        },
+        options: { inlineClassName: 'md-bold' },
+      },
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 18,
+          endLineNumber: 1,
+          endColumn: 26,
+        },
+        options: { inlineClassName: 'md-italic' },
+      },
+    ]);
+  });
+
   it('does not decorate escaped markers or URL-like spans', () => {
     const decorations = getMarkdownDecorations(
       modelFromLines(['Skip \\*escaped\\* and https://example.com/*path*'])

--- a/lib/markdown-decorations.test.ts
+++ b/lib/markdown-decorations.test.ts
@@ -1,0 +1,90 @@
+import { editor as Editor } from 'monaco-editor';
+
+import { getMarkdownDecorations } from './markdown-decorations';
+
+const modelFromLines = (lines: string[]) =>
+  ({
+    getLineCount: () => lines.length,
+    getLineContent: (lineNumber: number) => lines[lineNumber - 1],
+  }) as unknown as Editor.ITextModel;
+
+describe('getMarkdownDecorations', () => {
+  it('decorates heading text by level', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines(['# Title', '### Smaller'])
+    );
+
+    expect(decorations).toEqual([
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 3,
+          endLineNumber: 1,
+          endColumn: 8,
+        },
+        options: { inlineClassName: 'md-heading-1' },
+      },
+      {
+        range: {
+          startLineNumber: 2,
+          startColumn: 5,
+          endLineNumber: 2,
+          endColumn: 12,
+        },
+        options: { inlineClassName: 'md-heading-3' },
+      },
+    ]);
+  });
+
+  it('decorates only the asterisk marker for supported unordered lists', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines(['* list item', '- out of scope'])
+    );
+
+    expect(decorations).toEqual([
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: 1,
+          endColumn: 2,
+        },
+        options: { inlineClassName: 'md-list-marker' },
+      },
+    ]);
+  });
+
+  it('decorates supported italic spans', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines(['A *simple span* here'])
+    );
+
+    expect(decorations).toEqual([
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 3,
+          endLineNumber: 1,
+          endColumn: 16,
+        },
+        options: { inlineClassName: 'md-italic' },
+      },
+    ]);
+  });
+
+  it('does not decorate escaped markers or URL-like spans', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines(['Skip \\*escaped\\* and https://example.com/*path*'])
+    );
+
+    expect(decorations).toEqual([]);
+  });
+
+  it('does not decorate whitespace-padded italic markers', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines(['Skip * padded* and *padded *'])
+    );
+
+    expect(decorations).toEqual([]);
+  });
+});

--- a/lib/markdown-decorations.test.ts
+++ b/lib/markdown-decorations.test.ts
@@ -72,6 +72,109 @@ describe('getMarkdownDecorations', () => {
     ]);
   });
 
+  it('decorates inline spans inside unordered list items', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines([
+        '- **bold** and *italic* and ~~strike~~',
+        '  * _also italic_ and __bold__',
+        '+ ***both*** and ___also___',
+      ])
+    );
+
+    expect(decorations).toEqual([
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: 1,
+          endColumn: 2,
+        },
+        options: { inlineClassName: 'md-list-marker' },
+      },
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 3,
+          endLineNumber: 1,
+          endColumn: 11,
+        },
+        options: { inlineClassName: 'md-bold' },
+      },
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 16,
+          endLineNumber: 1,
+          endColumn: 24,
+        },
+        options: { inlineClassName: 'md-italic' },
+      },
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 29,
+          endLineNumber: 1,
+          endColumn: 39,
+        },
+        options: { inlineClassName: 'md-strikethrough' },
+      },
+      {
+        range: {
+          startLineNumber: 2,
+          startColumn: 3,
+          endLineNumber: 2,
+          endColumn: 4,
+        },
+        options: { inlineClassName: 'md-list-marker' },
+      },
+      {
+        range: {
+          startLineNumber: 2,
+          startColumn: 5,
+          endLineNumber: 2,
+          endColumn: 18,
+        },
+        options: { inlineClassName: 'md-italic' },
+      },
+      {
+        range: {
+          startLineNumber: 2,
+          startColumn: 23,
+          endLineNumber: 2,
+          endColumn: 31,
+        },
+        options: { inlineClassName: 'md-bold' },
+      },
+      {
+        range: {
+          startLineNumber: 3,
+          startColumn: 1,
+          endLineNumber: 3,
+          endColumn: 2,
+        },
+        options: { inlineClassName: 'md-list-marker' },
+      },
+      {
+        range: {
+          startLineNumber: 3,
+          startColumn: 3,
+          endLineNumber: 3,
+          endColumn: 13,
+        },
+        options: { inlineClassName: 'md-bold md-italic' },
+      },
+      {
+        range: {
+          startLineNumber: 3,
+          startColumn: 18,
+          endLineNumber: 3,
+          endColumn: 28,
+        },
+        options: { inlineClassName: 'md-bold md-italic' },
+      },
+    ]);
+  });
+
   it('decorates supported italic spans', () => {
     const decorations = getMarkdownDecorations(
       modelFromLines(['A *simple span* here'])

--- a/lib/markdown-decorations.test.ts
+++ b/lib/markdown-decorations.test.ts
@@ -72,6 +72,24 @@ describe('getMarkdownDecorations', () => {
     ]);
   });
 
+  it('decorates supported underscore italic spans', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines(['A _simple span_ here'])
+    );
+
+    expect(decorations).toEqual([
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 3,
+          endLineNumber: 1,
+          endColumn: 16,
+        },
+        options: { inlineClassName: 'md-italic' },
+      },
+    ]);
+  });
+
   it('decorates double-asterisk spans as bold instead of italic', () => {
     const decorations = getMarkdownDecorations(
       modelFromLines(['A **bold span** here'])
@@ -92,7 +110,7 @@ describe('getMarkdownDecorations', () => {
 
   it('decorates bold and italic spans independently', () => {
     const decorations = getMarkdownDecorations(
-      modelFromLines(['Use **bold** and *italic*'])
+      modelFromLines(['Use **bold** and *italic* and _also italic_'])
     );
 
     expect(decorations).toEqual([
@@ -114,6 +132,15 @@ describe('getMarkdownDecorations', () => {
         },
         options: { inlineClassName: 'md-italic' },
       },
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 31,
+          endLineNumber: 1,
+          endColumn: 44,
+        },
+        options: { inlineClassName: 'md-italic' },
+      },
     ]);
   });
 
@@ -127,7 +154,15 @@ describe('getMarkdownDecorations', () => {
 
   it('does not decorate whitespace-padded italic markers', () => {
     const decorations = getMarkdownDecorations(
-      modelFromLines(['Skip * padded* and *padded *'])
+      modelFromLines(['Skip * padded* and *padded * and _ padded_'])
+    );
+
+    expect(decorations).toEqual([]);
+  });
+
+  it('does not decorate underscores inside words', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines(['Keep snake_case_text literal'])
     );
 
     expect(decorations).toEqual([]);

--- a/lib/markdown-decorations.test.ts
+++ b/lib/markdown-decorations.test.ts
@@ -108,6 +108,33 @@ describe('getMarkdownDecorations', () => {
     ]);
   });
 
+  it('decorates renderer-compatible underscore spans', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines(['Decorate _foo_bar_ and __bold__'])
+    );
+
+    expect(decorations).toEqual([
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 10,
+          endLineNumber: 1,
+          endColumn: 19,
+        },
+        options: { inlineClassName: 'md-italic' },
+      },
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 24,
+          endLineNumber: 1,
+          endColumn: 32,
+        },
+        options: { inlineClassName: 'md-bold' },
+      },
+    ]);
+  });
+
   it('decorates double-asterisk spans as bold instead of italic', () => {
     const decorations = getMarkdownDecorations(
       modelFromLines(['A **bold span** here'])
@@ -122,6 +149,33 @@ describe('getMarkdownDecorations', () => {
           endColumn: 16,
         },
         options: { inlineClassName: 'md-bold' },
+      },
+    ]);
+  });
+
+  it('decorates combined bold and italic spans', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines(['***both*** and ___also___'])
+    );
+
+    expect(decorations).toEqual([
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: 1,
+          endColumn: 11,
+        },
+        options: { inlineClassName: 'md-bold md-italic' },
+      },
+      {
+        range: {
+          startLineNumber: 1,
+          startColumn: 16,
+          endLineNumber: 1,
+          endColumn: 26,
+        },
+        options: { inlineClassName: 'md-bold md-italic' },
       },
     ]);
   });
@@ -189,6 +243,31 @@ describe('getMarkdownDecorations', () => {
     );
 
     expect(decorations).toEqual([]);
+  });
+
+  it('does not decorate inline markers inside code spans or fenced code blocks', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines([
+        'Inline `**literal**` and `*literal*`',
+        '```',
+        '# Literal heading',
+        '**literal**',
+        '```',
+        'After **bold**',
+      ])
+    );
+
+    expect(decorations).toEqual([
+      {
+        range: {
+          startLineNumber: 6,
+          startColumn: 7,
+          endLineNumber: 6,
+          endColumn: 15,
+        },
+        options: { inlineClassName: 'md-bold' },
+      },
+    ]);
   });
 
   it('does not decorate whitespace-padded italic markers', () => {

--- a/lib/markdown-decorations.ts
+++ b/lib/markdown-decorations.ts
@@ -1,0 +1,104 @@
+import { editor as Editor } from 'monaco-editor';
+
+const urlPattern = /https?:\/\/\S+/g;
+const italicPattern = /\*([^\s*][^*]*[^\s*]|[^\s*])\*/g;
+
+type Span = {
+  start: number;
+  end: number;
+};
+
+const decoration = (
+  lineNumber: number,
+  startColumn: number,
+  endColumn: number,
+  inlineClassName: string
+): Editor.IModelDeltaDecoration => ({
+  range: {
+    startLineNumber: lineNumber,
+    startColumn,
+    endLineNumber: lineNumber,
+    endColumn,
+  },
+  options: { inlineClassName },
+});
+
+const spansForPattern = (line: string, pattern: RegExp): Span[] => {
+  const spans: Span[] = [];
+  let match;
+
+  pattern.lastIndex = 0;
+  while ((match = pattern.exec(line))) {
+    spans.push({
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+
+  return spans;
+};
+
+const overlapsSpan = (start: number, end: number, spans: Span[]) =>
+  spans.some((span) => start < span.end && end > span.start);
+
+const isEscaped = (line: string, index: number) => {
+  let slashCount = 0;
+  for (let i = index - 1; i >= 0 && line[i] === '\\'; i--) {
+    slashCount++;
+  }
+  return slashCount % 2 === 1;
+};
+
+export const getMarkdownDecorations = (
+  model?: Editor.ITextModel | null
+): Editor.IModelDeltaDecoration[] => {
+  if (!model) {
+    return [];
+  }
+
+  const decorations: Editor.IModelDeltaDecoration[] = [];
+
+  for (let lineNumber = 1; lineNumber <= model.getLineCount(); lineNumber++) {
+    const line = model.getLineContent(lineNumber);
+    const headingMatch = /^(#{1,6})\s+(.+)$/.exec(line);
+
+    if (headingMatch) {
+      const headingLevel = headingMatch[1].length;
+      decorations.push(
+        decoration(
+          lineNumber,
+          headingMatch[0].length - headingMatch[2].length + 1,
+          line.length + 1,
+          `md-heading-${headingLevel}`
+        )
+      );
+      continue;
+    }
+
+    if (/^\*\s+/.test(line)) {
+      decorations.push(decoration(lineNumber, 1, 2, 'md-list-marker'));
+      continue;
+    }
+
+    const urlSpans = spansForPattern(line, urlPattern);
+    italicPattern.lastIndex = 0;
+
+    let match;
+    while ((match = italicPattern.exec(line))) {
+      const start = match.index;
+      const end = start + match[0].length;
+
+      if (
+        isEscaped(line, start) ||
+        isEscaped(line, end - 1) ||
+        overlapsSpan(start, end, urlSpans)
+      ) {
+        continue;
+      }
+
+      decorations.push(decoration(lineNumber, start + 1, end + 1, 'md-italic'));
+    }
+  }
+
+  return decorations;
+};

--- a/lib/markdown-decorations.ts
+++ b/lib/markdown-decorations.ts
@@ -3,6 +3,7 @@ import { editor as Editor } from 'monaco-editor';
 const urlPattern = /https?:\/\/\S+/g;
 const boldPattern = /\*\*([^\s*][^*]*[^\s*]|[^\s*])\*\*/g;
 const italicPattern = /\*([^\s*][^*]*[^\s*]|[^\s*])\*/g;
+const underscoreItalicPattern = /_([^\s_][^_]*[^\s_]|[^\s_])_/g;
 
 type Span = {
   start: number;
@@ -48,6 +49,15 @@ const overlapsSpan = (start: number, end: number, spans: Span[]) =>
 
 const isPartOfAsteriskRun = (line: string, start: number, end: number) =>
   line[start - 1] === '*' || line[end] === '*';
+
+const isPartOfUnderscoreRun = (line: string, start: number, end: number) =>
+  line[start - 1] === '_' || line[end] === '_';
+
+const isWordCharacter = (character: string | undefined) =>
+  typeof character === 'string' && /\w/.test(character);
+
+const isInsideWord = (line: string, start: number, end: number) =>
+  isWordCharacter(line[start - 1]) || isWordCharacter(line[end]);
 
 const isEscaped = (line: string, index: number) => {
   let slashCount = 0;
@@ -117,6 +127,25 @@ export const getMarkdownDecorations = (
         isEscaped(line, start) ||
         isEscaped(line, end - 1) ||
         isPartOfAsteriskRun(line, start, end) ||
+        overlapsSpan(start, end, urlSpans) ||
+        overlapsSpan(start, end, inlineSpans)
+      ) {
+        continue;
+      }
+
+      inlineSpans.push({ start, end, inlineClassName: 'md-italic' });
+    }
+
+    underscoreItalicPattern.lastIndex = 0;
+    while ((match = underscoreItalicPattern.exec(line))) {
+      const start = match.index;
+      const end = start + match[0].length;
+
+      if (
+        isEscaped(line, start) ||
+        isEscaped(line, end - 1) ||
+        isPartOfUnderscoreRun(line, start, end) ||
+        isInsideWord(line, start, end) ||
         overlapsSpan(start, end, urlSpans) ||
         overlapsSpan(start, end, inlineSpans)
       ) {

--- a/lib/markdown-decorations.ts
+++ b/lib/markdown-decorations.ts
@@ -1,11 +1,16 @@
 import { editor as Editor } from 'monaco-editor';
 
 const urlPattern = /https?:\/\/\S+/g;
+const boldPattern = /\*\*([^\s*][^*]*[^\s*]|[^\s*])\*\*/g;
 const italicPattern = /\*([^\s*][^*]*[^\s*]|[^\s*])\*/g;
 
 type Span = {
   start: number;
   end: number;
+};
+
+type InlineSpan = Span & {
+  inlineClassName: string;
 };
 
 const decoration = (
@@ -40,6 +45,9 @@ const spansForPattern = (line: string, pattern: RegExp): Span[] => {
 
 const overlapsSpan = (start: number, end: number, spans: Span[]) =>
   spans.some((span) => start < span.end && end > span.start);
+
+const isPartOfAsteriskRun = (line: string, start: number, end: number) =>
+  line[start - 1] === '*' || line[end] === '*';
 
 const isEscaped = (line: string, index: number) => {
   let slashCount = 0;
@@ -81,9 +89,26 @@ export const getMarkdownDecorations = (
     }
 
     const urlSpans = spansForPattern(line, urlPattern);
-    italicPattern.lastIndex = 0;
+    const inlineSpans: InlineSpan[] = [];
 
     let match;
+    boldPattern.lastIndex = 0;
+    while ((match = boldPattern.exec(line))) {
+      const start = match.index;
+      const end = start + match[0].length;
+
+      if (
+        isEscaped(line, start) ||
+        isEscaped(line, end - 2) ||
+        overlapsSpan(start, end, urlSpans)
+      ) {
+        continue;
+      }
+
+      inlineSpans.push({ start, end, inlineClassName: 'md-bold' });
+    }
+
+    italicPattern.lastIndex = 0;
     while ((match = italicPattern.exec(line))) {
       const start = match.index;
       const end = start + match[0].length;
@@ -91,13 +116,28 @@ export const getMarkdownDecorations = (
       if (
         isEscaped(line, start) ||
         isEscaped(line, end - 1) ||
-        overlapsSpan(start, end, urlSpans)
+        isPartOfAsteriskRun(line, start, end) ||
+        overlapsSpan(start, end, urlSpans) ||
+        overlapsSpan(start, end, inlineSpans)
       ) {
         continue;
       }
 
-      decorations.push(decoration(lineNumber, start + 1, end + 1, 'md-italic'));
+      inlineSpans.push({ start, end, inlineClassName: 'md-italic' });
     }
+
+    inlineSpans
+      .sort((a, b) => a.start - b.start)
+      .forEach((span) => {
+        decorations.push(
+          decoration(
+            lineNumber,
+            span.start + 1,
+            span.end + 1,
+            span.inlineClassName
+          )
+        );
+      });
   }
 
   return decorations;

--- a/lib/markdown-decorations.ts
+++ b/lib/markdown-decorations.ts
@@ -171,10 +171,17 @@ export const getMarkdownDecorations = (
       decorations.push(
         decoration(lineNumber, markerColumn, markerColumn + 1, 'md-list-marker')
       );
-      continue;
     }
 
     const skippedSpans = [
+      ...(listMatch
+        ? [
+            {
+              start: listMatch[1].length,
+              end: listMatch[1].length + listMatch[2].length,
+            },
+          ]
+        : []),
       ...spansForPattern(line, urlPattern),
       ...codeSpansForLine(line),
     ];

--- a/lib/markdown-decorations.ts
+++ b/lib/markdown-decorations.ts
@@ -4,6 +4,7 @@ const urlPattern = /https?:\/\/\S+/g;
 const boldPattern = /\*\*([^\s*][^*]*[^\s*]|[^\s*])\*\*/g;
 const italicPattern = /\*([^\s*][^*]*[^\s*]|[^\s*])\*/g;
 const underscoreItalicPattern = /_([^\s_][^_]*[^\s_]|[^\s_])_/g;
+const strikethroughPattern = /~~([^\s~][^~]*[^\s~]|[^\s~])~~/g;
 
 type Span = {
   start: number;
@@ -93,8 +94,12 @@ export const getMarkdownDecorations = (
       continue;
     }
 
-    if (/^\*\s+/.test(line)) {
-      decorations.push(decoration(lineNumber, 1, 2, 'md-list-marker'));
+    const listMatch = /^(\s*)([-*+])\s+/.exec(line);
+    if (listMatch) {
+      const markerColumn = listMatch[1].length + 1;
+      decorations.push(
+        decoration(lineNumber, markerColumn, markerColumn + 1, 'md-list-marker')
+      );
       continue;
     }
 
@@ -153,6 +158,23 @@ export const getMarkdownDecorations = (
       }
 
       inlineSpans.push({ start, end, inlineClassName: 'md-italic' });
+    }
+
+    strikethroughPattern.lastIndex = 0;
+    while ((match = strikethroughPattern.exec(line))) {
+      const start = match.index;
+      const end = start + match[0].length;
+
+      if (
+        isEscaped(line, start) ||
+        isEscaped(line, end - 2) ||
+        overlapsSpan(start, end, urlSpans) ||
+        overlapsSpan(start, end, inlineSpans)
+      ) {
+        continue;
+      }
+
+      inlineSpans.push({ start, end, inlineClassName: 'md-strikethrough' });
     }
 
     inlineSpans

--- a/lib/markdown-decorations.ts
+++ b/lib/markdown-decorations.ts
@@ -1,10 +1,14 @@
 import { editor as Editor } from 'monaco-editor';
 
 const urlPattern = /https?:\/\/\S+/g;
-const boldPattern = /\*\*([^\s*][^*]*[^\s*]|[^\s*])\*\*/g;
-const italicPattern = /\*([^\s*][^*]*[^\s*]|[^\s*])\*/g;
-const underscoreItalicPattern = /_([^\s_][^_]*[^\s_]|[^\s_])_/g;
+const boldItalicPattern = /\*\*\*(\S[\s\S]*?)\*\*\*/g;
+const boldPattern = /\*\*(\S[\s\S]*?)\*\*/g;
+const italicPattern = /\*([^\s*][\s\S]*?)\*/g;
+const underscoreBoldItalicPattern = /\b___(\S[\s\S]*?)___\b/g;
+const underscoreBoldPattern = /\b__(\S[\s\S]*?)__\b/g;
+const underscoreItalicPattern = /\b_(\S[\s\S]*?)_\b/g;
 const strikethroughPattern = /~~([^\s~][^~]*[^\s~]|[^\s~])~~/g;
+const codeFencePattern = /^ {0,3}(`{3,}|~{3,})/;
 
 type Span = {
   start: number;
@@ -45,20 +49,34 @@ const spansForPattern = (line: string, pattern: RegExp): Span[] => {
   return spans;
 };
 
+const codeSpansForLine = (line: string): Span[] => {
+  const spans: Span[] = [];
+  let index = 0;
+
+  while (index < line.length) {
+    const start = line.indexOf('`', index);
+    if (start === -1) {
+      break;
+    }
+
+    const delimiterLength = line.slice(start).match(/^`+/)?.[0].length ?? 0;
+    const end = line.indexOf(
+      '`'.repeat(delimiterLength),
+      start + delimiterLength
+    );
+    if (end === -1) {
+      break;
+    }
+
+    spans.push({ start, end: end + delimiterLength });
+    index = end + delimiterLength;
+  }
+
+  return spans;
+};
+
 const overlapsSpan = (start: number, end: number, spans: Span[]) =>
   spans.some((span) => start < span.end && end > span.start);
-
-const isPartOfAsteriskRun = (line: string, start: number, end: number) =>
-  line[start - 1] === '*' || line[end] === '*';
-
-const isPartOfUnderscoreRun = (line: string, start: number, end: number) =>
-  line[start - 1] === '_' || line[end] === '_';
-
-const isWordCharacter = (character: string | undefined) =>
-  typeof character === 'string' && /\w/.test(character);
-
-const isInsideWord = (line: string, start: number, end: number) =>
-  isWordCharacter(line[start - 1]) || isWordCharacter(line[end]);
 
 const isEscaped = (line: string, index: number) => {
   let slashCount = 0;
@@ -66,6 +84,37 @@ const isEscaped = (line: string, index: number) => {
     slashCount++;
   }
   return slashCount % 2 === 1;
+};
+
+const hasTextBeforeClosingMarker = (text: string) => /\S$/.test(text);
+
+const addInlineSpansForPattern = (
+  line: string,
+  pattern: RegExp,
+  markerLength: number,
+  inlineClassName: string,
+  skippedSpans: Span[],
+  inlineSpans: InlineSpan[]
+) => {
+  let match;
+
+  pattern.lastIndex = 0;
+  while ((match = pattern.exec(line))) {
+    const start = match.index;
+    const end = start + match[0].length;
+
+    if (
+      !hasTextBeforeClosingMarker(match[1]) ||
+      isEscaped(line, start) ||
+      isEscaped(line, end - markerLength) ||
+      overlapsSpan(start, end, skippedSpans) ||
+      overlapsSpan(start, end, inlineSpans)
+    ) {
+      continue;
+    }
+
+    inlineSpans.push({ start, end, inlineClassName });
+  }
 };
 
 export const getMarkdownDecorations = (
@@ -76,9 +125,31 @@ export const getMarkdownDecorations = (
   }
 
   const decorations: Editor.IModelDeltaDecoration[] = [];
+  let codeFence: { character: string; length: number } | null = null;
 
   for (let lineNumber = 1; lineNumber <= model.getLineCount(); lineNumber++) {
     const line = model.getLineContent(lineNumber);
+    const codeFenceMatch = codeFencePattern.exec(line);
+
+    if (codeFence) {
+      if (
+        codeFenceMatch &&
+        codeFenceMatch[1][0] === codeFence.character &&
+        codeFenceMatch[1].length >= codeFence.length
+      ) {
+        codeFence = null;
+      }
+      continue;
+    }
+
+    if (codeFenceMatch) {
+      codeFence = {
+        character: codeFenceMatch[1][0],
+        length: codeFenceMatch[1].length,
+      };
+      continue;
+    }
+
     const headingMatch = /^(#{1,6})\s+(.+)$/.exec(line);
 
     if (headingMatch) {
@@ -103,79 +174,68 @@ export const getMarkdownDecorations = (
       continue;
     }
 
-    const urlSpans = spansForPattern(line, urlPattern);
+    const skippedSpans = [
+      ...spansForPattern(line, urlPattern),
+      ...codeSpansForLine(line),
+    ];
     const inlineSpans: InlineSpan[] = [];
 
-    let match;
-    boldPattern.lastIndex = 0;
-    while ((match = boldPattern.exec(line))) {
-      const start = match.index;
-      const end = start + match[0].length;
-
-      if (
-        isEscaped(line, start) ||
-        isEscaped(line, end - 2) ||
-        overlapsSpan(start, end, urlSpans)
-      ) {
-        continue;
-      }
-
-      inlineSpans.push({ start, end, inlineClassName: 'md-bold' });
-    }
-
-    italicPattern.lastIndex = 0;
-    while ((match = italicPattern.exec(line))) {
-      const start = match.index;
-      const end = start + match[0].length;
-
-      if (
-        isEscaped(line, start) ||
-        isEscaped(line, end - 1) ||
-        isPartOfAsteriskRun(line, start, end) ||
-        overlapsSpan(start, end, urlSpans) ||
-        overlapsSpan(start, end, inlineSpans)
-      ) {
-        continue;
-      }
-
-      inlineSpans.push({ start, end, inlineClassName: 'md-italic' });
-    }
-
-    underscoreItalicPattern.lastIndex = 0;
-    while ((match = underscoreItalicPattern.exec(line))) {
-      const start = match.index;
-      const end = start + match[0].length;
-
-      if (
-        isEscaped(line, start) ||
-        isEscaped(line, end - 1) ||
-        isPartOfUnderscoreRun(line, start, end) ||
-        isInsideWord(line, start, end) ||
-        overlapsSpan(start, end, urlSpans) ||
-        overlapsSpan(start, end, inlineSpans)
-      ) {
-        continue;
-      }
-
-      inlineSpans.push({ start, end, inlineClassName: 'md-italic' });
-    }
-
-    strikethroughPattern.lastIndex = 0;
-    while ((match = strikethroughPattern.exec(line))) {
-      const start = match.index;
-      const end = start + match[0].length;
-
-      if (
-        isEscaped(line, start) ||
-        isEscaped(line, end - 2) ||
-        overlapsSpan(start, end, urlSpans) ||
-        overlapsSpan(start, end, inlineSpans)
-      ) {
-        continue;
-      }
-
-      inlineSpans.push({ start, end, inlineClassName: 'md-strikethrough' });
-    }
+    addInlineSpansForPattern(
+      line,
+      boldItalicPattern,
+      3,
+      'md-bold md-italic',
+      skippedSpans,
+      inlineSpans
+    );
+    addInlineSpansForPattern(
+      line,
+      boldPattern,
+      2,
+      'md-bold',
+      skippedSpans,
+      inlineSpans
+    );
+    addInlineSpansForPattern(
+      line,
+      italicPattern,
+      1,
+      'md-italic',
+      skippedSpans,
+      inlineSpans
+    );
+    addInlineSpansForPattern(
+      line,
+      underscoreBoldItalicPattern,
+      3,
+      'md-bold md-italic',
+      skippedSpans,
+      inlineSpans
+    );
+    addInlineSpansForPattern(
+      line,
+      underscoreBoldPattern,
+      2,
+      'md-bold',
+      skippedSpans,
+      inlineSpans
+    );
+    addInlineSpansForPattern(
+      line,
+      underscoreItalicPattern,
+      1,
+      'md-italic',
+      skippedSpans,
+      inlineSpans
+    );
+    addInlineSpansForPattern(
+      line,
+      strikethroughPattern,
+      2,
+      'md-strikethrough',
+      skippedSpans,
+      inlineSpans
+    );
 
     inlineSpans
       .sort((a, b) => a.start - b.start)

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -35,6 +35,7 @@ import {
   getNotePosition,
   setNotePosition,
 } from './utils/note-scroll-position';
+import { getMarkdownDecorations } from './markdown-decorations';
 import { isMac, isSafari } from './utils/platform';
 import {
   withCheckboxCharacters,
@@ -155,8 +156,10 @@ class NoteContentEditor extends Component<Props> {
   monaco: Monaco | null = null;
   contentDiv = createRef<HTMLDivElement>();
   decorations: Editor.IEditorDecorationsCollection | undefined;
+  markdownDecorations: Editor.IEditorDecorationsCollection | undefined;
   matchesInNote: Editor.IModelDeltaDecoration[] = [];
   selectedDecoration: Editor.IEditorDecorationsCollection | undefined;
+  isComposing = false;
 
   state: OwnState = {
     content: '',
@@ -433,6 +436,17 @@ class NoteContentEditor extends Component<Props> {
     const titleDecoration = this.getTitleDecoration();
     titleDecoration &&
       this.editor?.createDecorationsCollection([titleDecoration]);
+
+    if (!this.isComposing) {
+      this.markdownDecorations?.clear();
+      const markdownDecorations = getMarkdownDecorations(
+        this.editor?.getModel()
+      );
+      if (markdownDecorations.length > 0) {
+        this.markdownDecorations =
+          this.editor?.createDecorationsCollection(markdownDecorations);
+      }
+    }
 
     // search highlights
     this.matchesInNote = this.searchMatches() ?? [];
@@ -958,6 +972,13 @@ class NoteContentEditor extends Component<Props> {
     // make component rerender after the decorators are set.
     this.setState({});
     editor.onDidChangeModelContent(() => this.setDecorators());
+    editor.onDidCompositionStart(() => {
+      this.isComposing = true;
+    });
+    editor.onDidCompositionEnd(() => {
+      this.isComposing = false;
+      this.setDecorators();
+    });
 
     // register completion provider for internal links
     const completionProviderHandle =

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -138,6 +138,10 @@ span[dir='ltr'] {
     font-style: italic;
   }
 
+  .md-bold {
+    font-weight: 600;
+  }
+
   .md-list-marker {
     opacity: 0.6;
   }

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -104,6 +104,43 @@ span[dir='ltr'] {
     background-color: var(--search-selection-color);
     padding: 2px 0;
   }
+
+  .md-heading-1 {
+    font-size: 1.6em;
+    font-weight: 600;
+  }
+
+  .md-heading-2 {
+    font-size: 1.4em;
+    font-weight: 600;
+  }
+
+  .md-heading-3 {
+    font-size: 1.2em;
+    font-weight: 600;
+  }
+
+  .md-heading-4 {
+    font-weight: 600;
+  }
+
+  .md-heading-5 {
+    font-weight: 600;
+    opacity: 0.9;
+  }
+
+  .md-heading-6 {
+    font-weight: 600;
+    opacity: 0.85;
+  }
+
+  .md-italic {
+    font-style: italic;
+  }
+
+  .md-list-marker {
+    opacity: 0.6;
+  }
 }
 
 /* Safari requires that it be displayed absolute so that it takes the full height

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -142,6 +142,10 @@ span[dir='ltr'] {
     font-weight: 600;
   }
 
+  .md-strikethrough {
+    text-decoration: line-through;
+  }
+
   .md-list-marker {
     opacity: 0.6;
   }


### PR DESCRIPTION
## Summary

Adds light source-visible Markdown formatting in the Monaco note editor.

Changes:
- Adds a Markdown decoration helper for headings, `**bold**`, `__bold__`, `*italic*`, `_italic_`, `***bold italic***`, `___bold italic___`, `~~strikethrough~~`, and `-` / `*` / `+` unordered-list markers, including indented list markers.
- Decorates inline bold, italic, bold-italic, and strikethrough spans inside unordered list item text while keeping the list marker decoration intact.
- Aligns asterisk and underscore inline delimiter matching more closely with the existing Showdown renderer settings, including literal mid-word underscore behavior.
- Skips Markdown inline decorations inside URL spans, inline code spans, and fenced code blocks so the editor does not preview formatting that the rendered Markdown would keep literal/code-formatted.
- Wires the helper into the existing Monaco decoration lifecycle with an IME-composition guard.
- Adds editor styles for heading levels, italic spans, bold spans, strikethrough spans, and list markers.
- Adds unit coverage for heading, list marker, inline formatting inside list items, italic, underscore italic, underscore bold, combined bold/italic, bold, strikethrough, escaped marker, whitespace-padded marker, underscore-in-word, URL-skip, inline-code-skip, and fenced-code-skip behavior.
- Keeps raw Markdown text unchanged; this is decoration-only source-visible formatting.

## Context

This is for Multica issue LAV-24: Desktop Command Palette and Markdown. It targets `trunk` directly and is intentionally separate from the command palette PR (#3360). The older Cmd+K-only search shortcut PR (#3356) was closed per direction.

Video:

https://github.com/user-attachments/assets/03529b95-7271-48c3-812e-1a5f1c57626e

## Testing

- `npx jest lib/markdown-decorations.test.ts --runInBand`
- `make test`
- `make lint-js` (passes with existing warnings)
- `make lint-scss`
- `git diff --check`
- `make build NODE_ENV=development`
