### PR TITLE
[codex] Add Cmd+K command palette modal

### DIFF
--- a/lib/dialogs/keybindings/index.tsx
+++ b/lib/dialogs/keybindings/index.tsx
@@ -52,6 +52,9 @@ export class AboutDialog extends Component<DispatchProps> {
                   <Keys keys={[CmdOrCtrl, '/']}>Show keyboard shortcuts</Keys>
                 </li>
                 <li>
+                  <Keys keys={[CmdOrCtrl, 'K']}>Show command palette</Keys>
+                </li>
+                <li>
                   <Keys keys={[CmdOrCtrl, 'Shift', 'F']}>
                     Toggle focus mode
                   </Keys>

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -46,6 +46,7 @@ import {
   getNotePosition,
   setNotePosition,
 } from './utils/note-scroll-position';
+import { viewExternalUrl } from './utils/url-utils';
 import { isMac, isSafari } from './utils/platform';
 import {
   withCheckboxCharacters,
@@ -137,13 +138,18 @@ type StateProps = {
 
 type DispatchProps = {
   clearSearch: () => any;
+  createNote: () => any;
   editNote: (noteId: T.EntityId, changes: Partial<T.Note>) => any;
   exportNotes: () => any;
   focusSearchField: () => any;
   insertTask: () => any;
   openNote: (noteId: T.EntityId) => any;
+  selectTrash: () => any;
+  showAbout: () => any;
+  showAllNotes: () => any;
   showKeyboardShortcuts: () => any;
   showPreferences: () => any;
+  showUntaggedNotes: () => any;
   storeEditorSelection: (
     noteId: T.EntityId,
     start: number,
@@ -860,17 +866,35 @@ class NoteContentEditor extends Component<Props> {
     this.clearSlashCommand();
 
     switch (command) {
+      case 'new':
+        this.props.createNote();
+        return;
       case 'search':
         this.props.focusSearchField();
+        return;
+      case 'all-notes':
+        this.props.showAllNotes();
+        return;
+      case 'untagged-notes':
+        this.props.showUntaggedNotes();
+        return;
+      case 'trash':
+        this.props.selectTrash();
+        return;
+      case 'settings':
+        this.props.showPreferences();
         return;
       case 'shortcuts':
         this.props.showKeyboardShortcuts();
         return;
+      case 'help':
+        viewExternalUrl('http://simplenote.com/help');
+        return;
+      case 'about':
+        this.props.showAbout();
+        return;
       case 'focus':
         this.props.toggleFocusMode();
-        return;
-      case 'pref':
-        this.props.showPreferences();
         return;
       case 'export':
         this.props.exportNotes();
@@ -1853,13 +1877,18 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   clearSearch: () => actions.ui.search(''),
+  createNote: actions.ui.createNote,
   editNote: actions.data.editNote,
   exportNotes: actions.data.exportNotes,
   focusSearchField: actions.ui.focusSearchField,
   insertTask: () => ({ type: 'INSERT_TASK' }),
   openNote: actions.ui.selectNote,
+  selectTrash: actions.ui.selectTrash,
+  showAbout: () => actions.ui.showDialog('ABOUT'),
+  showAllNotes: actions.ui.showAllNotes,
   showKeyboardShortcuts: () => actions.ui.showDialog('KEYBINDINGS'),
   showPreferences: () => actions.ui.showDialog('SETTINGS'),
+  showUntaggedNotes: actions.ui.showUntaggedNotes,
   storeEditorSelection: (noteId, start, end, direction) => ({
     type: 'STORE_EDITOR_SELECTION',
     noteId,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -32,6 +32,8 @@ import {
 import { getTerms } from './utils/filter-notes';
 import { noteTitleAndPreview } from './utils/note-utils';
 import {
+  getNextSlashCommandIndex,
+  getSlashCommandKeyAction,
   getSlashCommandSuggestions,
   getSlashCommandTrigger,
   SlashCommandId,
@@ -175,8 +177,8 @@ type SlashCommandPaletteState = {
 class NoteContentEditor extends Component<Props> {
   bootTimer: ReturnType<typeof setTimeout> | null = null;
   editor: Editor.IStandaloneCodeEditor | null = null;
-  monaco: Monaco | null = null;
   contentDiv = createRef<HTMLDivElement>();
+  slashCommandPalette = createRef<HTMLDivElement>();
   decorations: Editor.IEditorDecorationsCollection | undefined;
   matchesInNote: Editor.IModelDeltaDecoration[] = [];
   selectedDecoration: Editor.IEditorDecorationsCollection | undefined;
@@ -582,8 +584,8 @@ class NoteContentEditor extends Component<Props> {
     }
 
     const layout = editor.getLayoutInfo();
-    const paletteWidth = 280;
-    const paletteHeight = 190;
+    const paletteWidth = this.slashCommandPalette.current?.offsetWidth ?? 280;
+    const paletteHeight = this.slashCommandPalette.current?.offsetHeight ?? 180;
     const left = Math.max(
       8,
       Math.min(visiblePosition.left, layout.width - paletteWidth - 8)
@@ -676,9 +678,11 @@ class NoteContentEditor extends Component<Props> {
       return;
     }
 
-    const nextIndex =
-      (slashCommand.suggestions.length + slashCommand.selectedIndex + offset) %
-      slashCommand.suggestions.length;
+    const nextIndex = getNextSlashCommandIndex(
+      slashCommand.suggestions.length,
+      slashCommand.selectedIndex,
+      offset
+    );
 
     this.selectSlashCommand(nextIndex);
   };
@@ -722,7 +726,6 @@ class NoteContentEditor extends Component<Props> {
     }
 
     this.replaceSlashCommandToken(`/${suggestion.command.name}`);
-    Promise.resolve().then(this.updateSlashCommand);
   };
 
   executeSlashCommand = (commandId?: SlashCommandId) => {
@@ -760,39 +763,43 @@ class NoteContentEditor extends Component<Props> {
   handleEditorKeyDown = (event: IKeyboardEvent) => {
     const { slashCommand } = this.state;
     const browserEvent = event.browserEvent as KeyboardEvent;
+    const action = getSlashCommandKeyAction(
+      browserEvent.key,
+      browserEvent.isComposing,
+      !!slashCommand
+    );
 
-    if (!slashCommand || browserEvent.isComposing) {
+    if (!slashCommand || !action) {
       return;
     }
 
-    switch (browserEvent.key) {
-      case 'Tab':
+    switch (action) {
+      case 'complete':
         event.preventDefault();
         event.stopPropagation();
         this.completeSlashCommand();
         return;
-      case 'Enter':
+      case 'execute':
         event.preventDefault();
         event.stopPropagation();
         this.executeSlashCommand();
         return;
-      case 'ArrowDown':
+      case 'next':
         event.preventDefault();
         event.stopPropagation();
         this.selectNextSlashCommand(1);
         return;
-      case 'ArrowUp':
+      case 'previous':
         event.preventDefault();
         event.stopPropagation();
         this.selectNextSlashCommand(-1);
         return;
-      case 'Escape':
+      case 'cancel':
         event.preventDefault();
         event.stopPropagation();
         this.clearSlashCommand();
         return;
-      case ' ':
-      case 'Spacebar':
+      case 'cancel-and-type':
         this.clearSlashCommand();
         return;
     }
@@ -1004,7 +1011,6 @@ class NoteContentEditor extends Component<Props> {
 
   editorReady: EditorDidMount = (editor, monaco) => {
     this.editor = editor;
-    this.monaco = monaco;
 
     monaco.languages.registerLinkProvider('plaintext', {
       provideLinks: (model) => {
@@ -1183,11 +1189,6 @@ class NoteContentEditor extends Component<Props> {
 
     // Tab to indent lists and tasks
     editor.addCommand(monaco.KeyCode.Tab, () => {
-      if (this.state.slashCommand) {
-        this.completeSlashCommand();
-        return;
-      }
-
       const lineNumber = editor.getPosition()?.lineNumber;
       if (!lineNumber) {
         return;
@@ -1568,6 +1569,7 @@ class NoteContentEditor extends Component<Props> {
       <div
         aria-label="Slash commands"
         className="slash-command-palette"
+        ref={this.slashCommandPalette}
         role="listbox"
         style={{
           top: slashCommand.top,

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -37,8 +37,10 @@ import {
   getSlashCommandSuggestions,
   getSlashCommandTrigger,
   isSlashCommandPaletteShortcut,
+  shouldRemoveSlashCommandToken,
   SlashCommandId,
   SlashCommandSuggestion,
+  SlashCommandSource,
   SlashCommandTrigger,
 } from './slash-commands';
 import {
@@ -174,7 +176,7 @@ type OwnState = {
 
 type SlashCommandPaletteState = {
   lineNumber: number;
-  source: 'typed' | 'shortcut';
+  source: SlashCommandSource;
   trigger: SlashCommandTrigger;
   suggestions: SlashCommandSuggestion[];
   selectedIndex: number;
@@ -185,6 +187,7 @@ type SlashCommandPaletteState = {
 
 type SlashCommandTokenRange = {
   lineNumber: number;
+  source: SlashCommandSource;
   trigger: SlashCommandTrigger;
 };
 
@@ -202,6 +205,7 @@ class NoteContentEditor extends Component<Props> {
     startColumn: number;
   } | null = null;
   isRemovingShortcutSlashCommand = false;
+  isPreservingSlashCommandText = false;
 
   state: OwnState = {
     content: '',
@@ -582,7 +586,11 @@ class NoteContentEditor extends Component<Props> {
     this.slashCommandDecoration?.clear();
     this.slashCommandShortcutAnchor = null;
 
-    if (removeShortcutToken && tokenRange) {
+    if (
+      tokenRange &&
+      !this.isPreservingSlashCommandText &&
+      shouldRemoveSlashCommandToken(removeShortcutToken, tokenRange.source)
+    ) {
       this.removeSlashCommandToken(tokenRange);
     }
 
@@ -644,7 +652,7 @@ class NoteContentEditor extends Component<Props> {
     if (suggestions.length === 0) {
       this.clearSlashCommand({
         removeShortcutToken: source === 'shortcut',
-        tokenRange: { lineNumber: position.lineNumber, trigger },
+        tokenRange: { lineNumber: position.lineNumber, source, trigger },
       });
       return;
     }
@@ -852,6 +860,16 @@ class NoteContentEditor extends Component<Props> {
     this.replaceSlashCommandToken(`/${suggestion.command.name}`);
   };
 
+  typeThroughSlashCommand = (text: string) => {
+    this.isPreservingSlashCommandText = true;
+    try {
+      this.clearSlashCommand();
+      this.editor?.trigger('slash-command', 'type', { text });
+    } finally {
+      this.isPreservingSlashCommandText = false;
+    }
+  };
+
   executeSlashCommand = (commandId?: SlashCommandId) => {
     const { slashCommand } = this.state;
     const command =
@@ -942,7 +960,9 @@ class NoteContentEditor extends Component<Props> {
         this.clearSlashCommand({ removeShortcutToken: true });
         return;
       case 'cancel-and-type':
-        this.clearSlashCommand({ removeShortcutToken: true });
+        event.preventDefault();
+        event.stopPropagation();
+        this.typeThroughSlashCommand(' ');
         return;
     }
   };

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -196,6 +196,7 @@ class NoteContentEditor extends Component<Props> {
   editor: Editor.IStandaloneCodeEditor | null = null;
   contentDiv = createRef<HTMLDivElement>();
   slashCommandPalette = createRef<HTMLDivElement>();
+  selectedSlashCommandItem = createRef<HTMLButtonElement>();
   decorations: Editor.IEditorDecorationsCollection | undefined;
   matchesInNote: Editor.IModelDeltaDecoration[] = [];
   selectedDecoration: Editor.IEditorDecorationsCollection | undefined;
@@ -699,7 +700,7 @@ class NoteContentEditor extends Component<Props> {
     };
 
     this.setState({ slashCommand: nextSlashCommand }, () =>
-      this.updateSlashCommandGhostText(nextSlashCommand)
+      this.updateSlashCommandSelection(nextSlashCommand)
     );
   };
 
@@ -775,6 +776,17 @@ class NoteContentEditor extends Component<Props> {
     ]);
   };
 
+  scrollSelectedSlashCommandIntoView = () =>
+    this.selectedSlashCommandItem.current?.scrollIntoView({
+      block: 'nearest',
+      inline: 'nearest',
+    });
+
+  updateSlashCommandSelection = (slashCommand: SlashCommandPaletteState) => {
+    this.updateSlashCommandGhostText(slashCommand);
+    this.scrollSelectedSlashCommandIntoView();
+  };
+
   selectSlashCommand = (selectedIndex: number) => {
     const { slashCommand } = this.state;
     const selected = slashCommand?.suggestions[selectedIndex];
@@ -790,7 +802,7 @@ class NoteContentEditor extends Component<Props> {
     };
 
     this.setState({ slashCommand: nextSlashCommand }, () =>
-      this.updateSlashCommandGhostText(nextSlashCommand)
+      this.updateSlashCommandSelection(nextSlashCommand)
     );
   };
 
@@ -1753,6 +1765,7 @@ class NoteContentEditor extends Component<Props> {
                 this.executeSlashCommand(command.id);
               }}
               onMouseEnter={() => this.selectSlashCommand(index)}
+              ref={isSelected ? this.selectedSlashCommandItem : null}
               role="option"
               type="button"
             >

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -8,6 +8,7 @@ import Monaco, {
 import {
   editor as Editor,
   CancellationToken,
+  IKeyboardEvent,
   languages,
   IRange,
   Position,
@@ -30,6 +31,13 @@ import {
 } from './utils/clipboard/copy';
 import { getTerms } from './utils/filter-notes';
 import { noteTitleAndPreview } from './utils/note-utils';
+import {
+  getSlashCommandSuggestions,
+  getSlashCommandTrigger,
+  SlashCommandId,
+  SlashCommandSuggestion,
+  SlashCommandTrigger,
+} from './slash-commands';
 import {
   clearNotePositions,
   getNotePosition,
@@ -127,8 +135,12 @@ type StateProps = {
 type DispatchProps = {
   clearSearch: () => any;
   editNote: (noteId: T.EntityId, changes: Partial<T.Note>) => any;
+  exportNotes: () => any;
+  focusSearchField: () => any;
   insertTask: () => any;
   openNote: (noteId: T.EntityId) => any;
+  showKeyboardShortcuts: () => any;
+  showPreferences: () => any;
   storeEditorSelection: (
     noteId: T.EntityId,
     start: number,
@@ -137,6 +149,7 @@ type DispatchProps = {
   ) => any;
   storeNumberOfMatchesInNote: (matches: number) => any;
   storeSearchSelection: (index: number | null) => any;
+  toggleFocusMode: () => any;
 };
 
 type Props = OwnProps & StateProps & DispatchProps;
@@ -147,6 +160,16 @@ type OwnState = {
   noteId: T.EntityId | null;
   overTodo: boolean;
   searchQuery: string;
+  slashCommand: SlashCommandPaletteState | null;
+};
+
+type SlashCommandPaletteState = {
+  trigger: SlashCommandTrigger;
+  suggestions: SlashCommandSuggestion[];
+  selectedIndex: number;
+  top: number;
+  left: number;
+  ghostText: string;
 };
 
 class NoteContentEditor extends Component<Props> {
@@ -157,6 +180,7 @@ class NoteContentEditor extends Component<Props> {
   decorations: Editor.IEditorDecorationsCollection | undefined;
   matchesInNote: Editor.IModelDeltaDecoration[] = [];
   selectedDecoration: Editor.IEditorDecorationsCollection | undefined;
+  slashCommandDecoration: Editor.IEditorDecorationsCollection | undefined;
 
   state: OwnState = {
     content: '',
@@ -164,6 +188,7 @@ class NoteContentEditor extends Component<Props> {
     noteId: null,
     overTodo: false,
     searchQuery: '',
+    slashCommand: null,
   };
 
   static getDerivedStateFromProps(props: Props, state: OwnState) {
@@ -518,6 +543,261 @@ class NoteContentEditor extends Component<Props> {
 
   hasFocus = () => this.editor?.hasTextFocus() || false;
 
+  clearSlashCommand = () => {
+    this.slashCommandDecoration?.clear();
+    if (this.state.slashCommand) {
+      this.setState({ slashCommand: null });
+    }
+  };
+
+  updateSlashCommand = () => {
+    const editor = this.editor;
+    const model = editor?.getModel();
+    const position = editor?.getPosition();
+    const selection = editor?.getSelection();
+
+    if (!editor || !model || !position || !selection?.isEmpty()) {
+      this.clearSlashCommand();
+      return;
+    }
+
+    const line = model.getLineContent(position.lineNumber);
+    const trigger = getSlashCommandTrigger(line, position.column);
+
+    if (!trigger) {
+      this.clearSlashCommand();
+      return;
+    }
+
+    const suggestions = getSlashCommandSuggestions(trigger.query);
+    if (suggestions.length === 0) {
+      this.clearSlashCommand();
+      return;
+    }
+
+    const visiblePosition = editor.getScrolledVisiblePosition(position);
+    if (!visiblePosition) {
+      this.clearSlashCommand();
+      return;
+    }
+
+    const layout = editor.getLayoutInfo();
+    const paletteWidth = 280;
+    const paletteHeight = 190;
+    const left = Math.max(
+      8,
+      Math.min(visiblePosition.left, layout.width - paletteWidth - 8)
+    );
+    const top =
+      visiblePosition.top + paletteHeight > layout.height
+        ? Math.max(8, visiblePosition.top - paletteHeight)
+        : visiblePosition.top + visiblePosition.height + 6;
+
+    const previous = this.state.slashCommand;
+    const previousCommandId =
+      previous?.suggestions[previous.selectedIndex]?.command.id;
+    const selectedIndex = Math.max(
+      0,
+      suggestions.findIndex(({ command }) => command.id === previousCommandId)
+    );
+    const selected = suggestions[selectedIndex] ?? suggestions[0];
+    const nextSlashCommand = {
+      trigger,
+      suggestions,
+      selectedIndex,
+      top,
+      left,
+      ghostText: selected?.completion ?? '',
+    };
+
+    this.setState({ slashCommand: nextSlashCommand }, () =>
+      this.updateSlashCommandGhostText(nextSlashCommand)
+    );
+  };
+
+  updateSlashCommandGhostText = (slashCommand = this.state.slashCommand) => {
+    this.slashCommandDecoration?.clear();
+
+    if (!this.editor || !slashCommand?.ghostText) {
+      return;
+    }
+
+    const model = this.editor.getModel();
+    const position = this.editor.getPosition();
+
+    if (!model || !position) {
+      return;
+    }
+
+    const range = new Range(
+      position.lineNumber,
+      slashCommand.trigger.endColumn,
+      position.lineNumber,
+      slashCommand.trigger.endColumn
+    );
+
+    this.slashCommandDecoration = this.editor.createDecorationsCollection([
+      {
+        range,
+        options: {
+          showIfCollapsed: true,
+          after: {
+            content: slashCommand.ghostText,
+            inlineClassName: 'slash-command-ghost',
+            cursorStops: Editor.InjectedTextCursorStops.None,
+          },
+        },
+      },
+    ]);
+  };
+
+  selectSlashCommand = (selectedIndex: number) => {
+    const { slashCommand } = this.state;
+    const selected = slashCommand?.suggestions[selectedIndex];
+
+    if (!slashCommand || !selected) {
+      return;
+    }
+
+    const nextSlashCommand = {
+      ...slashCommand,
+      selectedIndex,
+      ghostText: selected.completion,
+    };
+
+    this.setState({ slashCommand: nextSlashCommand }, () =>
+      this.updateSlashCommandGhostText(nextSlashCommand)
+    );
+  };
+
+  selectNextSlashCommand = (offset: number) => {
+    const { slashCommand } = this.state;
+    if (!slashCommand) {
+      return;
+    }
+
+    const nextIndex =
+      (slashCommand.suggestions.length + slashCommand.selectedIndex + offset) %
+      slashCommand.suggestions.length;
+
+    this.selectSlashCommand(nextIndex);
+  };
+
+  replaceSlashCommandToken = (text: string) => {
+    const { slashCommand } = this.state;
+    const editor = this.editor;
+    const position = editor?.getPosition();
+
+    if (!slashCommand || !editor || !position) {
+      return;
+    }
+
+    const range = new Range(
+      position.lineNumber,
+      slashCommand.trigger.startColumn,
+      position.lineNumber,
+      slashCommand.trigger.endColumn
+    );
+
+    editor.executeEdits('slash-command', [
+      {
+        range,
+        text,
+        forceMoveMarkers: true,
+      },
+    ]);
+
+    editor.setPosition({
+      lineNumber: position.lineNumber,
+      column: slashCommand.trigger.startColumn + text.length,
+    });
+  };
+
+  completeSlashCommand = () => {
+    const { slashCommand } = this.state;
+    const suggestion = slashCommand?.suggestions[slashCommand.selectedIndex];
+
+    if (!slashCommand || !suggestion) {
+      return;
+    }
+
+    this.replaceSlashCommandToken(`/${suggestion.command.name}`);
+    Promise.resolve().then(this.updateSlashCommand);
+  };
+
+  executeSlashCommand = (commandId?: SlashCommandId) => {
+    const { slashCommand } = this.state;
+    const command =
+      commandId ??
+      slashCommand?.suggestions[slashCommand.selectedIndex]?.command.id;
+
+    if (!command) {
+      return;
+    }
+
+    this.replaceSlashCommandToken('');
+    this.clearSlashCommand();
+
+    switch (command) {
+      case 'search':
+        this.props.focusSearchField();
+        return;
+      case 'shortcuts':
+        this.props.showKeyboardShortcuts();
+        return;
+      case 'focus':
+        this.props.toggleFocusMode();
+        return;
+      case 'pref':
+        this.props.showPreferences();
+        return;
+      case 'export':
+        this.props.exportNotes();
+        return;
+    }
+  };
+
+  handleEditorKeyDown = (event: IKeyboardEvent) => {
+    const { slashCommand } = this.state;
+    const browserEvent = event.browserEvent as KeyboardEvent;
+
+    if (!slashCommand || browserEvent.isComposing) {
+      return;
+    }
+
+    switch (browserEvent.key) {
+      case 'Tab':
+        event.preventDefault();
+        event.stopPropagation();
+        this.completeSlashCommand();
+        return;
+      case 'Enter':
+        event.preventDefault();
+        event.stopPropagation();
+        this.executeSlashCommand();
+        return;
+      case 'ArrowDown':
+        event.preventDefault();
+        event.stopPropagation();
+        this.selectNextSlashCommand(1);
+        return;
+      case 'ArrowUp':
+        event.preventDefault();
+        event.stopPropagation();
+        this.selectNextSlashCommand(-1);
+        return;
+      case 'Escape':
+        event.preventDefault();
+        event.stopPropagation();
+        this.clearSlashCommand();
+        return;
+      case ' ':
+      case 'Spacebar':
+        this.clearSlashCommand();
+        return;
+    }
+  };
+
   handleChecklist = (event: Event) => {
     this.editor?.trigger('editorCommand', 'insertChecklist', null);
   };
@@ -724,6 +1004,7 @@ class NoteContentEditor extends Component<Props> {
 
   editorReady: EditorDidMount = (editor, monaco) => {
     this.editor = editor;
+    this.monaco = monaco;
 
     monaco.languages.registerLinkProvider('plaintext', {
       provideLinks: (model) => {
@@ -902,6 +1183,11 @@ class NoteContentEditor extends Component<Props> {
 
     // Tab to indent lists and tasks
     editor.addCommand(monaco.KeyCode.Tab, () => {
+      if (this.state.slashCommand) {
+        this.completeSlashCommand();
+        return;
+      }
+
       const lineNumber = editor.getPosition()?.lineNumber;
       if (!lineNumber) {
         return;
@@ -954,10 +1240,15 @@ class NoteContentEditor extends Component<Props> {
       window.addEventListener('input', this.handleUndoRedo, true);
     }
 
+    editor.onKeyDown(this.handleEditorKeyDown);
     this.setDecorators();
     // make component rerender after the decorators are set.
     this.setState({});
-    editor.onDidChangeModelContent(() => this.setDecorators());
+    editor.onDidChangeModelContent(() => {
+      this.setDecorators();
+      this.updateSlashCommand();
+    });
+    editor.onDidScrollChange(() => this.updateSlashCommand());
 
     // register completion provider for internal links
     const completionProviderHandle =
@@ -992,6 +1283,7 @@ class NoteContentEditor extends Component<Props> {
           e.reason === Editor.CursorChangeReason.Redo
         ) {
           // @TODO: Adjust selection in Undo/Redo
+          this.clearSlashCommand();
           return;
         }
 
@@ -1012,6 +1304,8 @@ class NoteContentEditor extends Component<Props> {
             newEnd,
             newDirection
           );
+
+        this.updateSlashCommand();
       }
     );
 
@@ -1263,6 +1557,54 @@ class NoteContentEditor extends Component<Props> {
     });
   };
 
+  renderSlashCommandPalette = () => {
+    const { slashCommand } = this.state;
+
+    if (!slashCommand) {
+      return null;
+    }
+
+    return (
+      <div
+        aria-label="Slash commands"
+        className="slash-command-palette"
+        role="listbox"
+        style={{
+          top: slashCommand.top,
+          left: slashCommand.left,
+        }}
+        onMouseDown={(event) => event.preventDefault()}
+      >
+        {slashCommand.suggestions.map(({ command }, index) => {
+          const isSelected = index === slashCommand.selectedIndex;
+          return (
+            <button
+              aria-selected={isSelected}
+              className={`slash-command-palette__item${
+                isSelected ? ' is-selected' : ''
+              }`}
+              key={command.id}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                this.executeSlashCommand(command.id);
+              }}
+              onMouseEnter={() => this.selectSlashCommand(index)}
+              role="option"
+              type="button"
+            >
+              <span className="slash-command-palette__command">
+                /{command.name}
+              </span>
+              <span className="slash-command-palette__title">
+                {command.title}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    );
+  };
+
   render() {
     const { lineLength, noteId, searchQuery, theme } = this.props;
     const { content, editor, overTodo } = this.state;
@@ -1365,6 +1707,7 @@ class NoteContentEditor extends Component<Props> {
             value={content}
           />
         )}
+        {this.renderSlashCommandPalette()}
       </div>
     );
   }
@@ -1391,8 +1734,12 @@ const mapStateToProps: S.MapState<StateProps> = (state) => ({
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
   clearSearch: () => actions.ui.search(''),
   editNote: actions.data.editNote,
+  exportNotes: actions.data.exportNotes,
+  focusSearchField: actions.ui.focusSearchField,
   insertTask: () => ({ type: 'INSERT_TASK' }),
   openNote: actions.ui.selectNote,
+  showKeyboardShortcuts: () => actions.ui.showDialog('KEYBINDINGS'),
+  showPreferences: () => actions.ui.showDialog('SETTINGS'),
   storeEditorSelection: (noteId, start, end, direction) => ({
     type: 'STORE_EDITOR_SELECTION',
     noteId,
@@ -1408,6 +1755,7 @@ const mapDispatchToProps: S.MapDispatch<DispatchProps> = {
     type: 'STORE_SEARCH_SELECTION',
     index,
   }),
+  toggleFocusMode: actions.settings.toggleFocusMode,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(NoteContentEditor);

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -101,6 +101,9 @@ const getEditorPadding = (lineLength: T.LineLength, width?: number) => {
   }
 };
 
+const getSlashCommandOptionId = (commandId: SlashCommandId) =>
+  `slash-command-option-${commandId}`;
+
 const getTextAfterBracket = (line: string, column: number) => {
   const precedingOpener = line.lastIndexOf('[', column);
   if (-1 === precedingOpener) {
@@ -274,6 +277,7 @@ class NoteContentEditor extends Component<Props> {
 
   componentWillUnmount() {
     setNotePosition(this.props.noteId, this.editor?.getScrollTop() ?? 0);
+    this.updateSlashCommandActiveDescendant(null);
 
     if (this.bootTimer) {
       clearTimeout(this.bootTimer);
@@ -585,6 +589,7 @@ class NoteContentEditor extends Component<Props> {
   } = {}) => {
     const slashCommand = this.state.slashCommand;
     this.slashCommandDecoration?.clear();
+    this.updateSlashCommandActiveDescendant(null);
     this.slashCommandShortcutAnchor = null;
 
     if (
@@ -782,9 +787,40 @@ class NoteContentEditor extends Component<Props> {
       inline: 'nearest',
     });
 
+  getSlashCommandInputArea = () =>
+    this.editor
+      ?.getDomNode()
+      ?.querySelector<HTMLTextAreaElement>('textarea.inputarea') ?? null;
+
+  updateSlashCommandActiveDescendant = (
+    slashCommand: SlashCommandPaletteState | null = this.state.slashCommand
+  ) => {
+    const inputArea = this.getSlashCommandInputArea();
+
+    if (!inputArea) {
+      return;
+    }
+
+    const selectedCommand =
+      slashCommand?.suggestions[slashCommand.selectedIndex]?.command;
+
+    if (!selectedCommand) {
+      inputArea.removeAttribute('aria-activedescendant');
+      inputArea.removeAttribute('aria-controls');
+      return;
+    }
+
+    inputArea.setAttribute('aria-controls', 'slash-command-palette');
+    inputArea.setAttribute(
+      'aria-activedescendant',
+      getSlashCommandOptionId(selectedCommand.id)
+    );
+  };
+
   updateSlashCommandSelection = (slashCommand: SlashCommandPaletteState) => {
     this.updateSlashCommandGhostText(slashCommand);
     this.scrollSelectedSlashCommandIntoView();
+    this.updateSlashCommandActiveDescendant(slashCommand);
   };
 
   selectSlashCommand = (selectedIndex: number) => {
@@ -1743,6 +1779,7 @@ class NoteContentEditor extends Component<Props> {
       <div
         aria-label="Slash commands"
         className="slash-command-palette"
+        id="slash-command-palette"
         ref={this.slashCommandPalette}
         role="listbox"
         style={{
@@ -1759,6 +1796,7 @@ class NoteContentEditor extends Component<Props> {
               className={`slash-command-palette__item${
                 isSelected ? ' is-selected' : ''
               }`}
+              id={getSlashCommandOptionId(command.id)}
               key={command.id}
               onMouseDown={(event) => {
                 event.preventDefault();

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -8,7 +8,6 @@ import Monaco, {
 import {
   editor as Editor,
   CancellationToken,
-  IKeyboardEvent,
   languages,
   IRange,
   Position,
@@ -32,16 +31,12 @@ import {
 import { getTerms } from './utils/filter-notes';
 import { noteTitleAndPreview } from './utils/note-utils';
 import {
-  getNextSlashCommandIndex,
-  getSlashCommandKeyAction,
-  getSlashCommandSuggestions,
-  getSlashCommandTrigger,
-  isSlashCommandPaletteShortcut,
-  shouldRemoveSlashCommandToken,
-  SlashCommandId,
-  SlashCommandSuggestion,
-  SlashCommandSource,
-  SlashCommandTrigger,
+  CommandPaletteCommandId,
+  CommandPaletteSuggestion,
+  getCommandPaletteKeyAction,
+  getCommandPaletteSuggestions,
+  getNextCommandPaletteIndex,
+  isCommandPaletteShortcut,
 } from './slash-commands';
 import {
   clearNotePositions,
@@ -101,8 +96,8 @@ const getEditorPadding = (lineLength: T.LineLength, width?: number) => {
   }
 };
 
-const getSlashCommandOptionId = (commandId: SlashCommandId) =>
-  `slash-command-option-${commandId}`;
+const getCommandPaletteOptionId = (commandId: CommandPaletteCommandId) =>
+  `command-palette-option-${commandId}`;
 
 const getTextAfterBracket = (line: string, column: number) => {
   const precedingOpener = line.lastIndexOf('[', column);
@@ -170,54 +165,37 @@ type Props = OwnProps & StateProps & DispatchProps;
 
 type OwnState = {
   content: string;
+  commandPalette: CommandPaletteState | null;
   editor: 'fast' | 'full';
   noteId: T.EntityId | null;
   overTodo: boolean;
   searchQuery: string;
-  slashCommand: SlashCommandPaletteState | null;
 };
 
-type SlashCommandPaletteState = {
-  lineNumber: number;
-  source: SlashCommandSource;
-  trigger: SlashCommandTrigger;
-  suggestions: SlashCommandSuggestion[];
+type CommandPaletteState = {
+  query: string;
+  suggestions: CommandPaletteSuggestion[];
   selectedIndex: number;
-  top: number;
-  left: number;
-  ghostText: string;
-};
-
-type SlashCommandTokenRange = {
-  lineNumber: number;
-  source: SlashCommandSource;
-  trigger: SlashCommandTrigger;
 };
 
 class NoteContentEditor extends Component<Props> {
   bootTimer: ReturnType<typeof setTimeout> | null = null;
   editor: Editor.IStandaloneCodeEditor | null = null;
   contentDiv = createRef<HTMLDivElement>();
-  slashCommandPalette = createRef<HTMLDivElement>();
-  selectedSlashCommandItem = createRef<HTMLButtonElement>();
+  commandPaletteInput = createRef<HTMLInputElement>();
+  selectedCommandPaletteItem = createRef<HTMLButtonElement>();
   decorations: Editor.IEditorDecorationsCollection | undefined;
   matchesInNote: Editor.IModelDeltaDecoration[] = [];
   selectedDecoration: Editor.IEditorDecorationsCollection | undefined;
-  slashCommandDecoration: Editor.IEditorDecorationsCollection | undefined;
-  slashCommandShortcutAnchor: {
-    lineNumber: number;
-    startColumn: number;
-  } | null = null;
-  isRemovingShortcutSlashCommand = false;
-  isPreservingSlashCommandText = false;
+  focusBeforeCommandPalette: HTMLElement | null = null;
 
   state: OwnState = {
     content: '',
+    commandPalette: null,
     editor: 'fast',
     noteId: null,
     overTodo: false,
     searchQuery: '',
-    slashCommand: null,
   };
 
   static getDerivedStateFromProps(props: Props, state: OwnState) {
@@ -277,7 +255,6 @@ class NoteContentEditor extends Component<Props> {
 
   componentWillUnmount() {
     setNotePosition(this.props.noteId, this.editor?.getScrollTop() ?? 0);
-    this.updateSlashCommandActiveDescendant(null);
 
     if (this.bootTimer) {
       clearTimeout(this.bootTimer);
@@ -384,8 +361,8 @@ class NoteContentEditor extends Component<Props> {
   };
 
   handleShortcut = (event: KeyboardEvent) => {
-    if (this.props.keyboardShortcuts && isSlashCommandPaletteShortcut(event)) {
-      this.openSlashCommandPaletteFromShortcut();
+    if (this.props.keyboardShortcuts && isCommandPaletteShortcut(event)) {
+      this.openCommandPalette();
       event.stopPropagation();
       event.preventDefault();
       return false;
@@ -580,356 +557,101 @@ class NoteContentEditor extends Component<Props> {
 
   hasFocus = () => this.editor?.hasTextFocus() || false;
 
-  clearSlashCommand = ({
-    removeShortcutToken = false,
-    tokenRange = this.state.slashCommand,
-  }: {
-    removeShortcutToken?: boolean;
-    tokenRange?: SlashCommandTokenRange | null;
-  } = {}) => {
-    const slashCommand = this.state.slashCommand;
-    this.slashCommandDecoration?.clear();
-    this.updateSlashCommandActiveDescendant(null);
-    this.slashCommandShortcutAnchor = null;
+  openCommandPalette = () => {
+    const suggestions = getCommandPaletteSuggestions('');
 
-    if (
-      tokenRange &&
-      !this.isPreservingSlashCommandText &&
-      shouldRemoveSlashCommandToken(removeShortcutToken, tokenRange.source)
-    ) {
-      this.removeSlashCommandToken(tokenRange);
+    if (!this.state.commandPalette) {
+      this.focusBeforeCommandPalette = document.activeElement as HTMLElement;
     }
 
-    if (slashCommand) {
-      this.setState({ slashCommand: null });
-    }
-  };
-
-  getSlashCommandSource = (
-    lineNumber: number,
-    trigger: SlashCommandTrigger
-  ): SlashCommandPaletteState['source'] => {
-    const previous = this.state.slashCommand;
-
-    if (
-      this.slashCommandShortcutAnchor?.lineNumber === lineNumber &&
-      this.slashCommandShortcutAnchor.startColumn === trigger.startColumn
-    ) {
-      return 'shortcut';
-    }
-
-    if (
-      previous?.source === 'shortcut' &&
-      previous.lineNumber === lineNumber &&
-      previous.trigger.startColumn === trigger.startColumn
-    ) {
-      return 'shortcut';
-    }
-
-    return 'typed';
-  };
-
-  updateSlashCommand = () => {
-    if (this.isRemovingShortcutSlashCommand) {
-      return;
-    }
-
-    const editor = this.editor;
-    const model = editor?.getModel();
-    const position = editor?.getPosition();
-    const selection = editor?.getSelection();
-
-    if (!editor || !model || !position || !selection?.isEmpty()) {
-      this.clearSlashCommand({ removeShortcutToken: true });
-      return;
-    }
-
-    const line = model.getLineContent(position.lineNumber);
-    const trigger = getSlashCommandTrigger(line, position.column);
-
-    if (!trigger) {
-      this.clearSlashCommand({ removeShortcutToken: true });
-      return;
-    }
-
-    const source = this.getSlashCommandSource(position.lineNumber, trigger);
-
-    const suggestions = getSlashCommandSuggestions(trigger.query);
-    if (suggestions.length === 0) {
-      this.clearSlashCommand({
-        removeShortcutToken: source === 'shortcut',
-        tokenRange: { lineNumber: position.lineNumber, source, trigger },
-      });
-      return;
-    }
-
-    const visiblePosition = editor.getScrolledVisiblePosition(position);
-    if (!visiblePosition) {
-      this.clearSlashCommand({ removeShortcutToken: true });
-      return;
-    }
-
-    const layout = editor.getLayoutInfo();
-    const paletteWidth = this.slashCommandPalette.current?.offsetWidth ?? 280;
-    const paletteHeight = this.slashCommandPalette.current?.offsetHeight ?? 180;
-    const left = Math.max(
-      8,
-      Math.min(visiblePosition.left, layout.width - paletteWidth - 8)
-    );
-    const top =
-      visiblePosition.top + paletteHeight > layout.height
-        ? Math.max(8, visiblePosition.top - paletteHeight)
-        : visiblePosition.top + visiblePosition.height + 6;
-
-    const previous = this.state.slashCommand;
-    if (source === 'typed') {
-      this.slashCommandShortcutAnchor = null;
-    }
-
-    const previousCommandId =
-      previous?.suggestions[previous.selectedIndex]?.command.id;
-    const selectedIndex = Math.max(
-      0,
-      suggestions.findIndex(({ command }) => command.id === previousCommandId)
-    );
-    const selected = suggestions[selectedIndex] ?? suggestions[0];
-    const nextSlashCommand = {
-      lineNumber: position.lineNumber,
-      source,
-      trigger,
-      suggestions,
-      selectedIndex,
-      top,
-      left,
-      ghostText: selected?.completion ?? '',
-    };
-
-    this.setState({ slashCommand: nextSlashCommand }, () =>
-      this.updateSlashCommandSelection(nextSlashCommand)
-    );
-  };
-
-  openSlashCommandPaletteFromShortcut = () => {
-    const editor = this.editor;
-    const position = editor?.getPosition();
-
-    if (!editor || !position) {
-      return;
-    }
-
-    editor.focus();
-
-    this.slashCommandShortcutAnchor = {
-      lineNumber: position.lineNumber,
-      startColumn: position.column,
-    };
-
-    editor.executeEdits('slash-command-shortcut', [
+    this.setState(
       {
-        range: new Range(
-          position.lineNumber,
-          position.column,
-          position.lineNumber,
-          position.column
-        ),
-        text: '/',
-        forceMoveMarkers: true,
-      },
-    ]);
-
-    editor.setPosition({
-      lineNumber: position.lineNumber,
-      column: position.column + 1,
-    });
-
-    this.updateSlashCommand();
-  };
-
-  updateSlashCommandGhostText = (slashCommand = this.state.slashCommand) => {
-    this.slashCommandDecoration?.clear();
-
-    if (!this.editor || !slashCommand?.ghostText) {
-      return;
-    }
-
-    const model = this.editor.getModel();
-    const position = this.editor.getPosition();
-
-    if (!model || !position) {
-      return;
-    }
-
-    const range = new Range(
-      slashCommand.lineNumber,
-      slashCommand.trigger.endColumn,
-      slashCommand.lineNumber,
-      slashCommand.trigger.endColumn
-    );
-
-    this.slashCommandDecoration = this.editor.createDecorationsCollection([
-      {
-        range,
-        options: {
-          showIfCollapsed: true,
-          after: {
-            content: slashCommand.ghostText,
-            inlineClassName: 'slash-command-ghost',
-            cursorStops: Editor.InjectedTextCursorStops.None,
-          },
+        commandPalette: {
+          query: '',
+          suggestions,
+          selectedIndex: 0,
         },
       },
-    ]);
+      () => this.commandPaletteInput.current?.focus()
+    );
   };
 
-  scrollSelectedSlashCommandIntoView = () =>
-    this.selectedSlashCommandItem.current?.scrollIntoView({
+  closeCommandPalette = ({ restoreFocus = true } = {}) => {
+    if (!this.state.commandPalette) {
+      return;
+    }
+
+    this.setState({ commandPalette: null }, () => {
+      if (restoreFocus) {
+        this.focusBeforeCommandPalette?.focus();
+      }
+      this.focusBeforeCommandPalette = null;
+    });
+  };
+
+  updateCommandPaletteQuery = (query: string) => {
+    const suggestions = getCommandPaletteSuggestions(query);
+
+    this.setState({
+      commandPalette: {
+        query,
+        suggestions,
+        selectedIndex: 0,
+      },
+    });
+  };
+
+  scrollSelectedCommandPaletteItemIntoView = () =>
+    this.selectedCommandPaletteItem.current?.scrollIntoView({
       block: 'nearest',
       inline: 'nearest',
     });
 
-  getSlashCommandInputArea = () =>
-    this.editor
-      ?.getDomNode()
-      ?.querySelector<HTMLTextAreaElement>('textarea.inputarea') ?? null;
+  selectCommandPaletteItem = (selectedIndex: number) => {
+    const { commandPalette } = this.state;
 
-  updateSlashCommandActiveDescendant = (
-    slashCommand: SlashCommandPaletteState | null = this.state.slashCommand
-  ) => {
-    const inputArea = this.getSlashCommandInputArea();
-
-    if (!inputArea) {
+    if (!commandPalette?.suggestions[selectedIndex]) {
       return;
     }
 
-    const selectedCommand =
-      slashCommand?.suggestions[slashCommand.selectedIndex]?.command;
-
-    if (!selectedCommand) {
-      inputArea.removeAttribute('aria-activedescendant');
-      inputArea.removeAttribute('aria-controls');
-      return;
-    }
-
-    inputArea.setAttribute('aria-controls', 'slash-command-palette');
-    inputArea.setAttribute(
-      'aria-activedescendant',
-      getSlashCommandOptionId(selectedCommand.id)
-    );
-  };
-
-  updateSlashCommandSelection = (slashCommand: SlashCommandPaletteState) => {
-    this.updateSlashCommandGhostText(slashCommand);
-    this.scrollSelectedSlashCommandIntoView();
-    this.updateSlashCommandActiveDescendant(slashCommand);
-  };
-
-  selectSlashCommand = (selectedIndex: number) => {
-    const { slashCommand } = this.state;
-    const selected = slashCommand?.suggestions[selectedIndex];
-
-    if (!slashCommand || !selected) {
-      return;
-    }
-
-    const nextSlashCommand = {
-      ...slashCommand,
-      selectedIndex,
-      ghostText: selected.completion,
-    };
-
-    this.setState({ slashCommand: nextSlashCommand }, () =>
-      this.updateSlashCommandSelection(nextSlashCommand)
-    );
-  };
-
-  selectNextSlashCommand = (offset: number) => {
-    const { slashCommand } = this.state;
-    if (!slashCommand) {
-      return;
-    }
-
-    const nextIndex = getNextSlashCommandIndex(
-      slashCommand.suggestions.length,
-      slashCommand.selectedIndex,
-      offset
-    );
-
-    this.selectSlashCommand(nextIndex);
-  };
-
-  replaceSlashCommandToken = (
-    text: string,
-    slashCommand: SlashCommandTokenRange | null = this.state.slashCommand
-  ) => {
-    const editor = this.editor;
-
-    if (!slashCommand || !editor) {
-      return;
-    }
-
-    const range = new Range(
-      slashCommand.lineNumber,
-      slashCommand.trigger.startColumn,
-      slashCommand.lineNumber,
-      slashCommand.trigger.endColumn
-    );
-
-    editor.executeEdits('slash-command', [
+    this.setState(
       {
-        range,
-        text,
-        forceMoveMarkers: true,
+        commandPalette: {
+          ...commandPalette,
+          selectedIndex,
+        },
       },
-    ]);
-
-    editor.setPosition({
-      lineNumber: slashCommand.lineNumber,
-      column: slashCommand.trigger.startColumn + text.length,
-    });
+      this.scrollSelectedCommandPaletteItemIntoView
+    );
   };
 
-  removeSlashCommandToken = (tokenRange: SlashCommandTokenRange) => {
-    this.isRemovingShortcutSlashCommand = true;
-    try {
-      this.replaceSlashCommandToken('', tokenRange);
-    } finally {
-      this.isRemovingShortcutSlashCommand = false;
-    }
-  };
+  selectNextCommandPaletteItem = (offset: number) => {
+    const { commandPalette } = this.state;
 
-  completeSlashCommand = () => {
-    const { slashCommand } = this.state;
-    const suggestion = slashCommand?.suggestions[slashCommand.selectedIndex];
-
-    if (!slashCommand || !suggestion) {
+    if (!commandPalette?.suggestions.length) {
       return;
     }
 
-    this.replaceSlashCommandToken(`/${suggestion.command.name}`);
+    this.selectCommandPaletteItem(
+      getNextCommandPaletteIndex(
+        commandPalette.suggestions.length,
+        commandPalette.selectedIndex,
+        offset
+      )
+    );
   };
 
-  typeThroughSlashCommand = (text: string) => {
-    this.isPreservingSlashCommandText = true;
-    try {
-      this.clearSlashCommand();
-      this.editor?.trigger('slash-command', 'type', { text });
-    } finally {
-      this.isPreservingSlashCommandText = false;
-    }
-  };
-
-  executeSlashCommand = (commandId?: SlashCommandId) => {
-    const { slashCommand } = this.state;
+  executeCommandPaletteCommand = (commandId?: CommandPaletteCommandId) => {
+    const { commandPalette } = this.state;
     const command =
       commandId ??
-      slashCommand?.suggestions[slashCommand.selectedIndex]?.command.id;
+      commandPalette?.suggestions[commandPalette.selectedIndex]?.command.id;
 
     if (!command) {
       return;
     }
 
-    this.replaceSlashCommandToken('');
-    this.clearSlashCommand();
+    this.closeCommandPalette({ restoreFocus: false });
 
     switch (command) {
       case 'new':
@@ -968,49 +690,40 @@ class NoteContentEditor extends Component<Props> {
     }
   };
 
-  handleEditorKeyDown = (event: IKeyboardEvent) => {
-    const { slashCommand } = this.state;
-    const browserEvent = event.browserEvent as KeyboardEvent;
-    const action = getSlashCommandKeyAction(
-      browserEvent.key,
-      browserEvent.isComposing,
-      !!slashCommand
+  handleCommandPaletteKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    const { commandPalette } = this.state;
+    const action = getCommandPaletteKeyAction(
+      event.key,
+      event.nativeEvent.isComposing,
+      !!commandPalette
     );
 
-    if (!slashCommand || !action) {
+    if (!commandPalette || !action) {
       return;
     }
 
     switch (action) {
-      case 'complete':
-        event.preventDefault();
-        event.stopPropagation();
-        this.completeSlashCommand();
-        return;
       case 'execute':
         event.preventDefault();
         event.stopPropagation();
-        this.executeSlashCommand();
+        this.executeCommandPaletteCommand();
         return;
       case 'next':
         event.preventDefault();
         event.stopPropagation();
-        this.selectNextSlashCommand(1);
+        this.selectNextCommandPaletteItem(1);
         return;
       case 'previous':
         event.preventDefault();
         event.stopPropagation();
-        this.selectNextSlashCommand(-1);
+        this.selectNextCommandPaletteItem(-1);
         return;
-      case 'cancel':
+      case 'close':
         event.preventDefault();
         event.stopPropagation();
-        this.clearSlashCommand({ removeShortcutToken: true });
-        return;
-      case 'cancel-and-type':
-        event.preventDefault();
-        event.stopPropagation();
-        this.typeThroughSlashCommand(' ');
+        this.closeCommandPalette();
         return;
     }
   };
@@ -1451,15 +1164,12 @@ class NoteContentEditor extends Component<Props> {
       window.addEventListener('input', this.handleUndoRedo, true);
     }
 
-    editor.onKeyDown(this.handleEditorKeyDown);
     this.setDecorators();
     // make component rerender after the decorators are set.
     this.setState({});
     editor.onDidChangeModelContent(() => {
       this.setDecorators();
-      this.updateSlashCommand();
     });
-    editor.onDidScrollChange(() => this.updateSlashCommand());
 
     // register completion provider for internal links
     const completionProviderHandle =
@@ -1494,7 +1204,6 @@ class NoteContentEditor extends Component<Props> {
           e.reason === Editor.CursorChangeReason.Redo
         ) {
           // @TODO: Adjust selection in Undo/Redo
-          this.clearSlashCommand();
           return;
         }
 
@@ -1515,8 +1224,6 @@ class NoteContentEditor extends Component<Props> {
             newEnd,
             newDirection
           );
-
-        this.updateSlashCommand();
       }
     );
 
@@ -1768,54 +1475,101 @@ class NoteContentEditor extends Component<Props> {
     });
   };
 
-  renderSlashCommandPalette = () => {
-    const { slashCommand } = this.state;
+  renderCommandPalette = () => {
+    const { commandPalette } = this.state;
 
-    if (!slashCommand) {
+    if (!commandPalette) {
       return null;
     }
 
+    const selectedCommand =
+      commandPalette.suggestions[commandPalette.selectedIndex]?.command;
+
     return (
       <div
-        aria-label="Slash commands"
-        className="slash-command-palette"
-        id="slash-command-palette"
-        ref={this.slashCommandPalette}
-        role="listbox"
-        style={{
-          top: slashCommand.top,
-          left: slashCommand.left,
+        className="command-palette-modal"
+        onClick={(event) => {
+          if (event.target === event.currentTarget) {
+            this.closeCommandPalette();
+          }
+          event.stopPropagation();
         }}
-        onMouseDown={(event) => event.preventDefault()}
+        onMouseDown={(event) => event.stopPropagation()}
       >
-        {slashCommand.suggestions.map(({ command }, index) => {
-          const isSelected = index === slashCommand.selectedIndex;
-          return (
-            <button
-              aria-selected={isSelected}
-              className={`slash-command-palette__item${
-                isSelected ? ' is-selected' : ''
-              }`}
-              id={getSlashCommandOptionId(command.id)}
-              key={command.id}
-              onMouseDown={(event) => {
-                event.preventDefault();
-                this.executeSlashCommand(command.id);
-              }}
-              onMouseEnter={() => this.selectSlashCommand(index)}
-              ref={isSelected ? this.selectedSlashCommandItem : null}
-              role="option"
-              type="button"
-            >
-              <span className="slash-command-palette__command">
-                /{command.name}
-              </span>
-              <span className="slash-command-palette__title">
-                {command.title}
-              </span>
-            </button>
-          );
-        })}
+        <div
+          aria-label="Command palette"
+          aria-modal="true"
+          className="command-palette"
+          role="dialog"
+        >
+          <input
+            aria-activedescendant={
+              selectedCommand
+                ? getCommandPaletteOptionId(selectedCommand.id)
+                : undefined
+            }
+            aria-controls="command-palette-list"
+            aria-expanded="true"
+            aria-label="Command"
+            autoComplete="off"
+            className="command-palette__input"
+            onChange={(event) =>
+              this.updateCommandPaletteQuery(event.target.value)
+            }
+            onKeyDown={this.handleCommandPaletteKeyDown}
+            placeholder="Search commands"
+            ref={this.commandPaletteInput}
+            role="combobox"
+            spellCheck={false}
+            type="text"
+            value={commandPalette.query}
+          />
+          <div
+            className="command-palette__list"
+            id="command-palette-list"
+            role="listbox"
+          >
+            {commandPalette.suggestions.length === 0 && (
+              <div className="command-palette__empty">No commands found</div>
+            )}
+            {commandPalette.suggestions.map(({ command }, index) => {
+              const isSelected = index === commandPalette.selectedIndex;
+              return (
+                <button
+                  aria-selected={isSelected}
+                  className={`command-palette__item${
+                    isSelected ? ' is-selected' : ''
+                  }`}
+                  id={getCommandPaletteOptionId(command.id)}
+                  key={command.id}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    this.executeCommandPaletteCommand(command.id);
+                  }}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                  }}
+                  onMouseEnter={() => this.selectCommandPaletteItem(index)}
+                  ref={isSelected ? this.selectedCommandPaletteItem : null}
+                  role="option"
+                  type="button"
+                >
+                  <span className="command-palette__item-copy">
+                    <span className="command-palette__title">
+                      {command.title}
+                    </span>
+                    <span className="command-palette__detail">
+                      {command.detail}
+                    </span>
+                  </span>
+                  <span className="command-palette__command">
+                    {command.name}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
       </div>
     );
   };
@@ -1922,7 +1676,7 @@ class NoteContentEditor extends Component<Props> {
             value={content}
           />
         )}
-        {this.renderSlashCommandPalette()}
+        {this.renderCommandPalette()}
       </div>
     );
   }

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -36,6 +36,7 @@ import {
   getSlashCommandKeyAction,
   getSlashCommandSuggestions,
   getSlashCommandTrigger,
+  isSlashCommandPaletteShortcut,
   SlashCommandId,
   SlashCommandSuggestion,
   SlashCommandTrigger,
@@ -166,12 +167,19 @@ type OwnState = {
 };
 
 type SlashCommandPaletteState = {
+  lineNumber: number;
+  source: 'typed' | 'shortcut';
   trigger: SlashCommandTrigger;
   suggestions: SlashCommandSuggestion[];
   selectedIndex: number;
   top: number;
   left: number;
   ghostText: string;
+};
+
+type SlashCommandTokenRange = {
+  lineNumber: number;
+  trigger: SlashCommandTrigger;
 };
 
 class NoteContentEditor extends Component<Props> {
@@ -183,6 +191,11 @@ class NoteContentEditor extends Component<Props> {
   matchesInNote: Editor.IModelDeltaDecoration[] = [];
   selectedDecoration: Editor.IEditorDecorationsCollection | undefined;
   slashCommandDecoration: Editor.IEditorDecorationsCollection | undefined;
+  slashCommandShortcutAnchor: {
+    lineNumber: number;
+    startColumn: number;
+  } | null = null;
+  isRemovingShortcutSlashCommand = false;
 
   state: OwnState = {
     content: '',
@@ -356,6 +369,13 @@ class NoteContentEditor extends Component<Props> {
   };
 
   handleShortcut = (event: KeyboardEvent) => {
+    if (this.props.keyboardShortcuts && isSlashCommandPaletteShortcut(event)) {
+      this.openSlashCommandPaletteFromShortcut();
+      event.stopPropagation();
+      event.preventDefault();
+      return false;
+    }
+
     const { ctrlKey, metaKey, shiftKey } = event;
     const key = event.key.toLowerCase();
 
@@ -545,21 +565,62 @@ class NoteContentEditor extends Component<Props> {
 
   hasFocus = () => this.editor?.hasTextFocus() || false;
 
-  clearSlashCommand = () => {
+  clearSlashCommand = ({
+    removeShortcutToken = false,
+    tokenRange = this.state.slashCommand,
+  }: {
+    removeShortcutToken?: boolean;
+    tokenRange?: SlashCommandTokenRange | null;
+  } = {}) => {
+    const slashCommand = this.state.slashCommand;
     this.slashCommandDecoration?.clear();
-    if (this.state.slashCommand) {
+    this.slashCommandShortcutAnchor = null;
+
+    if (removeShortcutToken && tokenRange) {
+      this.removeSlashCommandToken(tokenRange);
+    }
+
+    if (slashCommand) {
       this.setState({ slashCommand: null });
     }
   };
 
+  getSlashCommandSource = (
+    lineNumber: number,
+    trigger: SlashCommandTrigger
+  ): SlashCommandPaletteState['source'] => {
+    const previous = this.state.slashCommand;
+
+    if (
+      this.slashCommandShortcutAnchor?.lineNumber === lineNumber &&
+      this.slashCommandShortcutAnchor.startColumn === trigger.startColumn
+    ) {
+      return 'shortcut';
+    }
+
+    if (
+      previous?.source === 'shortcut' &&
+      previous.lineNumber === lineNumber &&
+      previous.trigger.startColumn === trigger.startColumn
+    ) {
+      return 'shortcut';
+    }
+
+    return 'typed';
+  };
+
   updateSlashCommand = () => {
+    if (this.isRemovingShortcutSlashCommand) {
+      return;
+    }
+
     const editor = this.editor;
     const model = editor?.getModel();
     const position = editor?.getPosition();
     const selection = editor?.getSelection();
 
     if (!editor || !model || !position || !selection?.isEmpty()) {
-      this.clearSlashCommand();
+      this.clearSlashCommand({ removeShortcutToken: true });
       return;
     }
 
@@ -567,19 +628,24 @@ class NoteContentEditor extends Component<Props> {
     const trigger = getSlashCommandTrigger(line, position.column);
 
     if (!trigger) {
-      this.clearSlashCommand();
+      this.clearSlashCommand({ removeShortcutToken: true });
       return;
     }
 
+    const source = this.getSlashCommandSource(position.lineNumber, trigger);
+
     const suggestions = getSlashCommandSuggestions(trigger.query);
     if (suggestions.length === 0) {
-      this.clearSlashCommand();
+      this.clearSlashCommand({
+        removeShortcutToken: source === 'shortcut',
+        tokenRange: { lineNumber: position.lineNumber, trigger },
+      });
       return;
     }
 
     const visiblePosition = editor.getScrolledVisiblePosition(position);
     if (!visiblePosition) {
-      this.clearSlashCommand();
+      this.clearSlashCommand({ removeShortcutToken: true });
       return;
     }
 
@@ -596,6 +662,10 @@ class NoteContentEditor extends Component<Props> {
         : visiblePosition.top + visiblePosition.height + 6;
 
     const previous = this.state.slashCommand;
+    if (source === 'typed') {
+      this.slashCommandShortcutAnchor = null;
+    }
+
     const previousCommandId =
       previous?.suggestions[previous.selectedIndex]?.command.id;
     const selectedIndex = Math.max(
@@ -604,6 +674,8 @@ class NoteContentEditor extends Component<Props> {
     );
     const selected = suggestions[selectedIndex] ?? suggestions[0];
     const nextSlashCommand = {
+      lineNumber: position.lineNumber,
+      source,
       trigger,
       suggestions,
       selectedIndex,
@@ -615,6 +687,42 @@ class NoteContentEditor extends Component<Props> {
     this.setState({ slashCommand: nextSlashCommand }, () =>
       this.updateSlashCommandGhostText(nextSlashCommand)
     );
+  };
+
+  openSlashCommandPaletteFromShortcut = () => {
+    const editor = this.editor;
+    const position = editor?.getPosition();
+
+    if (!editor || !position) {
+      return;
+    }
+
+    editor.focus();
+
+    this.slashCommandShortcutAnchor = {
+      lineNumber: position.lineNumber,
+      startColumn: position.column,
+    };
+
+    editor.executeEdits('slash-command-shortcut', [
+      {
+        range: new Range(
+          position.lineNumber,
+          position.column,
+          position.lineNumber,
+          position.column
+        ),
+        text: '/',
+        forceMoveMarkers: true,
+      },
+    ]);
+
+    editor.setPosition({
+      lineNumber: position.lineNumber,
+      column: position.column + 1,
+    });
+
+    this.updateSlashCommand();
   };
 
   updateSlashCommandGhostText = (slashCommand = this.state.slashCommand) => {
@@ -632,9 +740,9 @@ class NoteContentEditor extends Component<Props> {
     }
 
     const range = new Range(
-      position.lineNumber,
+      slashCommand.lineNumber,
       slashCommand.trigger.endColumn,
-      position.lineNumber,
+      slashCommand.lineNumber,
       slashCommand.trigger.endColumn
     );
 
@@ -687,19 +795,20 @@ class NoteContentEditor extends Component<Props> {
     this.selectSlashCommand(nextIndex);
   };
 
-  replaceSlashCommandToken = (text: string) => {
-    const { slashCommand } = this.state;
+  replaceSlashCommandToken = (
+    text: string,
+    slashCommand: SlashCommandTokenRange | null = this.state.slashCommand
+  ) => {
     const editor = this.editor;
-    const position = editor?.getPosition();
 
-    if (!slashCommand || !editor || !position) {
+    if (!slashCommand || !editor) {
       return;
     }
 
     const range = new Range(
-      position.lineNumber,
+      slashCommand.lineNumber,
       slashCommand.trigger.startColumn,
-      position.lineNumber,
+      slashCommand.lineNumber,
       slashCommand.trigger.endColumn
     );
 
@@ -712,9 +821,18 @@ class NoteContentEditor extends Component<Props> {
     ]);
 
     editor.setPosition({
-      lineNumber: position.lineNumber,
+      lineNumber: slashCommand.lineNumber,
       column: slashCommand.trigger.startColumn + text.length,
     });
+  };
+
+  removeSlashCommandToken = (tokenRange: SlashCommandTokenRange) => {
+    this.isRemovingShortcutSlashCommand = true;
+    try {
+      this.replaceSlashCommandToken('', tokenRange);
+    } finally {
+      this.isRemovingShortcutSlashCommand = false;
+    }
   };
 
   completeSlashCommand = () => {
@@ -797,10 +915,10 @@ class NoteContentEditor extends Component<Props> {
       case 'cancel':
         event.preventDefault();
         event.stopPropagation();
-        this.clearSlashCommand();
+        this.clearSlashCommand({ removeShortcutToken: true });
         return;
       case 'cancel-and-type':
-        this.clearSlashCommand();
+        this.clearSlashCommand({ removeShortcutToken: true });
         return;
     }
   };

--- a/lib/slash-commands.test.ts
+++ b/lib/slash-commands.test.ts
@@ -48,7 +48,19 @@ describe('slash commands', () => {
     it('returns all commands for an empty query', () => {
       expect(
         getSlashCommandSuggestions('').map(({ command }) => command.id)
-      ).toEqual(['search', 'shortcuts', 'focus', 'pref', 'export']);
+      ).toEqual([
+        'new',
+        'search',
+        'all-notes',
+        'untagged-notes',
+        'trash',
+        'settings',
+        'shortcuts',
+        'help',
+        'about',
+        'focus',
+        'export',
+      ]);
     });
 
     it('ranks exact aliases ahead of prefix matches', () => {
@@ -65,6 +77,11 @@ describe('slash commands', () => {
       expect(first.command.id).toBe('shortcuts');
       expect(first.completion).toBe('ortcuts');
       expect(first.exactMatch).toBe(false);
+    });
+
+    it('matches command aliases for settings and new notes', () => {
+      expect(getSlashCommandSuggestions('pref')[0].command.id).toBe('settings');
+      expect(getSlashCommandSuggestions('create')[0].command.id).toBe('new');
     });
 
     it('does not show ghost text for an exact command', () => {

--- a/lib/slash-commands.test.ts
+++ b/lib/slash-commands.test.ts
@@ -3,6 +3,7 @@ import {
   getSlashCommandKeyAction,
   getSlashCommandSuggestions,
   getSlashCommandTrigger,
+  isSlashCommandPaletteShortcut,
 } from './slash-commands';
 
 describe('slash commands', () => {
@@ -108,6 +109,50 @@ describe('slash commands', () => {
 
     it('ignores unrelated keys', () => {
       expect(getSlashCommandKeyAction('a', false, true)).toBeNull();
+    });
+  });
+
+  describe('isSlashCommandPaletteShortcut', () => {
+    const event = {
+      altKey: false,
+      ctrlKey: false,
+      isComposing: false,
+      key: 'k',
+      metaKey: false,
+      shiftKey: false,
+    };
+
+    it('matches Cmd+K and Ctrl+K', () => {
+      expect(isSlashCommandPaletteShortcut({ ...event, metaKey: true })).toBe(
+        true
+      );
+      expect(isSlashCommandPaletteShortcut({ ...event, ctrlKey: true })).toBe(
+        true
+      );
+    });
+
+    it('ignores modified, composing, and mixed modifier events', () => {
+      expect(
+        isSlashCommandPaletteShortcut({
+          ...event,
+          metaKey: true,
+          shiftKey: true,
+        })
+      ).toBe(false);
+      expect(
+        isSlashCommandPaletteShortcut({
+          ...event,
+          ctrlKey: true,
+          isComposing: true,
+        })
+      ).toBe(false);
+      expect(
+        isSlashCommandPaletteShortcut({
+          ...event,
+          ctrlKey: true,
+          metaKey: true,
+        })
+      ).toBe(false);
     });
   });
 });

--- a/lib/slash-commands.test.ts
+++ b/lib/slash-commands.test.ts
@@ -34,6 +34,10 @@ describe('slash commands', () => {
       expect(getSlashCommandTrigger('/search ', 9)).toBeNull();
     });
 
+    it('only detects a slash command at the end of the token', () => {
+      expect(getSlashCommandTrigger('/search', 3)).toBeNull();
+    });
+
     it('ignores command queries with punctuation', () => {
       expect(getSlashCommandTrigger('/search?', 9)).toBeNull();
     });

--- a/lib/slash-commands.test.ts
+++ b/lib/slash-commands.test.ts
@@ -4,6 +4,7 @@ import {
   getSlashCommandSuggestions,
   getSlashCommandTrigger,
   isSlashCommandPaletteShortcut,
+  shouldRemoveSlashCommandToken,
 } from './slash-commands';
 
 describe('slash commands', () => {
@@ -126,6 +127,15 @@ describe('slash commands', () => {
 
     it('ignores unrelated keys', () => {
       expect(getSlashCommandKeyAction('a', false, true)).toBeNull();
+    });
+  });
+
+  describe('shouldRemoveSlashCommandToken', () => {
+    it('only removes slash command text that was inserted by the shortcut', () => {
+      expect(shouldRemoveSlashCommandToken(true, 'shortcut')).toBe(true);
+      expect(shouldRemoveSlashCommandToken(true, 'typed')).toBe(false);
+      expect(shouldRemoveSlashCommandToken(false, 'shortcut')).toBe(false);
+      expect(shouldRemoveSlashCommandToken(true)).toBe(false);
     });
   });
 

--- a/lib/slash-commands.test.ts
+++ b/lib/slash-commands.test.ts
@@ -1,54 +1,15 @@
 import {
-  getNextSlashCommandIndex,
-  getSlashCommandKeyAction,
-  getSlashCommandSuggestions,
-  getSlashCommandTrigger,
-  isSlashCommandPaletteShortcut,
-  shouldRemoveSlashCommandToken,
+  getCommandPaletteKeyAction,
+  getCommandPaletteSuggestions,
+  getNextCommandPaletteIndex,
+  isCommandPaletteShortcut,
 } from './slash-commands';
 
-describe('slash commands', () => {
-  describe('getSlashCommandTrigger', () => {
-    it('detects a slash command token at the cursor', () => {
-      expect(getSlashCommandTrigger('Run /sh', 8)).toEqual({
-        token: '/sh',
-        query: 'sh',
-        startColumn: 5,
-        endColumn: 8,
-      });
-    });
-
-    it('detects an empty slash command query', () => {
-      expect(getSlashCommandTrigger('/', 2)).toEqual({
-        token: '/',
-        query: '',
-        startColumn: 1,
-        endColumn: 2,
-      });
-    });
-
-    it('ignores slashes that are part of another token', () => {
-      expect(getSlashCommandTrigger('https://simplenote.com', 9)).toBeNull();
-      expect(getSlashCommandTrigger('hello/search', 13)).toBeNull();
-    });
-
-    it('stops matching once the user types whitespace', () => {
-      expect(getSlashCommandTrigger('/search ', 9)).toBeNull();
-    });
-
-    it('only detects a slash command at the end of the token', () => {
-      expect(getSlashCommandTrigger('/search', 3)).toBeNull();
-    });
-
-    it('ignores command queries with punctuation', () => {
-      expect(getSlashCommandTrigger('/search?', 9)).toBeNull();
-    });
-  });
-
-  describe('getSlashCommandSuggestions', () => {
+describe('command palette', () => {
+  describe('getCommandPaletteSuggestions', () => {
     it('returns all commands for an empty query', () => {
       expect(
-        getSlashCommandSuggestions('').map(({ command }) => command.id)
+        getCommandPaletteSuggestions('').map(({ command }) => command.id)
       ).toEqual([
         'new',
         'search',
@@ -65,81 +26,71 @@ describe('slash commands', () => {
     });
 
     it('ranks exact aliases ahead of prefix matches', () => {
-      const [first] = getSlashCommandSuggestions('s');
+      const [first] = getCommandPaletteSuggestions('s');
 
       expect(first.command.id).toBe('search');
-      expect(first.completion).toBe('earch');
-      expect(first.exactMatch).toBe(true);
     });
 
-    it('returns ghost text for the best prefix match', () => {
-      const [first] = getSlashCommandSuggestions('sh');
+    it('ranks prefix matches by command order', () => {
+      const [first] = getCommandPaletteSuggestions('sh');
 
       expect(first.command.id).toBe('shortcuts');
-      expect(first.completion).toBe('ortcuts');
-      expect(first.exactMatch).toBe(false);
     });
 
     it('matches command aliases for settings and new notes', () => {
-      expect(getSlashCommandSuggestions('pref')[0].command.id).toBe('settings');
-      expect(getSlashCommandSuggestions('create')[0].command.id).toBe('new');
+      expect(getCommandPaletteSuggestions('pref')[0].command.id).toBe(
+        'settings'
+      );
+      expect(getCommandPaletteSuggestions('create')[0].command.id).toBe('new');
     });
 
-    it('does not show ghost text for an exact command', () => {
-      const [first] = getSlashCommandSuggestions('export');
+    it('matches command titles', () => {
+      expect(getCommandPaletteSuggestions('keyboard')[0].command.id).toBe(
+        'shortcuts'
+      );
+    });
 
-      expect(first.command.id).toBe('export');
-      expect(first.completion).toBe('');
-      expect(first.exactMatch).toBe(true);
+    it('normalizes command palette queries', () => {
+      expect(getCommandPaletteSuggestions('  SETTINGS  ')[0].command.id).toBe(
+        'settings'
+      );
     });
   });
 
-  describe('getNextSlashCommandIndex', () => {
+  describe('getNextCommandPaletteIndex', () => {
     it('wraps forward through the available suggestions', () => {
-      expect(getNextSlashCommandIndex(5, 4, 1)).toBe(0);
+      expect(getNextCommandPaletteIndex(5, 4, 1)).toBe(0);
     });
 
     it('wraps backward through the available suggestions', () => {
-      expect(getNextSlashCommandIndex(5, 0, -1)).toBe(4);
+      expect(getNextCommandPaletteIndex(5, 0, -1)).toBe(4);
     });
   });
 
-  describe('getSlashCommandKeyAction', () => {
+  describe('getCommandPaletteKeyAction', () => {
     it.each([
-      ['Tab', 'complete'],
       ['Enter', 'execute'],
       ['ArrowDown', 'next'],
       ['ArrowUp', 'previous'],
-      ['Escape', 'cancel'],
-      [' ', 'cancel-and-type'],
-      ['Spacebar', 'cancel-and-type'],
-    ])('maps %s to %s while slash commands are active', (key, action) => {
-      expect(getSlashCommandKeyAction(key, false, true)).toBe(action);
+      ['Escape', 'close'],
+    ])('maps %s to %s while the command palette is active', (key, action) => {
+      expect(getCommandPaletteKeyAction(key, false, true)).toBe(action);
     });
 
-    it('does not intercept keys when slash commands are inactive', () => {
-      expect(getSlashCommandKeyAction('Enter', false, false)).toBeNull();
+    it('does not intercept keys when the command palette is inactive', () => {
+      expect(getCommandPaletteKeyAction('Enter', false, false)).toBeNull();
     });
 
     it('does not intercept keys during IME composition', () => {
-      expect(getSlashCommandKeyAction('Enter', true, true)).toBeNull();
+      expect(getCommandPaletteKeyAction('Enter', true, true)).toBeNull();
     });
 
     it('ignores unrelated keys', () => {
-      expect(getSlashCommandKeyAction('a', false, true)).toBeNull();
+      expect(getCommandPaletteKeyAction('a', false, true)).toBeNull();
     });
   });
 
-  describe('shouldRemoveSlashCommandToken', () => {
-    it('only removes slash command text that was inserted by the shortcut', () => {
-      expect(shouldRemoveSlashCommandToken(true, 'shortcut')).toBe(true);
-      expect(shouldRemoveSlashCommandToken(true, 'typed')).toBe(false);
-      expect(shouldRemoveSlashCommandToken(false, 'shortcut')).toBe(false);
-      expect(shouldRemoveSlashCommandToken(true)).toBe(false);
-    });
-  });
-
-  describe('isSlashCommandPaletteShortcut', () => {
+  describe('isCommandPaletteShortcut', () => {
     const event = {
       altKey: false,
       ctrlKey: false,
@@ -150,31 +101,27 @@ describe('slash commands', () => {
     };
 
     it('matches Cmd+K and Ctrl+K', () => {
-      expect(isSlashCommandPaletteShortcut({ ...event, metaKey: true })).toBe(
-        true
-      );
-      expect(isSlashCommandPaletteShortcut({ ...event, ctrlKey: true })).toBe(
-        true
-      );
+      expect(isCommandPaletteShortcut({ ...event, metaKey: true })).toBe(true);
+      expect(isCommandPaletteShortcut({ ...event, ctrlKey: true })).toBe(true);
     });
 
     it('ignores modified, composing, and mixed modifier events', () => {
       expect(
-        isSlashCommandPaletteShortcut({
+        isCommandPaletteShortcut({
           ...event,
           metaKey: true,
           shiftKey: true,
         })
       ).toBe(false);
       expect(
-        isSlashCommandPaletteShortcut({
+        isCommandPaletteShortcut({
           ...event,
           ctrlKey: true,
           isComposing: true,
         })
       ).toBe(false);
       expect(
-        isSlashCommandPaletteShortcut({
+        isCommandPaletteShortcut({
           ...event,
           ctrlKey: true,
           metaKey: true,

--- a/lib/slash-commands.test.ts
+++ b/lib/slash-commands.test.ts
@@ -1,0 +1,71 @@
+import {
+  getSlashCommandSuggestions,
+  getSlashCommandTrigger,
+} from './slash-commands';
+
+describe('slash commands', () => {
+  describe('getSlashCommandTrigger', () => {
+    it('detects a slash command token at the cursor', () => {
+      expect(getSlashCommandTrigger('Run /sh', 8)).toEqual({
+        token: '/sh',
+        query: 'sh',
+        startColumn: 5,
+        endColumn: 8,
+      });
+    });
+
+    it('detects an empty slash command query', () => {
+      expect(getSlashCommandTrigger('/', 2)).toEqual({
+        token: '/',
+        query: '',
+        startColumn: 1,
+        endColumn: 2,
+      });
+    });
+
+    it('ignores slashes that are part of another token', () => {
+      expect(getSlashCommandTrigger('https://simplenote.com', 9)).toBeNull();
+      expect(getSlashCommandTrigger('hello/search', 13)).toBeNull();
+    });
+
+    it('stops matching once the user types whitespace', () => {
+      expect(getSlashCommandTrigger('/search ', 9)).toBeNull();
+    });
+
+    it('ignores command queries with punctuation', () => {
+      expect(getSlashCommandTrigger('/search?', 9)).toBeNull();
+    });
+  });
+
+  describe('getSlashCommandSuggestions', () => {
+    it('returns all commands for an empty query', () => {
+      expect(
+        getSlashCommandSuggestions('').map(({ command }) => command.id)
+      ).toEqual(['search', 'shortcuts', 'focus', 'pref', 'export']);
+    });
+
+    it('ranks exact aliases ahead of prefix matches', () => {
+      const [first] = getSlashCommandSuggestions('s');
+
+      expect(first.command.id).toBe('search');
+      expect(first.completion).toBe('earch');
+      expect(first.exactMatch).toBe(true);
+    });
+
+    it('returns ghost text for the best prefix match', () => {
+      const [first] = getSlashCommandSuggestions('sh');
+
+      expect(first.command.id).toBe('shortcuts');
+      expect(first.completion).toBe('ortcuts');
+      expect(first.exactMatch).toBe(false);
+    });
+
+    it('does not show ghost text for an exact command', () => {
+      const [first] = getSlashCommandSuggestions('export');
+
+      expect(first.command.id).toBe('export');
+      expect(first.completion).toBe('');
+      expect(first.exactMatch).toBe(true);
+    });
+  });
+});

--- a/lib/slash-commands.test.ts
+++ b/lib/slash-commands.test.ts
@@ -1,4 +1,6 @@
 import {
+  getNextSlashCommandIndex,
+  getSlashCommandKeyAction,
   getSlashCommandSuggestions,
   getSlashCommandTrigger,
 } from './slash-commands';
@@ -66,6 +68,42 @@ describe('slash commands', () => {
       expect(first.command.id).toBe('export');
       expect(first.completion).toBe('');
       expect(first.exactMatch).toBe(true);
+    });
+  });
+
+  describe('getNextSlashCommandIndex', () => {
+    it('wraps forward through the available suggestions', () => {
+      expect(getNextSlashCommandIndex(5, 4, 1)).toBe(0);
+    });
+
+    it('wraps backward through the available suggestions', () => {
+      expect(getNextSlashCommandIndex(5, 0, -1)).toBe(4);
+    });
+  });
+
+  describe('getSlashCommandKeyAction', () => {
+    it.each([
+      ['Tab', 'complete'],
+      ['Enter', 'execute'],
+      ['ArrowDown', 'next'],
+      ['ArrowUp', 'previous'],
+      ['Escape', 'cancel'],
+      [' ', 'cancel-and-type'],
+      ['Spacebar', 'cancel-and-type'],
+    ])('maps %s to %s while slash commands are active', (key, action) => {
+      expect(getSlashCommandKeyAction(key, false, true)).toBe(action);
+    });
+
+    it('does not intercept keys when slash commands are inactive', () => {
+      expect(getSlashCommandKeyAction('Enter', false, false)).toBeNull();
+    });
+
+    it('does not intercept keys during IME composition', () => {
+      expect(getSlashCommandKeyAction('Enter', true, true)).toBeNull();
+    });
+
+    it('ignores unrelated keys', () => {
+      expect(getSlashCommandKeyAction('a', false, true)).toBeNull();
     });
   });
 });

--- a/lib/slash-commands.ts
+++ b/lib/slash-commands.ts
@@ -1,4 +1,4 @@
-export type SlashCommandId =
+export type CommandPaletteCommandId =
   | 'new'
   | 'search'
   | 'all-notes'
@@ -11,38 +11,21 @@ export type SlashCommandId =
   | 'focus'
   | 'export';
 
-export type SlashCommand = {
-  id: SlashCommandId;
+export type CommandPaletteCommand = {
+  id: CommandPaletteCommandId;
   name: string;
   aliases: string[];
   title: string;
   detail: string;
 };
 
-export type SlashCommandTrigger = {
-  token: string;
-  query: string;
-  startColumn: number;
-  endColumn: number;
+export type CommandPaletteSuggestion = {
+  command: CommandPaletteCommand;
 };
 
-export type SlashCommandSuggestion = {
-  command: SlashCommand;
-  completion: string;
-  exactMatch: boolean;
-};
+export type CommandPaletteKeyAction = 'execute' | 'next' | 'previous' | 'close';
 
-export type SlashCommandSource = 'typed' | 'shortcut';
-
-export type SlashCommandKeyAction =
-  | 'complete'
-  | 'execute'
-  | 'next'
-  | 'previous'
-  | 'cancel'
-  | 'cancel-and-type';
-
-export const slashCommands: SlashCommand[] = [
+export const commandPaletteCommands: CommandPaletteCommand[] = [
   {
     id: 'new',
     name: 'new',
@@ -122,37 +105,12 @@ export const slashCommands: SlashCommand[] = [
   },
 ];
 
-export const getSlashCommandTrigger = (
-  line: string,
-  column: number
-): SlashCommandTrigger | null => {
-  const textBeforeCursor = line.slice(0, column - 1);
-  const token = /\S*$/.exec(textBeforeCursor)?.[0] ?? '';
-  const startIndex = textBeforeCursor.length - token.length;
-  const nextCharacter = line[column - 1];
+const normalizeQuery = (query: string) => query.trim().toLowerCase();
 
-  if (
-    !token.startsWith('/') ||
-    ('undefined' !== typeof nextCharacter && !/\s/.test(nextCharacter))
-  ) {
-    return null;
-  }
-
-  const query = token.slice(1).toLowerCase();
-
-  if (!/^[a-z]*$/.test(query)) {
-    return null;
-  }
-
-  return {
-    token,
-    query,
-    startColumn: startIndex + 1,
-    endColumn: column,
-  };
-};
-
-const scoreCommand = (command: SlashCommand, query: string): number | null => {
+const scoreCommand = (
+  command: CommandPaletteCommand,
+  query: string
+): number | null => {
   if (query.length === 0) {
     return 10;
   }
@@ -180,62 +138,46 @@ const scoreCommand = (command: SlashCommand, query: string): number | null => {
   return null;
 };
 
-export const getSlashCommandSuggestions = (
+export const getCommandPaletteSuggestions = (
   query: string
-): SlashCommandSuggestion[] =>
-  slashCommands
+): CommandPaletteSuggestion[] => {
+  const normalizedQuery = normalizeQuery(query);
+
+  return commandPaletteCommands
     .map((command, index) => ({
       command,
       index,
-      score: scoreCommand(command, query),
+      score: scoreCommand(command, normalizedQuery),
     }))
     .filter(
       (
         result
       ): result is {
-        command: SlashCommand;
+        command: CommandPaletteCommand;
         index: number;
         score: number;
       } => result.score !== null
     )
     .sort((a, b) => a.score - b.score || a.index - b.index)
-    .map(({ command }) => {
-      const exactMatch =
-        command.name === query || command.aliases.includes(query);
-      const completion = command.name.startsWith(query)
-        ? command.name.slice(query.length)
-        : command.name;
+    .map(({ command }) => ({ command }));
+};
 
-      return {
-        command,
-        completion,
-        exactMatch,
-      };
-    });
-
-export const getNextSlashCommandIndex = (
+export const getNextCommandPaletteIndex = (
   suggestionsLength: number,
   selectedIndex: number,
   offset: number
 ) => (suggestionsLength + selectedIndex + offset) % suggestionsLength;
 
-export const shouldRemoveSlashCommandToken = (
-  removeShortcutToken: boolean,
-  source?: SlashCommandSource
-) => removeShortcutToken && source === 'shortcut';
-
-export const getSlashCommandKeyAction = (
+export const getCommandPaletteKeyAction = (
   key: string,
   isComposing: boolean,
   isActive: boolean
-): SlashCommandKeyAction | null => {
+): CommandPaletteKeyAction | null => {
   if (!isActive || isComposing) {
     return null;
   }
 
   switch (key) {
-    case 'Tab':
-      return 'complete';
     case 'Enter':
       return 'execute';
     case 'ArrowDown':
@@ -243,16 +185,13 @@ export const getSlashCommandKeyAction = (
     case 'ArrowUp':
       return 'previous';
     case 'Escape':
-      return 'cancel';
-    case ' ':
-    case 'Spacebar':
-      return 'cancel-and-type';
+      return 'close';
     default:
       return null;
   }
 };
 
-export const isSlashCommandPaletteShortcut = ({
+export const isCommandPaletteShortcut = ({
   altKey,
   ctrlKey,
   isComposing,

--- a/lib/slash-commands.ts
+++ b/lib/slash-commands.ts
@@ -1,8 +1,14 @@
 export type SlashCommandId =
+  | 'new'
   | 'search'
+  | 'all-notes'
+  | 'untagged-notes'
+  | 'trash'
+  | 'settings'
   | 'shortcuts'
+  | 'help'
+  | 'about'
   | 'focus'
-  | 'pref'
   | 'export';
 
 export type SlashCommand = {
@@ -36,11 +42,46 @@ export type SlashCommandKeyAction =
 
 export const slashCommands: SlashCommand[] = [
   {
+    id: 'new',
+    name: 'new',
+    aliases: ['create'],
+    title: 'New note',
+    detail: 'Create a new note',
+  },
+  {
     id: 'search',
     name: 'search',
     aliases: ['s'],
     title: 'Search notes',
     detail: 'Focus the notes search field',
+  },
+  {
+    id: 'all-notes',
+    name: 'all',
+    aliases: ['allnotes'],
+    title: 'All notes',
+    detail: 'Show all notes',
+  },
+  {
+    id: 'untagged-notes',
+    name: 'untagged',
+    aliases: ['untaggednotes'],
+    title: 'Untagged notes',
+    detail: 'Show notes without tags',
+  },
+  {
+    id: 'trash',
+    name: 'trash',
+    aliases: [],
+    title: 'Trash',
+    detail: 'Show trashed notes',
+  },
+  {
+    id: 'settings',
+    name: 'settings',
+    aliases: ['pref', 'preferences'],
+    title: 'Settings',
+    detail: 'Open app settings',
   },
   {
     id: 'shortcuts',
@@ -50,18 +91,25 @@ export const slashCommands: SlashCommand[] = [
     detail: 'Show available keyboard shortcuts',
   },
   {
+    id: 'help',
+    name: 'help',
+    aliases: ['support'],
+    title: 'Help & Support',
+    detail: 'Open Simplenote help',
+  },
+  {
+    id: 'about',
+    name: 'about',
+    aliases: [],
+    title: 'About',
+    detail: 'Show app information',
+  },
+  {
     id: 'focus',
     name: 'focus',
     aliases: [],
     title: 'Focus mode',
     detail: 'Toggle focus mode',
-  },
-  {
-    id: 'pref',
-    name: 'pref',
-    aliases: [],
-    title: 'Preferences',
-    detail: 'Open app preferences',
   },
   {
     id: 'export',

--- a/lib/slash-commands.ts
+++ b/lib/slash-commands.ts
@@ -1,0 +1,158 @@
+export type SlashCommandId =
+  | 'search'
+  | 'shortcuts'
+  | 'focus'
+  | 'pref'
+  | 'export';
+
+export type SlashCommand = {
+  id: SlashCommandId;
+  name: string;
+  aliases: string[];
+  title: string;
+  detail: string;
+};
+
+export type SlashCommandTrigger = {
+  token: string;
+  query: string;
+  startColumn: number;
+  endColumn: number;
+};
+
+export type SlashCommandSuggestion = {
+  command: SlashCommand;
+  completion: string;
+  exactMatch: boolean;
+};
+
+export const slashCommands: SlashCommand[] = [
+  {
+    id: 'search',
+    name: 'search',
+    aliases: ['s'],
+    title: 'Search notes',
+    detail: 'Focus the notes search field',
+  },
+  {
+    id: 'shortcuts',
+    name: 'shortcuts',
+    aliases: [],
+    title: 'Keyboard shortcuts',
+    detail: 'Show available keyboard shortcuts',
+  },
+  {
+    id: 'focus',
+    name: 'focus',
+    aliases: [],
+    title: 'Focus mode',
+    detail: 'Toggle focus mode',
+  },
+  {
+    id: 'pref',
+    name: 'pref',
+    aliases: [],
+    title: 'Preferences',
+    detail: 'Open app preferences',
+  },
+  {
+    id: 'export',
+    name: 'export',
+    aliases: [],
+    title: 'Export notes',
+    detail: 'Start the notes export flow',
+  },
+];
+
+const tokenStartPattern = /\s/;
+
+export const getSlashCommandTrigger = (
+  line: string,
+  column: number
+): SlashCommandTrigger | null => {
+  const textBeforeCursor = line.slice(0, column - 1);
+  const tokenStart = Math.max(
+    textBeforeCursor.lastIndexOf(' '),
+    textBeforeCursor.lastIndexOf('\t')
+  );
+  const startIndex = tokenStart + 1;
+  const token = textBeforeCursor.slice(startIndex);
+
+  if (!token.startsWith('/') || tokenStartPattern.test(token)) {
+    return null;
+  }
+
+  const query = token.slice(1).toLowerCase();
+
+  if (!/^[a-z]*$/.test(query)) {
+    return null;
+  }
+
+  return {
+    token,
+    query,
+    startColumn: startIndex + 1,
+    endColumn: column,
+  };
+};
+
+const scoreCommand = (command: SlashCommand, query: string): number | null => {
+  if (query.length === 0) {
+    return 10;
+  }
+
+  if (command.name === query) {
+    return 0;
+  }
+
+  if (command.aliases.includes(query)) {
+    return 1;
+  }
+
+  if (command.name.startsWith(query)) {
+    return 2;
+  }
+
+  if (command.aliases.some((alias) => alias.startsWith(query))) {
+    return 3;
+  }
+
+  if (command.title.toLowerCase().includes(query)) {
+    return 4;
+  }
+
+  return null;
+};
+
+export const getSlashCommandSuggestions = (
+  query: string
+): SlashCommandSuggestion[] =>
+  slashCommands
+    .map((command, index) => ({
+      command,
+      index,
+      score: scoreCommand(command, query),
+    }))
+    .filter(
+      (
+        result
+      ): result is {
+        command: SlashCommand;
+        index: number;
+        score: number;
+      } => result.score !== null
+    )
+    .sort((a, b) => a.score - b.score || a.index - b.index)
+    .map(({ command }) => {
+      const exactMatch =
+        command.name === query || command.aliases.includes(query);
+      const completion = command.name.startsWith(query)
+        ? command.name.slice(query.length)
+        : command.name;
+
+      return {
+        command,
+        completion,
+        exactMatch,
+      };
+    });

--- a/lib/slash-commands.ts
+++ b/lib/slash-commands.ts
@@ -196,3 +196,25 @@ export const getSlashCommandKeyAction = (
       return null;
   }
 };
+
+export const isSlashCommandPaletteShortcut = ({
+  altKey,
+  ctrlKey,
+  isComposing,
+  key,
+  metaKey,
+  shiftKey,
+}: Pick<
+  KeyboardEvent,
+  'altKey' | 'ctrlKey' | 'isComposing' | 'key' | 'metaKey' | 'shiftKey'
+>) => {
+  const cmdOrCtrl = (ctrlKey || metaKey) && ctrlKey !== metaKey;
+
+  return (
+    cmdOrCtrl &&
+    !altKey &&
+    !shiftKey &&
+    !isComposing &&
+    key.toLowerCase() === 'k'
+  );
+};

--- a/lib/slash-commands.ts
+++ b/lib/slash-commands.ts
@@ -32,6 +32,8 @@ export type SlashCommandSuggestion = {
   exactMatch: boolean;
 };
 
+export type SlashCommandSource = 'typed' | 'shortcut';
+
 export type SlashCommandKeyAction =
   | 'complete'
   | 'execute'
@@ -216,6 +218,11 @@ export const getNextSlashCommandIndex = (
   selectedIndex: number,
   offset: number
 ) => (suggestionsLength + selectedIndex + offset) % suggestionsLength;
+
+export const shouldRemoveSlashCommandToken = (
+  removeShortcutToken: boolean,
+  source?: SlashCommandSource
+) => removeShortcutToken && source === 'shortcut';
 
 export const getSlashCommandKeyAction = (
   key: string,

--- a/lib/slash-commands.ts
+++ b/lib/slash-commands.ts
@@ -26,6 +26,14 @@ export type SlashCommandSuggestion = {
   exactMatch: boolean;
 };
 
+export type SlashCommandKeyAction =
+  | 'complete'
+  | 'execute'
+  | 'next'
+  | 'previous'
+  | 'cancel'
+  | 'cancel-and-type';
+
 export const slashCommands: SlashCommand[] = [
   {
     id: 'search',
@@ -156,3 +164,37 @@ export const getSlashCommandSuggestions = (
         exactMatch,
       };
     });
+
+export const getNextSlashCommandIndex = (
+  suggestionsLength: number,
+  selectedIndex: number,
+  offset: number
+) => (suggestionsLength + selectedIndex + offset) % suggestionsLength;
+
+export const getSlashCommandKeyAction = (
+  key: string,
+  isComposing: boolean,
+  isActive: boolean
+): SlashCommandKeyAction | null => {
+  if (!isActive || isComposing) {
+    return null;
+  }
+
+  switch (key) {
+    case 'Tab':
+      return 'complete';
+    case 'Enter':
+      return 'execute';
+    case 'ArrowDown':
+      return 'next';
+    case 'ArrowUp':
+      return 'previous';
+    case 'Escape':
+      return 'cancel';
+    case ' ':
+    case 'Spacebar':
+      return 'cancel-and-type';
+    default:
+      return null;
+  }
+};

--- a/lib/slash-commands.ts
+++ b/lib/slash-commands.ts
@@ -72,21 +72,19 @@ export const slashCommands: SlashCommand[] = [
   },
 ];
 
-const tokenStartPattern = /\s/;
-
 export const getSlashCommandTrigger = (
   line: string,
   column: number
 ): SlashCommandTrigger | null => {
   const textBeforeCursor = line.slice(0, column - 1);
-  const tokenStart = Math.max(
-    textBeforeCursor.lastIndexOf(' '),
-    textBeforeCursor.lastIndexOf('\t')
-  );
-  const startIndex = tokenStart + 1;
-  const token = textBeforeCursor.slice(startIndex);
+  const token = /\S*$/.exec(textBeforeCursor)?.[0] ?? '';
+  const startIndex = textBeforeCursor.length - token.length;
+  const nextCharacter = line[column - 1];
 
-  if (!token.startsWith('/') || tokenStartPattern.test(token)) {
+  if (
+    !token.startsWith('/') ||
+    ('undefined' !== typeof nextCharacter && !/\s/.test(nextCharacter))
+  ) {
     return null;
   }
 

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -104,11 +104,6 @@ span[dir='ltr'] {
     background-color: var(--search-selection-color);
     padding: 2px 0;
   }
-
-  .slash-command-ghost {
-    color: var(--placeholder-color);
-    opacity: 0.75;
-  }
 }
 
 /* Safari requires that it be displayed absolute so that it takes the full height
@@ -121,21 +116,59 @@ span[dir='ltr'] {
   width: 100%;
 }
 
-.slash-command-palette {
-  background: var(--background-color);
-  border: 1px solid var(--secondary-color);
-  border-radius: 4px;
-  box-shadow: 0 8px 24px var(--overlay-color);
-  color: var(--primary-color);
-  max-height: 180px;
-  min-width: 260px;
-  overflow: hidden auto;
-  padding: 4px;
-  position: absolute;
-  z-index: 20;
+.command-palette-modal {
+  align-items: flex-start;
+  background: transparent;
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: 15vh 16px 16px;
+  position: fixed;
+  z-index: 100;
 }
 
-.slash-command-palette__item {
+.command-palette {
+  background: var(--background-color);
+  border: 1px solid var(--secondary-color);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px var(--overlay-color);
+  color: var(--primary-color);
+  max-width: 560px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.command-palette__input {
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--secondary-color);
+  color: var(--primary-color);
+  font: inherit;
+  font-size: 16px;
+  line-height: 24px;
+  outline: 0;
+  padding: 12px 14px;
+  width: 100%;
+
+  &::placeholder {
+    color: var(--placeholder-color);
+  }
+}
+
+.command-palette__list {
+  max-height: min(320px, 50vh);
+  overflow: hidden auto;
+  padding: 4px;
+}
+
+.command-palette__empty {
+  color: var(--secondary-color);
+  font-size: 14px;
+  line-height: 20px;
+  padding: 12px 10px;
+}
+
+.command-palette__item {
   align-items: center;
   background: transparent;
   border: 0;
@@ -143,11 +176,12 @@ span[dir='ltr'] {
   color: inherit;
   cursor: pointer;
   display: flex;
+  justify-content: space-between;
   font: inherit;
   gap: 12px;
-  line-height: 20px;
-  min-height: 32px;
-  padding: 6px 8px;
+  line-height: 18px;
+  min-height: 48px;
+  padding: 7px 10px;
   text-align: left;
   width: 100%;
 
@@ -156,17 +190,35 @@ span[dir='ltr'] {
   }
 }
 
-.slash-command-palette__command {
+.command-palette__item-copy {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.command-palette__command {
   color: var(--accent-color);
-  flex: 0 0 88px;
+  flex: 0 0 auto;
+  font-size: 13px;
   font-weight: 600;
 }
 
-.slash-command-palette__title {
-  color: var(--primary-color);
+.command-palette__title,
+.command-palette__detail {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.command-palette__title {
+  color: var(--primary-color);
+}
+
+.command-palette__detail {
+  color: var(--secondary-color);
+  font-size: 13px;
 }
 
 .note-detail-textarea .note-content-editor-shell.cursor-pointer div {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -104,6 +104,11 @@ span[dir='ltr'] {
     background-color: var(--search-selection-color);
     padding: 2px 0;
   }
+
+  .slash-command-ghost {
+    color: var(--placeholder-color);
+    opacity: 0.75;
+  }
 }
 
 /* Safari requires that it be displayed absolute so that it takes the full height
@@ -114,6 +119,54 @@ span[dir='ltr'] {
   position: absolute;
   top: 0;
   width: 100%;
+}
+
+.slash-command-palette {
+  background: var(--background-color);
+  border: 1px solid var(--secondary-color);
+  border-radius: 4px;
+  box-shadow: 0 8px 24px var(--overlay-color);
+  color: var(--primary-color);
+  max-height: 180px;
+  min-width: 260px;
+  overflow: hidden;
+  padding: 4px;
+  position: absolute;
+  z-index: 20;
+}
+
+.slash-command-palette__item {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 3px;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  gap: 12px;
+  line-height: 20px;
+  min-height: 32px;
+  padding: 6px 8px;
+  text-align: left;
+  width: 100%;
+
+  &.is-selected {
+    background: var(--highlight-color);
+  }
+}
+
+.slash-command-palette__command {
+  color: var(--accent-color);
+  flex: 0 0 88px;
+  font-weight: 600;
+}
+
+.slash-command-palette__title {
+  color: var(--primary-color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .note-detail-textarea .note-content-editor-shell.cursor-pointer div {

--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -129,7 +129,7 @@ span[dir='ltr'] {
   color: var(--primary-color);
   max-height: 180px;
   min-width: 260px;
-  overflow: hidden;
+  overflow: hidden auto;
   padding: 4px;
   position: absolute;
   z-index: 20;


### PR DESCRIPTION
## Summary

- Adds a command palette modal that opens from the note editor with `Cmd+K` / `Ctrl+K`.
- Removes the previous `/` detection while editing: typing `/` in note content now stays plain note text and does not open or control the palette.
- Keeps palette search state outside Monaco, with a focused modal input, arrow-key selection, Enter execution, Escape dismissal, mouse selection, and scroll-into-view for the selected command.
- Reuses existing app actions for command execution instead of adding new parallel flows.

## Commands Included

- Search: `search`, `s`
- Keyboard shortcuts: `shortcuts`
- Focus mode: `focus`
- Settings / preferences: `settings`, `pref`, `preferences`
- Export: `export`
- New note: `new`, `create`
- All notes: `all`, `allnotes`
- Untagged notes: `untagged`, `untaggednotes`
- Trash: `trash`
- Help & Support: `help`, `support`
- About: `about`

## Context

This is for Multica issue LAV-24: Desktop Command Palette and Markdown. It is intentionally separate from the Markdown decorations PR (#3357), which targets `trunk` directly. The older Cmd+K-only search shortcut PR (#3356) was closed per direction, and Cmd/Ctrl+K now opens this command palette modal.

## Testing

- `npx jest lib/slash-commands.test.ts --runInBand`
- `make test`
- `make lint-js` (passes with existing warnings)
- `make lint-scss`
- `git diff --check`
- `make build NODE_ENV=development`
- `make dev-server PORT=4010` + `curl -I http://localhost:4010` returned HTTP 200
