### PR TITLE
Warn user when note sync fails

### DIFF
--- a/lib/note-list/note-cell.test.tsx
+++ b/lib/note-list/note-cell.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { NoteCell } from './note-cell';
+import { getSyncErrorMessage } from '../utils/sync-error-message';
+import type * as T from '../types';
+
+const noteId = 'note-1' as T.EntityId;
+
+const minimalNote: T.Note = {
+  content: 'Hello world',
+  creationDate: 0,
+  deleted: false,
+  modificationDate: 0,
+  systemTags: [],
+  tags: [],
+};
+
+const baseProps = {
+  displayMode: 'comfy' as T.ListDisplayMode,
+  invalidateHeight: jest.fn(),
+  isOffline: false,
+  isOpened: false,
+  lastUpdated: -Infinity,
+  note: minimalNote,
+  noteId,
+  openNote: jest.fn(),
+  pinNote: jest.fn(),
+  searchQuery: '',
+  showSyncSpinner: false,
+  style: {},
+  syncErrorCode: null as number | null,
+};
+
+describe('NoteCell status icons', () => {
+  describe('sync error', () => {
+    it('does not render a sync error icon when syncErrorCode is null', () => {
+      const { container } = render(<NoteCell {...baseProps} />);
+
+      expect(container.querySelector('.note-list-item-sync-error')).toBeNull();
+    });
+
+    it('renders a sync error icon with tooltip when syncErrorCode is set', () => {
+      const { container } = render(
+        <NoteCell {...baseProps} syncErrorCode={413} />
+      );
+
+      const syncError = container.querySelector('.note-list-item-sync-error');
+      expect(syncError).not.toBeNull();
+      expect(syncError?.getAttribute('title')).toBe(getSyncErrorMessage(413));
+    });
+
+    it('shows both pending and sync error icons during a retry', () => {
+      const { container } = render(
+        <NoteCell {...baseProps} showSyncSpinner syncErrorCode={413} />
+      );
+
+      expect(
+        container.querySelector('.note-list-item-pending-changes')
+      ).not.toBeNull();
+      expect(
+        container.querySelector('.note-list-item-sync-error')
+      ).not.toBeNull();
+    });
+
+    it('shows only the sync error icon after a failed sync', () => {
+      const { container } = render(
+        <NoteCell {...baseProps} syncErrorCode={413} />
+      );
+
+      expect(
+        container.querySelector('.note-list-item-pending-changes')
+      ).toBeNull();
+      expect(
+        container.querySelector('.note-list-item-sync-error')
+      ).not.toBeNull();
+    });
+  });
+
+  describe('pending changes', () => {
+    it('does not render a pending changes icon when showSyncSpinner is false', () => {
+      const { container } = render(<NoteCell {...baseProps} />);
+
+      expect(
+        container.querySelector('.note-list-item-pending-changes')
+      ).toBeNull();
+    });
+
+    it('renders a pending changes icon when showSyncSpinner is true', () => {
+      const { container } = render(<NoteCell {...baseProps} showSyncSpinner />);
+
+      expect(
+        container.querySelector('.note-list-item-pending-changes')
+      ).not.toBeNull();
+    });
+
+    it('marks pending changes as offline when isOffline is true', () => {
+      const { container } = render(
+        <NoteCell {...baseProps} showSyncSpinner isOffline />
+      );
+
+      expect(
+        container
+          .querySelector('.note-list-item-pending-changes')
+          ?.classList.contains('is-offline')
+      ).toBe(true);
+    });
+  });
+
+  describe('published', () => {
+    it('does not render a published icon when the note is not published', () => {
+      const { container } = render(<NoteCell {...baseProps} />);
+
+      expect(
+        container.querySelector('.note-list-item-published-icon')
+      ).toBeNull();
+      expect(container.querySelector('.published-note')).toBeNull();
+    });
+
+    it('renders a published icon and row class when publishURL is set', () => {
+      const { container } = render(
+        <NoteCell
+          {...baseProps}
+          note={{
+            ...minimalNote,
+            publishURL: 'https://publish.simplenote.com/abc',
+          }}
+        />
+      );
+
+      expect(
+        container.querySelector('.note-list-item-published-icon')
+      ).not.toBeNull();
+      expect(
+        container
+          .querySelector('.note-list-item')
+          ?.classList.contains('published-note')
+      ).toBe(true);
+    });
+  });
+});

--- a/lib/note-list/note-cell.tsx
+++ b/lib/note-list/note-cell.tsx
@@ -2,12 +2,14 @@ import React, { Component, CSSProperties } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 
+import AlertIcon from '../icons/attention';
 import PublishIcon from '../icons/published-small';
 import SmallPinnedIcon from '../icons/pinned-small';
 import SmallSyncIcon from '../icons/sync-small';
 import { decorateWith, makeFilterDecorator } from './decorators';
 import { getTerms } from '../utils/filter-notes';
 import { noteTitleAndPreview } from '../utils/note-utils';
+import { getSyncErrorMessage } from '../utils/sync-error-message';
 import { withCheckboxCharacters } from '../utils/task-transform';
 
 import actions from '../state/actions';
@@ -24,12 +26,13 @@ type OwnProps = {
 
 type StateProps = {
   displayMode: T.ListDisplayMode;
-  hasPendingChanges: boolean;
   isOffline: boolean;
   isOpened: boolean;
   lastUpdated: number;
   note?: T.Note;
   searchQuery: string;
+  showSyncSpinner: boolean;
+  syncErrorCode: number | null;
 };
 
 type DispatchProps = {
@@ -69,7 +72,6 @@ export class NoteCell extends Component<Props> {
   render() {
     const {
       displayMode,
-      hasPendingChanges,
       isOffline,
       isOpened,
       lastUpdated,
@@ -78,7 +80,9 @@ export class NoteCell extends Component<Props> {
       openNote,
       pinNote,
       searchQuery,
+      showSyncSpinner,
       style,
+      syncErrorCode,
     } = this.props;
 
     if (!note) {
@@ -149,13 +153,21 @@ export class NoteCell extends Component<Props> {
             )}
           </button>
           <div className="note-list-item-status-right">
-            {hasPendingChanges && (
+            {showSyncSpinner && (
               <span
                 className={classNames('note-list-item-pending-changes', {
                   'is-offline': isOffline,
                 })}
               >
                 <SmallSyncIcon />
+              </span>
+            )}
+            {null !== syncErrorCode && (
+              <span
+                className="note-list-item-sync-error"
+                title={getSyncErrorMessage(syncErrorCode)}
+              >
+                <AlertIcon />
               </span>
             )}
             {isPublished && (
@@ -175,12 +187,13 @@ const mapStateToProps: S.MapState<StateProps, OwnProps> = (
   { noteId }
 ) => ({
   displayMode: state.settings.noteDisplay,
-  hasPendingChanges: selectors.noteHasPendingChanges(state, noteId),
   isOffline: state.simperium.connectionStatus === 'offline',
   isOpened: state.ui.openedNote === noteId,
   lastUpdated: state.simperium.lastRemoteUpdate.get(noteId) ?? -Infinity,
   note: state.data.notes.get(noteId),
   searchQuery: state.ui.searchQuery,
+  showSyncSpinner: selectors.noteShowSyncSpinner(state, noteId),
+  syncErrorCode: state.simperium.syncErrors.get(noteId) ?? null,
 });
 
 const mapDispatchToProps: S.MapDispatch<DispatchProps> = {

--- a/lib/note-list/style.scss
+++ b/lib/note-list/style.scss
@@ -199,6 +199,7 @@
   }
 
   .note-list-item-pending-changes,
+  .note-list-item-sync-error,
   .note-list-item-published-icon {
     padding: 0 4px;
     color: var(--foreground-color);
@@ -207,6 +208,10 @@
       height: 16px;
       width: 16px;
     }
+  }
+
+  .note-list-item-sync-error {
+    color: var(--tertiary-highlight-color);
   }
 
   .note-list-item-pending-changes {

--- a/lib/state/action-types.ts
+++ b/lib/state/action-types.ts
@@ -275,6 +275,14 @@ export type NoteBucketRemove = Action<
   'NOTE_BUCKET_REMOVE',
   { noteId: T.EntityId }
 >;
+export type NoteSyncError = Action<
+  'NOTE_SYNC_ERROR',
+  {
+    noteId: T.EntityId;
+    errorCode: number;
+  }
+>;
+export type NoteSyncRetry = Action<'NOTE_SYNC_RETRY', { noteId: T.EntityId }>;
 export type NoteBucketUpdate = Action<
   'NOTE_BUCKET_UPDATE',
   { noteId: T.EntityId; note: T.Note; isIndexing: boolean }
@@ -370,6 +378,8 @@ export type ActionType =
   | MarkdownNote
   | NoteBucketRemove
   | NoteBucketUpdate
+  | NoteSyncError
+  | NoteSyncRetry
   | OpenNote
   | OpenRevision
   | OpenTag

--- a/lib/state/selectors.test.ts
+++ b/lib/state/selectors.test.ts
@@ -1,0 +1,83 @@
+import type { Ghost } from 'simperium';
+
+import { noteHasPendingChanges, noteShowSyncSpinner } from './selectors';
+import type * as S from './';
+import type * as T from '../types';
+
+const noteId = 'note-1' as T.EntityId;
+
+const localNote: T.Note = {
+  content: 'local content',
+  creationDate: 0,
+  deleted: false,
+  modificationDate: 1,
+  systemTags: [],
+  tags: [],
+};
+
+const ghostNote: T.Note = {
+  ...localNote,
+  content: 'server content',
+};
+
+const makeState = (
+  overrides: {
+    note?: T.Note;
+    ghost?: T.Note;
+    syncErrors?: Map<T.EntityId, number>;
+    syncRetrying?: Map<T.EntityId, true>;
+  } = {}
+): S.State => {
+  const note = overrides.note ?? localNote;
+  const ghost = overrides.ghost ?? ghostNote;
+  const noteGhosts = new Map<T.EntityId, Ghost<T.Note>>();
+
+  if (ghost) {
+    noteGhosts.set(noteId, { data: ghost } as Ghost<T.Note>);
+  }
+
+  return {
+    data: {
+      notes: new Map([[noteId, note]]),
+    },
+    simperium: {
+      ghosts: [new Map(), new Map([['note', noteGhosts]])],
+      syncErrors: overrides.syncErrors ?? new Map(),
+      syncRetrying: overrides.syncRetrying ?? new Map(),
+    },
+  } as unknown as S.State;
+};
+
+describe('noteShowSyncSpinner', () => {
+  it('returns false when local and ghost notes match', () => {
+    const state = makeState({ ghost: localNote });
+
+    expect(noteHasPendingChanges(state, noteId)).toBe(false);
+    expect(noteShowSyncSpinner(state, noteId)).toBe(false);
+  });
+
+  it('returns true for unsynced notes without a sync error', () => {
+    const state = makeState();
+
+    expect(noteHasPendingChanges(state, noteId)).toBe(true);
+    expect(noteShowSyncSpinner(state, noteId)).toBe(true);
+  });
+
+  it('returns false after a sync error until the user retries', () => {
+    const state = makeState({
+      syncErrors: new Map([[noteId, 413]]),
+    });
+
+    expect(noteHasPendingChanges(state, noteId)).toBe(true);
+    expect(noteShowSyncSpinner(state, noteId)).toBe(false);
+  });
+
+  it('returns true during a retry after a sync error', () => {
+    const state = makeState({
+      syncErrors: new Map([[noteId, 413]]),
+      syncRetrying: new Map([[noteId, true]]),
+    });
+
+    expect(noteShowSyncSpinner(state, noteId)).toBe(true);
+  });
+});

--- a/lib/state/selectors.ts
+++ b/lib/state/selectors.ts
@@ -44,6 +44,21 @@ export const noteHasPendingChanges: S.Selector<boolean> = (
     state.simperium.ghosts[1].get('note')?.get(noteId)?.data
   );
 
+export const noteShowSyncSpinner: S.Selector<boolean> = (
+  state,
+  noteId: T.EntityId
+) => {
+  if (!noteHasPendingChanges(state, noteId)) {
+    return false;
+  }
+
+  if (state.simperium.syncErrors.has(noteId)) {
+    return state.simperium.syncRetrying.has(noteId);
+  }
+
+  return true;
+};
+
 export const shouldShowEmailVerification: S.Selector<boolean> = ({
   data: { accountVerification: status },
 }) => status === 'unverified' || status === 'pending';

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -76,6 +76,17 @@ export const initSimperium =
     }
 
     const noteBucket = client.bucket('note');
+
+    // A rejected change stays in localQueue.sent because simperium only clears
+    // it on acknowledge. Release it so subsequent edits can sync.
+    const releaseStuckNoteChange = (noteId: T.EntityId) => {
+      const localQueue = (noteBucket.channel as any).localQueue;
+      if (localQueue.sent[noteId]) {
+        delete localQueue.sent[noteId];
+        localQueue.processQueue(noteId);
+      }
+    };
+
     noteBucket.channel.on(
       'update',
       (entityId, updatedEntity, original, patch, isIndexing) => {
@@ -128,6 +139,27 @@ export const initSimperium =
         entityId: entityId as T.EntityId,
         ccid: change.ccid,
       });
+    });
+
+    // fires when the server rejects a change with an error code the client
+    // can't recover from on its own, e.g. 413 when a note is too large.
+    // NB: must listen on the bucket, not the channel: the bucket forwards
+    // channel errors, and emitting 'error' on the listenerless bucket throws
+    noteBucket.on('error', (error, change) => {
+      const noteId = change?.id as T.EntityId | undefined;
+      const errorCode = (error as { code?: unknown })?.code;
+
+      debug(`sync error for note ${noteId}: ${errorCode}`);
+
+      if (noteId && 'number' === typeof errorCode) {
+        releaseStuckNoteChange(noteId);
+
+        dispatch({
+          type: 'NOTE_SYNC_ERROR',
+          noteId,
+          errorCode,
+        });
+      }
     });
 
     const tagBucket = client.bucket('tag');
@@ -230,8 +262,18 @@ export const initSimperium =
     });
 
     const noteQueue = new BucketQueue(noteBucket);
-    const queueNoteUpdate = (noteId: T.EntityId, delay = 2000) =>
+    const queueNoteUpdate = (
+      noteId: T.EntityId,
+      delay = 2000,
+      state: S.State = getState()
+    ) => {
+      if (state.simperium.syncErrors.has(noteId)) {
+        releaseStuckNoteChange(noteId);
+        dispatch({ type: 'NOTE_SYNC_RETRY', noteId });
+      }
+
       noteQueue.add(noteId, Date.now() + delay);
+    };
 
     const hasRequestedRevisions = new Set<T.EntityId>();
 
@@ -281,19 +323,19 @@ export const initSimperium =
             queueTagUpdate(tagHash);
           }
 
-          queueNoteUpdate(action.noteId);
+          queueNoteUpdate(action.noteId, 2000, prevState);
           return result;
         }
 
         case 'REMOVE_COLLABORATOR':
         case 'REMOVE_NOTE_TAG':
-          queueNoteUpdate(action.noteId);
+          queueNoteUpdate(action.noteId, 2000, prevState);
           return result;
 
         case 'CREATE_NOTE_WITH_ID':
         case 'INSERT_TASK_INTO_NOTE':
         case 'EDIT_NOTE':
-          queueNoteUpdate(action.noteId);
+          queueNoteUpdate(action.noteId, 2000, prevState);
           return result;
 
         case 'FILTER_NOTES':
@@ -357,7 +399,7 @@ export const initSimperium =
             }
           });
 
-          queueNoteUpdate(action.noteId, 10);
+          queueNoteUpdate(action.noteId, 10, prevState);
           return result;
         }
 
@@ -368,7 +410,7 @@ export const initSimperium =
         case 'PUBLISH_NOTE':
         case 'RESTORE_NOTE':
         case 'TRASH_NOTE':
-          queueNoteUpdate(action.noteId, 10);
+          queueNoteUpdate(action.noteId, 10, prevState);
           return result;
 
         case 'IMPORT_NOTE_WITH_ID': {
@@ -378,7 +420,7 @@ export const initSimperium =
               queueTagUpdate(tagHash, 10);
             }
           });
-          queueNoteUpdate(action.noteId, 10);
+          queueNoteUpdate(action.noteId, 10, prevState);
           return result;
         }
 
@@ -398,7 +440,7 @@ export const initSimperium =
 
           nextState.data.notes.forEach((note, noteId) => {
             if (prevState.data.notes.get(noteId) !== note) {
-              queueNoteUpdate(noteId);
+              queueNoteUpdate(noteId, 2000, prevState);
             }
           });
 
@@ -421,7 +463,7 @@ export const initSimperium =
           tagBucket.remove(t(action.tagName));
           nextState.data.notes.forEach((note, noteId) => {
             if (prevState.data.notes.get(noteId) !== note) {
-              queueNoteUpdate(noteId);
+              queueNoteUpdate(noteId, 2000, prevState);
             }
           });
           return result;

--- a/lib/state/simperium/reducer.test.ts
+++ b/lib/state/simperium/reducer.test.ts
@@ -1,0 +1,144 @@
+import simperiumReducer from './reducer';
+import type * as T from '../../types';
+
+const noteId = 'note-1' as T.EntityId;
+const otherNoteId = 'note-2' as T.EntityId;
+
+const minimalNote: T.Note = {
+  content: 'Hello',
+  creationDate: 0,
+  deleted: false,
+  modificationDate: 0,
+  systemTags: [],
+  tags: [],
+};
+
+const stateWithSyncError = () =>
+  simperiumReducer(undefined, {
+    type: 'NOTE_SYNC_ERROR',
+    noteId,
+    errorCode: 413,
+  });
+
+describe('simperium reducer syncErrors', () => {
+  it('sets error code on NOTE_SYNC_ERROR', () => {
+    const state = stateWithSyncError();
+
+    expect(state.syncErrors.get(noteId)).toBe(413);
+    expect(state.syncErrors.size).toBe(1);
+  });
+
+  it('preserves existing errors when setting a new one', () => {
+    const state = simperiumReducer(stateWithSyncError(), {
+      type: 'NOTE_SYNC_ERROR',
+      noteId: otherNoteId,
+      errorCode: 500,
+    });
+
+    expect(state.syncErrors.get(noteId)).toBe(413);
+    expect(state.syncErrors.get(otherNoteId)).toBe(500);
+    expect(state.syncErrors.size).toBe(2);
+  });
+
+  it.each([
+    [
+      'ACKNOWLEDGE_PENDING_CHANGE',
+      { type: 'ACKNOWLEDGE_PENDING_CHANGE', entityId: noteId, ccid: 'ccid-1' },
+    ],
+    [
+      'REMOTE_NOTE_UPDATE',
+      { type: 'REMOTE_NOTE_UPDATE', noteId, note: minimalNote },
+    ],
+    [
+      'REMOTE_NOTE_DELETE_FOREVER',
+      { type: 'REMOTE_NOTE_DELETE_FOREVER', noteId },
+    ],
+    ['DELETE_NOTE_FOREVER', { type: 'DELETE_NOTE_FOREVER', noteId }],
+    ['NOTE_BUCKET_REMOVE', { type: 'NOTE_BUCKET_REMOVE', noteId }],
+  ] as const)('clears sync error on %s', (_label, action) => {
+    const state = simperiumReducer(stateWithSyncError(), action);
+
+    expect(state.syncErrors.has(noteId)).toBe(false);
+    expect(state.syncErrors.size).toBe(0);
+  });
+
+  it.each([
+    [
+      'ACKNOWLEDGE_PENDING_CHANGE',
+      {
+        type: 'ACKNOWLEDGE_PENDING_CHANGE',
+        entityId: otherNoteId,
+        ccid: 'ccid-1',
+      },
+    ],
+    [
+      'REMOTE_NOTE_UPDATE',
+      { type: 'REMOTE_NOTE_UPDATE', noteId: otherNoteId, note: minimalNote },
+    ],
+    [
+      'REMOTE_NOTE_DELETE_FOREVER',
+      { type: 'REMOTE_NOTE_DELETE_FOREVER', noteId: otherNoteId },
+    ],
+    [
+      'DELETE_NOTE_FOREVER',
+      { type: 'DELETE_NOTE_FOREVER', noteId: otherNoteId },
+    ],
+    ['NOTE_BUCKET_REMOVE', { type: 'NOTE_BUCKET_REMOVE', noteId: otherNoteId }],
+  ] as const)(
+    'does not change syncErrors when clearing an unknown note on %s',
+    (_label, action) => {
+      const previousState = stateWithSyncError();
+      const state = simperiumReducer(previousState, action);
+
+      expect(state.syncErrors).toBe(previousState.syncErrors);
+      expect(state.syncErrors.get(noteId)).toBe(413);
+    }
+  );
+
+  it('keeps sync error on SUBMIT_PENDING_CHANGE', () => {
+    const previousState = stateWithSyncError();
+    const state = simperiumReducer(previousState, {
+      type: 'SUBMIT_PENDING_CHANGE',
+      entityId: noteId,
+      ccid: 'ccid-1',
+    });
+
+    expect(state.syncErrors).toBe(previousState.syncErrors);
+    expect(state.syncErrors.get(noteId)).toBe(413);
+  });
+
+  it('sets syncRetrying on NOTE_SYNC_RETRY', () => {
+    const state = simperiumReducer(stateWithSyncError(), {
+      type: 'NOTE_SYNC_RETRY',
+      noteId,
+    });
+
+    expect(state.syncRetrying.get(noteId)).toBe(true);
+  });
+
+  it('clears syncRetrying on NOTE_SYNC_ERROR', () => {
+    const previousState = simperiumReducer(stateWithSyncError(), {
+      type: 'NOTE_SYNC_RETRY',
+      noteId,
+    });
+    const state = simperiumReducer(previousState, {
+      type: 'NOTE_SYNC_ERROR',
+      noteId,
+      errorCode: 413,
+    });
+
+    expect(state.syncRetrying.has(noteId)).toBe(false);
+    expect(state.syncErrors.get(noteId)).toBe(413);
+  });
+
+  it('passes through on unknown actions', () => {
+    const previousState = stateWithSyncError();
+    const state = simperiumReducer(previousState, {
+      type: 'CHANGE_CONNECTION_STATUS',
+      status: 'green',
+    });
+
+    expect(state.syncErrors).toBe(previousState.syncErrors);
+    expect(state.syncErrors.get(noteId)).toBe(413);
+  });
+});

--- a/lib/state/simperium/reducer.ts
+++ b/lib/state/simperium/reducer.ts
@@ -60,6 +60,60 @@ const lastSync: A.Reducer<Map<T.EntityId, number>> = (
   }
 };
 
+const syncErrorNoteId = (action: A.ActionType): T.EntityId | undefined => {
+  switch (action.type) {
+    case 'ACKNOWLEDGE_PENDING_CHANGE':
+      return action.entityId;
+
+    case 'REMOTE_NOTE_UPDATE':
+    case 'REMOTE_NOTE_DELETE_FOREVER':
+    case 'DELETE_NOTE_FOREVER':
+    case 'NOTE_BUCKET_REMOVE':
+      return action.noteId;
+
+    default:
+      return undefined;
+  }
+};
+
+const syncErrors: A.Reducer<Map<T.EntityId, number>> = (
+  state = emptyMap as Map<T.EntityId, number>,
+  action
+) => {
+  if (action.type === 'NOTE_SYNC_ERROR') {
+    return new Map(state).set(action.noteId, action.errorCode);
+  }
+
+  const noteId = syncErrorNoteId(action);
+  if (!noteId || !state.has(noteId)) {
+    return state;
+  }
+
+  const next = new Map(state);
+  next.delete(noteId);
+  return next;
+};
+
+const syncRetrying: A.Reducer<Map<T.EntityId, true>> = (
+  state = emptyMap as Map<T.EntityId, true>,
+  action
+) => {
+  if (action.type === 'NOTE_SYNC_RETRY') {
+    return new Map(state).set(action.noteId, true);
+  }
+
+  const noteId =
+    action.type === 'NOTE_SYNC_ERROR' ? action.noteId : syncErrorNoteId(action);
+
+  if (!noteId || !state.has(noteId)) {
+    return state;
+  }
+
+  const next = new Map(state);
+  next.delete(noteId);
+  return next;
+};
+
 const lastRemoteUpdate: A.Reducer<Map<T.EntityId, number>> = (
   state = emptyMap as Map<T.EntityId, number>,
   action
@@ -80,4 +134,6 @@ export default combineReducers({
   ghosts,
   lastSync,
   lastRemoteUpdate,
+  syncErrors,
+  syncRetrying,
 });

--- a/lib/utils/sync-error-message.test.ts
+++ b/lib/utils/sync-error-message.test.ts
@@ -1,0 +1,15 @@
+import { getSyncErrorMessage } from './sync-error-message';
+
+describe('getSyncErrorMessage', () => {
+  it('returns a specific message for HTTP 413', () => {
+    expect(getSyncErrorMessage(413)).toBe(
+      'This note could not be synced because it is too large. Try removing content or splitting it into smaller notes.'
+    );
+  });
+
+  it('returns a generic message for other error codes', () => {
+    expect(getSyncErrorMessage(500)).toBe(
+      'This note could not be synced (error 500).'
+    );
+  });
+});

--- a/lib/utils/sync-error-message.ts
+++ b/lib/utils/sync-error-message.ts
@@ -1,0 +1,5 @@
+export function getSyncErrorMessage(errorCode: number): string {
+  return 413 === errorCode
+    ? 'This note could not be synced because it is too large. Try removing content or splitting it into smaller notes.'
+    : `This note could not be synced (error ${errorCode}).`;
+}


### PR DESCRIPTION
While experimenting with Simplenote and a new editor, I was testing performance with very large notes. I noticed that Simperium actually stops syncing notes of a certain size, but the user is never notified. This PR introduces an error indicator for 413 (doc too large) and other errors. 

### Fix

When note failed to sync we see the warning triangle:
<img width="1650" height="276" alt="CleanShot 2026-06-11 at 15 10 43@2x" src="https://github.com/user-attachments/assets/ffc85bcc-2ae9-4104-8b0e-34a15db2e350" />

When user changes the note (e.g. shortens it), the pending spinner shows until we either succeed or again get an error:
<img width="730" height="128" alt="CleanShot 2026-06-11 at 15 11 01@2x" src="https://github.com/user-attachments/assets/310168a3-2d03-48ff-92c0-6aa12c1e86ad" />

### Test

Get a sufficiently large random note:

```
head -c 1M /dev/urandom | pbcopy
```

- Add a new note and paste in the random note text.
- Wait for sync to fail
- **Expected**: Warning triangle shows
- Make a change to the note
- **Expected**: Pending spinner shows (triangle stays) and disappears when sync fails again
- Remove most of the text to make it sufficiently small
- **Expected**: Pending spinner comes up and once the sync completes the warning indicator disappears

### Release

Enhancements:
- Warn user when note sync fails