### PR TITLE
Re-enable NoteDoctor to sync notes on startup

### DIFF
--- a/lib/state/simperium/functions/note-doctor.test.ts
+++ b/lib/state/simperium/functions/note-doctor.test.ts
@@ -1,0 +1,100 @@
+import { NoteDoctor } from './note-doctor';
+import type { BucketQueue } from './bucket-queue';
+import type * as S from '../../';
+import type * as T from '../../../types';
+
+const noteId = 'note-1' as T.EntityId;
+
+const localNote: T.Note = {
+  content: 'local content',
+  creationDate: 0,
+  deleted: false,
+  modificationDate: 1,
+  systemTags: [],
+  tags: [],
+};
+
+const ghostNote: T.Note = {
+  ...localNote,
+  content: 'server content',
+};
+
+describe('NoteDoctor', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    window.requestIdleCallback = (callback) => {
+      callback({
+        didTimeout: false,
+        timeRemaining: () => 50,
+      });
+      return 1;
+    };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const runStartupScan = () => {
+    jest.advanceTimersByTime(1000);
+    jest.runOnlyPendingTimers();
+  };
+
+  it('queues unsynced notes for sync on startup', () => {
+    const queue = {
+      has: jest.fn().mockReturnValue(false),
+      add: jest.fn(),
+    } as unknown as BucketQueue<'note', T.Note>;
+
+    const store = {
+      getState: () =>
+        ({
+          data: {
+            notes: new Map([[noteId, localNote]]),
+          },
+          simperium: {
+            ghosts: [
+              new Map(),
+              new Map([['note', new Map([[noteId, { data: ghostNote }]])]]),
+            ],
+          },
+        }) as unknown as S.State,
+      dispatch: jest.fn(),
+    } as unknown as S.Store;
+
+    new NoteDoctor(store, queue);
+
+    runStartupScan();
+
+    expect(queue.add).toHaveBeenCalledWith(noteId, expect.any(Number));
+  });
+
+  it('does not queue notes that already match their ghost', () => {
+    const queue = {
+      has: jest.fn().mockReturnValue(false),
+      add: jest.fn(),
+    } as unknown as BucketQueue<'note', T.Note>;
+
+    const store = {
+      getState: () =>
+        ({
+          data: {
+            notes: new Map([[noteId, localNote]]),
+          },
+          simperium: {
+            ghosts: [
+              new Map(),
+              new Map([['note', new Map([[noteId, { data: localNote }]])]]),
+            ],
+          },
+        }) as unknown as S.State,
+      dispatch: jest.fn(),
+    } as unknown as S.Store;
+
+    new NoteDoctor(store, queue);
+
+    runStartupScan();
+
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+});

--- a/lib/state/simperium/middleware.ts
+++ b/lib/state/simperium/middleware.ts
@@ -6,7 +6,7 @@ import { BucketQueue } from './functions/bucket-queue';
 import { InMemoryBucket } from './functions/in-memory-bucket';
 import { InMemoryGhost } from './functions/in-memory-ghost';
 import { NoteBucket } from './functions/note-bucket';
-// import { NoteDoctor } from './functions/note-doctor';
+import { NoteDoctor } from './functions/note-doctor';
 import { PreferencesBucket } from './functions/preferences-bucket';
 import { ReduxGhost } from './functions/redux-ghost';
 import { TagBucket } from './functions/tag-bucket';
@@ -253,7 +253,7 @@ export const initSimperium =
     }
 
     // walk notes and queue any for sync which have discrepancies with their ghost
-    // new NoteDoctor(store, noteQueue);
+    new NoteDoctor(store, noteQueue);
 
     window.addEventListener('storage', (event) => {
       if (event.key === 'simplenote_logout') {


### PR DESCRIPTION
NoteDoctor scans for local/ghost discrepancies on idle and queues sync attempts. It was disabled during the 2020 rewrite and never turned back on. Looks to me like it was just forgotten in the already very complex rewrite, but please correct me if I'm wrong @dmsnell. The doctor would be quite useful in combination with https://github.com/Automattic/simplenote-electron/pull/3387.

### Fix

Uncommented code and added some automated tests.

### Release

Other changes:
- Re-enable NoteDoctor to sync notes on startup