### PR TITLE
Remove leftover CSC_FOR_PULL_REQUEST

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,7 +45,6 @@ steps:
       queue: mac
     env:
       IMAGE_ID: $IMAGE_ID
-      CSC_FOR_PULL_REQUEST: true
     plugins:
       - $CI_TOOLKIT_PLUGIN
       - $NVM_PLUGIN
@@ -97,8 +96,6 @@ steps:
       make build
       echo "--- Package"
       make package-linux SKIP_BUILD=true
-    env:
-      CSC_FOR_PULL_REQUEST: true
     artifact_paths:
       - release/*.deb
       - release/*.tar.gz


### PR DESCRIPTION
See https://linear.app/a8c/issue/AINFRA-2720.

For more details, refer for https://github.com/Automattic/wp-calypso/pull/112772

Notice that the Windows CI is failing on the PFX build, but that build is now obsolete. #3407 removes it.

<img width="1858" height="316" alt="image" src="https://github.com/user-attachments/assets/d3491664-0687-4780-b5ea-6ea9467d8221" />
