### PR TITLE
Harden Azure signing validation

### DIFF
--- a/.buildkite/commands/package_windows.ps1
+++ b/.buildkite/commands/package_windows.ps1
@@ -2,9 +2,8 @@
 $ErrorActionPreference = "Stop"
 
 # Windows code signing defaults to the PFX cert. Setting USE_AZURE_TRUSTED_SIGNING switches the NSIS
-# exe to Azure Trusted Signing (via the win.sign callback wired in by `make package-win32`); the PFX
-# is still provisioned so it stays available as a fallback. See AINFRA-2472 for the auto-update
-# publisher-name handover that gates a full cutover.
+# exe to Azure Trusted Signing (via the win.sign callback wired in by `make package-win32`). See
+# AINFRA-2472 for the auto-update publisher-name handover that gates a full cutover.
 $useAzure = -not [string]::IsNullOrEmpty($env:USE_AZURE_TRUSTED_SIGNING)
 
 If ($useAzure) {
@@ -41,16 +40,6 @@ If (-not (Test-Path $certPath)) {
 # path signs the NSIS exe from the store).
 # See https://buildkite.com/automattic/simplenote-electron/builds/71#01900b28-9508-4bfe-bc80-63464afeaa3e/292-567
 Import-PfxCertificate -FilePath $certPath -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $windowsCertPassword -AsPlainText -Force)
-
-If ($useAzure) {
-    # Azure mode signs the exe via the win.sign callback, which reads these from the process env for
-    # its PFX fallback. In PFX mode we deliberately do NOT export them: the exe signs via
-    # certificateSubjectName + the store import above, and exporting CSC_LINK would make
-    # electron-builder also sign the Store AppX with the PFX, whose publisher does not match the cert
-    # ("SignTool Error: An unexpected internal error has occurred").
-    $env:CSC_KEY_PASSWORD = $windowsCertPassword
-    $env:CSC_LINK = $certPath
-}
 
 Write-Host "--- :windows: Installing make"
 choco install make

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -100,6 +100,8 @@ steps:
     command: .buildkite/commands/package_windows.ps1
     env:
       USE_AZURE_TRUSTED_SIGNING: 1
+      # PFX remains the release path; keep validation artifacts out of releases.
+      PUBLISH: never
     artifact_paths:
       - release\*.exe
       - release\*.appx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS.md
+
+## Bootstrap
+
+Run `npm install --legacy-peer-deps`.
+
+## Checks
+
+Run `npm test` for unit tests.
+Run `npm run lint` for linting.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/scripts/azure-sign.cjs
+++ b/scripts/azure-sign.cjs
@@ -3,17 +3,15 @@
 // PFX is the default Windows signing path (electron-builder's native `certificateSubjectName`).
 // This callback is wired in only when `USE_AZURE_TRUSTED_SIGNING` is set, via
 // `-c.win.sign=./scripts/azure-sign.cjs` in the `package-win32` Make target — so reaching it
-// means Azure is the intended path. It prefers Azure and falls back to the PFX cert (signtool
-// `/f`) if the Azure env is somehow absent, throwing in CI when neither is available.
+// means Azure is the intended path. In CI, missing Azure env is a failure so validation cannot pass
+// with a PFX signature by mistake.
 //
 // electron-builder calls this once per file per signing-hash algorithm, after `rcedit` rewrites
 // the PE resource directory (so signatures are not orphaned). Azure Trusted Signing is
 // SHA256-only, so the SHA1 iteration is skipped here rather than signed twice.
 //
-// Azure env vars come from a8c-ci-toolkit's `setup_azure_trusted_signing.ps1`; the PFX inputs
-// (`CSC_LINK`, `CSC_KEY_PASSWORD`) from `setup_windows_code_signing.ps1`.
+// Azure env vars come from a8c-ci-toolkit's `setup_azure_trusted_signing.ps1`.
 
-const fs = require('node:fs');
 const childProcess = require('node:child_process');
 
 const AZURE_ENV_VARS = [
@@ -30,15 +28,7 @@ function nonBlank(value) {
 }
 
 function hasAzureEnv(env) {
-  return AZURE_ENV_VARS.every((name) => nonBlank(env[name]) !== undefined);
-}
-
-function pfxInputs(env) {
-  const file = nonBlank(env.CSC_LINK);
-  return {
-    file: file && fs.existsSync(file) ? file : undefined,
-    password: nonBlank(env.CSC_KEY_PASSWORD),
-  };
+  return missingAzureEnv(env).length === 0;
 }
 
 function buildAzureArgs(file, env) {
@@ -61,22 +51,8 @@ function buildAzureArgs(file, env) {
   ];
 }
 
-function buildPfxArgs(file, env, pfx) {
-  return [
-    'sign',
-    '/v',
-    '/fd',
-    'SHA256',
-    '/f',
-    pfx.file,
-    '/p',
-    pfx.password,
-    '/tr',
-    nonBlank(env.AZURE_TIMESTAMP_SERVER) || DEFAULT_TIMESTAMP_SERVER,
-    '/td',
-    'SHA256',
-    file,
-  ];
+function missingAzureEnv(env) {
+  return AZURE_ENV_VARS.filter((name) => nonBlank(env[name]) === undefined);
 }
 
 function runSigntool(signtool, args, file, method) {
@@ -108,7 +84,8 @@ module.exports = async function sign(configuration) {
     return;
   }
 
-  if (hasAzureEnv(env)) {
+  const missingAzureVars = missingAzureEnv(env);
+  if (missingAzureVars.length === 0) {
     runSigntool(
       nonBlank(env.SIGNTOOL_PATH),
       buildAzureArgs(file, env),
@@ -118,23 +95,10 @@ module.exports = async function sign(configuration) {
     return;
   }
 
-  const pfx = pfxInputs(env);
   if (env.CI && process.platform === 'win32') {
-    if (pfx.file && pfx.password) {
-      const signtool = nonBlank(env.SIGNTOOL_PATH) || 'signtool';
-      runSigntool(
-        signtool,
-        buildPfxArgs(file, env, pfx),
-        file,
-        'PFX certificate'
-      );
-      return;
-    }
     throw new Error(
-      `[azure-sign] No Windows signing credentials in CI for ${file}. ` +
-        `Azure not configured (${AZURE_ENV_VARS.join(', ')}); ` +
-        `PFX fallback unavailable (CSC_LINK ${pfx.file ? 'present' : 'missing'}, ` +
-        `CSC_KEY_PASSWORD ${pfx.password ? 'set' : 'missing'}).`
+      `[azure-sign] Azure Trusted Signing requested in CI for ${file}, ` +
+        `but setup did not provide: ${missingAzureVars.join(', ')}.`
     );
   }
 
@@ -145,7 +109,6 @@ module.exports = async function sign(configuration) {
 };
 
 module.exports.hasAzureEnv = hasAzureEnv;
-module.exports.pfxInputs = pfxInputs;
+module.exports.missingAzureEnv = missingAzureEnv;
 module.exports.buildAzureArgs = buildAzureArgs;
-module.exports.buildPfxArgs = buildPfxArgs;
 module.exports.AZURE_ENV_VARS = AZURE_ENV_VARS;

--- a/scripts/azure-sign.test.js
+++ b/scripts/azure-sign.test.js
@@ -1,4 +1,3 @@
-const fs = require('node:fs');
 const childProcess = require('node:child_process');
 const signer = require('./azure-sign.cjs');
 
@@ -6,11 +5,6 @@ const AZURE_ENV = {
   SIGNTOOL_PATH: 'C:\\sdk\\signtool.exe',
   AZURE_CODE_SIGNING_DLIB: 'C:\\azure\\Azure.CodeSigning.Dlib.dll',
   AZURE_METADATA_JSON: 'C:\\azure\\metadata.json',
-};
-
-const PFX_ENV = {
-  CSC_LINK: 'C:\\repo\\certificate.pfx',
-  CSC_KEY_PASSWORD: 's3cret',
 };
 
 describe('hasAzureEnv', () => {
@@ -29,16 +23,15 @@ describe('hasAzureEnv', () => {
   });
 });
 
-describe('pfxInputs', () => {
-  it('reports the file present only when CSC_LINK exists on disk', () => {
-    const spy = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
-    expect(signer.pfxInputs(PFX_ENV)).toEqual({
-      file: PFX_ENV.CSC_LINK,
-      password: 's3cret',
-    });
-    spy.mockReturnValue(false);
-    expect(signer.pfxInputs(PFX_ENV).file).toBeUndefined();
-    spy.mockRestore();
+describe('missingAzureEnv', () => {
+  it('lists the missing or blank Azure vars', () => {
+    expect(
+      signer.missingAzureEnv({
+        ...AZURE_ENV,
+        SIGNTOOL_PATH: '',
+        AZURE_METADATA_JSON: '   ',
+      })
+    ).toEqual(['SIGNTOOL_PATH', 'AZURE_METADATA_JSON']);
   });
 });
 
@@ -69,28 +62,6 @@ describe('buildAzureArgs', () => {
       AZURE_TIMESTAMP_SERVER: 'http://ts.example',
     });
     expect(args[args.indexOf('/tr') + 1]).toBe('http://ts.example');
-  });
-});
-
-describe('buildPfxArgs', () => {
-  it('signs SHA256-only via /f + /p', () => {
-    const pfx = { file: PFX_ENV.CSC_LINK, password: 's3cret' };
-    const args = signer.buildPfxArgs('app.exe', PFX_ENV, pfx);
-    expect(args).toEqual([
-      'sign',
-      '/v',
-      '/fd',
-      'SHA256',
-      '/f',
-      PFX_ENV.CSC_LINK,
-      '/p',
-      's3cret',
-      '/tr',
-      'http://timestamp.acs.microsoft.com',
-      '/td',
-      'SHA256',
-      'app.exe',
-    ]);
   });
 });
 
@@ -153,23 +124,16 @@ describe('sign callback dispatch', () => {
     );
   });
 
-  it('falls back to PFX in CI on Windows when Azure is absent', async () => {
+  it('fails in CI on Windows when Azure env is incomplete', async () => {
     setPlatform('win32');
-    process.env = { CI: 'true', ...PFX_ENV };
-    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
-    await signer({ path: 'app.exe' });
-    expect(spawn).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.arrayContaining(['/f', PFX_ENV.CSC_LINK]),
-      expect.anything()
-    );
-  });
-
-  it('throws naming missing inputs in CI on Windows with no credentials', async () => {
-    setPlatform('win32');
-    process.env = { CI: 'true' };
+    process.env = {
+      CI: 'true',
+      USE_AZURE_TRUSTED_SIGNING: '1',
+      CSC_LINK: 'C:\\repo\\certificate.pfx',
+      CSC_KEY_PASSWORD: 's3cret',
+    };
     await expect(signer({ path: 'app.exe' })).rejects.toThrow(
-      /CSC_LINK missing.*CSC_KEY_PASSWORD missing/s
+      /SIGNTOOL_PATH.*AZURE_CODE_SIGNING_DLIB.*AZURE_METADATA_JSON/s
     );
     expect(spawn).not.toHaveBeenCalled();
   });


### PR DESCRIPTION

Follow-up to #3380.

- The Azure Trusted Signing validation step now avoids publishing tag artifacts while PFX remains the release path.
- Adds a minimal `AGENTS.md`

<details>
<summary>Additional AI-generated details.</summary>


CI Azure signing also fails closed when setup misses required env, instead of falling back to PFX.

This also adds minimal repo agent instructions for future agent runs.

### Test

1. `npm run lint`
2. `npx jest --config=./jest.config.js --watchman=false`
3. `make -n package-win32 SKIP_BUILD=true USE_AZURE_TRUSTED_SIGNING=1 BUILDKITE_TAG=v0.0.0 PUBLISH=never`

### Release

These changes do not require release notes.

*Posted by Codex (GPT-5) on behalf of @mokagio with approval.*


</details>