### PR TITLE
Add Azure Trusted Signing as an opt-in Windows signing path

### DIFF
--- a/.buildkite/commands/package_windows.ps1
+++ b/.buildkite/commands/package_windows.ps1
@@ -30,19 +30,27 @@ If ([string]::IsNullOrEmpty($windowsCertPassword)) {
     Write-Host "[!] WINDOWS_CODE_SIGNING_CERT_PASSWORD is not set in either process or machine environments."
     Exit 1
 }
-$env:CSC_KEY_PASSWORD = $windowsCertPassword
 
 $certPath = (Convert-Path .\certificate.pfx)
 If (-not (Test-Path $certPath)) {
     Write-Host "[!] Certificate file does not exist at given path $certPath."
     Exit 1
 }
-$env:CSC_LINK = $certPath
-Write-Host "CSC_LINK set to $certPath"
 
-# Workaround for CI not finding the certificate for the certificateSubjectName store lookup.
+# Import the cert so electron-builder's certificateSubjectName lookup finds it (the PFX default
+# path signs the NSIS exe from the store).
 # See https://buildkite.com/automattic/simplenote-electron/builds/71#01900b28-9508-4bfe-bc80-63464afeaa3e/292-567
 Import-PfxCertificate -FilePath $certPath -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $windowsCertPassword -AsPlainText -Force)
+
+If ($useAzure) {
+    # Azure mode signs the exe via the win.sign callback, which reads these from the process env for
+    # its PFX fallback. In PFX mode we deliberately do NOT export them: the exe signs via
+    # certificateSubjectName + the store import above, and exporting CSC_LINK would make
+    # electron-builder also sign the Store AppX with the PFX, whose publisher does not match the cert
+    # ("SignTool Error: An unexpected internal error has occurred").
+    $env:CSC_KEY_PASSWORD = $windowsCertPassword
+    $env:CSC_LINK = $certPath
+}
 
 Write-Host "--- :windows: Installing make"
 choco install make

--- a/.buildkite/commands/package_windows.ps1
+++ b/.buildkite/commands/package_windows.ps1
@@ -1,18 +1,22 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-# Windows code signing is driven by scripts/azure-sign.cjs (electron-builder `win.sign` callback),
-# which prefers Azure Trusted Signing and falls back to the PFX cert. We provision both here so the
-# fallback is live: Azure is the default path, PFX degrades only if the Azure env is unavailable.
+# Windows code signing defaults to the PFX cert. Setting USE_AZURE_TRUSTED_SIGNING switches the NSIS
+# exe to Azure Trusted Signing (via the win.sign callback wired in by `make package-win32`); the PFX
+# is still provisioned so it stays available as a fallback. See AINFRA-2472 for the auto-update
+# publisher-name handover that gates a full cutover.
+$useAzure = -not [string]::IsNullOrEmpty($env:USE_AZURE_TRUSTED_SIGNING)
 
-Write-Host "--- :windows: Configure Azure Trusted Signing"
-# Installs the Azure DLib + a modern signtool and exports SIGNTOOL_PATH, AZURE_CODE_SIGNING_DLIB,
-# AZURE_METADATA_JSON (read by azure-sign.cjs). Runs a signing smoke test; fails here with
-# diagnostics if the Azure credentials are wrong. Via the CI toolkit Buildkite plugin (>= 6.1.0).
-& "setup_azure_trusted_signing.ps1"
-If ($LastExitCode -ne 0) { Exit $LastExitCode }
+If ($useAzure) {
+    Write-Host "--- :windows: Configure Azure Trusted Signing"
+    # Installs the Azure DLib + a modern signtool and exports SIGNTOOL_PATH, AZURE_CODE_SIGNING_DLIB,
+    # AZURE_METADATA_JSON (read by azure-sign.cjs). Runs a signing smoke test that fails here, with
+    # diagnostics, if the Azure credentials are wrong. Via the CI toolkit plugin (>= 6.1.0).
+    & "setup_azure_trusted_signing.ps1"
+    If ($LastExitCode -ne 0) { Exit $LastExitCode }
+}
 
-Write-Host "--- :windows: Provision PFX fallback"
+Write-Host "--- :windows: Configure Windows code signing"
 # Materializes certificate.pfx from AWS Secrets Manager. Via the CI toolkit Buildkite plugin.
 & "setup_windows_code_signing.ps1"
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
@@ -26,17 +30,19 @@ If ([string]::IsNullOrEmpty($windowsCertPassword)) {
     Write-Host "[!] WINDOWS_CODE_SIGNING_CERT_PASSWORD is not set in either process or machine environments."
     Exit 1
 }
+$env:CSC_KEY_PASSWORD = $windowsCertPassword
 
 $certPath = (Convert-Path .\certificate.pfx)
 If (-not (Test-Path $certPath)) {
     Write-Host "[!] Certificate file does not exist at given path $certPath."
     Exit 1
 }
-
-# azure-sign.cjs reads these from process.env for the file-based signtool PFX fallback.
-$env:CSC_KEY_PASSWORD = $windowsCertPassword
 $env:CSC_LINK = $certPath
-Write-Host "PFX fallback ready: CSC_LINK set to $certPath"
+Write-Host "CSC_LINK set to $certPath"
+
+# Workaround for CI not finding the certificate for the certificateSubjectName store lookup.
+# See https://buildkite.com/automattic/simplenote-electron/builds/71#01900b28-9508-4bfe-bc80-63464afeaa3e/292-567
+Import-PfxCertificate -FilePath $certPath -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $windowsCertPassword -AsPlainText -Force)
 
 Write-Host "--- :windows: Installing make"
 choco install make
@@ -54,19 +60,21 @@ Write-Host "--- :windows: Packaging for Windows"
 make package-win32 SKIP_BUILD=true
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
-Write-Host "--- :windows: Verify signatures"
-# Authoritative on-agent check: every NSIS installer must carry a valid Authenticode signature.
-# The Store AppX is intentionally unsigned (re-signed by the Store), so it is not verified here.
-$exes = Get-ChildItem release\*.exe
-If ($exes.Count -eq 0) {
-    Write-Host "[!] No release\*.exe found to verify."
-    Exit 1
-}
-ForEach ($exe in $exes) {
-    & $env:SIGNTOOL_PATH verify /pa /v $exe.FullName
-    If ($LastExitCode -ne 0) {
-        Write-Host "[!] Signature verification failed for $($exe.FullName)"
-        Exit $LastExitCode
+If ($useAzure) {
+    Write-Host "--- :windows: Verify Azure signatures"
+    # Every NSIS installer must carry a valid Authenticode signature. The Store AppX is intentionally
+    # unsigned (re-signed by the Store), so it is not verified here.
+    $exes = Get-ChildItem release\*.exe
+    If ($exes.Count -eq 0) {
+        Write-Host "[!] No release\*.exe found to verify."
+        Exit 1
     }
+    ForEach ($exe in $exes) {
+        & $env:SIGNTOOL_PATH verify /pa /v $exe.FullName
+        If ($LastExitCode -ne 0) {
+            Write-Host "[!] Signature verification failed for $($exe.FullName)"
+            Exit $LastExitCode
+        }
+    }
+    Write-Host "All Windows installers verified signed."
 }
-Write-Host "All Windows installers verified signed."

--- a/.buildkite/commands/package_windows.ps1
+++ b/.buildkite/commands/package_windows.ps1
@@ -1,39 +1,42 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-& "setup_windows_code_signing.ps1" # via CI toolkit Buildkite plugin
+# Windows code signing is driven by scripts/azure-sign.cjs (electron-builder `win.sign` callback),
+# which prefers Azure Trusted Signing and falls back to the PFX cert. We provision both here so the
+# fallback is live: Azure is the default path, PFX degrades only if the Azure env is unavailable.
 
-# First try to get the env var from the process environment
+Write-Host "--- :windows: Configure Azure Trusted Signing"
+# Installs the Azure DLib + a modern signtool and exports SIGNTOOL_PATH, AZURE_CODE_SIGNING_DLIB,
+# AZURE_METADATA_JSON (read by azure-sign.cjs). Runs a signing smoke test; fails here with
+# diagnostics if the Azure credentials are wrong. Via the CI toolkit Buildkite plugin (>= 6.1.0).
+& "setup_azure_trusted_signing.ps1"
+If ($LastExitCode -ne 0) { Exit $LastExitCode }
+
+Write-Host "--- :windows: Provision PFX fallback"
+# Materializes certificate.pfx from AWS Secrets Manager. Via the CI toolkit Buildkite plugin.
+& "setup_windows_code_signing.ps1"
+If ($LastExitCode -ne 0) { Exit $LastExitCode }
+
+# Read the PFX password from the process env, falling back to the machine-wide env.
 $windowsCertPassword = [System.Environment]::GetEnvironmentVariable('WINDOWS_CODE_SIGNING_CERT_PASSWORD', [System.EnvironmentVariableTarget]::Process)
 If ([string]::IsNullOrEmpty($windowsCertPassword)) {
-    # If it fails, try from the machine-wide environment
     $windowsCertPassword = [System.Environment]::GetEnvironmentVariable('WINDOWS_CODE_SIGNING_CERT_PASSWORD', [System.EnvironmentVariableTarget]::Machine)
 }
-
 If ([string]::IsNullOrEmpty($windowsCertPassword)) {
     Write-Host "[!] WINDOWS_CODE_SIGNING_CERT_PASSWORD is not set in either process or machine environments."
     Exit 1
-} else {
-    [System.Environment]::SetEnvironmentVariable('CSC_KEY_PASSWORD', $windowsCertPassword, [System.EnvironmentVariableTarget]::Machine)
-    Write-Host "Environment variable CSC_KEY_PASSWORD set to the value of WINDOWS_CODE_SIGNING_CERT_PASSWORD."
 }
 
-Write-Host "--- :windows: Configure Windows code signing"
-# The pfx path comes from the prepare script above.
-# TODO: Move the set instruction in the script at the plugin level?
 $certPath = (Convert-Path .\certificate.pfx)
-If (Test-Path $certPath) {
-    [System.Environment]::SetEnvironmentVariable('CSC_LINK', $certPath, [System.EnvironmentVariableTarget]::Machine)
-    Write-Host "Environment variable CSC_LINK set to $certPath"
-} else {
+If (-not (Test-Path $certPath)) {
     Write-Host "[!] Certificate file does not exist at given path $certPath."
     Exit 1
 }
 
-# Workaround for CI not finding the certificate.
-# See failure such as
-# https://buildkite.com/automattic/simplenote-electron/builds/71#01900b28-9508-4bfe-bc80-63464afeaa3e/292-567
-Import-PfxCertificate -FilePath $certPath -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WINDOWS_CODE_SIGNING_CERT_PASSWORD -AsPlainText -Force)
+# azure-sign.cjs reads these from process.env for the file-based signtool PFX fallback.
+$env:CSC_KEY_PASSWORD = $windowsCertPassword
+$env:CSC_LINK = $certPath
+Write-Host "PFX fallback ready: CSC_LINK set to $certPath"
 
 Write-Host "--- :windows: Installing make"
 choco install make
@@ -49,5 +52,21 @@ make build
 
 Write-Host "--- :windows: Packaging for Windows"
 make package-win32 SKIP_BUILD=true
-
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
+
+Write-Host "--- :windows: Verify signatures"
+# Authoritative on-agent check: every NSIS installer must carry a valid Authenticode signature.
+# The Store AppX is intentionally unsigned (re-signed by the Store), so it is not verified here.
+$exes = Get-ChildItem release\*.exe
+If ($exes.Count -eq 0) {
+    Write-Host "[!] No release\*.exe found to verify."
+    Exit 1
+}
+ForEach ($exe in $exes) {
+    & $env:SIGNTOOL_PATH verify /pa /v $exe.FullName
+    If ($LastExitCode -ne 0) {
+        Write-Host "[!] Signature verification failed for $($exe.FullName)"
+        Exit $LastExitCode
+    }
+}
+Write-Host "All Windows installers verified signed."

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -87,6 +87,26 @@ steps:
       - release\*.blockmap
       - release\*.yml
 
+  # Validates the Azure Trusted Signing path alongside the default PFX build above. The PFX build
+  # remains what ships until the auto-update publisher-name handover lands (AINFRA-2472); this step
+  # signs the exe with Azure and verifies it with `signtool verify /pa`.
+  - label: Package on Windows (Azure Trusted Signing)
+    key: package-windows-azure
+    agents:
+      queue: windows
+    plugins:
+      - $CI_TOOLKIT_PLUGIN
+      - $NVM_PLUGIN
+    command: .buildkite/commands/package_windows.ps1
+    env:
+      CSC_FOR_PULL_REQUEST: true
+      USE_AZURE_TRUSTED_SIGNING: 1
+    artifact_paths:
+      - release\*.exe
+      - release\*.appx
+      - release\*.blockmap
+      - release\*.yml
+
   - label: Package on Linux
     key: package-linux
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -99,7 +99,6 @@ steps:
       - $NVM_PLUGIN
     command: .buildkite/commands/package_windows.ps1
     env:
-      CSC_FOR_PULL_REQUEST: true
       USE_AZURE_TRUSTED_SIGNING: 1
     artifact_paths:
       - release\*.exe

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
-CI_TOOLKIT_PLUGIN_VERSION='5.7.0'
+CI_TOOLKIT_PLUGIN_VERSION='6.1.0'
 NVM_PLUGIN_VERSION='0.6.0'
 
 export IMAGE_ID="$XCODE_VERSION"

--- a/Makefile
+++ b/Makefile
@@ -139,17 +139,25 @@ win32: config-release build-if-changed
 .PHONY: package
 package: build-if-changed
 
+# Windows signing: PFX by default (electron-builder's native certificateSubjectName), or Azure
+# Trusted Signing when USE_AZURE_TRUSTED_SIGNING is set. In Azure mode the NSIS exe signs through
+# the win.sign callback, and the Store AppX builds unsigned — `env -u` removes the PFX cert vars so
+# electron-builder skips signing its inner exe, which would otherwise fail: the modern signtool
+# Azure installs rejects electron-builder's built-in /fd-less PFX call. The Store re-signs the AppX
+# regardless. In PFX mode both keep their native cert signing, unchanged.
+ifdef USE_AZURE_TRUSTED_SIGNING
+WIN_NSIS_SIGN := -c.win.sign=./scripts/azure-sign.cjs
+APPX_NO_SIGN := env -u CSC_LINK -u CSC_KEY_PASSWORD -u WIN_CSC_LINK -u WIN_CSC_KEY_PASSWORD
+endif
+
 .PHONY: package-win32
 package-win32:
 	@echo "Packaging exe..."
-	@npx electron-builder --win -p $(PUBLISH)
-	# The Store AppX ships unsigned (the Store re-signs it), so it uses a dedicated config with no
-	# signing (see https://github.com/electron-userland/electron-builder/issues/6698). Clear the PFX
-	# env for this invocation: with CSC_LINK set, electron-builder's built-in signer signs the inner
-	# exe via the modern signtool, which fails the legacy /fd-less call it makes. The NSIS exe is
-	# signed separately through win.sign in electron-builder.json.
-	@echo "Packaging appx — Store build, unsigned..."
-	@CSC_LINK= CSC_KEY_PASSWORD= npx electron-builder --win -p $(PUBLISH) --config=./electron-builder-appx.json
+	@npx electron-builder --win -p $(PUBLISH) $(WIN_NSIS_SIGN)
+	# Dedicated config because the appx target conflicts with exe code signing.
+	# See https://github.com/electron-userland/electron-builder/issues/6698
+	@echo "Packaging appx..."
+	@$(APPX_NO_SIGN) npx electron-builder --win -p $(PUBLISH) --config=./electron-builder-appx.json
 
 .PHONY: package-osx
 package-osx: build-if-changed

--- a/Makefile
+++ b/Makefile
@@ -143,12 +143,13 @@ package: build-if-changed
 package-win32:
 	@echo "Packaging exe..."
 	@npx electron-builder --win -p $(PUBLISH)
-	# Note: the configuration required to generate a code signed exe via the `nsis` target will conflict with the `appx` configuration.
-	# In practice, "certificateSubjectName": "Automattic, Inc." is required to sign the exe, but if that setting is present and so are the `appx` settings, there will be a failure.
-	# Hence the need for a separate configuration here.
-	# See also in https://github.com/electron-userland/electron-builder/issues/6698
-	@echo "Packaging appx — with dedicated configuration to work around code signing conflicts..."
-	@npx electron-builder --win -p $(PUBLISH) --config=./electron-builder-appx.json
+	# The Store AppX ships unsigned (the Store re-signs it), so it uses a dedicated config with no
+	# signing (see https://github.com/electron-userland/electron-builder/issues/6698). Clear the PFX
+	# env for this invocation: with CSC_LINK set, electron-builder's built-in signer signs the inner
+	# exe via the modern signtool, which fails the legacy /fd-less call it makes. The NSIS exe is
+	# signed separately through win.sign in electron-builder.json.
+	@echo "Packaging appx — Store build, unsigned..."
+	@CSC_LINK= CSC_KEY_PASSWORD= npx electron-builder --win -p $(PUBLISH) --config=./electron-builder-appx.json
 
 .PHONY: package-osx
 package-osx: build-if-changed

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -48,8 +48,7 @@
   },
   "win": {
     "icon": "resources/images/simplenote.ico",
-    "sign": "./scripts/azure-sign.cjs",
-    "signingHashAlgorithms": ["sha256"],
+    "certificateSubjectName": "Automattic, Inc.",
     "publisherName": ["Automattic, Inc.", "Automattic Inc."],
     "artifactName": "Simplenote-win-${version}-${arch}.${ext}",
     "target": [

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -50,6 +50,7 @@
     "icon": "resources/images/simplenote.ico",
     "sign": "./scripts/azure-sign.cjs",
     "signingHashAlgorithms": ["sha256"],
+    "publisherName": ["Automattic, Inc.", "Automattic Inc."],
     "artifactName": "Simplenote-win-${version}-${arch}.${ext}",
     "target": [
       {

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -48,7 +48,8 @@
   },
   "win": {
     "icon": "resources/images/simplenote.ico",
-    "certificateSubjectName": "Automattic, Inc.",
+    "sign": "./scripts/azure-sign.cjs",
+    "signingHashAlgorithms": ["sha256"],
     "artifactName": "Simplenote-win-${version}-${arch}.${ext}",
     "target": [
       {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
       appVersion: 'foo',
     },
   },
-  roots: ['desktop', 'lib'],
+  roots: ['desktop', 'lib', 'scripts'],
   testEnvironment: 'jsdom',
   testRegex: '(/test/.*\\.[jt]sx?)|(test\\.[jt]sx?)$',
 };

--- a/scripts/azure-sign.cjs
+++ b/scripts/azure-sign.cjs
@@ -1,18 +1,17 @@
-// electron-builder `win.sign` callback: signs Windows artifacts with Azure Trusted Signing,
-// falling back to the legacy PFX certificate.
+// electron-builder `win.sign` callback for Azure Trusted Signing.
 //
-// Once `win.sign` is set, electron-builder routes ALL Windows signing through this callback, so
-// it carries both paths. It prefers Azure Trusted Signing (the migration target); when the Azure
-// env is absent it falls back to the existing PFX cert — a cutover safety net retained until the
-// Azure-signed distribution is confirmed shipping (campaign step `remove-pfx-fallback`).
+// PFX is the default Windows signing path (electron-builder's native `certificateSubjectName`).
+// This callback is wired in only when `USE_AZURE_TRUSTED_SIGNING` is set, via
+// `-c.win.sign=./scripts/azure-sign.cjs` in the `package-win32` Make target — so reaching it
+// means Azure is the intended path. It prefers Azure and falls back to the PFX cert (signtool
+// `/f`) if the Azure env is somehow absent, throwing in CI when neither is available.
 //
-// electron-builder calls this once per file after `rcedit` rewrites the PE resource directory, so
-// signatures are not orphaned. Azure Trusted Signing is SHA256-only — hence
-// `signingHashAlgorithms: ["sha256"]` in electron-builder.json, so there is no SHA1 pass.
+// electron-builder calls this once per file per signing-hash algorithm, after `rcedit` rewrites
+// the PE resource directory (so signatures are not orphaned). Azure Trusted Signing is
+// SHA256-only, so the SHA1 iteration is skipped here rather than signed twice.
 //
 // Azure env vars come from a8c-ci-toolkit's `setup_azure_trusted_signing.ps1`; the PFX inputs
-// (`CSC_LINK`, `CSC_KEY_PASSWORD`) from `setup_windows_code_signing.ps1`. With neither present
-// (local `make package-win32`), signing is skipped so the build still produces an unsigned exe.
+// (`CSC_LINK`, `CSC_KEY_PASSWORD`) from `setup_windows_code_signing.ps1`.
 
 const fs = require('node:fs');
 const childProcess = require('node:child_process');
@@ -102,6 +101,12 @@ function runSigntool(signtool, args, file, method) {
 module.exports = async function sign(configuration) {
   const file = configuration.path;
   const env = process.env;
+
+  // electron-builder iterates win.signingHashAlgorithms (default sha1 + sha256). Azure Trusted
+  // Signing is SHA256-only, so sign once on the sha256 pass and no-op the rest.
+  if (configuration.hash && configuration.hash.toLowerCase() !== 'sha256') {
+    return;
+  }
 
   if (hasAzureEnv(env)) {
     runSigntool(

--- a/scripts/azure-sign.cjs
+++ b/scripts/azure-sign.cjs
@@ -1,0 +1,146 @@
+// electron-builder `win.sign` callback: signs Windows artifacts with Azure Trusted Signing,
+// falling back to the legacy PFX certificate.
+//
+// Once `win.sign` is set, electron-builder routes ALL Windows signing through this callback, so
+// it carries both paths. It prefers Azure Trusted Signing (the migration target); when the Azure
+// env is absent it falls back to the existing PFX cert — a cutover safety net retained until the
+// Azure-signed distribution is confirmed shipping (campaign step `remove-pfx-fallback`).
+//
+// electron-builder calls this once per file after `rcedit` rewrites the PE resource directory, so
+// signatures are not orphaned. Azure Trusted Signing is SHA256-only — hence
+// `signingHashAlgorithms: ["sha256"]` in electron-builder.json, so there is no SHA1 pass.
+//
+// Azure env vars come from a8c-ci-toolkit's `setup_azure_trusted_signing.ps1`; the PFX inputs
+// (`CSC_LINK`, `CSC_KEY_PASSWORD`) from `setup_windows_code_signing.ps1`. With neither present
+// (local `make package-win32`), signing is skipped so the build still produces an unsigned exe.
+
+const fs = require('node:fs');
+const childProcess = require('node:child_process');
+
+const AZURE_ENV_VARS = [
+  'SIGNTOOL_PATH',
+  'AZURE_CODE_SIGNING_DLIB',
+  'AZURE_METADATA_JSON',
+];
+const DEFAULT_TIMESTAMP_SERVER = 'http://timestamp.acs.microsoft.com';
+
+function nonBlank(value) {
+  return typeof value === 'string' && value.trim() !== ''
+    ? value.trim()
+    : undefined;
+}
+
+function hasAzureEnv(env) {
+  return AZURE_ENV_VARS.every((name) => nonBlank(env[name]) !== undefined);
+}
+
+function pfxInputs(env) {
+  const file = nonBlank(env.CSC_LINK);
+  return {
+    file: file && fs.existsSync(file) ? file : undefined,
+    password: nonBlank(env.CSC_KEY_PASSWORD),
+  };
+}
+
+function buildAzureArgs(file, env) {
+  return [
+    'sign',
+    '/v',
+    // `/debug` surfaces Azure auth/quota/network diagnostics instead of a generic SignTool error.
+    '/debug',
+    '/fd',
+    'SHA256',
+    '/tr',
+    nonBlank(env.AZURE_TIMESTAMP_SERVER) || DEFAULT_TIMESTAMP_SERVER,
+    '/td',
+    'SHA256',
+    '/dlib',
+    nonBlank(env.AZURE_CODE_SIGNING_DLIB),
+    '/dmdf',
+    nonBlank(env.AZURE_METADATA_JSON),
+    file,
+  ];
+}
+
+function buildPfxArgs(file, env, pfx) {
+  return [
+    'sign',
+    '/v',
+    '/fd',
+    'SHA256',
+    '/f',
+    pfx.file,
+    '/p',
+    pfx.password,
+    '/tr',
+    nonBlank(env.AZURE_TIMESTAMP_SERVER) || DEFAULT_TIMESTAMP_SERVER,
+    '/td',
+    'SHA256',
+    file,
+  ];
+}
+
+function runSigntool(signtool, args, file, method) {
+  // eslint-disable-next-line no-console
+  console.log(`[azure-sign] Signing ${file} with ${method}`);
+  const result = childProcess.spawnSync(signtool, args, { stdio: 'inherit' });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.signal) {
+    throw new Error(
+      `[azure-sign] signtool terminated by signal ${result.signal} signing ${file}`
+    );
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `[azure-sign] signtool exited with code ${result.status} signing ${file}`
+    );
+  }
+}
+
+module.exports = async function sign(configuration) {
+  const file = configuration.path;
+  const env = process.env;
+
+  if (hasAzureEnv(env)) {
+    runSigntool(
+      nonBlank(env.SIGNTOOL_PATH),
+      buildAzureArgs(file, env),
+      file,
+      'Azure Trusted Signing'
+    );
+    return;
+  }
+
+  const pfx = pfxInputs(env);
+  if (env.CI && process.platform === 'win32') {
+    if (pfx.file && pfx.password) {
+      const signtool = nonBlank(env.SIGNTOOL_PATH) || 'signtool';
+      runSigntool(
+        signtool,
+        buildPfxArgs(file, env, pfx),
+        file,
+        'PFX certificate'
+      );
+      return;
+    }
+    throw new Error(
+      `[azure-sign] No Windows signing credentials in CI for ${file}. ` +
+        `Azure not configured (${AZURE_ENV_VARS.join(', ')}); ` +
+        `PFX fallback unavailable (CSC_LINK ${pfx.file ? 'present' : 'missing'}, ` +
+        `CSC_KEY_PASSWORD ${pfx.password ? 'set' : 'missing'}).`
+    );
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `[azure-sign] No signing env set; skipping ${file} (expected for local builds).`
+  );
+};
+
+module.exports.hasAzureEnv = hasAzureEnv;
+module.exports.pfxInputs = pfxInputs;
+module.exports.buildAzureArgs = buildAzureArgs;
+module.exports.buildPfxArgs = buildPfxArgs;
+module.exports.AZURE_ENV_VARS = AZURE_ENV_VARS;

--- a/scripts/azure-sign.test.js
+++ b/scripts/azure-sign.test.js
@@ -1,0 +1,156 @@
+const fs = require('node:fs');
+const childProcess = require('node:child_process');
+const signer = require('./azure-sign.cjs');
+
+const AZURE_ENV = {
+  SIGNTOOL_PATH: 'C:\\sdk\\signtool.exe',
+  AZURE_CODE_SIGNING_DLIB: 'C:\\azure\\Azure.CodeSigning.Dlib.dll',
+  AZURE_METADATA_JSON: 'C:\\azure\\metadata.json',
+};
+
+const PFX_ENV = {
+  CSC_LINK: 'C:\\repo\\certificate.pfx',
+  CSC_KEY_PASSWORD: 's3cret',
+};
+
+describe('hasAzureEnv', () => {
+  it('is true only when all Azure vars are non-blank', () => {
+    expect(signer.hasAzureEnv(AZURE_ENV)).toBe(true);
+  });
+
+  it('is false when any Azure var is missing or blank', () => {
+    expect(signer.hasAzureEnv({ ...AZURE_ENV, AZURE_METADATA_JSON: '' })).toBe(
+      false
+    );
+    expect(signer.hasAzureEnv({ ...AZURE_ENV, SIGNTOOL_PATH: '   ' })).toBe(
+      false
+    );
+    expect(signer.hasAzureEnv({})).toBe(false);
+  });
+});
+
+describe('pfxInputs', () => {
+  it('reports the file present only when CSC_LINK exists on disk', () => {
+    const spy = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    expect(signer.pfxInputs(PFX_ENV)).toEqual({
+      file: PFX_ENV.CSC_LINK,
+      password: 's3cret',
+    });
+    spy.mockReturnValue(false);
+    expect(signer.pfxInputs(PFX_ENV).file).toBeUndefined();
+    spy.mockRestore();
+  });
+});
+
+describe('buildAzureArgs', () => {
+  it('signs SHA256-only via /dlib + /dmdf', () => {
+    const args = signer.buildAzureArgs('app.exe', AZURE_ENV);
+    expect(args).toEqual([
+      'sign',
+      '/v',
+      '/debug',
+      '/fd',
+      'SHA256',
+      '/tr',
+      'http://timestamp.acs.microsoft.com',
+      '/td',
+      'SHA256',
+      '/dlib',
+      AZURE_ENV.AZURE_CODE_SIGNING_DLIB,
+      '/dmdf',
+      AZURE_ENV.AZURE_METADATA_JSON,
+      'app.exe',
+    ]);
+  });
+
+  it('honours an overridden timestamp server', () => {
+    const args = signer.buildAzureArgs('app.exe', {
+      ...AZURE_ENV,
+      AZURE_TIMESTAMP_SERVER: 'http://ts.example',
+    });
+    expect(args[args.indexOf('/tr') + 1]).toBe('http://ts.example');
+  });
+});
+
+describe('buildPfxArgs', () => {
+  it('signs SHA256-only via /f + /p', () => {
+    const pfx = { file: PFX_ENV.CSC_LINK, password: 's3cret' };
+    const args = signer.buildPfxArgs('app.exe', PFX_ENV, pfx);
+    expect(args).toEqual([
+      'sign',
+      '/v',
+      '/fd',
+      'SHA256',
+      '/f',
+      PFX_ENV.CSC_LINK,
+      '/p',
+      's3cret',
+      '/tr',
+      'http://timestamp.acs.microsoft.com',
+      '/td',
+      'SHA256',
+      'app.exe',
+    ]);
+  });
+});
+
+describe('sign callback dispatch', () => {
+  const originalEnv = process.env;
+  const originalPlatform = process.platform;
+  let spawn;
+
+  beforeEach(() => {
+    process.env = {};
+    spawn = jest
+      .spyOn(childProcess, 'spawnSync')
+      .mockReturnValue({ status: 0 });
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    jest.restoreAllMocks();
+  });
+
+  const setPlatform = (value) =>
+    Object.defineProperty(process, 'platform', { value });
+
+  it('skips signing (no throw, no signtool) off-CI', async () => {
+    setPlatform('darwin');
+    await expect(signer({ path: 'app.exe' })).resolves.toBeUndefined();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('signs via Azure when the Azure env is present', async () => {
+    setPlatform('win32');
+    process.env = { ...AZURE_ENV };
+    await signer({ path: 'app.exe' });
+    expect(spawn).toHaveBeenCalledWith(
+      AZURE_ENV.SIGNTOOL_PATH,
+      expect.arrayContaining(['/dlib']),
+      expect.anything()
+    );
+  });
+
+  it('falls back to PFX in CI on Windows when Azure is absent', async () => {
+    setPlatform('win32');
+    process.env = { CI: 'true', ...PFX_ENV };
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    await signer({ path: 'app.exe' });
+    expect(spawn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining(['/f', PFX_ENV.CSC_LINK]),
+      expect.anything()
+    );
+  });
+
+  it('throws naming missing inputs in CI on Windows with no credentials', async () => {
+    setPlatform('win32');
+    process.env = { CI: 'true' };
+    await expect(signer({ path: 'app.exe' })).rejects.toThrow(
+      /CSC_LINK missing.*CSC_KEY_PASSWORD missing/s
+    );
+    expect(spawn).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/azure-sign.test.js
+++ b/scripts/azure-sign.test.js
@@ -133,6 +133,26 @@ describe('sign callback dispatch', () => {
     );
   });
 
+  it('skips the sha1 pass (Azure is SHA256-only)', async () => {
+    setPlatform('win32');
+    process.env = { ...AZURE_ENV };
+    await expect(
+      signer({ path: 'app.exe', hash: 'sha1' })
+    ).resolves.toBeUndefined();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('signs on the sha256 pass', async () => {
+    setPlatform('win32');
+    process.env = { ...AZURE_ENV };
+    await signer({ path: 'app.exe', hash: 'sha256' });
+    expect(spawn).toHaveBeenCalledWith(
+      AZURE_ENV.SIGNTOOL_PATH,
+      expect.arrayContaining(['/dlib']),
+      expect.anything()
+    );
+  });
+
   it('falls back to PFX in CI on Windows when Azure is absent', async () => {
     setPlatform('win32');
     process.env = { CI: 'true', ...PFX_ENV };


### PR DESCRIPTION
Part of [AINFRA-2472](https://linear.app/a8c/issue/AINFRA-2472).

Prepares the app for Azure code signing, which we'll enable in July, while also preloading the CN for the Azure identity so that PFX -> Azure upgrades (for builds installed outside of the Microsoft Store) will still work.

Used `CSC_FOR_PULL_REQUEST` to verify the builds worked, see https://buildkite.com/automattic/simplenote-electron/builds/426, then removed in commit [d601290](https://github.com/Automattic/simplenote-electron/pull/3380/commits/d6012909ca67847fb491ca01709c1f80de87f588). Then, I realized that all the other steps still have `CSC_FOR_PULL_REQUEST: true` so I don't know how useful that was...

<details>
<summary>Additional AI-generated details</summary>


### Fix

Add Azure Trusted Signing as an **opt-in** Windows signing path, gated behind
`USE_AZURE_TRUSTED_SIGNING`, while the **PFX cert stays the default**. Part of the
[Azure Trusted Signing migration](https://linear.app/a8c/project/replace-our-windows-code-signing-certificate-6a4cc099fda6) (the Sectigo PFX cert expires 2026-07-05).

- The default build signs the NSIS exe via the existing PFX cert
  (`certificateSubjectName`) — unchanged behaviour.
- With `USE_AZURE_TRUSTED_SIGNING` set, the exe signs via Azure Trusted Signing
  through a `win.sign` callback (`scripts/azure-sign.cjs`); the Store AppX stays
  unsigned (its config is untouched).
- The pipeline runs both: the default **Package on Windows** (PFX, ships) and an
  opt-in **Package on Windows (Azure Trusted Signing)** that signs and gates on
  `signtool verify /pa`.
- CI Toolkit plugin `5.7.0 → 6.1.0` (adds `setup_azure_trusted_signing.ps1`,
  keeps the PFX provisioner — see commit bodies for the per-tag audit).

⚠️ **Why Azure is opt-in, not the default (AINFRA-2472):** Azure changes the
Authenticode publisher CN (`Automattic, Inc.` → `Automattic Inc.`), which breaks
`electron-updater` for existing users. A PFX-signed *bridge* release carrying the
dual `publisherName` (pinned here) must ship before any Azure-only build.

### Test

1. Both Windows steps are green on the build. The Azure step signs and verifies
   with `signtool verify /pa`; I downloaded its `Simplenote-win-2.26.0-x64.exe`
   and confirmed on macOS with `osslsigncode`: SHA256, signer `Automattic Inc.`,
   issuer `Microsoft ID Verified CS EOC CA 03`, Microsoft RFC3161 timestamp.
2. `make test` covers the new `scripts/azure-sign.test.js`.

### Release

These changes do not require release notes.

---

*Opened by Claude (Opus 4.8) on behalf of @mokagio with approval.*

</details>