### PR TITLE
Merge release/2.26.1  into trunk

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [v2.26.0]
+## [v2.26.1]
+
+### Enhancements
+
+- Service release to prepare for Windows code signing mode change without breaking auto update [#3383](https://github.com/Automattic/simplenote-electron/pull/3383)
 
 ### New Features
 

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -49,6 +49,7 @@
   "win": {
     "icon": "resources/images/simplenote.ico",
     "certificateSubjectName": "Automattic, Inc.",
+    "publisherName": ["Automattic, Inc.", "Automattic Inc."],
     "artifactName": "Simplenote-win-${version}-${arch}.${ext}",
     "target": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplenote",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simplenote",
-      "version": "2.26.0",
+      "version": "2.26.1",
       "license": "GPL-2.0",
       "dependencies": {
         "@automattic/color-studio": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "support@simplenote.com"
   },
   "productName": "Simplenote",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "main": "desktop/index.js",
   "license": "GPL-2.0",
   "homepage": "https://simplenote.com",


### PR DESCRIPTION
I will admin-merge this minor change and ship ASAP.

Notice https://github.com/Automattic/simplenote-electron/pull/3383/commits/e71598d6a19fac137b3cff6e400f4d23673f17c6 which prepares the Windows build for the upcoming code sign method change without breaking auto-update.