### PR TITLE
perf: fix bucket queue timer loop

### DIFF
--- a/lib/state/simperium/functions/bucket-queue.test.ts
+++ b/lib/state/simperium/functions/bucket-queue.test.ts
@@ -113,6 +113,9 @@ describe('BucketQueue', () => {
 
     queue.add('note-1', Date.now());
 
+    jest.advanceTimersByTime(9999);
+    expect(bucket.touch).not.toHaveBeenCalled();
+
     bucket.isIndexing = false;
     bucket.emit('index');
 

--- a/lib/state/simperium/functions/bucket-queue.test.ts
+++ b/lib/state/simperium/functions/bucket-queue.test.ts
@@ -1,0 +1,140 @@
+import { BucketQueue } from './bucket-queue';
+
+import type { Bucket } from 'simperium';
+
+type MockBucket = {
+  name: string;
+  isIndexing: boolean;
+  on: jest.Mock;
+  touch: jest.Mock;
+  emit: (event: string) => void;
+};
+
+const makeBucket = (): MockBucket => {
+  const handlers = new Map<string, Array<() => void>>();
+  return {
+    name: 'note',
+    isIndexing: false,
+    on: jest.fn((event: string, handler: () => void) => {
+      handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+    }),
+    touch: jest.fn().mockResolvedValue(undefined),
+    emit: (event: string) => handlers.get(event)?.forEach((cb) => cb()),
+  };
+};
+
+const makeQueue = (bucket: MockBucket) =>
+  new BucketQueue(bucket as unknown as Bucket<'note', unknown>);
+
+const setOnline = (onLine: boolean) =>
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    value: onLine,
+  });
+
+describe('BucketQueue', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setOnline(true);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('syncs nothing while the queue is empty', () => {
+    const bucket = makeBucket();
+    makeQueue(bucket);
+
+    jest.advanceTimersByTime(60000);
+    expect(bucket.touch).not.toHaveBeenCalled();
+  });
+
+  it('syncs an entity once its deadline passes', () => {
+    const bucket = makeBucket();
+    const queue = makeQueue(bucket);
+
+    queue.add('note-1', Date.now() + 100);
+    expect(queue.has('note-1')).toBe(true);
+
+    jest.advanceTimersByTime(99);
+    expect(bucket.touch).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(bucket.touch).toHaveBeenCalledTimes(1);
+    expect(bucket.touch).toHaveBeenCalledWith('note-1');
+    expect(queue.has('note-1')).toBe(false);
+  });
+
+  it('keeps the earliest deadline when an entity is re-added', () => {
+    const bucket = makeBucket();
+    const queue = makeQueue(bucket);
+
+    queue.add('note-1', Date.now() + 1000);
+    queue.add('note-1', Date.now() + 5000);
+
+    jest.advanceTimersByTime(1000);
+    expect(bucket.touch).toHaveBeenCalledTimes(1);
+    expect(bucket.touch).toHaveBeenCalledWith('note-1');
+  });
+
+  it('syncs all due entities', () => {
+    const bucket = makeBucket();
+    const queue = makeQueue(bucket);
+
+    queue.add('note-1', Date.now() + 10);
+    queue.add('note-2', Date.now() + 10);
+
+    jest.advanceTimersByTime(50);
+    expect(bucket.touch).toHaveBeenCalledTimes(2);
+    expect(bucket.touch).toHaveBeenCalledWith('note-1');
+    expect(bucket.touch).toHaveBeenCalledWith('note-2');
+  });
+
+  it('waits while the bucket is indexing and syncs afterwards', () => {
+    const bucket = makeBucket();
+    bucket.isIndexing = true;
+    const queue = makeQueue(bucket);
+
+    queue.add('note-1', Date.now());
+
+    jest.advanceTimersByTime(9999);
+    expect(bucket.touch).not.toHaveBeenCalled();
+
+    bucket.isIndexing = false;
+    jest.advanceTimersByTime(1);
+    expect(bucket.touch).toHaveBeenCalledWith('note-1');
+  });
+
+  it('reschedules when indexing finishes', () => {
+    const bucket = makeBucket();
+    bucket.isIndexing = true;
+    const queue = makeQueue(bucket);
+
+    queue.add('note-1', Date.now());
+
+    bucket.isIndexing = false;
+    bucket.emit('index');
+
+    jest.advanceTimersByTime(0);
+    expect(bucket.touch).toHaveBeenCalledWith('note-1');
+  });
+
+  it('does not sync while offline and recovers on the online event', () => {
+    const bucket = makeBucket();
+    const queue = makeQueue(bucket);
+
+    setOnline(false);
+    queue.add('note-1', Date.now());
+
+    jest.advanceTimersByTime(30000);
+    expect(bucket.touch).not.toHaveBeenCalled();
+    expect(queue.has('note-1')).toBe(true);
+
+    setOnline(true);
+    window.dispatchEvent(new Event('online'));
+
+    jest.advanceTimersByTime(0);
+    expect(bucket.touch).toHaveBeenCalledWith('note-1');
+  });
+});

--- a/lib/state/simperium/functions/bucket-queue.ts
+++ b/lib/state/simperium/functions/bucket-queue.ts
@@ -3,7 +3,6 @@ import type { Bucket, EntityId } from 'simperium';
 
 export class BucketQueue<BucketName, EntityType> {
   log: ReturnType<typeof debugFactory>;
-  nextDeadline = Date.now() + 1000;
   bucket: Bucket<BucketName, EntityType>;
   queue: Map<EntityId, number>;
   runTimer: ReturnType<typeof setTimeout> | null = null;
@@ -17,14 +16,11 @@ export class BucketQueue<BucketName, EntityType> {
     // so reschedule to cull the 1s delay normally set when indexing
     bucket.on('index', () => this.schedule());
     window.addEventListener('online', () => this.schedule());
-
-    this.schedule();
   }
 
   add(entityId: EntityId, deadline: number): void {
     const existingDeadline = this.queue.get(entityId) ?? Infinity;
     const nextDeadline = Math.min(deadline, existingDeadline);
-    this.nextDeadline = Math.min(this.nextDeadline, nextDeadline);
 
     this.log(`added "${entityId}" with deadline ${new Date(nextDeadline)}`);
 
@@ -37,17 +33,36 @@ export class BucketQueue<BucketName, EntityType> {
   }
 
   private run(): void {
+    this.runTimer = null;
     this.process();
     this.schedule();
   }
 
+  private nextDeadline(): number | null {
+    let next = Infinity;
+    for (const deadline of this.queue.values()) {
+      next = Math.min(next, deadline);
+    }
+    return next === Infinity ? null : next;
+  }
+
   private schedule(): void {
-    this.runTimer && clearTimeout(this.runTimer);
+    if (this.runTimer) {
+      clearTimeout(this.runTimer);
+      this.runTimer = null;
+    }
+
+    // an empty queue needs no timer; `add()` will reschedule
+    const deadline = this.nextDeadline();
+    if (deadline === null) {
+      return;
+    }
+
     this.runTimer = setTimeout(
       () => this.run(),
       this.bucket.isIndexing || !navigator.onLine
         ? 10000
-        : this.nextDeadline - Date.now()
+        : Math.max(0, deadline - Date.now())
     );
   }
 


### PR DESCRIPTION
Noticed this while profiling for other work.

### Fix

When there is no work on the `BucketQueue` it ends up rescheduling itself constantly, which causes 2.9% of the main thread to spend time on just setting and clearing timeouts. On my machine I get roughly 650 tasks per second due to the BucketQueue's constant rescheduling.

We can optimize this by only running the scheduler when there is work in the bucket and avoid causing any work on the main thread when there is no work to do.

### Test

I added tests that are green for both the new and old implementations, demonstrating that the change doesn't actually change any relevant behavior.

### Release

Other changes:
- Improve performance and energy usage by reducing work executed when idle