### PR TITLE
Only apply markdown decorations when the note has markdown enabled

### DIFF
--- a/lib/markdown-decorations.test.ts
+++ b/lib/markdown-decorations.test.ts
@@ -36,6 +36,15 @@ describe('getMarkdownDecorations', () => {
     ]);
   });
 
+  it('returns no decorations when markdown is disabled', () => {
+    const decorations = getMarkdownDecorations(
+      modelFromLines(['# Title', '**bold**']),
+      false
+    );
+
+    expect(decorations).toEqual([]);
+  });
+
   it('decorates supported unordered list markers', () => {
     const decorations = getMarkdownDecorations(
       modelFromLines(['* list item', '- second item', '  + nested item'])

--- a/lib/markdown-decorations.ts
+++ b/lib/markdown-decorations.ts
@@ -118,9 +118,10 @@ const addInlineSpansForPattern = (
 };
 
 export const getMarkdownDecorations = (
-  model?: Editor.ITextModel | null
+  model?: Editor.ITextModel | null,
+  markdownEnabled = true
 ): Editor.IModelDeltaDecoration[] => {
-  if (!model) {
+  if (!model || !markdownEnabled) {
     return [];
   }
 

--- a/lib/note-content-editor.tsx
+++ b/lib/note-content-editor.tsx
@@ -477,9 +477,12 @@ class NoteContentEditor extends Component<Props> {
       this.editor?.createDecorationsCollection([titleDecoration]);
 
     if (!this.isComposing) {
+      // Clear unconditionally so decorations are removed when markdown is
+      // toggled off, and only recompute when the note has markdown enabled.
       this.markdownDecorations?.clear();
       const markdownDecorations = getMarkdownDecorations(
-        this.editor?.getModel()
+        this.editor?.getModel(),
+        this.props.note.systemTags.includes('markdown')
       );
       if (markdownDecorations.length > 0) {
         this.markdownDecorations =


### PR DESCRIPTION
Fixes #3379.

Markdown decorations (headings, bold, italic, list markers, and so on) were applied in the editor even when the note had Markdown disabled. Every other Markdown behavior in `note-content-editor.tsx` gates on the note's `markdown` system tag, but the decoration path in `setDecorators` did not, so a plain note with a line like `# comment` or `*.conf` still got heading/emphasis styling. This is the v2.26.0 regression reported in #3379.

## Changes proposed

- `markdown-decorations.ts`: `getMarkdownDecorations` now takes a `markdownEnabled` flag (defaults to `true`) and returns `[]` when it is false.
- `note-content-editor.tsx`: pass `note.systemTags.includes('markdown')`. The existing `clear()` stays unconditional, so decorations are removed when Markdown is toggled off on an open note.
- `markdown-decorations.test.ts`: add a case asserting no decorations are returned when markdown is disabled.

## Testing instructions

`npx jest lib/markdown-decorations.test.ts`

Or manually: open a note with Markdown disabled and a body containing `# heading` or `**bold**`, confirm the text stays plain, then toggle Markdown on and confirm the styling appears.
