### PR TITLE
Allow copying from history view; copy rich-text and plaintext MIME types.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v2.25.0]
+
+### New Features
+
+- Added support for selecting and copying text from older versions of notes in History [#3358](https://github.com/Automattic/simplenote-electron/pull/3358)
+
+### Enhancements
+
+- Improved Markdown copy and paste support so copied notes include rich HTML for external apps and pasted HTML is converted into readable Markdown [#3358](https://github.com/Automattic/simplenote-electron/pull/3358)
+
 ## [v2.24.0]
 
 ### New Features

--- a/lib/app-layout/index.tsx
+++ b/lib/app-layout/index.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 
 import MenuBar from '../menu-bar';
 import NoteToolbar from '../note-toolbar';
-import RevisionSelector from '../revision-selector';
 import SearchField from '../search-field';
 import SimplenoteCompactLogo from '../icons/simplenote-compact';
 import NoteRevisions from '../note-revisions';
@@ -29,7 +28,6 @@ const NotePreview = React.lazy(
 );
 
 type StateProps = {
-  hasRevisions: boolean;
   isFocusMode: boolean;
   isNavigationOpen: boolean;
   isNoteInfoOpen: boolean;
@@ -86,7 +84,6 @@ export class AppLayout extends Component<Props> {
   render = () => {
     const {
       showNoteList,
-      hasRevisions,
       isFocusMode = false,
       isNavigationOpen,
       isNoteInfoOpen,
@@ -114,36 +111,25 @@ export class AppLayout extends Component<Props> {
       </TransitionDelayEnter>
     );
 
-    const hiddenByRevisions = showRevisions ? true : undefined;
-
     return (
       <div
         className={mainClasses}
         aria-hidden={isNavigationOpen ? true : undefined}
       >
         <Suspense fallback={placeholder}>
-          <aside
-            aria-hidden={hiddenByRevisions}
-            aria-label="Notes list"
-            className="app-layout__source-column"
-          >
+          <aside aria-label="Notes list" className="app-layout__source-column">
             <MenuBar />
             <SearchField />
             <NoteList />
           </aside>
           {editorVisible && (
             <main aria-label="Note editor" className="app-layout__note-column">
-              <NoteToolbar aria-hidden={hiddenByRevisions} />
+              <NoteToolbar />
               {showRevisions ? (
-                <NoteRevisions
-                  aria-hidden={hiddenByRevisions}
-                  noteId={openedNote}
-                  note={openedRevision}
-                />
+                <NoteRevisions noteId={openedNote} note={openedRevision} />
               ) : (
                 <NoteEditor />
               )}
-              {hasRevisions && <RevisionSelector />}
             </main>
           )}
         </Suspense>
@@ -153,8 +139,6 @@ export class AppLayout extends Component<Props> {
 }
 
 const mapStateToProps: S.MapState<StateProps> = (state) => ({
-  hasRevisions:
-    state.ui.showRevisions && state.data.noteRevisions.has(state.ui.openedNote),
   keyboardShortcutsAreOpen: selectors.isDialogOpen(state, 'KEYBINDINGS'),
   keyboardShortcuts: state.settings.keyboardShortcuts,
   isFocusMode: state.settings.focusModeEnabled,

--- a/lib/components/note-preview/index.tsx
+++ b/lib/components/note-preview/index.tsx
@@ -2,9 +2,19 @@ import React, { FunctionComponent, useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
 
 import { checkboxRegex } from '../../utils/task-transform';
+import {
+  buildPreviewClipboardPayload,
+  shouldCopyWholePreview,
+  writeClipboardPayload,
+} from '../../utils/clipboard/copy';
 import renderToNode from '../../note-detail/render-to-node';
 import { viewExternalUrl } from '../../utils/url-utils';
 import { withCheckboxCharacters } from '../../utils/task-transform';
+import {
+  isSameDocumentLink,
+  normalizeSafeLinkHref,
+} from '../../utils/url-safety';
+import { warmMarkdownRenderer } from '../../utils/render-note-to-html';
 
 import actions from '../../state/actions';
 
@@ -12,8 +22,7 @@ import * as S from '../../state';
 import * as T from '../../types';
 
 type OwnProps = {
-  noteId: T.EntityId;
-  note?: T.Note;
+  noteId?: T.EntityId | null;
 };
 
 type StateProps = {
@@ -42,39 +51,56 @@ export const NotePreview: FunctionComponent<Props> = ({
   searchQuery,
   showRenderedView,
 }) => {
-  const previewNode = useRef<HTMLDivElement>();
+  const previewNode = useRef<HTMLDivElement | null>(null);
+  const renderVersion = useRef(0);
   useEffect(() => {
     const copyRenderedNote = (event: ClipboardEvent) => {
-      if (!isFocused) {
-        return true;
+      const preview = previewNode.current;
+
+      if (
+        !isFocused ||
+        !note ||
+        !preview ||
+        !event.clipboardData ||
+        !shouldCopyWholePreview(
+          preview,
+          document.getSelection(),
+          document.activeElement
+        )
+      ) {
+        return;
       }
 
-      // Only copy the rendered content if nothing is selected
-      if (!document.getSelection().isCollapsed) {
-        return true;
+      const didWrite = writeClipboardPayload(
+        event.clipboardData,
+        buildPreviewClipboardPayload(
+          note.content,
+          showRenderedView,
+          preview.textContent ?? ''
+        )
+      );
+
+      if (didWrite) {
+        event.preventDefault();
       }
-
-      const div = document.createElement('div');
-      renderToNode(div, note.content, searchQuery).then(() => {
-        try {
-          // this works in Chrome and Safari but not Firefox
-          event.clipboardData.setData('text/plain', div.innerHTML);
-        } catch (DOMException) {
-          // try it the Firefox way - this works in Firefox and Chrome
-          navigator.clipboard.writeText(div.innerHTML);
-        }
-      });
-
-      event.preventDefault();
     };
 
     document.addEventListener('copy', copyRenderedNote, false);
     return () => document.removeEventListener('copy', copyRenderedNote, false);
-  }, [isFocused, searchQuery]);
+  }, [isFocused, note?.content, showRenderedView]);
 
   useEffect(() => {
+    const preview = previewNode.current;
     const handleClick = (event: MouseEvent) => {
-      for (let node = event.target; node !== null; node = node.parentNode) {
+      for (
+        let node = event.target as Node | null;
+        node !== null;
+        node = node.parentNode
+      ) {
+        if (!(node instanceof HTMLElement)) {
+          continue;
+        }
+
         if (node.tagName === 'A') {
           event.preventDefault();
           event.stopPropagation();
@@ -99,8 +125,12 @@ export const NotePreview: FunctionComponent<Props> = ({
           }
 
           // skip internal note links (e.g. anchor links, footnotes)
-          if (!tag.href.startsWith('http://localhost')) {
-            viewExternalUrl(tag.href);
+          if (!isSameDocumentLink(tag.href)) {
+            const href = normalizeSafeLinkHref(tag.href);
+
+            if (href) {
+              viewExternalUrl(href);
+            }
           }
 
           return;
@@ -110,15 +140,22 @@ export const NotePreview: FunctionComponent<Props> = ({
       // There are times when showdown will put lists inside of the same
       // UL as a tasklist. This causes those lists to look like they are
       // checkboxes. This insures that we are only getting true checkboxes.
+      const target = event.target;
       const element =
-        event?.target?.tagName === 'INPUT'
-          ? event.target.parentElement
-          : event.target;
+        target instanceof HTMLInputElement
+          ? target.parentElement
+          : target instanceof HTMLElement
+            ? target
+            : null;
       if (element?.children[0]?.tagName === 'INPUT') {
+        if (!note || !noteId) {
+          return;
+        }
+
         event.preventDefault();
         event.stopPropagation();
 
-        const allTasks = previewNode!.current.querySelectorAll(
+        const allTasks = preview!.querySelectorAll(
           '[data-markdown-root] .task-list-item'
         );
         const taskIndex = Array.prototype.indexOf.call(allTasks, element);
@@ -143,21 +180,30 @@ export const NotePreview: FunctionComponent<Props> = ({
         return;
       }
     };
-    previewNode.current?.addEventListener('click', handleClick, true);
-    return () =>
-      previewNode.current?.removeEventListener('click', handleClick, true);
-  }, [note.content]);
+    preview?.addEventListener('click', handleClick, true);
+    return () => preview?.removeEventListener('click', handleClick, true);
+  }, [editNote, note?.content, noteId, notes, openNote]);
 
   useEffect(() => {
     if (!previewNode.current) {
       return;
     }
+
+    const renderTarget = previewNode.current;
+    const version = ++renderVersion.current;
+
     if (note?.content && showRenderedView) {
-      renderToNode(previewNode.current, note!.content, searchQuery);
+      warmMarkdownRenderer();
+
+      const nextPreview = document.createElement('div');
+      renderTarget.textContent = '';
+      renderToNode(nextPreview, note!.content, searchQuery).then(() => {
+        if (version === renderVersion.current) {
+          renderTarget.innerHTML = nextPreview.innerHTML;
+        }
+      });
     } else {
-      previewNode.current.innerText = withCheckboxCharacters(
-        note?.content ?? ''
-      );
+      renderTarget.innerText = withCheckboxCharacters(note?.content ?? '');
     }
   }, [note?.content, searchQuery, showRenderedView]);
 
@@ -166,8 +212,10 @@ export const NotePreview: FunctionComponent<Props> = ({
       <div className="note-detail note-detail-preview">
         <div
           ref={previewNode}
+          aria-label="Note preview"
           className="note-detail-markdown note-preview"
           data-markdown-root
+          tabIndex={0}
         >
           {!showRenderedView && withCheckboxCharacters(note?.content ?? '')}
         </div>
@@ -178,7 +226,7 @@ export const NotePreview: FunctionComponent<Props> = ({
 
 const mapStateToProps: S.MapState<StateProps, OwnProps> = (state, props) => {
   const noteId = props.noteId ?? state.ui.openedNote;
-  const note = props.note ?? state.data.notes.get(noteId);
+  const note = (noteId ? state.data.notes.get(noteId) : null) ?? null;
 
   return {
     isFocused: state.ui.dialogs.length === 0 && !state.ui.showNoteActions,

--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -1,9 +1,16 @@
 import { TKQItem, TracksAPI } from './analytics/types';
 import { compose } from 'redux';
 
-import { electronAPI } from './preload';
-
 import * as S from './state';
+
+type ElectronAPI = {
+  confirmLogout: (changes: string) => 'export' | 'reconsider' | 'logout';
+  send: (channel: string, data?: unknown) => void;
+  receive: (channel: string, callback: (data: any) => void) => void;
+  removeListener: (channel: string) => void;
+  isMac: boolean;
+  isLinux: boolean;
+};
 
 declare global {
   const __TEST__: boolean;
@@ -21,7 +28,7 @@ declare global {
   interface Window {
     __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: typeof compose;
     analyticsEnabled: boolean;
-    electron: typeof electronAPI;
+    electron: ElectronAPI;
     location: Location;
     testEvents: (string | [string, ...any[]])[];
     _tkq: TKQItem[] & { a: unknown };

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -19,6 +19,15 @@ import {
 import { searchNotes, tagsFromSearch } from './search';
 import actions from './state/actions';
 import * as selectors from './state/selectors';
+import {
+  clipboardHtmlToMarkdown,
+  clipboardItemsHtmlToMarkdown,
+  insertMarkdownPaste,
+} from './utils/clipboard/html-to-markdown';
+import {
+  buildSourceClipboardPayload,
+  writeClipboardPayload,
+} from './utils/clipboard/copy';
 import { getTerms } from './utils/filter-notes';
 import { noteTitleAndPreview } from './utils/note-utils';
 import {
@@ -31,6 +40,7 @@ import {
   withCheckboxCharacters,
   withCheckboxSyntax,
 } from './utils/task-transform';
+import { warmMarkdownRenderer } from './utils/render-note-to-html';
 
 import * as S from './state';
 import * as T from './types';
@@ -205,7 +215,10 @@ class NoteContentEditor extends Component<Props> {
     this.props.storeHasFocus(this.hasFocus);
     window.addEventListener('resize', clearNotePositions);
     window.addEventListener('toggleChecklist', this.handleChecklist, true);
+    document.addEventListener('copy', this.handleCopy);
+    document.addEventListener('paste', this.handlePaste, true);
     this.toggleShortcuts(true);
+    this.warmMarkdownRendererIfNeeded();
   }
 
   componentWillUnmount() {
@@ -216,6 +229,8 @@ class NoteContentEditor extends Component<Props> {
     }
     window.electron?.removeListener('editorCommand');
     window.removeEventListener('input', this.handleUndoRedo, true);
+    document.removeEventListener('copy', this.handleCopy);
+    document.removeEventListener('paste', this.handlePaste, true);
     window.removeEventListener('toggleChecklist', this.handleChecklist, true);
     window.removeEventListener('resize', clearNotePositions, true);
     this.toggleShortcuts(false);
@@ -398,7 +413,20 @@ class NoteContentEditor extends Component<Props> {
     ) {
       this.setSearchSelection(this.props.selectedSearchMatchIndex);
     }
+
+    if (
+      prevProps.noteId !== this.props.noteId ||
+      prevProps.note.systemTags !== this.props.note.systemTags
+    ) {
+      this.warmMarkdownRendererIfNeeded();
+    }
   }
+
+  warmMarkdownRendererIfNeeded = () => {
+    if (this.props.note.systemTags.includes('markdown')) {
+      warmMarkdownRenderer();
+    }
+  };
 
   setDecorators = () => {
     // special styling for title (first line)
@@ -492,6 +520,90 @@ class NoteContentEditor extends Component<Props> {
 
   handleChecklist = (event: Event) => {
     this.editor?.trigger('editorCommand', 'insertChecklist', null);
+  };
+
+  handleCopy = (event: ClipboardEvent) => {
+    if (!this.editor?.hasTextFocus() || !event.clipboardData) {
+      return;
+    }
+
+    const plainText = event.clipboardData.getData('text/plain');
+
+    if (!plainText) {
+      return;
+    }
+
+    const didWrite = writeClipboardPayload(
+      event.clipboardData,
+      buildSourceClipboardPayload(
+        plainText,
+        this.props.note.systemTags.includes('markdown')
+      )
+    );
+
+    if (didWrite) {
+      event.preventDefault();
+    }
+  };
+
+  handlePaste = (event: ClipboardEvent) => {
+    if (event.defaultPrevented || !this.editor?.hasTextFocus()) {
+      return;
+    }
+
+    const markdown = clipboardHtmlToMarkdown(event.clipboardData);
+
+    if (!markdown) {
+      return;
+    }
+
+    if (insertMarkdownPaste(this.editor, markdown)) {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+    }
+  };
+
+  pasteFromClipboard = async () => {
+    const editor = this.editor;
+
+    if (!editor) {
+      return;
+    }
+
+    editor.focus();
+
+    const markdown = await this.readClipboardMarkdown();
+
+    if (markdown && insertMarkdownPaste(editor, markdown)) {
+      return;
+    }
+
+    const text = await this.readClipboardText();
+
+    if (text !== null && insertMarkdownPaste(editor, text)) {
+      return;
+    }
+
+    editor.trigger('contextMenu', 'editor.action.clipboardPasteAction', null);
+  };
+
+  readClipboardMarkdown = async (): Promise<string | null> => {
+    try {
+      return await clipboardItemsHtmlToMarkdown(
+        await navigator.clipboard?.read?.()
+      );
+    } catch {
+      return null;
+    }
+  };
+
+  readClipboardText = async (): Promise<string | null> => {
+    try {
+      return (await navigator.clipboard?.readText?.()) ?? null;
+    } catch {
+      return null;
+    }
   };
 
   handleUndoRedo = (e: Event) => {
@@ -652,6 +764,7 @@ class NoteContentEditor extends Component<Props> {
     // see https://github.com/Microsoft/monaco-editor/issues/1058#issuecomment-468681208
     const idsToRemove = [
       'editor.action.changeAll',
+      'editor.action.clipboardPasteAction',
       'editor.action.quickCommand',
     ];
 
@@ -729,7 +842,8 @@ class NoteContentEditor extends Component<Props> {
       },
     });
 
-    // re-add keybindings for cut/copy/paste so they show labels
+    // re-add keybindings for cut/copy so they show labels. Paste needs the
+    // browser paste event so rich clipboard HTML can be converted first.
     monaco.editor.addKeybindingRules([
       {
         keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyX,
@@ -741,11 +855,6 @@ class NoteContentEditor extends Component<Props> {
         command: 'editor.action.clipboardCopyAction',
         when: 'allowBrowserKeybinding && editorTextFocus',
       },
-      {
-        keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV,
-        command: 'editor.action.clipboardPasteAction',
-        when: 'allowBrowserKeybinding && editorTextFocus',
-      },
     ]);
 
     // cancel selection that bubbles up to clear any search terms
@@ -755,6 +864,14 @@ class NoteContentEditor extends Component<Props> {
       keybindings: [monaco.KeyCode.Escape],
       keybindingContext: '!suggestWidgetVisible',
       run: this.cancelSelectionOrSearch,
+    });
+
+    editor.addAction({
+      id: 'context_paste',
+      label: 'Paste',
+      contextMenuGroupId: '9_cutcopypaste',
+      contextMenuOrder: 3,
+      run: this.pasteFromClipboard,
     });
 
     editor.addAction({
@@ -849,15 +966,6 @@ class NoteContentEditor extends Component<Props> {
         this.completionProvider(this.state.noteId, editor)
       );
     editor.onDidDispose(() => completionProviderHandle?.dispose());
-
-    document.oncopy = (event) => {
-      // @TODO: This is selecting everything in the app but we should only
-      //        need to intercept copy events coming from the editor
-      event.clipboardData?.setData(
-        'text/plain',
-        withCheckboxSyntax(event.clipboardData.getData('text/plain'))
-      );
-    };
 
     const [startOffset, endOffset, direction] = this.props.editorSelection;
     const start = this.editor.getModel()?.getPositionAt(startOffset);
@@ -1209,6 +1317,7 @@ class NoteContentEditor extends Component<Props> {
               autoIndent: 'keep',
               autoSurround: 'never',
               automaticLayout: true,
+              copyWithSyntaxHighlighting: false,
               // @ts-ignore, @see https://github.com/microsoft/monaco-editor/issues/3829
               'bracketPairColorization.enabled': false,
               codeLens: false,

--- a/lib/note-revisions/index.tsx
+++ b/lib/note-revisions/index.tsx
@@ -1,38 +1,288 @@
-import React, { Component } from 'react';
+import React, { Component, createRef } from 'react';
 import { connect } from 'react-redux';
 
-import NotePreview from '../components/note-preview';
+import RevisionSelector from '../revision-selector';
 import TagChip from '../components/tag-chip';
+import renderToNode from '../note-detail/render-to-node';
+import {
+  buildPreviewClipboardPayload,
+  buildSourceClipboardPayload,
+  shouldCopyWholePreview,
+  writeClipboardPayload,
+} from '../utils/clipboard/copy';
+import { warmMarkdownRenderer } from '../utils/render-note-to-html';
 import { noteCanonicalTags } from '../state/selectors';
 import { tagHashOf } from '../utils/tag-hash';
+import { withCheckboxSyntax } from '../utils/task-transform';
 
 import type * as S from '../state';
 import type * as T from '../types';
 
 type OwnProps = {
-  noteId: T.EntityId;
-  note?: T.Note;
+  noteId: T.EntityId | null;
+  note?: T.Note | null;
 };
 
 type StateProps = {
+  editMode: boolean;
+  keyboardShortcuts: boolean;
+  markdownEnabled: boolean;
+  searchQuery: string;
   tags: Array<{ name: T.TagName; deleted: boolean }>;
   noteId: T.EntityId | null;
   note: T.Note | null;
 };
 
-type Props = OwnProps &
-  StateProps &
-  Pick<React.HTMLProps<HTMLDivElement>, 'aria-hidden'>;
+type DispatchProps = {
+  cancelRevision: () => any;
+  toggleEditMode: () => any;
+};
+
+type Props = OwnProps & StateProps & DispatchProps;
+
+type RevisionPreviewProps = {
+  content: string;
+  searchQuery: string;
+};
+
+export class RevisionPreview extends Component<RevisionPreviewProps> {
+  static displayName = 'RevisionPreview';
+
+  previewContent = createRef<HTMLDivElement>();
+  renderVersion = 0;
+
+  componentDidMount() {
+    this.renderPreview();
+  }
+
+  componentDidUpdate(prevProps: RevisionPreviewProps) {
+    if (
+      prevProps.content !== this.props.content ||
+      prevProps.searchQuery !== this.props.searchQuery
+    ) {
+      this.renderPreview();
+    }
+  }
+
+  componentWillUnmount() {
+    this.renderVersion++;
+  }
+
+  focus = () => {
+    this.previewContent.current?.focus();
+  };
+
+  disablePreviewControls = () => {
+    const previewContent = this.previewContent.current;
+
+    previewContent?.querySelectorAll('a').forEach((link) => {
+      link.setAttribute('aria-disabled', 'true');
+      link.setAttribute('tabindex', '-1');
+    });
+
+    previewContent
+      ?.querySelectorAll<HTMLInputElement>('input')
+      .forEach((input) => {
+        input.disabled = true;
+        input.tabIndex = -1;
+      });
+  };
+
+  handleInteractiveEvent = (event: React.SyntheticEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLElement | null;
+
+    if (!target?.closest('a, input')) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  handleCopy = (event: React.ClipboardEvent<HTMLDivElement>) => {
+    const previewContent = this.previewContent.current;
+
+    if (
+      !previewContent ||
+      !event.clipboardData ||
+      !shouldCopyWholePreview(
+        previewContent,
+        document.getSelection(),
+        document.activeElement
+      )
+    ) {
+      return;
+    }
+
+    const didWrite = writeClipboardPayload(
+      event.clipboardData,
+      buildPreviewClipboardPayload(
+        this.props.content,
+        true,
+        previewContent.textContent ?? ''
+      )
+    );
+
+    if (didWrite) {
+      event.preventDefault();
+    }
+  };
+
+  renderPreview = () => {
+    const previewContent = this.previewContent.current;
+
+    if (!previewContent) {
+      return;
+    }
+
+    const renderVersion = ++this.renderVersion;
+    const renderTarget = document.createElement('div');
+    previewContent.textContent = '';
+    warmMarkdownRenderer();
+
+    renderToNode(renderTarget, this.props.content, this.props.searchQuery).then(
+      () => {
+        if (renderVersion !== this.renderVersion) {
+          return;
+        }
+
+        previewContent.innerHTML = renderTarget.innerHTML;
+        this.disablePreviewControls();
+      }
+    );
+  };
+
+  render() {
+    return (
+      <div
+        ref={this.previewContent}
+        aria-label="Revision preview"
+        className="note-revisions-content note-revisions-preview note-detail-markdown note-preview"
+        data-markdown-root
+        onClickCapture={this.handleInteractiveEvent}
+        onCopy={this.handleCopy}
+        onKeyDownCapture={this.handleInteractiveEvent}
+        role="region"
+        tabIndex={0}
+      />
+    );
+  }
+}
 
 export class NoteRevisions extends Component<Props> {
   static displayName = 'NoteRevisions';
 
+  revisionContent = createRef<HTMLTextAreaElement>();
+  revisionPreview = createRef<RevisionPreview>();
+
+  componentDidMount() {
+    this.focusActiveContent();
+    this.warmMarkdownRendererIfNeeded();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.shouldShowPreview(prevProps) !== this.shouldShowPreview()) {
+      this.focusActiveContent();
+    }
+
+    if (
+      prevProps.markdownEnabled !== this.props.markdownEnabled ||
+      prevProps.noteId !== this.props.noteId
+    ) {
+      this.warmMarkdownRendererIfNeeded();
+    }
+  }
+
+  warmMarkdownRendererIfNeeded = () => {
+    if (this.props.markdownEnabled) {
+      warmMarkdownRenderer();
+    }
+  };
+
+  focusActiveContent = () => {
+    if (this.shouldShowPreview()) {
+      this.revisionPreview.current?.focus();
+      return;
+    }
+
+    this.revisionContent.current?.focus();
+  };
+
+  shouldShowPreview = (props = this.props) => {
+    return props.markdownEnabled && !props.editMode;
+  };
+
+  handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      this.props.cancelRevision();
+      return;
+    }
+
+    if (
+      !this.props.keyboardShortcuts ||
+      !this.props.markdownEnabled ||
+      !(event.ctrlKey || event.metaKey) ||
+      !event.shiftKey ||
+      event.key.toLowerCase() !== 'p'
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    this.props.toggleEditMode();
+  };
+
+  handleSourceCopy = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const source = event.currentTarget;
+    const selectedContent = source.value.slice(
+      source.selectionStart,
+      source.selectionEnd
+    );
+
+    if (!selectedContent || !event.clipboardData) {
+      return;
+    }
+
+    const didWrite = writeClipboardPayload(
+      event.clipboardData,
+      buildSourceClipboardPayload(selectedContent, this.props.markdownEnabled)
+    );
+
+    if (didWrite) {
+      event.preventDefault();
+    }
+  };
+
   render() {
-    const { note, noteId, tags, 'aria-hidden': ariaHidden } = this.props;
+    const { note, searchQuery, tags } = this.props;
+    const content = withCheckboxSyntax(note?.content ?? '');
 
     return (
-      <div aria-hidden={ariaHidden} className="note-revisions">
-        <NotePreview noteId={noteId} note={note} />
+      <section
+        aria-label="History"
+        className="note-revisions"
+        onKeyDown={this.handleKeyDown}
+      >
+        {this.shouldShowPreview() ? (
+          <RevisionPreview
+            ref={this.revisionPreview}
+            content={content}
+            searchQuery={searchQuery}
+          />
+        ) : (
+          <textarea
+            ref={this.revisionContent}
+            aria-label="Revision source"
+            className="note-revisions-content"
+            onCopy={this.handleSourceCopy}
+            readOnly
+            spellCheck={false}
+            value={content}
+          />
+        )}
         <div className="note-revisions-tag-list">
           {tags.map(({ name, deleted }) => (
             <TagChip
@@ -43,30 +293,48 @@ export class NoteRevisions extends Component<Props> {
             />
           ))}
         </div>
-      </div>
+        <RevisionSelector />
+      </section>
     );
   }
 }
 
 const mapStateToProps: S.MapState<StateProps, OwnProps> = (state, props) => {
   const noteId = props.noteId ?? state.ui.openedNote;
-  const note = props.note ?? state.data.notes.get(noteId);
+  const note =
+    props.note ?? (noteId ? state.data.notes.get(noteId) : null) ?? null;
+  const liveNote = noteId ? state.data.notes.get(noteId) : null;
   const restoreDeletedTags = state.ui.restoreDeletedTags;
 
-  const tags = noteCanonicalTags(state, note)
-    .map((tagName) => {
-      const tagHash = tagHashOf(tagName);
-      return { name: tagName, deleted: !state.data.tags.has(tagHash) };
-    })
-    .filter((tag) => {
-      return restoreDeletedTags || !tag.deleted;
-    });
+  const tags = note
+    ? noteCanonicalTags(state, note)
+        .map((tagName) => {
+          const tagHash = tagHashOf(tagName);
+          return { name: tagName, deleted: !state.data.tags.has(tagHash) };
+        })
+        .filter((tag) => {
+          return restoreDeletedTags || !tag.deleted;
+        })
+    : [];
 
   return {
+    editMode: state.ui.editMode,
+    keyboardShortcuts: state.settings.keyboardShortcuts,
+    markdownEnabled: !!liveNote?.systemTags.includes('markdown'),
+    searchQuery: state.ui.searchQuery,
     tags,
     noteId,
     note,
   };
 };
 
-export default connect(mapStateToProps)(NoteRevisions);
+const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
+  cancelRevision: () => ({
+    type: 'CLOSE_REVISION',
+  }),
+  toggleEditMode: () => ({
+    type: 'TOGGLE_EDIT_MODE',
+  }),
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(NoteRevisions);

--- a/lib/note-revisions/style.scss
+++ b/lib/note-revisions/style.scss
@@ -1,12 +1,44 @@
+@use '../../scss/variables' as *;
+
 .note-revisions {
   background-color: var(--background-color);
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
-  padding-top: 20px;
+  min-height: 0;
+  user-select: text;
+
+  .note-revisions-content {
+    background-color: var(--background-color);
+    border: 0;
+    color: var(--primary-color);
+    cursor: text;
+    display: block;
+    flex: 1 1 auto;
+    font: 16px/1.5 $sans;
+    margin: 0;
+    min-height: 0;
+    overflow: auto;
+    overflow-wrap: anywhere;
+    padding: 20px calc((100% - #{$max-content-width}) / 2);
+    resize: none;
+    user-select: text;
+    white-space: pre-wrap;
+    word-break: normal;
+
+    &:focus {
+      outline: none;
+    }
+
+    &:focus-visible {
+      outline: $focus-outline;
+      outline-offset: -2px;
+    }
+  }
 
   .note-revisions-tag-list {
     display: flex;
+    flex: 0 0 auto;
     justify-content: flex-start;
     flex-wrap: wrap;
     line-height: 1.75em;
@@ -14,5 +46,19 @@
     overflow: auto;
     max-height: calc(2.5 * 1.75em + 16px); // about 2.5 rows
     padding: 8px 12px;
+  }
+
+  @media only screen and (width <= 1400px) {
+    .note-revisions-content {
+      padding: 20px 10%;
+    }
+  }
+}
+
+.is-line-length-full {
+  .note-revisions {
+    .note-revisions-content {
+      padding: 20px 25px;
+    }
   }
 }

--- a/lib/note-revisions/test.tsx
+++ b/lib/note-revisions/test.tsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+
+import { NoteRevisions } from './';
+import renderToNode from '../note-detail/render-to-node';
+
+jest.mock('../revision-selector', () => {
+  const ReactForMock = require('react');
+
+  return function MockRevisionSelector() {
+    return ReactForMock.createElement('div', {
+      'data-testid': 'revision-selector',
+    });
+  };
+});
+
+jest.mock('../note-detail/render-to-node', () => ({
+  __esModule: true,
+  default: jest.fn((node: HTMLElement) => {
+    node.innerHTML =
+      '<h1>Heading</h1><p>Keep <strong>markdown</strong> source.</p><ul><li class="task-list-item"><input type="checkbox">first task</li></ul><p><a href="https://example.com">Example link</a></p>';
+    return Promise.resolve();
+  }),
+}));
+
+describe('NoteRevisions', () => {
+  const note = {
+    content: '# Heading\n\n\ue000 first task\n\nKeep **markdown** source.',
+    creationDate: 1,
+    deleted: false,
+    modificationDate: 2,
+    systemTags: ['markdown'],
+    tags: [],
+  };
+
+  const renderNoteRevisions = (
+    props: Partial<React.ComponentProps<typeof NoteRevisions>> = {}
+  ) => {
+    const cancelRevision = jest.fn();
+    const toggleEditMode = jest.fn();
+
+    return {
+      cancelRevision,
+      toggleEditMode,
+      ...render(
+        <NoteRevisions
+          cancelRevision={cancelRevision}
+          editMode={true}
+          keyboardShortcuts={true}
+          markdownEnabled={true}
+          note={note}
+          noteId={'note-id'}
+          searchQuery=""
+          tags={[]}
+          toggleEditMode={toggleEditMode}
+          {...props}
+        />
+      ),
+    };
+  };
+
+  it('renders revision source as read-only selectable text', () => {
+    const { container, getByLabelText, getByTestId } = renderNoteRevisions();
+
+    const source = getByLabelText('Revision source') as HTMLTextAreaElement;
+
+    expect(source.readOnly).toBe(true);
+    expect(source.value).toContain('# Heading');
+    expect(source.value).toContain('- [ ] first task');
+    expect(source.value).not.toContain('\ue000');
+    expect(source.value).toContain('Keep **markdown** source.');
+    source.focus();
+    expect(document.activeElement).toBe(source);
+    source.setSelectionRange(11, 27);
+    expect(source.value.slice(source.selectionStart, source.selectionEnd)).toBe(
+      '- [ ] first task'
+    );
+    expect(container.querySelector('[aria-hidden="true"]')).toBe(null);
+    expect(getByTestId('revision-selector')).toBeTruthy();
+  });
+
+  it('keeps History open for source clicks and closes on Escape', () => {
+    const { cancelRevision, container, getByLabelText } = renderNoteRevisions();
+
+    const source = getByLabelText('Revision source') as HTMLTextAreaElement;
+
+    fireEvent.click(source);
+    expect(cancelRevision).not.toHaveBeenCalled();
+
+    source.focus();
+    source.setSelectionRange(0, 9);
+    expect(source.value.slice(source.selectionStart, source.selectionEnd)).toBe(
+      '# Heading'
+    );
+
+    fireEvent.keyDown(container.querySelector('.note-revisions')!, {
+      key: 'Escape',
+    });
+
+    expect(cancelRevision).toHaveBeenCalledTimes(1);
+  });
+
+  it('copies selected revision source without private checkbox glyphs', () => {
+    const { getByLabelText } = renderNoteRevisions();
+    const source = getByLabelText('Revision source') as HTMLTextAreaElement;
+    const clipboardData = {
+      clearData: jest.fn(),
+      setData: jest.fn(),
+    };
+
+    source.focus();
+    source.setSelectionRange(11, 27);
+    fireEvent.copy(source, { clipboardData });
+
+    expect(clipboardData.setData).toHaveBeenCalledWith(
+      'text/plain',
+      '- [ ] first task'
+    );
+  });
+
+  it('uses the existing preview shortcut while History is focused', () => {
+    const { container, toggleEditMode } = renderNoteRevisions();
+
+    fireEvent.keyDown(container.querySelector('.note-revisions')!, {
+      ctrlKey: true,
+      key: 'p',
+      shiftKey: true,
+    });
+
+    expect(toggleEditMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a markdown revision preview when preview mode is active', async () => {
+    const { getByLabelText, queryByLabelText } = renderNoteRevisions({
+      editMode: false,
+    });
+
+    const preview = getByLabelText('Revision preview');
+
+    await waitFor(() => {
+      expect(preview.querySelector('h1')?.textContent).toBe('Heading');
+    });
+
+    expect(queryByLabelText('Revision source')).toBe(null);
+    expect(renderToNode).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      '# Heading\n\n- [ ] first task\n\nKeep **markdown** source.',
+      ''
+    );
+  });
+
+  it('keeps plain-text revisions in source mode even when preview is active', () => {
+    const plainTextNote = { ...note, systemTags: [] };
+    const { getByLabelText, queryByLabelText } = renderNoteRevisions({
+      editMode: false,
+      markdownEnabled: false,
+      note: plainTextNote,
+    });
+
+    expect(getByLabelText('Revision source')).toBeTruthy();
+    expect(queryByLabelText('Revision preview')).toBe(null);
+  });
+
+  it('switches from revision preview back to selectable source', async () => {
+    const { getByLabelText, rerender } = renderNoteRevisions({
+      editMode: false,
+    });
+
+    await waitFor(() => {
+      expect(
+        getByLabelText('Revision preview').querySelector('h1')
+      ).toBeTruthy();
+    });
+
+    rerender(
+      <NoteRevisions
+        cancelRevision={jest.fn()}
+        editMode={true}
+        keyboardShortcuts={true}
+        markdownEnabled={true}
+        note={note}
+        noteId={'note-id'}
+        searchQuery=""
+        tags={[]}
+        toggleEditMode={jest.fn()}
+      />
+    );
+
+    const source = getByLabelText('Revision source') as HTMLTextAreaElement;
+    source.setSelectionRange(0, 9);
+
+    expect(source.value.slice(source.selectionStart, source.selectionEnd)).toBe(
+      '# Heading'
+    );
+  });
+
+  it('keeps rendered revision preview controls inert', async () => {
+    const { cancelRevision, getByLabelText } = renderNoteRevisions({
+      editMode: false,
+    });
+    const preview = getByLabelText('Revision preview');
+
+    await waitFor(() => {
+      expect(preview.querySelector('input')?.disabled).toBe(true);
+    });
+
+    const link = preview.querySelector('a')!;
+    const checkbox = preview.querySelector('input')!;
+
+    expect(link.getAttribute('aria-disabled')).toBe('true');
+    expect(link.getAttribute('tabindex')).toBe('-1');
+    expect(checkbox.tabIndex).toBe(-1);
+
+    fireEvent.click(link);
+    fireEvent.click(checkbox);
+
+    expect(cancelRevision).not.toHaveBeenCalled();
+  });
+});

--- a/lib/revision-selector/index.tsx
+++ b/lib/revision-selector/index.tsx
@@ -1,6 +1,5 @@
-import React, { CSSProperties, Component, ChangeEventHandler } from 'react';
+import React, { Component, ChangeEventHandler } from 'react';
 import { connect } from 'react-redux';
-import FocusTrap from 'focus-trap-react';
 import { format } from 'date-fns/format';
 import classNames from 'classnames';
 import IconButton from '../icon-button';
@@ -13,16 +12,9 @@ import { getRevision } from '../state/selectors';
 import * as S from '../state';
 import * as T from '../types';
 
-type OwnProps = {
-  onUpdateContent: Function;
-  resetIsViewingRevisions: Function;
-  cancelRevision: Function;
-  updateNoteTags: Function;
-};
-
 type StateProps = {
   isViewingRevisions: boolean;
-  noteId: T.EntityId;
+  noteId: T.EntityId | null;
   note: T.Note | null;
   openedRevision: number | null;
   revision: T.Note | null;
@@ -37,13 +29,13 @@ type DispatchProps = {
   toggleRestoringDeletedTags: () => any;
 };
 
-type Props = OwnProps & StateProps & DispatchProps;
+type Props = StateProps & DispatchProps;
 
 export class RevisionSelector extends Component<Props> {
   onAcceptRevision = () => {
     const { noteId, revision, restoreRevision } = this.props;
 
-    if (!revision) {
+    if (!noteId || !revision) {
       return;
     }
 
@@ -53,12 +45,16 @@ export class RevisionSelector extends Component<Props> {
   onSelectRevision: ChangeEventHandler<HTMLInputElement> = ({
     target: { value },
   }) => {
-    const { revisions } = this.props;
+    const { noteId, revisions } = this.props;
 
     const selection = parseInt(value, 10);
-    const revision = [...revisions.keys()][selection];
+    const revision = revisions ? [...revisions.keys()][selection] : null;
 
-    this.props.openRevision(this.props.noteId, revision);
+    if (!noteId || !revision) {
+      return;
+    }
+
+    this.props.openRevision(noteId, revision);
   };
 
   onCancelRevision = () => {
@@ -75,33 +71,33 @@ export class RevisionSelector extends Component<Props> {
       toggleRestoringDeletedTags,
     } = this.props;
 
-    if (!isViewingRevisions) {
+    if (!isViewingRevisions || !revisions) {
       return null;
     }
 
-    const selectedIndex =
-      revisions && openedRevision
-        ? [...revisions.keys()].indexOf(openedRevision)
-        : -1;
+    const revisionKeys = [...revisions.keys()];
+    const selectedIndex = openedRevision
+      ? revisionKeys.indexOf(openedRevision)
+      : -1;
+    const maxIndex = Math.max(revisionKeys.length - 1, 1);
+    const sliderValue = selectedIndex > -1 ? selectedIndex : maxIndex;
     const isNewest =
-      !openedRevision ||
-      (openedRevision && selectedIndex === revisions?.size - 1);
+      !openedRevision || revisionKeys.length <= 1 || selectedIndex === maxIndex;
 
     const leftPos = Number(
       // Based on ((selected - min) * 100) / (max - min);
       // min is equal to 1
       // max is the number of size of revisions -1.
-      (((selectedIndex === -1 ? revisions?.size - 1 : selectedIndex) - 1) *
-        100) /
-        (revisions?.size - 2)
+      revisionKeys.length > 2
+        ? (((sliderValue - 1) * 100) / (revisionKeys.length - 2)).toFixed(2)
+        : 100
     );
 
     const datePos = `calc(${leftPos}% + (${8 - leftPos * 0.15}px))`;
 
+    const revisionNote = openedRevision ? revisions.get(openedRevision) : note;
     const revisionDate = format(
-      (openedRevision
-        ? revisions.get(openedRevision).modificationDate
-        : note.modificationDate) * 1000,
+      (revisionNote?.modificationDate ?? note?.modificationDate ?? 0) * 1000,
       'MMM d, yyyy h:mm a'
     );
 
@@ -110,84 +106,66 @@ export class RevisionSelector extends Component<Props> {
     });
 
     return (
-      <FocusTrap
-        focusTrapOptions={{
-          clickOutsideDeactivates: true,
-          // Fallback required due to RevisionSelect's placement within
-          // Suspsense, which hides elements preventing focus. https://git.io/Jqep9
-          fallbackFocus: 'body',
-          onDeactivate: this.onCancelRevision,
-        }}
-      >
-        <div
-          className={mainClasses}
-          role="dialog"
-          aria-labelledby="revision-slider-title"
-        >
-          <div className="revision-selector-inner">
-            <div id="revision-slider-title" className="revision-slider-title">
-              History
-            </div>
-            <div
-              aria-hidden
-              className="revision-date"
-              style={{ left: datePos }}
-            >
-              {revisionDate}
-            </div>
-            <div className="revision-slider">
-              <Slider
-                aria-valuetext={`Revision from ${revisionDate}`}
-                disabled={!revisions || revisions.size === 0}
-                min={
-                  1 /* don't allow reverting to the very first version because that's a blank note */
-                }
-                max={revisions?.size - 1}
-                value={selectedIndex > -1 ? selectedIndex : revisions?.size - 1}
-                onChange={this.onSelectRevision}
-              />
-            </div>
-            <section className="revision-actions">
-              <label
-                className="revision-deleted-tags-label"
-                htmlFor="revision-deleted-tags-checkbox"
-              >
-                <CheckboxControl
-                  id="revision-deleted-tags-checkbox"
-                  checked={restoreDeletedTags}
-                  isStandard
-                  onChange={toggleRestoringDeletedTags}
-                />
-                <span className="revision-deleted-tags-text">
-                  Restore deleted tags
-                </span>
-                <span>
-                  <IconButton
-                    icon={<SmallHelpIcon />}
-                    title="Any deleted tags associated with the restored version of this note will be re-added to your list of tags."
-                  />
-                </span>
-              </label>
-              <div className="revision-buttons">
-                <button
-                  className="button button-secondary button-compact"
-                  onClick={this.onCancelRevision}
-                >
-                  Cancel
-                </button>
-                <button
-                  aria-label={`Restore revision from ${revisionDate}`}
-                  disabled={!!isNewest}
-                  className="button button-primary button-compact"
-                  onClick={this.onAcceptRevision}
-                >
-                  Restore
-                </button>
-              </div>
-            </section>
+      <div className={mainClasses} role="group" aria-label="History controls">
+        <div className="revision-selector-inner">
+          <div id="revision-slider-title" className="revision-slider-title">
+            History
           </div>
+          <div aria-hidden className="revision-date" style={{ left: datePos }}>
+            {revisionDate}
+          </div>
+          <div className="revision-slider">
+            <Slider
+              aria-valuetext={`Revision from ${revisionDate}`}
+              disabled={revisionKeys.length <= 1}
+              min={
+                1 /* don't allow reverting to the very first version because that's a blank note */
+              }
+              max={maxIndex}
+              value={sliderValue}
+              onChange={this.onSelectRevision}
+            />
+          </div>
+          <section className="revision-actions">
+            <label
+              className="revision-deleted-tags-label"
+              htmlFor="revision-deleted-tags-checkbox"
+            >
+              <CheckboxControl
+                id="revision-deleted-tags-checkbox"
+                checked={restoreDeletedTags}
+                isStandard
+                onChange={toggleRestoringDeletedTags}
+              />
+              <span className="revision-deleted-tags-text">
+                Restore deleted tags
+              </span>
+              <span>
+                <IconButton
+                  icon={<SmallHelpIcon />}
+                  title="Any deleted tags associated with the restored version of this note will be re-added to your list of tags."
+                />
+              </span>
+            </label>
+            <div className="revision-buttons">
+              <button
+                className="button button-secondary button-compact"
+                onClick={this.onCancelRevision}
+              >
+                Cancel
+              </button>
+              <button
+                aria-label={`Restore revision from ${revisionDate}`}
+                disabled={!!isNewest}
+                className="button button-primary button-compact"
+                onClick={this.onAcceptRevision}
+              >
+                Restore
+              </button>
+            </div>
+          </section>
         </div>
-      </FocusTrap>
+      </div>
     );
   }
 }

--- a/lib/state/ui/reducer.ts
+++ b/lib/state/ui/reducer.ts
@@ -383,6 +383,7 @@ const showRevisions: A.Reducer<boolean> = (state = false, action) => {
     case 'REVISIONS_TOGGLE':
       return !state;
     case 'CLOSE_REVISION':
+    case 'NAVIGATION_TOGGLE':
     case 'OPEN_NOTE':
     case 'SELECT_NOTE':
     case 'CREATE_NOTE_WITH_ID':

--- a/lib/types/turndown.d.ts
+++ b/lib/types/turndown.d.ts
@@ -1,0 +1,29 @@
+declare module 'turndown' {
+  type TurndownOptions = {
+    bulletListMarker?: string;
+    codeBlockStyle?: 'indented' | 'fenced';
+    emDelimiter?: '_' | '*';
+    headingStyle?: 'setext' | 'atx';
+    hr?: string;
+    strongDelimiter?: '__' | '**';
+  };
+
+  type TurndownReplacementOptions = {
+    bulletListMarker: string;
+  };
+
+  type TurndownRule = {
+    filter: string | string[];
+    replacement: (
+      content: string,
+      node: Node,
+      options: TurndownReplacementOptions
+    ) => string;
+  };
+
+  export default class TurndownService {
+    constructor(options?: TurndownOptions);
+    addRule(key: string, rule: TurndownRule): this;
+    turndown(input: string | Node): string;
+  }
+}

--- a/lib/utils/clipboard/copy.test.ts
+++ b/lib/utils/clipboard/copy.test.ts
@@ -1,0 +1,140 @@
+import { renderNoteToHtmlIfReady } from '../render-note-to-html';
+
+import {
+  buildPreviewClipboardPayload,
+  buildSourceClipboardPayload,
+  sanitizeClipboardHtml,
+  shouldCopyWholePreview,
+  writeClipboardPayload,
+} from './copy';
+import { SIMPLENOTE_SOURCE_HTML_MARKER } from './html-to-markdown';
+
+jest.mock('../render-note-to-html', () => ({
+  renderNoteToHtmlIfReady: jest.fn(),
+}));
+
+const mockedRenderNoteToHtmlIfReady =
+  renderNoteToHtmlIfReady as jest.MockedFunction<
+    typeof renderNoteToHtmlIfReady
+  >;
+
+const createClipboardData = () => {
+  const data = new Map<string, string>();
+
+  return {
+    clearData: jest.fn((format: string) => data.delete(format)),
+    getData: jest.fn((format: string) => data.get(format) ?? ''),
+    setData: jest.fn((format: string, value: string) =>
+      data.set(format, value)
+    ),
+  };
+};
+
+describe('clipboard copy helpers', () => {
+  beforeEach(() => {
+    mockedRenderNoteToHtmlIfReady.mockReset();
+  });
+
+  it('writes exact source text and clears Monaco HTML metadata', () => {
+    mockedRenderNoteToHtmlIfReady.mockReturnValue('<h1>Heading</h1>');
+
+    const clipboardData = createClipboardData();
+    const payload = buildSourceClipboardPayload('\ue000 task\n# Heading', true);
+
+    expect(writeClipboardPayload(clipboardData, payload)).toBe(true);
+    expect(clipboardData.clearData).toHaveBeenCalledWith('text/html');
+    expect(clipboardData.clearData).toHaveBeenCalledWith('vscode-editor-data');
+    expect(clipboardData.getData('text/plain')).toBe('- [ ] task\n# Heading');
+    expect(clipboardData.getData('text/html')).toContain(
+      SIMPLENOTE_SOURCE_HTML_MARKER
+    );
+    expect(clipboardData.getData('text/html')).toContain('<h1>Heading</h1>');
+  });
+
+  it('keeps plaintext notes plain-only', () => {
+    const payload = buildSourceClipboardPayload('plain text', false);
+
+    expect(payload).toEqual({ plain: 'plain text' });
+    expect(mockedRenderNoteToHtmlIfReady).not.toHaveBeenCalled();
+  });
+
+  it('falls back to source-only copy when the renderer is cold', () => {
+    mockedRenderNoteToHtmlIfReady.mockReturnValue(null);
+
+    expect(buildSourceClipboardPayload('# Heading', true)).toEqual({
+      html: null,
+      plain: '# Heading',
+    });
+  });
+
+  it('sanitizes outbound clipboard HTML more strictly than preview markup', () => {
+    const html = sanitizeClipboardHtml(`
+        <h1 class="search-match" onclick="alert(1)">Heading</h1>
+        <p style="color: red">Body</p>
+        <img src="http://127.0.0.1/pixel.jpg" alt="Local tracker">
+        <img src="https://example.com/photo.jpg" alt="Photo" data-id="1">
+        <script>alert(1)</script>
+        <template><p>template text</p></template>
+      `);
+
+    expect(html).toContain('<h1>Heading</h1>');
+    expect(html).toContain('<p>Body</p>');
+    expect(html).toContain('Local tracker');
+    expect(html).toContain(
+      '<img src="https://example.com/photo.jpg" alt="Photo">'
+    );
+    expect(html).not.toContain('onclick');
+    expect(html).not.toContain('style=');
+    expect(html).not.toContain('data-id');
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('<template');
+    expect(html).not.toContain('alert(1)');
+    expect(html).not.toContain('template text');
+  });
+
+  it('removes hidden outbound clipboard elements', () => {
+    const html = sanitizeClipboardHtml(`
+        <p>Visible</p>
+        <span style="display: none">display hidden</span>
+        <span style="visibility: hidden">visibility hidden</span>
+        <span style="opacity: 0">opacity hidden</span>
+      `);
+
+    expect(html).toContain('<p>Visible</p>');
+    expect(html).not.toContain('display hidden');
+    expect(html).not.toContain('visibility hidden');
+    expect(html).not.toContain('opacity hidden');
+  });
+
+  it('builds readable preview text without marking preview HTML as source', () => {
+    mockedRenderNoteToHtmlIfReady.mockReturnValue(
+      '<h1>Heading</h1><p><strong>Bold</strong></p>'
+    );
+
+    const payload = buildPreviewClipboardPayload('# Heading\n\n**Bold**', true);
+
+    expect(payload.plain).toBe('# Heading\n\n**Bold**');
+    expect(payload.html).toBe('<h1>Heading</h1><p><strong>Bold</strong></p>');
+    expect(payload.html).not.toContain(SIMPLENOTE_SOURCE_HTML_MARKER);
+  });
+
+  it('only whole-copies previews when focus or selection is inside the preview', () => {
+    const preview = document.createElement('div');
+    const outside = document.createElement('button');
+    preview.tabIndex = 0;
+    document.body.append(preview, outside);
+
+    preview.focus();
+    expect(
+      shouldCopyWholePreview(preview, document.getSelection(), preview)
+    ).toBe(true);
+
+    outside.focus();
+    expect(
+      shouldCopyWholePreview(preview, document.getSelection(), outside)
+    ).toBe(false);
+
+    preview.remove();
+    outside.remove();
+  });
+});

--- a/lib/utils/clipboard/copy.ts
+++ b/lib/utils/clipboard/copy.ts
@@ -1,0 +1,305 @@
+import {
+  htmlToMarkdown,
+  SIMPLENOTE_SOURCE_HTML_MARKER,
+} from './html-to-markdown';
+import { renderNoteToHtmlIfReady } from '../render-note-to-html';
+import { withCheckboxSyntax } from '../task-transform';
+import { normalizeSafeImageSrc, normalizeSafeLinkHref } from '../url-safety';
+
+const monacoClipboardMetadata = 'vscode-editor-data';
+
+const allowedClipboardTags = new Set([
+  'a',
+  'b',
+  'br',
+  'blockquote',
+  'code',
+  'del',
+  'div',
+  'em',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'hr',
+  'i',
+  'img',
+  'input',
+  'li',
+  'ol',
+  'p',
+  'pre',
+  's',
+  'span',
+  'strong',
+  'table',
+  'tbody',
+  'td',
+  'th',
+  'thead',
+  'tr',
+  'ul',
+]);
+
+const forbiddenClipboardTags = new Set([
+  'audio',
+  'canvas',
+  'embed',
+  'form',
+  'head',
+  'html',
+  'iframe',
+  'link',
+  'math',
+  'meta',
+  'object',
+  'script',
+  'style',
+  'svg',
+  'template',
+  'video',
+]);
+
+type ClipboardWriter = Pick<DataTransfer, 'setData'> &
+  Partial<Pick<DataTransfer, 'clearData' | 'getData'>>;
+
+type ClipboardPayload = {
+  html?: string | null;
+  plain: string;
+};
+
+const isHidden = (node: Element): boolean => {
+  const style = node instanceof HTMLElement ? node.style : null;
+  const styleValue = (property: string) =>
+    style?.getPropertyValue(property).trim().toLowerCase() ?? '';
+  const opacity = styleValue('opacity');
+
+  return (
+    node.hasAttribute('hidden') ||
+    node.hasAttribute('inert') ||
+    node.getAttribute('aria-hidden') === 'true' ||
+    styleValue('display') === 'none' ||
+    styleValue('visibility') === 'hidden' ||
+    (opacity !== '' && Number(opacity) === 0)
+  );
+};
+
+const replaceNodeWithText = (node: Element, text: string) => {
+  node.parentNode?.replaceChild(document.createTextNode(text), node);
+};
+
+const unwrapNode = (node: Element) => {
+  const parent = node.parentNode;
+
+  if (!parent) {
+    return;
+  }
+
+  while (node.firstChild) {
+    parent.insertBefore(node.firstChild, node);
+  }
+
+  parent.removeChild(node);
+};
+
+const textFromHtml = (html: string): string => {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+
+  return (doc.body.textContent ?? '').replace(/\n{3,}/g, '\n\n').trim();
+};
+
+export const sanitizeClipboardHtml = (html: string): string => {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT);
+  const nodes: Element[] = [];
+
+  while (walker.nextNode()) {
+    nodes.push(walker.currentNode as Element);
+  }
+
+  nodes.forEach((node) => {
+    if (!node.parentNode) {
+      return;
+    }
+
+    const tagName = node.nodeName.toLowerCase();
+
+    if (isHidden(node) || forbiddenClipboardTags.has(tagName)) {
+      node.parentNode.removeChild(node);
+      return;
+    }
+
+    if (!allowedClipboardTags.has(tagName)) {
+      unwrapNode(node);
+      return;
+    }
+
+    if (tagName === 'a') {
+      const href = normalizeSafeLinkHref(node.getAttribute('href'));
+      Array.from(node.attributes).forEach(({ name }) =>
+        node.removeAttribute(name)
+      );
+
+      if (href) {
+        node.setAttribute('href', href);
+      }
+      return;
+    }
+
+    if (tagName === 'img') {
+      const src = normalizeSafeImageSrc(node.getAttribute('src'));
+      const alt = (node.getAttribute('alt') ?? '').replace(/\s+/g, ' ').trim();
+
+      if (!src) {
+        replaceNodeWithText(node, alt);
+        return;
+      }
+
+      Array.from(node.attributes).forEach(({ name }) =>
+        node.removeAttribute(name)
+      );
+      node.setAttribute('src', src);
+
+      if (alt) {
+        node.setAttribute('alt', alt);
+      }
+      return;
+    }
+
+    if (tagName === 'input') {
+      if (node.getAttribute('type') !== 'checkbox') {
+        node.parentNode.removeChild(node);
+        return;
+      }
+
+      const checked = node.hasAttribute('checked');
+      Array.from(node.attributes).forEach(({ name }) =>
+        node.removeAttribute(name)
+      );
+      node.setAttribute('type', 'checkbox');
+      node.setAttribute('disabled', '');
+
+      if (checked) {
+        node.setAttribute('checked', '');
+      }
+      return;
+    }
+
+    if (tagName === 'ol') {
+      const start = node.getAttribute('start');
+      Array.from(node.attributes).forEach(({ name }) =>
+        node.removeAttribute(name)
+      );
+
+      if (start && /^\d+$/.test(start)) {
+        node.setAttribute('start', start);
+      }
+      return;
+    }
+
+    Array.from(node.attributes).forEach(({ name }) =>
+      node.removeAttribute(name)
+    );
+  });
+
+  return doc.body.innerHTML;
+};
+
+export const buildSourceClipboardPayload = (
+  plainText: string,
+  markdownEnabled: boolean
+): ClipboardPayload => {
+  const plain = withCheckboxSyntax(plainText);
+
+  if (!markdownEnabled) {
+    return { plain };
+  }
+
+  const renderedHtml = renderNoteToHtmlIfReady(plain);
+
+  return {
+    plain,
+    html: renderedHtml
+      ? `${SIMPLENOTE_SOURCE_HTML_MARKER}${sanitizeClipboardHtml(renderedHtml)}`
+      : null,
+  };
+};
+
+export const buildPreviewClipboardPayload = (
+  content: string,
+  markdownEnabled: boolean,
+  fallbackText = ''
+): ClipboardPayload => {
+  if (!markdownEnabled) {
+    return { plain: withCheckboxSyntax(fallbackText || content) };
+  }
+
+  const renderedHtml = renderNoteToHtmlIfReady(content);
+
+  if (!renderedHtml) {
+    return { plain: withCheckboxSyntax(fallbackText || content) };
+  }
+
+  const html = sanitizeClipboardHtml(renderedHtml);
+
+  return {
+    html,
+    plain: htmlToMarkdown(html) ?? textFromHtml(html) ?? fallbackText,
+  };
+};
+
+export const writeClipboardPayload = (
+  clipboardData: ClipboardWriter,
+  payload: ClipboardPayload
+): boolean => {
+  try {
+    clipboardData.clearData?.('text/html');
+    clipboardData.clearData?.(monacoClipboardMetadata);
+    clipboardData.setData('text/plain', payload.plain);
+
+    if (payload.html) {
+      clipboardData.setData('text/html', payload.html);
+    }
+
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+export const selectionIsInsideNode = (
+  node: Node,
+  selection: Selection | null
+): boolean => {
+  if (!selection || selection.rangeCount === 0) {
+    return false;
+  }
+
+  const anchorNode = selection.anchorNode;
+  const focusNode = selection.focusNode;
+
+  return (
+    !!anchorNode &&
+    !!focusNode &&
+    node.contains(anchorNode) &&
+    node.contains(focusNode)
+  );
+};
+
+export const shouldCopyWholePreview = (
+  node: HTMLElement,
+  selection: Selection | null,
+  activeElement: Element | null
+): boolean => {
+  if (selection && !selection.isCollapsed) {
+    return false;
+  }
+
+  return (
+    node.contains(activeElement) ||
+    activeElement === node ||
+    selectionIsInsideNode(node, selection)
+  );
+};

--- a/lib/utils/clipboard/html-to-markdown.test.ts
+++ b/lib/utils/clipboard/html-to-markdown.test.ts
@@ -1,0 +1,375 @@
+import {
+  clipboardHtmlToMarkdown,
+  clipboardItemsHtmlToMarkdown,
+  htmlToMarkdown,
+  insertMarkdownPaste,
+  resolveClipboardPaste,
+  SIMPLENOTE_SOURCE_HTML_MARKER,
+} from './html-to-markdown';
+
+describe('htmlToMarkdown', () => {
+  it('converts currently supported Markdown block and inline features', () => {
+    expect(
+      htmlToMarkdown(`
+        <h1>Trip Plan</h1>
+        <p><strong>Bold</strong>, <em>italic</em>, <del>old</del>, <code>inline()</code></p>
+        <blockquote>Bring layers</blockquote>
+        <pre><code class="code language-js highlighted">const city = 'Oslo';</code></pre>
+        <hr>
+      `)
+    ).toBe(
+      [
+        '# Trip Plan',
+        '',
+        '**Bold**, *italic*, ~~old~~, `inline()`',
+        '',
+        '> Bring layers',
+        '',
+        '```js',
+        "const city = 'Oslo';",
+        '```',
+        '',
+        '---',
+      ].join('\n')
+    );
+  });
+
+  it('converts lists and checklists into readable Markdown source', () => {
+    expect(
+      htmlToMarkdown(`
+        <ul>
+          <li><input type="checkbox" checked>Booked train</li>
+          <li><input type="checkbox">Pack adapter</li>
+          <li>Neighborhoods
+            <ol start="3">
+              <li>Grunerlokka</li>
+            </ol>
+          </li>
+        </ul>
+      `)
+    ).toBe(
+      [
+        '- [x] Booked train',
+        '- [ ] Pack adapter',
+        '- Neighborhoods',
+        '    3. Grunerlokka',
+      ].join('\n')
+    );
+  });
+
+  it('keeps safe links and images and drops unsafe link targets', () => {
+    expect(
+      htmlToMarkdown(`
+        <p>
+          <a href="https://example.com/path?q=1">safe</a>
+          <a href="mailto:test@example.com">mail</a>
+          <a href="simplenote://note/abc-123">note</a>
+          <a href="javascript:alert(1)">unsafe</a>
+          <img src="https://example.com/photo.jpg" alt="Photo">
+          <img src="data:image/svg+xml;base64,abc" alt="Vector">
+        </p>
+      `)
+    ).toBe(
+      '[safe](https://example.com/path?q=1) [mail](mailto:test@example.com) [note](simplenote://note/abc-123) unsafe ![Photo](https://example.com/photo.jpg) Vector'
+    );
+  });
+
+  it('drops unsafe images to escaped readable alt text', () => {
+    expect(
+      htmlToMarkdown(`
+        <p>
+          <img src="http://127.0.0.1/photo.jpg" alt="![tracker](https://example.com/pixel)">
+          <img src="https://example.com/photo.jpg" alt="Photo [one]">
+        </p>
+      `)
+    ).toBe(
+      '!\\[tracker\\](https://example.com/pixel) ![Photo one](https://example.com/photo.jpg)'
+    );
+  });
+
+  it('converts simple tables and falls back to tab-separated rows for irregular tables', () => {
+    expect(
+      htmlToMarkdown(`
+        <table>
+          <tr><th>City</th><th>Days</th></tr>
+          <tr><td>Kyoto</td><td>3</td></tr>
+        </table>
+      `)
+    ).toBe(['| City | Days |', '| --- | --- |', '| Kyoto | 3 |'].join('\n'));
+
+    expect(
+      htmlToMarkdown(`
+        <table>
+          <tr><td>One</td><td>Two</td></tr>
+          <tr><td>Three</td></tr>
+        </table>
+      `)
+    ).toBe('One\tTwo\nThree');
+  });
+
+  it('removes hostile or unsupported HTML without persisting raw tags', () => {
+    expect(
+      htmlToMarkdown(`
+        <style>.x { color: red; }</style>
+        <script>alert("x")</script>
+        <iframe src="https://example.com"></iframe>
+        <p onclick="alert(1)" style="color: red">Visible <span hidden>hidden</span></p>
+        <svg><text>svg text</text></svg>
+        <form><input value="secret"></form>
+        <template><p>template text</p></template>
+      `)
+    ).toBe('Visible');
+  });
+
+  it('removes common hidden text patterns from rich HTML', () => {
+    expect(
+      htmlToMarkdown(`
+        <p>Visible</p>
+        <span style="display: none">display hidden</span>
+        <span style="visibility: hidden">visibility hidden</span>
+        <span style="opacity: 0">transparent</span>
+        <span style="font-size: 0">zero font</span>
+        <span inert>inert text</span>
+        <span class="assistive visually-hidden text">class-hidden</span>
+        <span style="clip: rect(0, 0, 0, 0)">clipped</span>
+        <span style="clip-path: inset(50%)">clip path</span>
+        <span style="position:absolute; left:-9999px">offscreen</span>
+        <span style="position:fixed; text-indent:-1000px">indented</span>
+        <span style="mso-hide: all">office hidden</span>
+      `)
+    ).toBe('Visible');
+  });
+
+  it('escapes literal Markdown from pasted text content', () => {
+    expect(
+      htmlToMarkdown(
+        '<p># Not a heading and [not a link](https://bad.test)</p>'
+      )
+    ).toBe('\\# Not a heading and \\[not a link\\](https://bad.test)');
+  });
+
+  it('returns null for empty or unsupported content', () => {
+    expect(htmlToMarkdown('')).toBe(null);
+    expect(htmlToMarkdown('<script>alert(1)</script>')).toBe(null);
+  });
+
+  it('keeps browser article selections within supported Markdown features', () => {
+    expect(
+      htmlToMarkdown(`
+        <article>
+          <h1>Browser Article Clip</h1>
+          <p><strong>Bold lead</strong> and <em>quiet emphasis</em> with <a href="https://example.com/route?q=1">safe route</a>.</p>
+          <ul>
+            <li>First browser bullet</li>
+            <li>Second browser bullet</li>
+          </ul>
+          <table>
+            <tr><th>City</th><th>Days</th></tr>
+            <tr><td>Porto</td><td>2</td></tr>
+          </table>
+          <span hidden>hidden browser text</span>
+        </article>
+      `)
+    ).toBe(
+      [
+        '# Browser Article Clip',
+        '',
+        '**Bold lead** and *quiet emphasis* with [safe route](https://example.com/route?q=1).',
+        '',
+        '- First browser bullet',
+        '- Second browser bullet',
+        '',
+        '| City | Days |',
+        '| --- | --- |',
+        '| Porto | 2 |',
+      ].join('\n')
+    );
+  });
+
+  it('keeps document-editor fragments readable while dropping style-only HTML', () => {
+    expect(
+      htmlToMarkdown(`
+        <h2 id="docs-internal-guid-test"><span style="font-weight:700">Document Editor Style Clip</span></h2>
+        <p class="MsoNormal"><b>Confirmed booking</b> with <i>late arrival</i> and <s>old platform</s>.</p>
+        <ol start="3"><li><span>Third train option</span></li></ol>
+        <ul><li><input type="checkbox" checked>Visa scan uploaded</li></ul>
+        <p><a href="javascript:alert(1)" style="color:red">unsafe doc link</a></p>
+        <p><span style="font-size:24px;color:red">Styled text remains readable</span></p>
+      `)
+    ).toBe(
+      [
+        '## Document Editor Style Clip',
+        '',
+        '**Confirmed booking** with *late arrival* and ~~old platform~~.',
+        '',
+        '3. Third train option',
+        '',
+        '- [x] Visa scan uploaded',
+        '',
+        'unsafe doc link',
+        '',
+        'Styled text remains readable',
+      ].join('\n')
+    );
+  });
+});
+
+describe('clipboardHtmlToMarkdown', () => {
+  it('reads only text/html from clipboard data', () => {
+    const clipboardData = {
+      getData: jest.fn((format: string) =>
+        format === 'text/html' ? '<h2>Heading</h2>' : '<h1>wrong</h1>'
+      ),
+    };
+
+    expect(clipboardHtmlToMarkdown(clipboardData)).toBe('## Heading');
+    expect(clipboardData.getData).toHaveBeenCalledWith('text/html');
+    expect(clipboardData.getData).toHaveBeenCalledWith('text/plain');
+  });
+
+  it('prefers paired plain text for Simplenote-marked HTML', () => {
+    const clipboardData = {
+      getData: jest.fn((format: string) =>
+        format === 'text/html'
+          ? `${SIMPLENOTE_SOURCE_HTML_MARKER}<h1>Rendered</h1>`
+          : '# Source'
+      ),
+    };
+
+    expect(clipboardHtmlToMarkdown(clipboardData)).toBe('# Source');
+  });
+
+  it('does not convert marked HTML when paired plain text is empty', () => {
+    const clipboardData = {
+      getData: jest.fn((format: string) =>
+        format === 'text/html'
+          ? `${SIMPLENOTE_SOURCE_HTML_MARKER}<h1>Rendered</h1>`
+          : ''
+      ),
+    };
+
+    expect(clipboardHtmlToMarkdown(clipboardData)).toBe(null);
+  });
+});
+
+describe('resolveClipboardPaste', () => {
+  it('converts unmarked HTML before considering plain fallback', () => {
+    expect(
+      resolveClipboardPaste({ html: '<h2>Rich</h2>', plain: 'Plain' }, true)
+    ).toBe('## Rich');
+  });
+
+  it('falls back to plain text when requested and rich HTML is unusable', () => {
+    expect(
+      resolveClipboardPaste(
+        { html: '<script>alert(1)</script>', plain: 'Plain' },
+        true
+      )
+    ).toBe('Plain');
+  });
+});
+
+describe('clipboardItemsHtmlToMarkdown', () => {
+  it('reads the first supported text/html clipboard item', async () => {
+    const plainTextItem = {
+      types: ['text/plain'],
+      getType: jest.fn(),
+    };
+    const htmlItem = {
+      types: ['text/html', 'text/plain'],
+      getType: jest.fn(async () => ({
+        text: async () => '<h2>Heading</h2>',
+      })),
+    };
+    const clipboardItems = [plainTextItem, htmlItem] as unknown as NonNullable<
+      Parameters<typeof clipboardItemsHtmlToMarkdown>[0]
+    >;
+
+    await expect(clipboardItemsHtmlToMarkdown(clipboardItems)).resolves.toBe(
+      '## Heading'
+    );
+    expect(plainTextItem.getType).not.toHaveBeenCalled();
+    expect(htmlItem.getType).toHaveBeenCalledWith('text/html');
+  });
+
+  it('returns null when clipboard items have no usable rich text', async () => {
+    const clipboardItems = [
+      {
+        types: ['text/plain'],
+        getType: jest.fn(),
+      },
+      {
+        types: ['text/html'],
+        getType: jest.fn(async () => ({
+          text: async () => '<script></script>',
+        })),
+      },
+    ] as unknown as NonNullable<
+      Parameters<typeof clipboardItemsHtmlToMarkdown>[0]
+    >;
+
+    await expect(clipboardItemsHtmlToMarkdown(clipboardItems)).resolves.toBe(
+      null
+    );
+  });
+});
+
+describe('insertMarkdownPaste', () => {
+  it('inserts converted Markdown into every editor selection as one undoable paste', () => {
+    const selections = [
+      {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 5,
+      },
+    ];
+    const editor = {
+      executeEdits: jest.fn(),
+      getSelections: jest.fn(() => selections),
+      pushUndoStop: jest.fn(),
+    };
+
+    expect(insertMarkdownPaste(editor, '- [ ] Pack adapter')).toBe(true);
+    expect(editor.pushUndoStop).toHaveBeenCalledTimes(2);
+    expect(editor.executeEdits).toHaveBeenCalledWith('richPaste', [
+      {
+        range: selections[0],
+        text: '\ue000 Pack adapter',
+        forceMoveMarkers: true,
+      },
+    ]);
+  });
+
+  it('does not intercept paste when the editor has no selection', () => {
+    const editor = {
+      executeEdits: jest.fn(),
+      getSelections: jest.fn(() => null),
+      pushUndoStop: jest.fn(),
+    };
+
+    expect(insertMarkdownPaste(editor, '# Heading')).toBe(false);
+    expect(editor.executeEdits).not.toHaveBeenCalled();
+    expect(editor.pushUndoStop).not.toHaveBeenCalled();
+  });
+
+  it('does not create an edit for an empty clipboard payload', () => {
+    const editor = {
+      executeEdits: jest.fn(),
+      getSelections: jest.fn(() => [
+        {
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: 1,
+          endColumn: 5,
+        },
+      ]),
+      pushUndoStop: jest.fn(),
+    };
+
+    expect(insertMarkdownPaste(editor, '')).toBe(false);
+    expect(editor.getSelections).not.toHaveBeenCalled();
+    expect(editor.executeEdits).not.toHaveBeenCalled();
+    expect(editor.pushUndoStop).not.toHaveBeenCalled();
+  });
+});

--- a/lib/utils/clipboard/html-to-markdown.ts
+++ b/lib/utils/clipboard/html-to-markdown.ts
@@ -1,0 +1,504 @@
+import TurndownService from 'turndown';
+
+import { withCheckboxCharacters } from '../task-transform';
+import { normalizeSafeImageSrc, normalizeSafeLinkHref } from '../url-safety';
+
+const forbiddenTags = new Set([
+  'audio',
+  'canvas',
+  'embed',
+  'form',
+  'head',
+  'html',
+  'iframe',
+  'link',
+  'math',
+  'meta',
+  'object',
+  'script',
+  'style',
+  'svg',
+  'template',
+  'video',
+]);
+
+const hiddenClassNames = ['hidden', 'sr-only', 'visually-hidden'];
+const languageClassPrefix = 'language-';
+const supportedLanguageName = /^[a-zA-Z0-9_-]+$/;
+
+const allowedTags = new Set([
+  'a',
+  'article',
+  'b',
+  'br',
+  'blockquote',
+  'body',
+  'code',
+  'del',
+  'div',
+  'em',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'hr',
+  'i',
+  'img',
+  'input',
+  'li',
+  'ol',
+  'p',
+  'pre',
+  's',
+  'section',
+  'span',
+  'strike',
+  'strong',
+  'table',
+  'tbody',
+  'td',
+  'th',
+  'thead',
+  'tr',
+  'ul',
+]);
+
+export const SIMPLENOTE_SOURCE_HTML_MARKER =
+  '<!--simplenote-clipboard-source:v1-->';
+
+type TurndownNode = HTMLElement & {
+  isBlock?: boolean;
+};
+
+type RichPasteEditor<Selection> = {
+  executeEdits: (
+    source: string,
+    edits: Array<{
+      range: Selection;
+      text: string;
+      forceMoveMarkers: boolean;
+    }>
+  ) => unknown;
+  getSelections: () => Selection[] | null;
+  pushUndoStop: () => unknown;
+};
+
+type ClipboardItemReader = Pick<ClipboardItem, 'getType' | 'types'>;
+
+const isHidden = (node: Element): boolean => {
+  const style = node instanceof HTMLElement ? node.style : null;
+  const styleValue = (property: string) =>
+    style?.getPropertyValue(property).trim().toLowerCase() ?? '';
+  const hasHiddenClass = hiddenClassNames.some((className) =>
+    node.classList.contains(className)
+  );
+  const opacity = styleValue('opacity');
+  const fontSize = styleValue('font-size');
+  const position = styleValue('position');
+  const offsetProperties = ['left', 'right', 'top', 'bottom'];
+  const hasNegativeOffset = offsetProperties.some(
+    (property) => parseFloat(styleValue(property)) <= -100
+  );
+  const hasNegativeTextIndent = parseFloat(styleValue('text-indent')) <= -100;
+
+  return (
+    node.hasAttribute('hidden') ||
+    node.hasAttribute('inert') ||
+    node.getAttribute('aria-hidden') === 'true' ||
+    hasHiddenClass ||
+    styleValue('display') === 'none' ||
+    styleValue('visibility') === 'hidden' ||
+    (opacity !== '' && parseFloat(opacity) === 0) ||
+    (fontSize !== '' && parseFloat(fontSize) === 0) ||
+    /(?:^|;)\s*mso-hide\s*:\s*all\s*(?:;|$)/i.test(
+      node.getAttribute('style') ?? ''
+    ) ||
+    /^rect\s*\(\s*0(?:px)?\s*,\s*0(?:px)?\s*,\s*0(?:px)?\s*,\s*0(?:px)?\s*\)$/.test(
+      styleValue('clip')
+    ) ||
+    /^inset\s*\(\s*(?:50%|100%)\s*\)$/.test(styleValue('clip-path')) ||
+    ((position === 'absolute' || position === 'fixed') &&
+      (hasNegativeOffset || hasNegativeTextIndent))
+  );
+};
+
+const safeLink = (href: string | null): string | null => {
+  return normalizeSafeLinkHref(href);
+};
+
+const safeImageSource = (src: string | null): string | null => {
+  return normalizeSafeImageSrc(src);
+};
+
+const replaceNodeWithText = (node: Element, text: string) => {
+  node.parentNode?.replaceChild(document.createTextNode(text), node);
+};
+
+const unwrapNode = (node: Element) => {
+  const parent = node.parentNode;
+
+  if (!parent) {
+    return;
+  }
+
+  while (node.firstChild) {
+    parent.insertBefore(node.firstChild, node);
+  }
+
+  parent.removeChild(node);
+};
+
+const textForUnsafeImage = (node: Element) => {
+  const alt = node.getAttribute('alt')?.trim().replace(/\s+/g, ' ');
+
+  return alt ? alt : '';
+};
+
+const prepareHtmlForMarkdown = (html: string): HTMLElement => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT);
+  const nodes: Element[] = [];
+
+  while (walker.nextNode()) {
+    nodes.push(walker.currentNode as Element);
+  }
+
+  nodes.forEach((node) => {
+    const tagName = node.nodeName.toLowerCase();
+
+    if (!node.parentNode) {
+      return;
+    }
+
+    if (isHidden(node) || forbiddenTags.has(tagName)) {
+      node.parentNode.removeChild(node);
+      return;
+    }
+
+    if (!allowedTags.has(tagName)) {
+      unwrapNode(node);
+      return;
+    }
+
+    if (tagName === 'a') {
+      const href = safeLink(node.getAttribute('href'));
+      Array.from(node.attributes).forEach(({ name }) =>
+        node.removeAttribute(name)
+      );
+
+      if (href) {
+        node.setAttribute('href', href);
+      }
+      return;
+    }
+
+    if (tagName === 'img') {
+      const src = safeImageSource(node.getAttribute('src'));
+      const alt = node.getAttribute('alt') ?? '';
+
+      if (!src) {
+        replaceNodeWithText(node, textForUnsafeImage(node));
+        return;
+      }
+
+      Array.from(node.attributes).forEach(({ name }) =>
+        node.removeAttribute(name)
+      );
+      node.setAttribute('src', src);
+      node.setAttribute('alt', alt);
+      return;
+    }
+
+    if (tagName === 'input') {
+      if (node.getAttribute('type') !== 'checkbox' || !node.closest('li')) {
+        node.parentNode.removeChild(node);
+        return;
+      }
+
+      replaceNodeWithText(node, node.hasAttribute('checked') ? '[x] ' : '[ ] ');
+      return;
+    }
+
+    if (tagName === 'ol') {
+      const start = node.getAttribute('start');
+      Array.from(node.attributes).forEach(({ name }) =>
+        node.removeAttribute(name)
+      );
+
+      if (start && /^\d+$/.test(start)) {
+        node.setAttribute('start', start);
+      }
+      return;
+    }
+
+    if (tagName === 'code') {
+      const language = Array.from(node.classList)
+        .map((className) =>
+          className.startsWith(languageClassPrefix)
+            ? className.slice(languageClassPrefix.length)
+            : null
+        )
+        .find(
+          (language) =>
+            language !== null && supportedLanguageName.test(language)
+        );
+      Array.from(node.attributes).forEach(({ name }) =>
+        node.removeAttribute(name)
+      );
+
+      if (language) {
+        node.setAttribute('class', `language-${language}`);
+      }
+      return;
+    }
+
+    Array.from(node.attributes).forEach(({ name }) =>
+      node.removeAttribute(name)
+    );
+  });
+
+  return doc.body;
+};
+
+const tableCellText = (cell: Element) =>
+  (cell.textContent ?? '').replace(/\s+/g, ' ').trim().replace(/\|/g, '\\|');
+
+const tableToMarkdown = (table: Element): string => {
+  const rows = Array.from(table.querySelectorAll('tr'))
+    .map((row) => Array.from(row.children).map(tableCellText))
+    .filter((row) => row.some((cell) => cell.length > 0));
+
+  if (!rows.length) {
+    return '';
+  }
+
+  const columnCount = Math.max(...rows.map((row) => row.length));
+
+  if (!columnCount || rows.some((row) => row.length !== columnCount)) {
+    return rows.map((row) => row.join('\t')).join('\n');
+  }
+
+  const [header, ...body] = rows;
+  const separator = Array(columnCount).fill('---');
+  const markdownRows = [header, separator, ...body].map(
+    (row) => `| ${row.join(' | ')} |`
+  );
+
+  return `\n\n${markdownRows.join('\n')}\n\n`;
+};
+
+const normalizeMarkdown = (markdown: string): string | null => {
+  const normalized = markdown
+    .replace(/\u00a0/g, ' ')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+  return normalized.length ? normalized : null;
+};
+
+const turndownService = new TurndownService({
+  bulletListMarker: '-',
+  codeBlockStyle: 'fenced',
+  emDelimiter: '*',
+  headingStyle: 'atx',
+  hr: '---',
+  strongDelimiter: '**',
+});
+
+turndownService.addRule('lineItems', {
+  filter: 'li',
+  replacement: (content, node, options) => {
+    const trimmedContent = content
+      .replace(/^\n+/, '')
+      .replace(/\n+$/, '\n')
+      .replace(/\n/gm, '\n    ')
+      .replace(/^\\\[( |x)\\\]\s+/, '[$1] ');
+    const parent = node.parentNode as HTMLElement;
+    let prefix = `${options.bulletListMarker} `;
+
+    if (parent?.nodeName === 'OL') {
+      const start = parent.getAttribute('start');
+      const index = Array.prototype.indexOf.call(parent.children, node);
+      prefix = `${start ? Number(start) + index : index + 1}. `;
+    }
+
+    return (
+      prefix +
+      trimmedContent +
+      (node.nextSibling && !/\n$/.test(trimmedContent) ? '\n' : '')
+    );
+  },
+});
+
+turndownService.addRule('strikethrough', {
+  filter: ['del', 's', 'strike'],
+  replacement: (content) => (content.trim() ? `~~${content}~~` : ''),
+});
+
+turndownService.addRule('links', {
+  filter: 'a',
+  replacement: (content, node) => {
+    const href = safeLink((node as TurndownNode).getAttribute('href'));
+    const text = content.trim();
+
+    if (!text) {
+      return href ?? '';
+    }
+
+    return href ? `[${content}](${href.replace(/([()])/g, '\\$1')})` : content;
+  },
+});
+
+turndownService.addRule('images', {
+  filter: 'img',
+  replacement: (content, node) => {
+    const element = node as TurndownNode;
+    const src = safeImageSource(element.getAttribute('src'));
+
+    if (!src) {
+      return element.getAttribute('alt') ?? '';
+    }
+
+    const alt = (element.getAttribute('alt') ?? '')
+      .replace(/[\r\n]+/g, ' ')
+      .replace(/[[\]]/g, '');
+
+    return `![${alt}](${src.replace(/([()])/g, '\\$1')})`;
+  },
+});
+
+turndownService.addRule('tables', {
+  filter: 'table',
+  replacement: (_content, node) => tableToMarkdown(node as TurndownNode),
+});
+
+export const htmlToMarkdown = (html: string): string | null => {
+  if (!html.trim()) {
+    return null;
+  }
+
+  const prepared = prepareHtmlForMarkdown(html);
+
+  return normalizeMarkdown(turndownService.turndown(prepared));
+};
+
+export const hasSimplenoteSourceHtmlMarker = (
+  html: string | null | undefined
+): boolean => html?.includes(SIMPLENOTE_SOURCE_HTML_MARKER) ?? false;
+
+type ClipboardPastePayload = {
+  html?: string | null;
+  plain?: string | null;
+};
+
+export const resolveClipboardPaste = (
+  { html, plain }: ClipboardPastePayload,
+  includePlainFallback = false
+): string | null => {
+  const plainText = plain ?? null;
+
+  if (html && hasSimplenoteSourceHtmlMarker(html)) {
+    return plainText && plainText.length > 0 ? plainText : null;
+  }
+
+  if (html) {
+    const markdown = htmlToMarkdown(html);
+
+    if (markdown) {
+      return markdown;
+    }
+  }
+
+  return includePlainFallback && plainText && plainText.length > 0
+    ? plainText
+    : null;
+};
+
+export const clipboardHtmlToMarkdown = (
+  clipboardData: Pick<DataTransfer, 'getData'> | null | undefined
+): string | null => {
+  const html = clipboardData?.getData('text/html');
+  const plain = clipboardData?.getData('text/plain');
+
+  return resolveClipboardPaste({ html, plain });
+};
+
+const readClipboardItemText = async (
+  item: ClipboardItemReader,
+  type: string
+): Promise<string | null> => {
+  if (!item.types.includes(type)) {
+    return null;
+  }
+
+  try {
+    return await (await item.getType(type)).text();
+  } catch (e) {
+    return null;
+  }
+};
+
+export const clipboardItemsHtmlToMarkdown = async (
+  clipboardItems: ClipboardItemReader[] | null | undefined,
+  includePlainFallback = true
+): Promise<string | null> => {
+  for (const item of clipboardItems ?? []) {
+    if (!item.types.includes('text/html')) {
+      continue;
+    }
+
+    const html = await readClipboardItemText(item, 'text/html');
+    const plain = await readClipboardItemText(item, 'text/plain');
+    const markdown = resolveClipboardPaste({ html, plain });
+
+    if (markdown) {
+      return markdown;
+    }
+  }
+
+  if (includePlainFallback) {
+    for (const item of clipboardItems ?? []) {
+      const plain = await readClipboardItemText(item, 'text/plain');
+
+      if (plain) {
+        return plain;
+      }
+    }
+  }
+
+  return null;
+};
+
+export const insertMarkdownPaste = <Selection>(
+  editor: RichPasteEditor<Selection>,
+  markdown: string
+): boolean => {
+  if (markdown.length === 0) {
+    return false;
+  }
+
+  const selections = editor.getSelections();
+
+  if (!selections?.length) {
+    return false;
+  }
+
+  const text = withCheckboxCharacters(markdown);
+
+  editor.pushUndoStop();
+  editor.executeEdits(
+    'richPaste',
+    selections.map((selection) => ({
+      range: selection,
+      text,
+      forceMoveMarkers: true,
+    }))
+  );
+  editor.pushUndoStop();
+
+  return true;
+};

--- a/lib/utils/render-note-to-html.ts
+++ b/lib/utils/render-note-to-html.ts
@@ -1,5 +1,7 @@
 import { sanitizeHtml } from './sanitize-html';
 
+type Showdown = typeof import('showdown');
+
 const enableCheckboxes = {
   type: 'output',
   regex: '<input type="checkbox" disabled',
@@ -12,29 +14,69 @@ const removeLineBreaks = {
   replace: '>',
 };
 
-export const renderNoteToHtml = (content: string) => {
-  return import(/* webpackChunkName: 'showdown' */ 'showdown').then(
-    ({ default: showdown }) => {
+let showdownModule: Showdown | null = null;
+let showdownPromise: Promise<Showdown> | null = null;
+
+const loadShowdown = () => {
+  if (showdownModule) {
+    return Promise.resolve(showdownModule);
+  }
+
+  if (!showdownPromise) {
+    showdownPromise = import(
+      /* webpackChunkName: 'showdown' */ 'showdown'
+    ).then((module) => {
+      const showdown = ((module as any).default ?? module) as Showdown;
+
       showdown.extension('enableCheckboxes', enableCheckboxes);
       showdown.extension('removeLineBreaks', removeLineBreaks);
-      const markdownConverter = new showdown.Converter({
-        extensions: ['enableCheckboxes', 'removeLineBreaks'],
-      });
-      markdownConverter.setFlavor('github');
-      markdownConverter.setOption('ghMentions', false);
-      markdownConverter.setOption('literalMidWordUnderscores', true);
-      markdownConverter.setOption('simpleLineBreaks', false); // override GFM
-      markdownConverter.setOption('smoothLivePreview', true);
-      markdownConverter.setOption('splitAdjacentBlockquotes', true);
-      markdownConverter.setOption('strikethrough', true); // ~~strikethrough~~
-      markdownConverter.setOption('tables', true); // table syntax
+      showdownModule = showdown;
 
-      const transformedContent = content.replace(
-        /([ \t\u2000-\u200a]*)\u2022(\s)/gm,
-        '$1-$2'
-      ); // normalized bullets
+      return showdown;
+    });
+  }
 
-      return sanitizeHtml(markdownConverter.makeHtml(transformedContent));
-    }
+  return showdownPromise;
+};
+
+const makeMarkdownConverter = (showdown: Showdown) => {
+  const markdownConverter = new showdown.Converter({
+    extensions: ['enableCheckboxes', 'removeLineBreaks'],
+  });
+  markdownConverter.setFlavor('github');
+  markdownConverter.setOption('ghMentions', false);
+  markdownConverter.setOption('literalMidWordUnderscores', true);
+  markdownConverter.setOption('simpleLineBreaks', false); // override GFM
+  markdownConverter.setOption('smoothLivePreview', true);
+  markdownConverter.setOption('splitAdjacentBlockquotes', true);
+  markdownConverter.setOption('strikethrough', true); // ~~strikethrough~~
+  markdownConverter.setOption('tables', true); // table syntax
+
+  return markdownConverter;
+};
+
+const normalizeMarkdownBullets = (content: string) =>
+  content.replace(/([ \t\u2000-\u200a]*)\u2022(\s)/gm, '$1-$2');
+
+const renderWithShowdown = (showdown: Showdown, content: string) => {
+  const markdownConverter = makeMarkdownConverter(showdown);
+  const transformedContent = normalizeMarkdownBullets(content);
+
+  return sanitizeHtml(markdownConverter.makeHtml(transformedContent));
+};
+
+export const warmMarkdownRenderer = () => loadShowdown().then(() => undefined);
+
+export const renderNoteToHtmlIfReady = (content: string): string | null => {
+  if (!showdownModule) {
+    return null;
+  }
+
+  return renderWithShowdown(showdownModule, content);
+};
+
+export const renderNoteToHtml = (content: string) => {
+  return loadShowdown().then((showdown) =>
+    renderWithShowdown(showdown, content)
   );
 };

--- a/lib/utils/sanitize-html.ts
+++ b/lib/utils/sanitize-html.ts
@@ -1,6 +1,6 @@
-import isemail from 'isemail';
-import validUrl from 'valid-url';
 import { filter } from 'lodash';
+
+import { normalizeSafeImageSrc, normalizeSafeLinkHref } from './url-safety';
 
 /**
  * Determine if a given tag is allowed
@@ -81,10 +81,7 @@ const isAllowedAttr = (tagName: string, attrName: string, value: string) => {
     case 'a':
       switch (attrName) {
         case 'href':
-          // disallow any protocol except for http://, https://, and simplenote://
-          return ['http', 'https', 'simplenote'].includes(
-            value.toLowerCase().trim().split('://')[0]
-          );
+          return !!normalizeSafeLinkHref(value);
         case 'alt':
         case 'rel':
         case 'title':
@@ -96,10 +93,11 @@ const isAllowedAttr = (tagName: string, attrName: string, value: string) => {
     case 'img':
       switch (attrName) {
         case 'alt':
-        case 'src':
         case 'title':
         case 'width':
           return true;
+        case 'src':
+          return !!normalizeSafeImageSrc(value);
         default:
           return false;
       }
@@ -182,6 +180,10 @@ const isForbidden = (node: Element) => {
   }
 };
 
+const replaceNodeWithText = (node: Element, text: string) => {
+  node.parentNode?.replaceChild(document.createTextNode(text), node);
+};
+
 /**
  * Sanitizes input HTML for security and styling
  *
@@ -193,12 +195,7 @@ export const sanitizeHtml = (content: string) => {
   const doc = parser.parseFromString(content, 'text/html');
 
   // this will let us visit every single DOM node programmatically
-  const walker = doc.createTreeWalker(
-    doc.body,
-    NodeFilter.SHOW_ALL,
-    null,
-    false // IE11 requires this last argument
-  );
+  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ALL, null);
 
   /**
    * we don't want to remove nodes while walking the tree
@@ -249,33 +246,31 @@ export const sanitizeHtml = (content: string) => {
         return false;
       }
 
-      // only valid http(s) URLs are allowed
-      if (('href' === name || 'src' === name) && validUrl.isWebUri(value)) {
-        return false;
-      }
-
-      // emails must be reasonably-verifiable email addresses
-      if (
-        'href' === name &&
-        value.startsWith('mailto:') &&
-        isemail.validate(value.slice(7))
-      ) {
-        return false;
-      }
-
       return true;
     }).forEach(({ name }) => node.removeAttribute(name));
 
+    if ('img' === tagName) {
+      const src = normalizeSafeImageSrc(node.getAttribute('src'));
+
+      if (!src) {
+        replaceNodeWithText(node, node.getAttribute('alt') ?? '');
+        continue;
+      }
+
+      node.setAttribute('src', src);
+    }
+
     // of course, all links need to be normalized since
     // they now exist inside of our new context
-    const hrefAttribute = 'a' === tagName && node.getAttribute('href');
-    if (
-      'a' === tagName &&
-      'string' === typeof hrefAttribute &&
-      !hrefAttribute.startsWith('mailto:')
-    ) {
-      node.setAttribute('target', '_blank');
-      node.setAttribute('rel', 'external noopener noreferrer');
+    const hrefAttribute =
+      'a' === tagName && normalizeSafeLinkHref(node.getAttribute('href'));
+    if ('a' === tagName && 'string' === typeof hrefAttribute) {
+      node.setAttribute('href', hrefAttribute);
+
+      if (!hrefAttribute.startsWith('mailto:')) {
+        node.setAttribute('target', '_blank');
+        node.setAttribute('rel', 'external noopener noreferrer');
+      }
     }
 
     // add `list-style:none` for 'task-list-item's

--- a/lib/utils/url-safety.test.ts
+++ b/lib/utils/url-safety.test.ts
@@ -1,0 +1,62 @@
+import {
+  isLocalOrPrivateHostname,
+  isSameDocumentLink,
+  normalizeSafeImageSrc,
+  normalizeSafeLinkHref,
+} from './url-safety';
+
+describe('url-safety', () => {
+  it('normalizes safe links and rejects executable links', () => {
+    expect(normalizeSafeLinkHref('https://example.com/a')).toBe(
+      'https://example.com/a'
+    );
+    expect(normalizeSafeLinkHref('mailto:test@example.com')).toBe(
+      'mailto:test@example.com'
+    );
+    expect(normalizeSafeLinkHref('simplenote://note/abc-123')).toBe(
+      'simplenote://note/abc-123'
+    );
+    expect(normalizeSafeLinkHref('javascript:alert(1)')).toBe(null);
+  });
+
+  it('allows only public-looking HTTPS image sources', () => {
+    expect(normalizeSafeImageSrc('https://example.com/photo.jpg')).toBe(
+      'https://example.com/photo.jpg'
+    );
+    expect(normalizeSafeImageSrc('http://example.com/photo.jpg')).toBe(null);
+    expect(normalizeSafeImageSrc('https://user@example.com/photo.jpg')).toBe(
+      null
+    );
+    expect(normalizeSafeImageSrc('https://localhost/photo.jpg')).toBe(null);
+    expect(normalizeSafeImageSrc('https://127.0.0.1/photo.jpg')).toBe(null);
+    expect(normalizeSafeImageSrc('https://192.168.1.10/photo.jpg')).toBe(null);
+    expect(normalizeSafeImageSrc('data:image/png;base64,abc')).toBe(null);
+  });
+
+  it('detects local and private hostnames', () => {
+    expect(isLocalOrPrivateHostname('localhost')).toBe(true);
+    expect(isLocalOrPrivateHostname('127.0.0.1')).toBe(true);
+    expect(isLocalOrPrivateHostname('10.1.2.3')).toBe(true);
+    expect(isLocalOrPrivateHostname('172.20.1.1')).toBe(true);
+    expect(isLocalOrPrivateHostname('192.168.1.1')).toBe(true);
+    expect(isLocalOrPrivateHostname('::1')).toBe(true);
+    expect(isLocalOrPrivateHostname('::ffff:7f00:1')).toBe(true);
+    expect(isLocalOrPrivateHostname('fe80::1')).toBe(true);
+    expect(isLocalOrPrivateHostname('example.com')).toBe(false);
+  });
+
+  it('recognizes same-document anchor links', () => {
+    expect(
+      isSameDocumentLink(
+        'http://localhost:4000/#heading',
+        'http://localhost:4000/'
+      )
+    ).toBe(true);
+    expect(
+      isSameDocumentLink(
+        'http://localhost:4000/other#heading',
+        'http://localhost:4000/'
+      )
+    ).toBe(false);
+  });
+});

--- a/lib/utils/url-safety.ts
+++ b/lib/utils/url-safety.ts
@@ -1,0 +1,135 @@
+import isemail from 'isemail';
+
+const safeSimplenoteLink = /^simplenote:\/\/note\/[a-zA-Z0-9-]+$/;
+
+const ipv4Parts = (hostname: string): number[] | null => {
+  const parts = hostname.split('.');
+
+  if (parts.length !== 4 || parts.some((part) => !/^\d+$/.test(part))) {
+    return null;
+  }
+
+  const numbers = parts.map((part) => Number(part));
+
+  return numbers.every((part) => part >= 0 && part <= 255) ? numbers : null;
+};
+
+const isPrivateOrLocalIpv4 = (hostname: string): boolean => {
+  const parts = ipv4Parts(hostname);
+
+  if (!parts) {
+    return false;
+  }
+
+  const [a, b] = parts;
+
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    a >= 224
+  );
+};
+
+const isPrivateOrLocalIpv6 = (hostname: string): boolean => {
+  const normalized = hostname.toLowerCase();
+  const mappedIpv4 = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/.exec(normalized)?.[1];
+
+  return (
+    normalized === '::' ||
+    normalized === '::1' ||
+    normalized === '0:0:0:0:0:0:0:1' ||
+    normalized.startsWith('::ffff:') ||
+    normalized.startsWith('fe80:') ||
+    /^f[cd][0-9a-f]{2}:/.test(normalized) ||
+    (mappedIpv4 ? isPrivateOrLocalIpv4(mappedIpv4) : false)
+  );
+};
+
+export const isLocalOrPrivateHostname = (hostname: string): boolean => {
+  const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, '$1');
+
+  return (
+    normalized === 'localhost' ||
+    normalized.endsWith('.localhost') ||
+    isPrivateOrLocalIpv4(normalized) ||
+    isPrivateOrLocalIpv6(normalized)
+  );
+};
+
+export const normalizeSafeLinkHref = (href: string | null): string | null => {
+  if (!href) {
+    return null;
+  }
+
+  const trimmed = href.trim();
+
+  if (safeSimplenoteLink.test(trimmed)) {
+    return trimmed;
+  }
+
+  try {
+    const url = new URL(trimmed);
+
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return url.href;
+    }
+
+    if (
+      url.protocol === 'mailto:' &&
+      isemail.validate(trimmed.slice('mailto:'.length))
+    ) {
+      return trimmed;
+    }
+  } catch (e) {
+    return null;
+  }
+
+  return null;
+};
+
+export const normalizeSafeImageSrc = (src: string | null): string | null => {
+  if (!src) {
+    return null;
+  }
+
+  try {
+    const url = new URL(src.trim());
+
+    if (
+      url.protocol !== 'https:' ||
+      url.username ||
+      url.password ||
+      isLocalOrPrivateHostname(url.hostname)
+    ) {
+      return null;
+    }
+
+    return url.href;
+  } catch (e) {
+    return null;
+  }
+};
+
+export const isSameDocumentLink = (
+  href: string,
+  currentHref: string = window.location.href
+): boolean => {
+  try {
+    const url = new URL(href, currentHref);
+    const current = new URL(currentHref);
+
+    return (
+      !!url.hash &&
+      url.origin === current.origin &&
+      url.pathname === current.pathname &&
+      url.search === current.search
+    );
+  } catch (e) {
+    return false;
+  }
+};


### PR DESCRIPTION
Resolves #3042 
Resolves #2898

## Summary

This 100% vibe-coded change addresses two frustrations with copying in the editor:

 1. It’s not possible to copy content from a revision because clicking outside of the revision slider closes the history view.
 2. Copying and pasting is rich-text unaware and only copies Markdown source as plaintext.

These changes fix the history viewer and require an explicit click to close (or a keypress of the `Escape` key, or by navigating to another note). This is a different behavior than the click-outside-to-close model, but it may be more ergonomic, because the old behavior prevents copying parts of an old version of a post.

Secondarily, several issues arose during the work on this feature relating to copy and paste behaviors. The app should be more aware of HTML/richly-formatted content when pasting, and will send _two_ copies of copied content into the paste buffer: a `text/plain` version containing the markup source; and a `text/html` version containing the rendered note. This makes it possible for other applications to use the rendered content after copying.

A side-effect of this change is that it’s now possible to preserve basic formatting when pasting HTML content into the app, as it parses the inbound HTML, sanitizes it, and creates Markdown syntax from the HTML.

## Before / After

These videos demonstrate both aspects of this change:

 1. They attempt to select and copy a portion of an old revision of a note.
 2. They copy a note’s content and then paste it into another app, showing how the copied content, even if copied from the Markdown source itself, retains its formatting through the copy.

As a note on this, most applications provide an alternative paste mode where it’s still possible to paste the plaintext content. In the _After_ video, the plaintext content is automatically pasted into the search box since it doesn’t support rich content, but in something like an email, it would likely be possible with a combination like Cmd + Opt + V or “Paste without formatting.”

https://github.com/user-attachments/assets/0ddd166b-ef47-4d6f-968b-ad0747f7940d


https://github.com/user-attachments/assets/4db160af-e0dd-4084-9415-60d2e3f727ce

