### PR TITLE
feat(cli): add standalone CLI module — full command set, SEA single-f…

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,6 +26,13 @@ steps:
       .buildkite/commands/install_node_dependencies.sh
       echo "--- :jest: Test"
       npm test
+      echo "--- :jest: CLI contract tests"
+      npx jest lib/cli/__tests__/contract --silent
+      echo "--- :jest: CLI coverage gate"
+      npx jest --config lib/cli/jest.config.cjs --coverage --silent
+      echo "--- :esbuild: CLI production build"
+      node lib/cli/scripts/build.mjs
+      node lib/cli/dist/cli.js --version
 
   # Notice that we build the app in each platform because it takes ~1-2 minutes
   # to do so which is comparable to a dedicated build step, archiving the

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ vendor/
 .DS_Store
 dev-app-update.yml
 lib/state/data/test_account.json
+.simplenote-cli/
 # Ignore all files in the .configure-files folder apart from the encoded ones
 !.configure-files/*.enc

--- a/bin/simplenote-cli
+++ b/bin/simplenote-cli
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+'use strict';
+
+require('../lib/cli/bootstrap.ts');

--- a/bin/simplenote-cli.js
+++ b/bin/simplenote-cli.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+'use strict';
+
+require('../lib/cli/bootstrap.ts');

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ['dist/', 'eslint.config.mjs'],
+    ignores: ['**/dist/', 'eslint.config.mjs'],
   },
   ...compat.extends(
     'eslint:recommended',

--- a/lib/cli/.gitignore
+++ b/lib/cli/.gitignore
@@ -1,0 +1,8 @@
+coverage/
+dist/
+node_modules/
+# 模块 vendored 源码（桌面端副本隔离层）必须入库：根 .gitignore 的 `vendor/`
+# 规则在任意层级生效，会一并排除 lib/cli/vendor/，导致全新 checkout 后
+# tsc/esbuild/jest 全部解析失败。以下取反规则仅针对本目录，不触碰根文件。
+!vendor/
+!vendor/**

--- a/lib/cli/README.md
+++ b/lib/cli/README.md
@@ -1,0 +1,108 @@
+# Simplenote CLI
+
+Simplenote 的命令行客户端（独立版本线 `0.1.0`），通过 Simperium REST API 读写笔记。本模块与桌面应用的版本相互独立，`--version` 报告的是 CLI 自身版本。
+
+## 安装与运行
+
+```bash
+# 推荐：--silent 避免 npm 的 banner 污染 stdout 上的 --json 输出
+npm run --silent cli -- <command> [args]
+
+# 或构建后直接运行（跳过 npm 包装与 tsx 桥）
+cd lib/cli && npm run build && node dist/cli.js <command> [args]
+```
+
+`npm run cli` 走仓库根 `bin/simplenote-cli.js`（tsx 桥，需要根 devDependencies 并读取仓库根 config.json）；构建后的 `dist/cli.js` 是 esbuild 打成的单文件 CommonJS，只依赖本模块声明的 dependencies，可脱离仓库运行。
+
+## 分发与安装
+
+| 方式 | 命令 | 产物 / 使用 |
+| --- | --- | --- |
+| npm 包 | `npm pack`（prepack 自动执行 `npm run build`） | `simplenote-cli-0.1.0.tgz`；消费方 `npm i <tarball>` 后 `npx simplenote-cli` |
+| 单文件可执行（SEA） | `cd lib/cli && npm run build:sea` | `dist/simplenote-cli(.exe)`；单文件拷贝即用，不依赖 Node 运行时或同目录 manifest |
+| 安装到 PATH | `node lib/cli/scripts/install.mjs` | 复制 exe 与版本 manifest 到 `~/.local/bin/`；卸载：`node lib/cli/scripts/install.mjs --uninstall`（幂等） |
+
+`dist/` 与 `coverage/` 已由 `lib/cli/.gitignore` 排除，构建产物不入库。
+
+网络与密钥注入：
+
+- CN 网络下偶发的 IPv6 解析黑洞：源码运行请用 `node --dns-result-order=ipv4first ...`（仓库根 `npm run cli` 已内置该参数）；SEA 打包产物暂未内置该参数，待后续版本补齐。
+- 生产 app_key 经 `SIMPLENOTE_APP_KEY` 环境注入（见「环境变量」），无需改写仓库根 `config.json`（其内是开发 app key，直接用于密码登录会 401）。
+
+## 命令一览
+
+| 命令 | 说明 |
+| --- | --- |
+| `login` | 登录（密码经 `SIMPLENOTE_PASSWORD`，或 magic-link 验证码交互） |
+| `logout` | 删除本地凭据 |
+| `whoami [--json]` | 打印当前登录用户名 |
+| `list [--limit=N] [--json]` | 列出笔记摘要，按最近修改排序 |
+| `show <id> [--json]` | 显示单条笔记内容 |
+| `search "<query>" [--limit=N] [--json]` | 搜索笔记内容（支持 `tag:` 过滤器） |
+| `edit <id> "<content>" [--json]` | 替换笔记内容（也支持 `--content=` 或 `--file=`） |
+| `create "<content>" [--tags=a,b] [--json]` | 创建笔记（也支持 `--content=` 或 `--file=`） |
+| `add --file=notes.json [--json]` | 从 JSON 数组文件批量创建笔记（幂等） |
+| `export [--format=all\|json\|markdown\|zip] [--output=DIR]` | 导出笔记 |
+
+通用标志（所有命令可用，位置任意）：
+
+- `-v, --version`：打印 CLI 版本后退出
+- `-h, --help`：全局帮助；`cli <command> --help` 查看单命令细节
+- `--verbose`：向 stderr 输出请求级诊断（或设置 `SIMPLENOTE_CLI_DEBUG=1`）
+
+`list`/`search` 默认跳过回收站；加 `--include-trashed` 保留。`--` 终止标志解析，例如 `create -- "--not-a-flag"` 会创建内容为 `--not-a-flag` 的笔记。
+
+`list`/`search` 需要拉取账户的**全量索引**（Simperium index 按 storage order 返回，无法在服务端排序或截断），成本与账户笔记总量成正比，`--limit` 只控制输出条数。大账户请优先使用 `search` 或 `export`。
+
+## 退出码
+
+| 码 | 含义 |
+| --- | --- |
+| 0 | 成功 |
+| 1 | 用法错误 |
+| 2 | 认证失败（登录被限流 HTTP 429 时按 3 而非 2 退出） |
+| 3 | 网络错误 |
+| 4 | 笔记不存在 |
+| 5 | 冲突 |
+| 6 | 中断（Ctrl-C） |
+| 7 | 部分完成（批量命令遇错） |
+| 99 | 未预期错误 |
+
+退出码是脚本可依赖的公开契约，不随错误消息文案变化。认证失败（2）优先于参数值错误（1）：同一参数错误在未登录时按 2 退出、已登录时按 1 退出（未知旗标在凭证加载前校验，恒按 1 退出）；脚本分支请以 2 优先判断。
+
+## 环境变量
+
+| 变量 | 说明 |
+| --- | --- |
+| `SIMPLENOTE_USER` | `login` 的用户名 |
+| `SIMPLENOTE_PASSWORD` | `login` 的密码（设置后走密码登录，否则走 magic-link） |
+| `SIMPLENOTE_APP_KEY` | 覆盖密码登录所用的 app_key（优先级高于 config.json） |
+| `SIMPLENOTE_CLI_TIMEOUT_MS` | 单请求超时（默认 15000；分页拉取的剩余预算下限 1000ms） |
+| `SIMPLENOTE_CLI_TOTAL_TIMEOUT_MS` | 整个分页拉取的预算（默认 120000） |
+| `SIMPLENOTE_CLI_DEBUG` | 设为 `1` 等效于 `--verbose` |
+| `SIMPLENOTE_APP_ID` | 覆盖 Simperium app id（高级选项，默认生产 app id） |
+| `SIMPLENOTE_ACCOUNT_BASE` | 覆盖账户服务基址（高级选项，默认 app.simplenote.com） |
+
+## 输出通道契约
+
+- `--json` 的机器输出一律走 **stdout**；诊断、进度、警告一律走 **stderr**。
+- `--help` / `<command> --help` 输出走 **stderr**（保证 stdout 留给管道数据；`--version` 走 stdout）。
+- 非 JSON 模式下 `create` 将新笔记 id 输出到 **stdout**（脚本消费 id 时同样用 `npm run --silent`）；其余命令非 JSON 模式 stdout 无输出（`edit` 仅 stderr 提示）。
+- 管道消费 `--json` 时请用 `npm run --silent cli -- list --json` 或直接调用 `node dist/cli.js`（构建后），否则 npm 自己的 banner 会混入 stdout 破坏载荷。
+
+## 安全
+
+- 登录凭据以**明文**存储在 `~/.simplenote-cli/credentials.json`。
+- POSIX 上写入强制 `0600`，通过「私有临时文件 + 原子 rename」落盘，写失败会清理临时文件，避免泄漏包含有效 token 的残留文件。
+- `loadCredentials()` 每次读取会做权限自检：若文件被 group/other 可读（如 `0644`），向 stderr 告警并提示 `chmod 600` 修复。该自检是缓解而非根治——不要在共享机器上把该文件权限放宽。
+- **Windows 局限**：chmod 是 no-op，访问控制由 ACL 决定，权限自检在 Windows 上跳过。请通过 NTFS ACL 限制该文件的访问。
+- 生产 app_key 建议经 `SIMPLENOTE_APP_KEY` 环境注入：仓库根 `config.json` 默认携带的是开发 key，直接用于密码登录会因 app 失配而 401。
+- 密码登录持续失败时改用 magic-link 登录（取消 `SIMPLENOTE_PASSWORD`，交互输入验证码）。
+
+## 开发与测试
+
+- 单元测试：`cd lib/cli && npm test`（或 `npx jest lib/cli`，走仓库根配置，无覆盖率门禁）
+- 覆盖率门禁：`cd lib/cli && npm run coverage`（等价 `npx jest --config lib/cli/jest.config.cjs --coverage`，阈值 80/75/80/80）
+- 契约测试：`npx jest lib/cli/__tests__/contract`（本地回环服务器，离线可跑）
+- 代码规范：`npx eslint lib/cli`（0 error；`no-console` warning 为既有基线）
+- 凭据测试注意：权限告警用例通过 mock `process.platform` 与 `fs.stat` 覆盖，Windows 宿主上真实 chmod 为 no-op，不影响断言。

--- a/lib/cli/__tests__/add.test.ts
+++ b/lib/cli/__tests__/add.test.ts
@@ -1,0 +1,838 @@
+jest.mock('../note-source.ts', () => ({
+  createNoteSource: jest.fn(),
+}));
+
+jest.mock('fs/promises', () => ({
+  readFile: jest.fn(),
+}));
+
+import * as fs from 'fs/promises';
+import { createNoteSource } from '../note-source.ts';
+import { addCommand, parseAddOptions } from '../commands/add.ts';
+import {
+  IMPORT_CONCURRENCY,
+  MAX_CONSECUTIVE_FAILURES,
+} from '../cli-constants.ts';
+import {
+  AbortedError,
+  AuthError,
+  CliError,
+  NetworkError,
+  PartialError,
+  RateLimitError,
+  UsageError,
+} from '../domain/errors.ts';
+import type { Credentials } from '../domain/types.ts';
+
+const mockCreate = jest.fn();
+const mockFind = jest.fn();
+const mockSource = {
+  create: mockCreate,
+  find: mockFind,
+};
+
+const credentials: Credentials = {
+  access_token: 'tok',
+  username: 'user@example.com',
+};
+
+describe('parseAddOptions', () => {
+  it('requires --file', () => {
+    expect(() => parseAddOptions([])).toThrow('add requires --file');
+  });
+
+  it('parses --file and --json', () => {
+    expect(parseAddOptions(['--file=notes.json', '--json'])).toEqual({
+      file: 'notes.json',
+      json: true,
+    });
+  });
+
+  it('rejects duplicate --file', () => {
+    expect(() => parseAddOptions(['--file=a', '--file=b'])).toThrow(
+      'Provide --file= once'
+    );
+  });
+
+  it('rejects an empty --file= value instead of reading ""', () => {
+    expect(() => parseAddOptions(['--file='])).toThrow(
+      '--file cannot be empty'
+    );
+  });
+
+  it('rejects a bare --file with a precise message', () => {
+    // `--file` without `=` is a forgotten value, not a missing argument.
+    expect(() => parseAddOptions(['--file'])).toThrow(
+      '--file requires a value, e.g. --file=notes.json'
+    );
+  });
+});
+
+describe('addCommand', () => {
+  beforeEach(() => {
+    (createNoteSource as jest.Mock).mockReturnValue(mockSource);
+    mockFind.mockResolvedValue([]);
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    mockCreate.mockReset();
+    mockFind.mockReset();
+  });
+
+  it('creates each note from the file and prints all ids', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one', tags: ['a'] }, { content: 'two' }])
+    );
+    mockCreate
+      .mockResolvedValueOnce({ id: 'n1', version: 1 })
+      .mockResolvedValueOnce({ id: 'n2', version: 1 });
+
+    await addCommand(credentials, ['--file=notes.json']);
+
+    expect(fs.readFile).toHaveBeenCalledWith('notes.json', 'utf8');
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+    expect(mockCreate).toHaveBeenNthCalledWith(1, {
+      content: 'one',
+      tags: ['a'],
+    });
+    expect(mockCreate).toHaveBeenNthCalledWith(2, { content: 'two' });
+    expect(logSpy.mock.calls.map((call) => call[0])).toEqual(['n1', 'n2']);
+  });
+
+  it('throws PartialError (exit 7) when some notes fail', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one' }, { content: 'two' }])
+    );
+    mockCreate
+      .mockResolvedValueOnce({ id: 'n1', version: 1 })
+      .mockRejectedValueOnce(new Error('boom'));
+
+    let thrown: unknown;
+    try {
+      await addCommand(credentials, ['--file=notes.json']);
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(PartialError);
+    expect((thrown as PartialError).code).toBe(7);
+    expect(errorSpy).toHaveBeenCalledWith('Created 1, failed 1');
+    expect(errorSpy).toHaveBeenCalledWith('  [1] boom');
+  });
+
+  it('skips notes that already exist (idempotent)', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one', tags: ['a'] }, { content: 'two' }])
+    );
+    mockFind.mockResolvedValue([
+      { id: 'existing', data: { content: 'one', tags: ['a'] } } as any,
+    ]);
+    mockCreate.mockResolvedValue({ id: 'n2', version: 1 });
+
+    await addCommand(credentials, ['--file=notes.json']);
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledWith({ content: 'two' });
+  });
+
+  // Server-side tags may carry stray whitespace (e.g. created by the desktop
+  // app) while import-file tags are trimmed before fingerprinting; the
+  // fingerprint must trim both sides or "work" vs "work " silently re-imports
+  // an existing note as a duplicate.
+  it('treats server tags with surrounding whitespace as equal for dedup', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one', tags: ['work'] }])
+    );
+    mockFind.mockResolvedValue([
+      {
+        id: 'existing',
+        data: { content: 'one', tags: [' work '] },
+      } as any,
+    ]);
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    await addCommand(credentials, ['--file=notes.json']);
+
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // M-03: search matches tags case-insensitively, so the dedup fingerprint
+  // folds casing too — otherwise an import after a case-only tag difference
+  // would duplicate the note.
+  it('treats server tags with different casing as equal for dedup', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one', tags: ['work'] }])
+    );
+    mockFind.mockResolvedValue([
+      { id: 'existing', data: { content: 'one', tags: ['WORK'] } } as any,
+    ]);
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    await addCommand(credentials, ['--file=notes.json']);
+
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // M-03: an export round-trip normalizes line breaks to CRLF; a re-import
+  // with LF must still collide on the fingerprint or it duplicates every note.
+  it('treats CRLF and LF line breaks as equal for dedup', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one\r\ntwo\r\nthree' }])
+    );
+    mockFind.mockResolvedValue([
+      { id: 'existing', data: { content: 'one\ntwo\nthree' } } as any,
+    ]);
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    await addCommand(credentials, ['--file=notes.json']);
+
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('re-imports a note that was moved to the trash', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one' }])
+    );
+    mockFind.mockResolvedValue([
+      { id: 'trashed', data: { content: 'one', deleted: true } } as any,
+    ]);
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    await addCommand(credentials, ['--file=notes.json']);
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('de-duplicates repeated entries inside one import file', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'same' }, { content: 'same' }])
+    );
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    await addCommand(credentials, ['--file=notes.json']);
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a missing notes file as a usage error (exit 1)', async () => {
+    (fs.readFile as jest.Mock).mockRejectedValue(
+      new Error('ENOENT: no such file or directory')
+    );
+
+    let thrown: unknown;
+    try {
+      await addCommand(credentials, ['--file=missing.json']);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UsageError);
+    expect((thrown as UsageError).code).toBe(1);
+  });
+
+  // "Partial" (7) is a lie when nothing at all was created: a script that
+  // branches on 7 reports a half-done import that in fact never started.
+  it('reports the underlying failure code when no note was created', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one' }])
+    );
+    mockCreate.mockRejectedValue(new NetworkError('boom'));
+
+    let thrown: unknown;
+    try {
+      await addCommand(credentials, ['--file=notes.json']);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(CliError);
+    expect((thrown as CliError).code).toBe(3);
+    expect((thrown as CliError).message).toContain('1 of 1 notes failed');
+  });
+
+  // A bad token makes every remaining create futile. Continuing produced one
+  // error line per note and still exited 7 instead of "log in again" (2).
+  it('stops at the first auth failure instead of trying every note', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify(
+        Array.from({ length: 10 }, (_, i) => ({ content: `n${i}` }))
+      )
+    );
+    mockCreate.mockRejectedValue(new AuthError('Unauthorized'));
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    let thrown: unknown;
+    try {
+      await addCommand(credentials, ['--file=notes.json']);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(AuthError);
+    expect((thrown as AuthError).code).toBe(2);
+    // The pool launches one wave before the first auth failure is observed;
+    // nothing beyond that wave is attempted.
+    expect(mockCreate).toHaveBeenCalledTimes(IMPORT_CONCURRENCY);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('note(s) not attempted')
+    );
+  });
+
+  it('throws on invalid JSON', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue('not json');
+
+    await expect(
+      addCommand(credentials, ['--file=notes.json'])
+    ).rejects.toThrow('Invalid JSON');
+  });
+
+  it('throws on an empty array', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue('[]');
+
+    await expect(
+      addCommand(credentials, ['--file=notes.json'])
+    ).rejects.toThrow('non-empty JSON array');
+  });
+
+  it('throws on an entry with blank content', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: '  ' }])
+    );
+
+    await expect(
+      addCommand(credentials, ['--file=notes.json'])
+    ).rejects.toThrow('entry 0 has no non-blank content');
+  });
+
+  it('throws when an entry is a primitive, not an object', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(JSON.stringify([42]));
+
+    await expect(
+      addCommand(credentials, ['--file=notes.json'])
+    ).rejects.toThrow('entry 0 is not an object');
+  });
+
+  it('throws when an entry is itself an array', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(JSON.stringify([['nested']]));
+
+    await expect(
+      addCommand(credentials, ['--file=notes.json'])
+    ).rejects.toThrow('entry 0 is not an object');
+  });
+
+  it('throws when tags is not an array', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one', tags: 'work' }])
+    );
+
+    await expect(
+      addCommand(credentials, ['--file=notes.json'])
+    ).rejects.toThrow('entry 0 has invalid tags');
+  });
+
+  it('throws when a tag is not a string', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one', tags: ['a', 5] }])
+    );
+
+    await expect(
+      addCommand(credentials, ['--file=notes.json'])
+    ).rejects.toThrow('entry 0 has invalid tags');
+  });
+
+  // Shares normalizeTags with parseTags: surrounding whitespace is trimmed and
+  // empty tags are dropped so the dedup fingerprint agrees with `create --tags=`.
+  it('trims and drops blank tags before importing', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one', tags: [' a ', '', 'b'] }])
+    );
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    await addCommand(credentials, ['--file=notes.json']);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      content: 'one',
+      tags: ['a', 'b'],
+    });
+    expect(logSpy).toHaveBeenCalledWith('n1');
+  });
+
+  it('preserves a valid tags array', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one', tags: ['a', 'b'] }])
+    );
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    await addCommand(credentials, ['--file=notes.json']);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      content: 'one',
+      tags: ['a', 'b'],
+    });
+  });
+
+  it('rejects a tag containing whitespace or a comma', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one', tags: ['a\nb'] }])
+    );
+
+    await expect(
+      addCommand(credentials, ['--file=notes.json'])
+    ).rejects.toThrow('whitespace or a comma');
+  });
+
+  it('rejects a tag with an internal space before importing', async () => {
+    // `a b` matches the desktop separator semantics: a value that can never
+    // be found again by `tag:` must not be creatable via an import file.
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one', tags: ['a b'] }])
+    );
+
+    await expect(
+      addCommand(credentials, ['--file=notes.json'])
+    ).rejects.toThrow('whitespace or a comma');
+  });
+
+  it('deduplicates repeated tags before importing', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one', tags: ['a', 'a', 'b'] }])
+    );
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    await addCommand(credentials, ['--file=notes.json']);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      content: 'one',
+      tags: ['a', 'b'],
+    });
+    expect(logSpy).toHaveBeenCalledWith('n1');
+  });
+
+  // A backend that is down fails every note. Without the early stop the CLI
+  // ground through all 10 entries one-by-one, each waiting on its own timeout,
+  // before reporting a partial failure. The streak cap gives up once the
+  // outcome is no longer in doubt: one pool wave plus whatever raced in before
+  // the cap was observed — never the whole file.
+  it('stops early after MAX_CONSECUTIVE_FAILURES consecutive failures', async () => {
+    const entries = Array.from({ length: 10 }, (_, i) => ({
+      content: `n${i}`,
+    }));
+    (fs.readFile as jest.Mock).mockResolvedValue(JSON.stringify(entries));
+    mockCreate.mockRejectedValue(new NetworkError('boom'));
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    let thrown: unknown;
+    try {
+      await addCommand(credentials, ['--file=notes.json']);
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(PartialError);
+    // The first wave all fails in the same tick, so exactly one pool of
+    // requests lands before every worker observes the stop; the rest are
+    // skipped once the backend is clearly unavailable.
+    expect(mockCreate).toHaveBeenCalledTimes(IMPORT_CONCURRENCY);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Stopped early after ${MAX_CONSECUTIVE_FAILURES} consecutive failures`
+      )
+    );
+  });
+
+  // A success in the middle of a failing streak proves the backend is
+  // intermittent rather than categorically down, so the streak resets and the
+  // import continues instead of bailing on a transient blip.
+  it('resets the failure streak after a success', async () => {
+    const entries = Array.from({ length: 9 }, (_, i) => ({
+      content: `n${i}`,
+    }));
+    (fs.readFile as jest.Mock).mockResolvedValue(JSON.stringify(entries));
+    mockCreate
+      .mockRejectedValueOnce(new NetworkError('boom'))
+      .mockRejectedValueOnce(new NetworkError('boom'))
+      .mockRejectedValueOnce(new NetworkError('boom'))
+      .mockRejectedValueOnce(new NetworkError('boom'))
+      .mockResolvedValueOnce({ id: 'ok', version: 1 })
+      .mockRejectedValueOnce(new NetworkError('boom'))
+      .mockRejectedValueOnce(new NetworkError('boom'))
+      .mockRejectedValueOnce(new NetworkError('boom'))
+      .mockRejectedValueOnce(new NetworkError('boom'));
+
+    let thrown: unknown;
+    try {
+      await addCommand(credentials, ['--file=notes.json']);
+    } catch (e) {
+      thrown = e;
+    }
+
+    // Without the reset, four failures + four failures would hit the cap;
+    // the success in between resets the streak, so every entry is attempted.
+    expect(mockCreate).toHaveBeenCalledTimes(9);
+    expect(thrown).toBeInstanceOf(PartialError);
+  });
+
+  // A Ctrl-C used to be indistinguishable from a flaky server: AbortedError
+  // is not an AuthError, so the loop kept going and burned through
+  // MAX_CONSECUTIVE_FAILURES more (instantly rejected) creates before giving
+  // up, then blamed the backend in the summary.
+  it('stops at the first cancellation instead of burning the failure budget', async () => {
+    const entries = Array.from({ length: 20 }, (_, i) => ({
+      content: `n${i}`,
+    }));
+    (fs.readFile as jest.Mock).mockResolvedValue(JSON.stringify(entries));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockCreate
+      .mockResolvedValueOnce({ id: 'n0', version: 1 })
+      .mockRejectedValue(new AbortedError('Request aborted'));
+
+    let thrown: unknown;
+    try {
+      await addCommand(credentials, ['--file=notes.json']);
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(AbortedError);
+    expect((thrown as AbortedError).code).toBe(6);
+    // One success then one pool wave of cancelled attempts — not the budget.
+    expect(mockCreate).toHaveBeenCalledTimes(IMPORT_CONCURRENCY);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Interrupted; 19 note(s) not attempted')
+    );
+  });
+
+  // E-4: a 429 is the server asking us to slow down — on a write path with no
+  // retries every further entry is refused too, so the batch stops at the
+  // first one and the summary names the real cause instead of "backend
+  // unavailable" or a generic partial failure.
+  it('stops at the first rate limit instead of burning the failure budget', async () => {
+    const entries = Array.from({ length: 20 }, (_, i) => ({
+      content: `n${i}`,
+    }));
+    (fs.readFile as jest.Mock).mockResolvedValue(JSON.stringify(entries));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockCreate
+      .mockResolvedValueOnce({ id: 'n0', version: 1 })
+      .mockRejectedValue(
+        new RateLimitError(
+          'Too many requests (HTTP 429). Simperium API error: HTTP 429'
+        )
+      );
+
+    let thrown: unknown;
+    try {
+      await addCommand(credentials, ['--file=notes.json']);
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(RateLimitError);
+    expect((thrown as RateLimitError).code).toBe(3);
+    // One success then one pool wave of rate-limited attempts — not the budget.
+    expect(mockCreate).toHaveBeenCalledTimes(IMPORT_CONCURRENCY);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Rate limited (HTTP 429); 19 note(s) not attempted'
+      )
+    );
+  });
+
+  // An import that dies on entry N has already created N-1 notes server-side.
+  // Throwing before the report left the user with no record of which ids
+  // landed; the dedup makes a re-run safe, but the ids are still the output.
+  it('prints the ids that landed before rethrowing a terminal error', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one' }, { content: 'two' }])
+    );
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockCreate
+      .mockResolvedValueOnce({ id: 'landed', version: 1 })
+      .mockRejectedValueOnce(new AuthError('Unauthorized'));
+
+    await expect(
+      addCommand(credentials, ['--file=notes.json'])
+    ).rejects.toBeInstanceOf(AuthError);
+
+    expect(logSpy.mock.calls.map((call) => call[0])).toEqual(['landed']);
+  });
+
+  // `(error as Error).message` on a non-Error rejection rendered as
+  // "undefined", which told the user nothing about what went wrong.
+  it('renders a non-Error rejection instead of printing undefined', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'one' }, { content: 'two' }])
+    );
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockCreate
+      .mockResolvedValueOnce({ id: 'n1', version: 1 })
+      .mockRejectedValueOnce('upstream exploded');
+
+    await expect(
+      addCommand(credentials, ['--file=notes.json'])
+    ).rejects.toBeInstanceOf(PartialError);
+
+    expect(errorSpy).toHaveBeenCalledWith('  [1] upstream exploded');
+  });
+
+  it('throws on a null entry', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(JSON.stringify([null]));
+
+    await expect(
+      addCommand(credentials, ['--file=notes.json'])
+    ).rejects.toThrow('entry 0 is not an object');
+  });
+
+  // The JSON report is the machine-readable surface for scripts. Every field
+  // must agree with the human-readable path (same counts, same stop reason),
+  // and a fully successful batch must not claim it stopped early.
+  it('prints a structured JSON report in --json mode', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([
+        { content: 'ok' },
+        { content: 'dup' },
+        { content: 'dup' },
+      ])
+    );
+    mockFind.mockResolvedValue([
+      { id: 'x', data: { content: 'dup', tags: [] } } as any,
+    ]);
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    await addCommand(credentials, ['--file=notes.json', '--json']);
+
+    const report = JSON.parse(logSpy.mock.calls[0][0] as string) as {
+      created: Array<{ index: number; id: string; version: number }>;
+      skipped: Array<{ index: number }>;
+      failures: Array<{ index: number; error: string }>;
+      stoppedEarly: boolean;
+      stopReason: string;
+      unattempted: number;
+    };
+    expect(report.created).toEqual([{ index: 0, id: 'n1', version: 1 }]);
+    expect(report.skipped).toEqual([{ index: 1 }, { index: 2 }]);
+    // N-2: skipped entries carry only their index — the dedup keys off the
+    // fingerprint, so echoing the full content would double the report size.
+    expect(JSON.stringify(report)).not.toContain('content');
+    expect(report.failures).toEqual([]);
+    expect(report.stoppedEarly).toBe(false);
+    expect(report.stopReason).toBe('complete');
+    expect(report.unattempted).toBe(0);
+  });
+
+  // ── R6 并发语义 ──────────────────────────────────────────────────────────
+  // The pool serializes entries per fingerprint: the successor awaits its
+  // key's previous outcome instead of racing it. A failed predecessor lets the
+  // successor try (mirroring the serial loop); a success dedups it.
+  it('【并发语义】同指纹前驱失败后，后驱仍会尝试', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'dup' }, { content: 'dup' }])
+    );
+    mockCreate
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ id: 'n2', version: 1 });
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    let thrown: unknown;
+    try {
+      await addCommand(credentials, ['--file=notes.json']);
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(PartialError);
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+    // The failed duplicate is a failure, the retried one lands.
+    expect(logSpy.mock.calls.map((call) => call[0])).toEqual(['n2']);
+  });
+
+  it('【并发语义】同指纹并发条目不会重复创建', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([
+        { content: 'dup' },
+        { content: 'dup' },
+        { content: 'dup' },
+      ])
+    );
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    await addCommand(credentials, ['--file=notes.json']);
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls.map((call) => call[0])).toEqual(['n1']);
+  });
+
+  // The chain tail is released once settled (B.3). This must not weaken the
+  // dedup: 200 entries over 100 distinct fingerprints still create exactly one
+  // note per fingerprint — a leaked or prematurely removed chain would let a
+  // duplicate through (or, with an intermediate link deleted, race a create).
+  it('【并发语义】大文件导入按指纹去重（尾守卫回收不破坏幂等）', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify(
+        Array.from({ length: 200 }, (_, i) => ({ content: `note-${i % 100}` }))
+      )
+    );
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    await addCommand(credentials, ['--file=notes.json']);
+
+    expect(mockCreate).toHaveBeenCalledTimes(100);
+    expect(logSpy.mock.calls).toHaveLength(100);
+  });
+
+  // Completion order is nondeterministic under concurrency, but the report is
+  // restored to input order so the index column keeps pointing at the file.
+  it('【并发语义】created/skipped/failures 按 index 升序输出', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([
+        { content: 'a' },
+        { content: 'b' },
+        { content: 'c' },
+        { content: 'd' },
+      ])
+    );
+    mockCreate.mockImplementation(
+      (entry: { content: string }) =>
+        new Promise((resolve) => {
+          // Reverse delay: the last entry finishes first.
+          const delay = { a: 30, b: 20, c: 10, d: 0 }[entry.content] ?? 0;
+          setTimeout(() => resolve({ id: entry.content, version: 1 }), delay);
+        })
+    );
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await addCommand(credentials, ['--file=notes.json']);
+
+    expect(logSpy.mock.calls.map((call) => call[0])).toEqual([
+      'a',
+      'b',
+      'c',
+      'd',
+    ]);
+  });
+
+  it('【并发语义】连续失败触发停止且 unattempted 正确', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify(
+        Array.from({ length: 10 }, (_, i) => ({ content: `n${i}` }))
+      )
+    );
+    mockCreate.mockRejectedValue(new NetworkError('boom'));
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    let thrown: unknown;
+    try {
+      await addCommand(credentials, ['--file=notes.json', '--json']);
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(mockCreate).toHaveBeenCalledTimes(IMPORT_CONCURRENCY);
+    const report = JSON.parse(logSpy.mock.calls[0][0] as string) as {
+      failures: Array<{ index: number; error: string }>;
+      stoppedEarly: boolean;
+      stopReason: string;
+      unattempted: number;
+    };
+    expect(report.failures).toHaveLength(IMPORT_CONCURRENCY);
+    expect(report.stoppedEarly).toBe(true);
+    expect(report.stopReason).toBe('consecutive-failures');
+    expect(report.unattempted).toBe(10 - IMPORT_CONCURRENCY);
+    expect(thrown).toBeInstanceOf(PartialError);
+  });
+
+  it('【并发语义】terminal（auth/aborted）停止后不再消费剩余条目', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify(
+        Array.from({ length: 10 }, (_, i) => ({ content: `n${i}` }))
+      )
+    );
+    mockCreate.mockRejectedValue(new AbortedError('Request aborted'));
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    let thrown: unknown;
+    try {
+      await addCommand(credentials, ['--file=notes.json', '--json']);
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(AbortedError);
+    expect((thrown as AbortedError).code).toBe(6);
+    expect(mockCreate).toHaveBeenCalledTimes(IMPORT_CONCURRENCY);
+    const report = JSON.parse(logSpy.mock.calls[0][0] as string) as {
+      created: Array<{ index: number }>;
+      failures: Array<{ index: number }>;
+      stoppedEarly: boolean;
+      stopReason: string;
+      unattempted: number;
+    };
+    expect(report.created).toEqual([]);
+    expect(report.failures).toEqual([]);
+    expect(report.stoppedEarly).toBe(true);
+    expect(report.stopReason).toBe('aborted');
+    expect(report.unattempted).toBe(10);
+  });
+
+  // A1：per-key 串行化必须是"链"而非"扇出"。旧实现里两个 follower 会同时
+  // await 同一个失败的前驱，双双 fall-through 并发创建 —— 3 条同指纹条目
+  // 首条失败会产出 2 条重复笔记。修复后第 3 条只能在前驱尝试结束后再决定。
+  it('【并发语义】同指纹 3 条且首条失败时严格串行，不扇出重复创建', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([
+        { content: 'dup' },
+        { content: 'dup' },
+        { content: 'dup' },
+      ])
+    );
+    mockCreate
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ id: 'n2', version: 1 });
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    let thrown: unknown;
+    try {
+      await addCommand(credentials, ['--file=notes.json']);
+    } catch (e) {
+      thrown = e;
+    }
+
+    // 失败 1 次 + 串行重试 1 次 = 恰好 2 次创建（旧实现会并发 3 次）
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls.map((call) => call[0])).toEqual(['n2']);
+  });
+
+  // NFC：macOS 存 NFD、Windows/Linux 存 NFC，"café" 跨平台导出→导入必须去重。
+  it('【幂等】NFC 与 NFD 形式同一文本去重', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue(
+      JSON.stringify([{ content: 'caf\u00e9 au lait' }])
+    );
+    mockFind.mockResolvedValue([
+      {
+        id: 'existing',
+        data: { content: 'cafe\u0301 au lait' } as any,
+      },
+    ]);
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    await addCommand(credentials, ['--file=notes.json']);
+
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});

--- a/lib/cli/__tests__/app.test.ts
+++ b/lib/cli/__tests__/app.test.ts
@@ -1,0 +1,986 @@
+jest.mock('../store.ts', () => ({
+  loadCredentials: jest.fn(),
+  clearCredentials: jest.fn(),
+  saveCredentials: jest.fn(),
+}));
+
+jest.mock('../commands/list.ts', () => ({
+  listCommand: jest.fn(),
+  parseListOptions: jest.fn(),
+}));
+
+// doLogin's password path delegates to auth.ts; the magic-link path opens a
+// readline prompt, which we stub so the test never blocks on stdin.
+jest.mock('../auth.ts', () => ({
+  login: jest.fn(),
+  requestLoginEmail: jest.fn(),
+  completeLogin: jest.fn(),
+}));
+
+jest.mock('readline/promises', () => ({
+  createInterface: jest.fn(() => ({
+    question: jest.fn().mockResolvedValue('ABC123'),
+    close: jest.fn(),
+  })),
+}));
+
+import {
+  clearCredentials,
+  loadCredentials,
+  saveCredentials,
+} from '../store.ts';
+import { listCommand } from '../commands/list.ts';
+import { setVerbose } from '../logging.ts';
+import {
+  doLogin,
+  flushStdio,
+  HELP,
+  ignoreBrokenPipe,
+  installSignalHandlers,
+  labelled,
+  main,
+  run,
+  validateFlags,
+} from '../app.ts';
+import {
+  login as mockLogin,
+  requestLoginEmail as mockRequest,
+  completeLogin as mockComplete,
+} from '../auth.ts';
+import {
+  AuthError,
+  AbortedError,
+  CliError,
+  EXIT_ABORTED,
+  EXIT_NETWORK,
+  NetworkError,
+  NotFoundError,
+  UsageError,
+} from '../domain/errors.ts';
+import type { Credentials } from '../domain/types.ts';
+
+// jsdom's setTimeout returns a number (no unref()), but flushStdio relies on
+// `setTimeout(...).unref()` to drop the guard timer from the event loop.
+// Replace it with a shim that actually schedules the callback via the real
+// timer yet returns a Timer-like object carrying unref(). Scoped to this test
+// file's VM context, so it never touches the real global.
+const realSetTimeout = global.setTimeout.bind(global);
+global.setTimeout = ((
+  fn: (...args: unknown[]) => void,
+  ms?: number,
+  ...args: unknown[]
+) => {
+  realSetTimeout(fn as TimerHandler, ms as number, ...(args as []));
+  return {
+    unref: () => {},
+    ref: () => {},
+    hasRef: () => false,
+  } as unknown as ReturnType<typeof setTimeout>;
+}) as typeof setTimeout;
+
+const credentials: Credentials = {
+  access_token: 'tok',
+  username: 'user@example.com',
+};
+
+async function capture(work: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await work();
+    return undefined;
+  } catch (error) {
+    return error;
+  }
+}
+
+describe('validateFlags', () => {
+  it('accepts the flags a command declares', () => {
+    expect(() =>
+      validateFlags('list', ['limit', 'json'], ['--limit=5', '--json'])
+    ).not.toThrow();
+  });
+
+  // Ignoring `--limt=5` gave the user the default 20 notes and no hint that
+  // the run had not done what they asked.
+  it('rejects a typo and names the accepted flags', () => {
+    const error = (() => {
+      try {
+        validateFlags('list', ['limit', 'json'], ['--limt=5']);
+      } catch (thrown) {
+        return thrown;
+      }
+    })();
+
+    expect(error).toBeInstanceOf(UsageError);
+    expect((error as UsageError).code).toBe(1);
+    expect((error as UsageError).message).toContain('--limt=5');
+    expect((error as UsageError).message).toContain('--limit');
+  });
+
+  it('ignores positionals and anything after "--"', () => {
+    expect(() =>
+      validateFlags('create', ['json'], ['hello', '--', '--not-a-flag'])
+    ).not.toThrow();
+  });
+
+  it('【场景】多个未知旗标 【目的】验证复数文案与完整罗列 【校验点】message 【预期】Unknown flags 且逐项列出', () => {
+    const error = (() => {
+      try {
+        validateFlags('list', ['limit'], ['--json', '--nope=1']);
+      } catch (thrown) {
+        return thrown;
+      }
+    })();
+
+    expect(error).toBeInstanceOf(UsageError);
+    expect((error as UsageError).code).toBe(1);
+    expect((error as UsageError).message).toContain('Unknown flags for list');
+    expect((error as UsageError).message).toContain('--json, --nope=1');
+  });
+
+  it('【场景】命令不接受任何旗标 【目的】验证提示语兜底 【校验点】message 【预期】显示 (none)', () => {
+    const error = (() => {
+      try {
+        validateFlags('login', [], ['--json']);
+      } catch (thrown) {
+        return thrown;
+      }
+    })();
+
+    expect(error).toBeInstanceOf(UsageError);
+    expect((error as UsageError).message).toContain('(none)');
+  });
+});
+
+describe('labelled', () => {
+  it('prefixes the message but keeps the exit code', () => {
+    const error = labelled(
+      new NotFoundError('Note not found: n1'),
+      'Show failed'
+    );
+
+    expect(error).toBeInstanceOf(CliError);
+    expect(error.code).toBe(4);
+    expect(error.message).toBe('Show failed: Note not found: n1');
+  });
+
+  it('maps an unclassified failure to the operational code', () => {
+    expect(
+      labelled(new TypeError('x is not a function'), 'List failed').code
+    ).toBe(3);
+  });
+
+  it('【场景】原始错误携带 stack 【目的】验证重新标记不丢失调用栈 【校验点】stack 【预期】原栈保留', () => {
+    const original = new NotFoundError('Note not found: n1');
+    original.stack = 'preserved stack line';
+
+    const relabelled = labelled(original, 'Show failed');
+
+    expect(relabelled.message).toBe('Show failed: Note not found: n1');
+    expect(relabelled.code).toBe(4);
+    expect(relabelled.stack).toBe('preserved stack line');
+  });
+
+  it('【场景】非 Error 值被标记 【目的】验证字符串化兜底 【校验点】message/code 【预期】String 内容 + 网络码 3', () => {
+    const relabelled = labelled('oops', 'List failed');
+    expect(relabelled.message).toBe('List failed: oops');
+    expect(relabelled.code).toBe(3);
+  });
+});
+
+describe('run', () => {
+  let errorSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    (loadCredentials as jest.Mock).mockResolvedValue(credentials);
+    (listCommand as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    (loadCredentials as jest.Mock).mockReset();
+    (clearCredentials as jest.Mock).mockReset();
+    (listCommand as jest.Mock).mockReset();
+    setVerbose(false);
+    delete process.env.SIMPLENOTE_CLI_DEBUG;
+  });
+
+  it('prints help to stderr, keeping stdout free for piped output', async () => {
+    await run([]);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Usage:'));
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('prints the CLI version to stdout with --version', async () => {
+    await run(['--version']);
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/\d+\.\d+\.\d+/));
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(loadCredentials).not.toHaveBeenCalled();
+  });
+
+  it('prints the CLI version to stdout with -v', async () => {
+    await run(['-v']);
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/\d+\.\d+\.\d+/));
+    expect(loadCredentials).not.toHaveBeenCalled();
+  });
+
+  it('prints a command help and exits before touching credentials', async () => {
+    await run(['list', '--help']);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Usage: npm run cli -- list')
+    );
+    expect(loadCredentials).not.toHaveBeenCalled();
+    expect(listCommand).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts -h as a command help alias', async () => {
+    await run(['show', '-h']);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Usage: npm run cli -- show')
+    );
+    expect(loadCredentials).not.toHaveBeenCalled();
+  });
+
+  it('prints help for login and logout too', async () => {
+    await run(['login', '--help']);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Usage: npm run cli -- login')
+    );
+    expect(mockLogin).not.toHaveBeenCalled();
+
+    errorSpy.mockClear();
+    await run(['logout', '--help']);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Usage: npm run cli -- logout')
+    );
+    expect(clearCredentials).not.toHaveBeenCalled();
+  });
+
+  it('still rejects an unknown command carrying --help', async () => {
+    const error = await capture(() => run(['frobnicate', '--help']));
+
+    expect(error).toBeInstanceOf(UsageError);
+    expect((error as UsageError).code).toBe(1);
+  });
+
+  it('treats --help after a "--" terminator as literal content', async () => {
+    await run(['list', '--', '--help']);
+
+    // 帮助拦截未触发：--help 作为字面位置参数原样传给命令处理器。
+    expect(listCommand).toHaveBeenCalledWith(credentials, ['--', '--help']);
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Usage: npm run cli -- list')
+    );
+  });
+
+  // B1-3：`-h` 紧邻位置参数时是数据不是帮助请求（edit <id> "-h" 写文本；
+  // search "foo" -h 不是帮助，但 search 会按"多余位置参数"拒绝并提示用引号）。
+  // 旧实现把整个 rest 扫一遍，合法内容被吞。
+  it('does not treat "-h" beside a positional as a help request', async () => {
+    await run(['list', '123', '-h']);
+
+    expect(listCommand).toHaveBeenCalledWith(credentials, ['123', '-h']);
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Usage: npm run cli -- list')
+    );
+  });
+
+  it('still prints help when -h accompanies only flags', async () => {
+    await run(['show', '--json', '-h']);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Usage: npm run cli -- show')
+    );
+    expect(loadCredentials).not.toHaveBeenCalled();
+  });
+
+  it('accepts --verbose on an authenticated command without flag errors', async () => {
+    await run(['list', '--verbose', '--limit=1']);
+
+    expect(listCommand).toHaveBeenCalledWith(credentials, [
+      '--verbose',
+      '--limit=1',
+    ]);
+  });
+
+  it('accepts --verbose on login/logout without flag errors', async () => {
+    (clearCredentials as jest.Mock).mockResolvedValue(undefined);
+    await run(['logout', '--verbose']);
+
+    expect(clearCredentials).toHaveBeenCalled();
+  });
+
+  it('rejects an unknown command as a usage error', async () => {
+    const error = await capture(() => run(['frobnicate']));
+
+    expect(error).toBeInstanceOf(UsageError);
+    expect((error as UsageError).code).toBe(1);
+  });
+
+  // Argv is validated before credentials are loaded, so a typo costs a
+  // millisecond instead of a round trip plus a misleading result.
+  it('rejects an unknown flag before touching credentials', async () => {
+    const error = await capture(() => run(['list', '--limt=5']));
+
+    expect(error).toBeInstanceOf(UsageError);
+    expect(loadCredentials).not.toHaveBeenCalled();
+  });
+
+  it('passes the remaining argv straight to the command', async () => {
+    await run(['list', '--limit=3', '--json']);
+
+    expect(listCommand).toHaveBeenCalledWith(credentials, [
+      '--limit=3',
+      '--json',
+    ]);
+  });
+
+  it('asks the user to log in when there are no stored credentials', async () => {
+    (loadCredentials as jest.Mock).mockResolvedValue(undefined);
+
+    const error = await capture(() => run(['list']));
+
+    expect(error).toBeInstanceOf(AuthError);
+    expect((error as AuthError).code).toBe(2);
+    expect(listCommand).not.toHaveBeenCalled();
+  });
+
+  // Classification is by type. The previous string match on the message meant
+  // rewording an error silently changed the process exit code.
+  it('labels a command failure without losing its exit code', async () => {
+    (listCommand as jest.Mock).mockRejectedValue(
+      new NotFoundError('Note not found: n1')
+    );
+
+    const error = (await capture(() => run(['list']))) as CliError;
+
+    expect(error.code).toBe(4);
+    expect(error.message).toBe('List failed: Note not found: n1');
+  });
+
+  it('prints the username, and a JSON object with --json', async () => {
+    await run(['whoami']);
+    expect(logSpy).toHaveBeenCalledWith('user@example.com');
+
+    logSpy.mockClear();
+    await run(['whoami', '--json']);
+    expect(JSON.parse(logSpy.mock.calls[0][0] as string)).toEqual({
+      username: 'user@example.com',
+    });
+  });
+
+  // `whoami extra` used to print the username and silently ignore `extra`.
+  // The dispatcher re-labels command failures (Whoami failed: ...) but keeps
+  // the exit code, which is what callers branch on.
+  it('rejects a stray positional argument on whoami', async () => {
+    const error = (await capture(() => run(['whoami', 'extra']))) as CliError;
+
+    expect(error).toBeInstanceOf(CliError);
+    expect(error.code).toBe(1);
+    expect(error.message).toContain('Too many arguments for whoami');
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stray positional argument on login', async () => {
+    const error = (await capture(() =>
+      run(['login', 'user@example.com'])
+    )) as CliError;
+
+    expect(error).toBeInstanceOf(CliError);
+    expect(error.code).toBe(1);
+  });
+
+  it('logs out without requiring stored credentials', async () => {
+    (clearCredentials as jest.Mock).mockResolvedValue(undefined);
+
+    await run(['logout']);
+
+    expect(clearCredentials).toHaveBeenCalled();
+    expect(loadCredentials).not.toHaveBeenCalled();
+  });
+});
+
+describe('HELP documentation', () => {
+  it('【场景】帮助文本完整性 【目的】验证命令与退出码文档齐全 【校验点】关键命令/环境变量/退出码表 【预期】均出现', () => {
+    expect(HELP).toContain('login');
+    expect(HELP).toContain('logout');
+    expect(HELP).toContain('list [--limit=N]');
+    expect(HELP).toContain('add --file=notes.json');
+    expect(HELP).toContain('Exit codes:');
+    expect(HELP).toContain('7 partial');
+    expect(HELP).toContain('SIMPLENOTE_CLI_TOTAL_TIMEOUT_MS');
+  });
+
+  it('【场景】新增能力文档 【目的】--version/命令帮助/verbose/通道契约/超时下限均入文档 【校验点】关键文案 【预期】逐项出现', () => {
+    expect(HELP).toContain('-v, --version');
+    expect(HELP).toContain('<command> --help');
+    expect(HELP).toContain('--verbose');
+    expect(HELP).toContain('SIMPLENOTE_CLI_DEBUG');
+    expect(HELP).toContain(
+      'goes to stdout; diagnostics and progress go to stderr'
+    );
+    expect(HELP).toContain(
+      'the leftover budget of a paged fetch is floored at 1000ms'
+    );
+  });
+});
+
+describe('run login/logout edge paths', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    delete process.env.SIMPLENOTE_USER;
+    delete process.env.SIMPLENOTE_PASSWORD;
+    (loadCredentials as jest.Mock).mockReset();
+    (mockLogin as jest.Mock).mockReset();
+    (mockRequest as jest.Mock).mockReset();
+    (mockComplete as jest.Mock).mockReset();
+    (saveCredentials as jest.Mock).mockReset();
+    (clearCredentials as jest.Mock).mockReset();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.SIMPLENOTE_USER;
+    delete process.env.SIMPLENOTE_PASSWORD;
+  });
+
+  it('【场景】环境变量提供账号密码 【目的】验证 run 层转发给密码登录 【校验点】mockLogin 入参/凭证持久化/未读取旧凭证 【预期】login+save 且不 load', async () => {
+    process.env.SIMPLENOTE_USER = 'u@example.com';
+    process.env.SIMPLENOTE_PASSWORD = 'pw';
+    const creds: Credentials = {
+      access_token: 'tok',
+      username: 'u@example.com',
+    };
+    (mockLogin as jest.Mock).mockResolvedValue(creds);
+    (saveCredentials as jest.Mock).mockResolvedValue(undefined);
+
+    await run(['login']);
+
+    expect(mockLogin).toHaveBeenCalledWith('u@example.com', 'pw');
+    expect(saveCredentials).toHaveBeenCalledWith(creds);
+    expect(loadCredentials).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith('Logged in as u@example.com');
+  });
+
+  it('【场景】未设置 SIMPLENOTE_USER 【目的】验证认证前置校验 【校验点】异常类型与退出码 【预期】AuthError code 2', async () => {
+    const error = (await capture(() => run(['login']))) as CliError;
+
+    expect(error).toBeInstanceOf(CliError);
+    expect(error.code).toBe(2);
+    expect(error.message).toContain('Login failed');
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  it('【场景】登录成功但持久化失败 【目的】错误消息不再伪装成网络故障 【校验点】code/message 【预期】code 3 且消息明示 token 未落盘', async () => {
+    process.env.SIMPLENOTE_USER = 'u@example.com';
+    process.env.SIMPLENOTE_PASSWORD = 'pw';
+    const creds: Credentials = {
+      access_token: 'tok',
+      username: 'u@example.com',
+    };
+    (mockLogin as jest.Mock).mockResolvedValue(creds);
+    (saveCredentials as jest.Mock).mockRejectedValue(
+      new CliError(EXIT_NETWORK, 'Could not persist credentials at /x: EACCES')
+    );
+
+    const error = (await capture(() => run(['login']))) as CliError;
+
+    expect(error.code).toBe(3);
+    expect(error.message).toContain('Login failed');
+    expect(error.message).toContain('Could not persist credentials');
+  });
+
+  it('【场景】登出时凭证清理失败 【目的】验证错误重标记但保留退出码 【校验点】message/code 【预期】Logout failed + 网络码 3', async () => {
+    (clearCredentials as jest.Mock).mockRejectedValue(
+      new NetworkError('disk error')
+    );
+
+    const error = (await capture(() => run(['logout']))) as CliError;
+
+    expect(error).toBeInstanceOf(CliError);
+    expect(error.code).toBe(3);
+    expect(error.message).toBe('Logout failed: disk error');
+  });
+});
+
+describe('ignoreBrokenPipe', () => {
+  // `cli list --json | head -3` closes the pipe early. Exiting 0 there turned
+  // "auth failed, and the reader hung up" into a success for `set -e` scripts.
+  // 模块级 guard 单例使 ignoreBrokenPipe 只安装一次，两个分支必须共享同一次
+  // 安装：EPIPE 吞掉并释放流，非 EPIPE 原样放行（不吞错、不破坏退出码）。
+  it('swallows EPIPE but leaves non-EPIPE errors untouched', () => {
+    const previousExitCode = process.exitCode;
+    const before = process.stdout.listenerCount('error');
+    const destroy = jest
+      .spyOn(process.stdout, 'destroy')
+      .mockImplementation(() => process.stdout);
+
+    try {
+      process.exitCode = 2;
+      ignoreBrokenPipe();
+
+      const handler = process.stdout.listeners('error').at(-1) as (
+        error: NodeJS.ErrnoException
+      ) => void;
+
+      handler(Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }));
+      expect(process.exitCode).toBe(2);
+      expect(destroy).toHaveBeenCalled();
+      destroy.mockClear();
+
+      handler(Object.assign(new Error('EACCES'), { code: 'EACCES' }));
+      expect(process.exitCode).toBe(2);
+      expect(destroy).not.toHaveBeenCalled();
+    } finally {
+      // Leave the shared process streams exactly as they were found.
+      while (process.stdout.listenerCount('error') > before) {
+        process.stdout.removeListener(
+          'error',
+          process.stdout.listeners('error').at(-1) as () => void
+        );
+      }
+      if (process.stderr.listenerCount('error') > 0) {
+        process.stderr.removeListener(
+          'error',
+          process.stderr.listeners('error').at(-1) as () => void
+        );
+      }
+      destroy.mockRestore();
+      process.exitCode = previousExitCode;
+    }
+  });
+});
+
+describe('doLogin', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    // The magic-link branch opens a readline prompt, which needs a terminal.
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+  });
+
+  afterEach(() => {
+    delete process.env.SIMPLENOTE_USER;
+    delete process.env.SIMPLENOTE_PASSWORD;
+    delete (process.stdin as { isTTY?: boolean }).isTTY;
+    jest.restoreAllMocks();
+    (saveCredentials as jest.Mock).mockReset();
+    (mockLogin as jest.Mock).mockReset();
+    (mockRequest as jest.Mock).mockReset();
+    (mockComplete as jest.Mock).mockReset();
+  });
+
+  // Without SIMPLENOTE_USER there is nothing to log in as; this is a usage
+  // problem, not an auth failure against the server.
+  it('requires SIMPLENOTE_USER', async () => {
+    const error = await capture(() => doLogin());
+    expect(error).toBeInstanceOf(AuthError);
+    expect((error as AuthError).code).toBe(2);
+  });
+
+  it('logs in with a password and persists the token', async () => {
+    process.env.SIMPLENOTE_USER = 'u@example.com';
+    process.env.SIMPLENOTE_PASSWORD = 'pw';
+    const creds: Credentials = {
+      access_token: 'tok',
+      username: 'u@example.com',
+    };
+    (mockLogin as jest.Mock).mockResolvedValue(creds);
+
+    await doLogin();
+
+    expect(mockLogin).toHaveBeenCalledWith('u@example.com', 'pw');
+    expect(saveCredentials).toHaveBeenCalledWith(creds);
+    expect(errorSpy).toHaveBeenCalledWith('Logged in as u@example.com');
+  });
+
+  // The magic-link branch must not call password `login`; it requests a code
+  // email, prompts for the 6-char code, and completes login with it.
+  it('uses the magic-link flow when no password is set', async () => {
+    process.env.SIMPLENOTE_USER = 'u@example.com';
+    (mockRequest as jest.Mock).mockResolvedValue(undefined);
+    const creds: Credentials = {
+      access_token: 'tok',
+      username: 'u@example.com',
+    };
+    (mockComplete as jest.Mock).mockResolvedValue(creds);
+
+    await doLogin();
+
+    expect(mockLogin).not.toHaveBeenCalled();
+    expect(mockRequest).toHaveBeenCalled();
+    expect(mockComplete).toHaveBeenCalledWith('u@example.com', 'ABC123');
+    expect(saveCredentials).toHaveBeenCalledWith(creds);
+  });
+
+  // E4：纯空白的密码不是密码——带着空白值去请求 /authorize 只会得到一个
+  // 用户无法与"密码错误"区分的 401。空白必须与未设置一样走魔法链接；而
+  // 判断只做 trim，发送仍传原值（合法密码可含首尾空格）。
+  it('uses the magic-link flow when SIMPLENOTE_PASSWORD is blank', async () => {
+    process.env.SIMPLENOTE_USER = 'u@example.com';
+    process.env.SIMPLENOTE_PASSWORD = '   ';
+    (mockRequest as jest.Mock).mockResolvedValue(undefined);
+    const creds: Credentials = {
+      access_token: 'tok',
+      username: 'u@example.com',
+    };
+    (mockComplete as jest.Mock).mockResolvedValue(creds);
+
+    await doLogin();
+
+    expect(mockLogin).not.toHaveBeenCalled();
+    expect(mockRequest).toHaveBeenCalled();
+    expect(mockComplete).toHaveBeenCalledWith('u@example.com', 'ABC123');
+    expect(saveCredentials).toHaveBeenCalledWith(creds);
+  });
+
+  // With piped stdin readline's prompt either yields an empty line (burning a
+  // single-use code against the server) or never settles (hanging the CLI).
+  // A non-interactive stdin must fail fast before the code email is sent.
+  it('fails fast when stdin is not interactive', async () => {
+    process.env.SIMPLENOTE_USER = 'u@example.com';
+    (process.stdin as { isTTY?: boolean }).isTTY = false;
+
+    const error = await capture(() => doLogin());
+
+    expect(error).toBeInstanceOf(UsageError);
+    expect((error as UsageError).code).toBe(1);
+    expect((error as UsageError).message).toContain('interactive terminal');
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(mockComplete).not.toHaveBeenCalled();
+  });
+
+  // 异常故障：验证码提示阶段 readline 因中断以 AbortError 拒绝（Ctrl-C 落在
+  // question 等待期）——必须归类为「登录取消」（exit 6）而不是崩溃或误报超时。
+  it('reports a readline abort as a cancellation instead of a crash', async () => {
+    process.env.SIMPLENOTE_USER = 'u@example.com';
+    (mockRequest as jest.Mock).mockResolvedValue(undefined);
+    const readlineMock = jest.requireMock('readline/promises') as {
+      createInterface: jest.Mock;
+    };
+    readlineMock.createInterface.mockReturnValue({
+      question: jest
+        .fn()
+        .mockRejectedValue(
+          Object.assign(new Error('aborted'), { name: 'AbortError' })
+        ),
+      close: jest.fn(),
+    });
+
+    try {
+      const error = await capture(() => doLogin());
+
+      expect(error).toBeInstanceOf(AbortedError);
+      expect((error as Error).message).toContain('Login cancelled');
+      expect(mockComplete).not.toHaveBeenCalled();
+    } finally {
+      readlineMock.createInterface.mockReturnValue({
+        question: jest.fn().mockResolvedValue('ABC123'),
+        close: jest.fn(),
+      });
+    }
+  });
+
+  // A blank-but-set variable must fail exactly like a missing one: the auth
+  // layer normalizes downstream, so a whitespace-only value would otherwise
+  // reach the server as an empty username (or waste a code email).
+  it('fails fast on a blank SIMPLENOTE_USER', async () => {
+    process.env.SIMPLENOTE_USER = '   ';
+    delete process.env.SIMPLENOTE_PASSWORD;
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+
+    const error = await capture(() => doLogin());
+
+    expect(error).toBeInstanceOf(AuthError);
+    expect((error as AuthError).code).toBe(2);
+    expect((error as AuthError).message).toContain('non-blank');
+    expect(mockLogin).not.toHaveBeenCalled();
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(mockComplete).not.toHaveBeenCalled();
+  });
+});
+
+describe('installSignalHandlers', () => {
+  let onSpy: jest.SpyInstance;
+  let offSpy: jest.SpyInstance;
+  let exitSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    onSpy = jest.spyOn(process, 'on');
+    offSpy = jest.spyOn(process, 'off');
+    exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    onSpy.mockRestore();
+    offSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  function grabHandler(
+    name: 'SIGINT' | 'SIGTERM'
+  ): (...args: unknown[]) => void {
+    const handler = onSpy.mock.calls.find((call) => call[0] === name)?.[1];
+    expect(handler).toBeInstanceOf(Function);
+    return handler as (...args: unknown[]) => void;
+  }
+
+  it('returns an active lifecycle and aborts on SIGINT', () => {
+    const lifecycle = installSignalHandlers();
+    const handler = grabHandler('SIGINT');
+
+    expect(lifecycle.aborted()).toBe(false);
+    expect(lifecycle.signal.aborted).toBe(false);
+
+    handler();
+
+    expect(lifecycle.aborted()).toBe(true);
+    expect(lifecycle.signal.aborted).toBe(true);
+    lifecycle.dispose();
+  });
+
+  it('registers the same handler for SIGINT and SIGTERM', () => {
+    const lifecycle = installSignalHandlers();
+    expect(grabHandler('SIGINT')).toBe(grabHandler('SIGTERM'));
+    lifecycle.dispose();
+  });
+
+  // A single Ctrl-C asks for a graceful stop; a second means "I mean it" and
+  // must end the process at once rather than waiting out the in-flight work.
+  it('exits immediately on a second interrupt', () => {
+    const lifecycle = installSignalHandlers();
+    const handler = grabHandler('SIGINT');
+
+    handler();
+    handler();
+
+    expect(exitSpy).toHaveBeenCalledWith(EXIT_ABORTED);
+    lifecycle.dispose();
+  });
+
+  it('dispose removes both signal listeners and resets the external signal', () => {
+    const lifecycle = installSignalHandlers();
+    const handler = grabHandler('SIGINT');
+
+    lifecycle.dispose();
+
+    expect(offSpy).toHaveBeenCalledWith('SIGINT', handler);
+    expect(offSpy).toHaveBeenCalledWith('SIGTERM', handler);
+  });
+});
+
+describe('main', () => {
+  let errorSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    (loadCredentials as jest.Mock).mockResolvedValue(credentials);
+    (listCommand as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    (loadCredentials as jest.Mock).mockReset();
+    (listCommand as jest.Mock).mockReset();
+    process.exitCode = undefined;
+    setVerbose(false);
+    delete process.env.SIMPLENOTE_CLI_DEBUG;
+  });
+
+  it('returns 0 after printing help', async () => {
+    const code = await main(['help']);
+    expect(code).toBe(0);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Usage:'));
+  });
+
+  it('returns 0 and prints the version for --version', async () => {
+    const code = await main(['--version']);
+    expect(code).toBe(0);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/\d+\.\d+\.\d+/));
+  });
+
+  it('returns 0 for a command help without loading credentials', async () => {
+    const code = await main(['list', '--help']);
+    expect(code).toBe(0);
+    expect(loadCredentials).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Usage: npm run cli -- list')
+    );
+  });
+
+  it('exposes the error stack only under --verbose', async () => {
+    (listCommand as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    const code = await main(['list', '--verbose']);
+    expect(code).toBe(3);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('List failed: boom')
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Error: boom')
+    );
+
+    // 非 verbose 时不输出 stack，避免噪音。
+    errorSpy.mockClear();
+    (listCommand as jest.Mock).mockRejectedValue(new Error('boom2'));
+    await main(['list']);
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Error: boom2')
+    );
+  });
+
+  // R6: the signal handlers now outlive the run and are disposed only after
+  // stdio drains, so a run must never leak listeners on the shared process.
+  it('disposes the signal handlers by the time the run returns', async () => {
+    const sigintBefore = process.listenerCount('SIGINT');
+    const sigtermBefore = process.listenerCount('SIGTERM');
+
+    await main(['help']);
+
+    expect(process.listenerCount('SIGINT')).toBe(sigintBefore);
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore);
+  });
+
+  it('returns 1 for an unknown command', async () => {
+    const code = await main(['frobnicate']);
+    expect(code).toBe(1);
+  });
+
+  it('returns 1 for a usage error (unknown flag)', async () => {
+    const code = await main(['list', '--limt=5']);
+    expect(code).toBe(1);
+  });
+
+  it('returns 2 when no credentials are stored', async () => {
+    (loadCredentials as jest.Mock).mockResolvedValue(undefined);
+    const code = await main(['list']);
+    expect(code).toBe(2);
+  });
+
+  it('returns 0 for a successful authenticated command', async () => {
+    const code = await main(['list', '--json']);
+    expect(code).toBe(0);
+    expect(listCommand).toHaveBeenCalledWith(credentials, ['--json']);
+  });
+
+  // An interrupted run must report "aborted" (6) regardless of which layer
+  // noticed the cancellation first — an aborted fetch surfacing as a network
+  // error would otherwise be indistinguishable from a real outage.
+  it('reports aborted (6) when interrupted mid-run', async () => {
+    const onSpy = jest.spyOn(process, 'on');
+    (listCommand as jest.Mock).mockImplementation(async () => {
+      const handler = onSpy.mock.calls.find(
+        (call) => call[0] === 'SIGINT'
+      )?.[1] as (() => void) | undefined;
+      if (handler) handler();
+      throw new AuthError('boom');
+    });
+
+    const code = await main(['list']);
+
+    expect(code).toBe(EXIT_ABORTED);
+    expect(process.exitCode).toBe(EXIT_ABORTED);
+    onSpy.mockRestore();
+  });
+
+  // N-1: a Ctrl-C that lands while no fetch is in flight (the local phase —
+  // export writing files, login persisting credentials) does not make run()
+  // throw — the command completes normally. The fallback check in main() must
+  // still map that to aborted (6) instead of a silent exit 0.
+  it('returns 6 when interrupted even if the command completes normally', async () => {
+    const onSpy = jest.spyOn(process, 'on');
+    (listCommand as jest.Mock).mockImplementation(async () => {
+      const handler = onSpy.mock.calls.find(
+        (call) => call[0] === 'SIGINT'
+      )?.[1] as (() => void) | undefined;
+      if (handler) handler();
+      // Local phase: no fetch to cancel, the command just finishes.
+    });
+
+    const code = await main(['list']);
+
+    expect(code).toBe(EXIT_ABORTED);
+    expect(process.exitCode).toBe(EXIT_ABORTED);
+    onSpy.mockRestore();
+  });
+});
+
+describe('flushStdio', () => {
+  // When stdout is a pipe, Node's writes are asynchronous; the race against an
+  // unref'd guard must resolve (not hang) once the buffers are drained. The
+  // resolved value is `[undefined, undefined]` when the drains win or
+  // `undefined` when the guard wins — either way it must resolve, never hang.
+  async function flushResolves(): Promise<boolean> {
+    const result = await flushStdio();
+    return result === undefined || Array.isArray(result);
+  }
+
+  it('resolves once stdio is drained', async () => {
+    await expect(flushResolves()).resolves.toBe(true);
+  });
+
+  it('still resolves when a stream is mid-write (guard fires)', async () => {
+    const writeSpy = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => false);
+    // Fire the guard immediately so the race wins even if drain never calls
+    // back, instead of waiting the full FLUSH_GUARD_MS.
+    const setTimeoutSpy = jest
+      .spyOn(global, 'setTimeout')
+      .mockImplementation((fn) => {
+        (fn as () => void)();
+        return { unref: () => {} } as unknown as ReturnType<typeof setTimeout>;
+      });
+    try {
+      await expect(flushResolves()).resolves.toBe(true);
+    } finally {
+      writeSpy.mockRestore();
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  // 生命周期/资源：stdout 仍有缓冲（writableLength > 0）时必须走
+  // `write('', cb)` 的 drain 分支等待落盘回调，而不是立即 resolve 丢数据。
+  it('waits on a stream that still holds buffered data', async () => {
+    const original = Object.getOwnPropertyDescriptor(
+      process.stdout,
+      'writableLength'
+    );
+    Object.defineProperty(process.stdout, 'writableLength', {
+      value: 1024,
+      configurable: true,
+    });
+    const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(((
+      _chunk: unknown,
+      cb?: unknown
+    ) => {
+      (cb as () => void)?.();
+      return true;
+    }) as never);
+
+    try {
+      await expect(flushResolves()).resolves.toBe(true);
+      expect(writeSpy).toHaveBeenCalledWith('', expect.any(Function));
+    } finally {
+      writeSpy.mockRestore();
+      if (original) {
+        Object.defineProperty(process.stdout, 'writableLength', original);
+      }
+    }
+  });
+});

--- a/lib/cli/__tests__/auth.test.ts
+++ b/lib/cli/__tests__/auth.test.ts
@@ -1,0 +1,426 @@
+import { completeLogin, login, requestLoginEmail } from '../auth.ts';
+import { AuthError, NetworkError, RateLimitError } from '../domain/errors.ts';
+
+/**
+ * A stand-in for a real `fetch` Response.
+ *
+ * infra/http.ts buffers the body with a single `text()` call inside the
+ * request deadline, so a double that only implements `json()` no longer
+ * reflects how the code is actually driven.
+ */
+function fakeResponse(
+  status: number,
+  body: unknown = {},
+  headers: Record<string, string> = {}
+): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: new Headers(headers),
+    text: async () => (body === undefined ? '' : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe('login', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns credentials when authorize succeeds', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      fakeResponse(200, {
+        access_token: 'tok-123',
+        username: 'user@example.com',
+      })
+    );
+
+    const credentials = await login('user@example.com', 'password');
+
+    expect(credentials).toEqual({
+      access_token: 'tok-123',
+      username: 'user@example.com',
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://auth.simperium.com/1/chalk-bump-f49/authorize/',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'X-Simperium-API-Key': expect.any(String),
+        }),
+      })
+    );
+  });
+
+  it('throws when authorize returns a non-200 status', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      fakeResponse(401, { error: 'bad credentials' })
+    );
+
+    await expect(login('user@example.com', 'wrong')).rejects.toThrow(
+      'Auth failed: HTTP 401'
+    );
+  });
+
+  it('【场景】401 认证失败 【目的】F-1 缓解：引导改用 magic-link 登录 【校验点】异常文案 【预期】含 magic-link 引导句', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      fakeResponse(401, { error: 'invalid app credentials' })
+    );
+
+    await expect(login('user@example.com', 'wrong')).rejects.toThrow(
+      'use magic-link login instead (unset SIMPLENOTE_PASSWORD)'
+    );
+  });
+
+  it('【场景】非 401 认证失败 【目的】非凭据类失败不误导用户 【校验点】异常文案 【预期】不含 magic-link 引导句', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      fakeResponse(403, { error: 'forbidden' })
+    );
+
+    await expect(login('user@example.com', 'wrong')).rejects.toThrow(
+      'Auth failed: HTTP 403'
+    );
+    await expect(login('user@example.com', 'wrong')).rejects.not.toThrow(
+      'magic-link'
+    );
+  });
+
+  it('throws when the response body is malformed', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      fakeResponse(200, { unexpected: 'shape' })
+    );
+
+    await expect(login('user@example.com', 'password')).rejects.toThrow(
+      'Auth response malformed'
+    );
+  });
+
+  it('classifies auth failures as exit code 2', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(401));
+
+    let thrown: unknown;
+    try {
+      await login('user@example.com', 'wrong');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(AuthError);
+    expect((thrown as AuthError).code).toBe(2);
+  });
+
+  it('never retries the authorize call', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(503));
+
+    await expect(login('user@example.com', 'pw')).rejects.toThrow('HTTP 503');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // Magic-link flows (requestLoginEmail/completeLogin) already normalized the
+  // username; the password flow must behave the same so whoami prints one
+  // address regardless of which flow produced the login.
+  it('【场景】用户名含大小写与空白 【目的】与 magic-link 流程保持用户名归一化一致 【校验点】请求体与返回凭证 【预期】trim 后小写', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      fakeResponse(200, {
+        access_token: 'tok-123',
+        username: 'user@example.com',
+      })
+    );
+
+    const credentials = await login('  User@Example.COM ', 'password');
+
+    expect(credentials.username).toBe('user@example.com');
+    const body = JSON.parse(
+      (global.fetch as jest.Mock).mock.calls[0][1].body as string
+    );
+    expect(body.username).toBe('user@example.com');
+  });
+});
+
+describe('requestLoginEmail', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('POSTs the username to the request-login endpoint', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(200));
+
+    await requestLoginEmail('user@example.com');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://app.simplenote.com/account/request-login',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          username: 'user@example.com',
+          request_source: 'electron',
+        }),
+      })
+    );
+  });
+
+  it('throws when the endpoint is not ok', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(500));
+
+    await expect(requestLoginEmail('user@example.com')).rejects.toThrow(
+      'Request login failed: HTTP 500'
+    );
+  });
+});
+
+describe('completeLogin', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns credentials from sync_token', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      fakeResponse(200, { sync_token: 'sync-xyz' })
+    );
+
+    const credentials = await completeLogin('user@example.com', 'ABCDEF');
+
+    expect(credentials).toEqual({
+      access_token: 'sync-xyz',
+      username: 'user@example.com',
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://app.simplenote.com/account/complete-login',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          username: 'user@example.com',
+          auth_code: 'ABCDEF',
+        }),
+      })
+    );
+  });
+
+  it('throws when the endpoint is not ok', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(400));
+
+    await expect(completeLogin('user@example.com', 'ABCDEF')).rejects.toThrow(
+      'Complete login failed: HTTP 400'
+    );
+  });
+
+  it('rejects an empty code locally without touching the server', async () => {
+    await expect(completeLogin('user@example.com', '')).rejects.toThrow(
+      'Login code is empty'
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects a whitespace-only code locally without touching the server', async () => {
+    await expect(completeLogin('user@example.com', '   ')).rejects.toThrow(
+      'Login code is empty'
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('strips internal whitespace from the code before sending', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      fakeResponse(200, { sync_token: 'sync-xyz' })
+    );
+
+    await completeLogin('user@example.com', 'ABC DEF');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://app.simplenote.com/account/complete-login',
+      expect.objectContaining({
+        body: JSON.stringify({
+          username: 'user@example.com',
+          auth_code: 'ABCDEF',
+        }),
+      })
+    );
+  });
+
+  it('reports a friendly message when rate-limited', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(429));
+
+    let thrown: unknown;
+    try {
+      await completeLogin('user@example.com', 'ABCDEF');
+    } catch (error) {
+      thrown = error;
+    }
+
+    // A 429 is a throttle, not a bad credential: it keeps the network exit
+    // code (3) and its own class so CI can tell "slow down" from "wrong code".
+    expect(thrown).toBeInstanceOf(RateLimitError);
+    expect((thrown as RateLimitError).code).toBe(3);
+    expect((thrown as Error).message).toContain(
+      'Too many login requests in a short time. Wait a few minutes and try again.'
+    );
+  });
+
+  it('throws when the response body is malformed', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(200, {}));
+
+    await expect(completeLogin('user@example.com', 'ABCDEF')).rejects.toThrow(
+      'Complete login response malformed'
+    );
+  });
+});
+
+describe('requestLoginEmail normalization', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('【场景】用户名含大小写与空白 【目的】验证邮箱归一化 【校验点】请求体 username 【预期】trim 后小写', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(200));
+
+    await requestLoginEmail('  User@Example.COM ');
+
+    const body = JSON.parse(
+      (global.fetch as jest.Mock).mock.calls[0][1].body as string
+    );
+    expect(body.username).toBe('user@example.com');
+  });
+
+  it('【场景】传输层故障 【目的】验证网络错误分类 【校验点】异常类型/退出码 【预期】NetworkError 且 code 3', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('ENOTFOUND'));
+
+    let thrown: unknown;
+    try {
+      await requestLoginEmail('user@example.com');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect((thrown as NetworkError).code).toBe(3);
+  });
+
+  it('【场景】429 限流 【目的】验证限流与凭据错误区分 【校验点】异常类型/退出码 【预期】RateLimitError 且 code 3', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(429));
+
+    let thrown: unknown;
+    try {
+      await requestLoginEmail('user@example.com');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(RateLimitError);
+    expect((thrown as RateLimitError).code).toBe(3);
+    expect((thrown as Error).message).toContain(
+      'Too many login requests in a short time'
+    );
+  });
+});
+
+describe('completeLogin normalization', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('【场景】用户名与验证码含空白/大小写 【目的】验证归一化后入库 【校验点】请求体与返回凭证 【预期】username 小写、code 大写', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      fakeResponse(200, { sync_token: 'sync-xyz' })
+    );
+
+    const credentials = await completeLogin('  User@Example.com ', ' abcd ');
+
+    expect(credentials).toEqual({
+      access_token: 'sync-xyz',
+      username: 'user@example.com',
+    });
+    const body = JSON.parse(
+      (global.fetch as jest.Mock).mock.calls[0][1].body as string
+    );
+    expect(body.username).toBe('user@example.com');
+    expect(body.auth_code).toBe('ABCD');
+  });
+
+  it('【场景】传输层故障 【目的】验证网络错误分类 【校验点】异常类型 【预期】NetworkError', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('ECONNRESET'));
+
+    await expect(
+      completeLogin('user@example.com', 'ABCDEF')
+    ).rejects.toBeInstanceOf(NetworkError);
+  });
+});
+
+describe('login failure classification', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('【场景】429 限流 【目的】分类为网络错误而非凭据无效 【校验点】异常类型与退出码 【预期】RateLimitError 且 code 3', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(fakeResponse(429));
+
+    let thrown: unknown;
+    try {
+      await login('user@example.com', 'pw');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(RateLimitError);
+    expect((thrown as RateLimitError).code).toBe(3);
+    expect((thrown as Error).message).toContain(
+      'Too many login requests in a short time'
+    );
+  });
+
+  it('【场景】传输层故障 【目的】区分网络故障与认证失败 【校验点】异常类型与退出码 【预期】NetworkError 且 code 3', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('ECONNRESET'));
+
+    let thrown: unknown;
+    try {
+      await login('user@example.com', 'pw');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect((thrown as NetworkError).code).toBe(3);
+  });
+
+  it('【场景】成功响应但 body 非 JSON 【目的】验证非 JSON 响应兜底 【校验点】异常类型与文案 【预期】NetworkError 且含 non-JSON', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      status: 200,
+      ok: true,
+      headers: new Headers(),
+      text: async () => '<html>captive portal</html>',
+    } as unknown as Response);
+
+    let thrown: unknown;
+    try {
+      await login('user@example.com', 'pw');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect((thrown as NetworkError).message).toContain('non-JSON body');
+  });
+});

--- a/lib/cli/__tests__/bootstrap.test.ts
+++ b/lib/cli/__tests__/bootstrap.test.ts
@@ -1,0 +1,166 @@
+/**
+ * bootstrap.ts is the executable entry point: importing it runs `main()` and
+ * wires the outcome — or an unexpected failure — into `process.exit`.
+ *
+ * This suite never lets a real timer or a real `process.exit` fire. `main`
+ * and `flushStdio` are controlled through mocks, and `setTimeout` is replaced
+ * with a capture so the "exit after the event loop goes idle" behaviour can be
+ * asserted deterministically.
+ */
+jest.mock('../app.ts', () => {
+  const actual = jest.requireActual('../app.ts') as typeof import('../app.ts');
+  return {
+    ...actual,
+    main: jest.fn(),
+    flushStdio: jest.fn(),
+  };
+});
+
+import { flushStdio as mockFlushStdio, main as mockMain } from '../app.ts';
+import { EXIT_OK, EXIT_UNKNOWN } from '../domain/errors.ts';
+
+type CapturedTimer = { fn: () => void; ms: number };
+let captured: CapturedTimer[];
+const realSetTimeout = global.setTimeout.bind(global);
+
+/**
+ * Drains the microtask chain started by `main()` without touching timers.
+ * The real `setTimeout` captured at load time is used (jsdom has no
+ * `setImmediate`), and a 0ms timer fires only after the microtask queue is
+ * empty — by then both the success chain (`main().then(exitWhenIdle)`) and
+ * the failure chain (`catch(async ...)` with its awaited `flushStdio`)
+ * have settled.
+ */
+function settle(): Promise<void> {
+  return new Promise((resolve) => realSetTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+  captured = [];
+  (mockMain as jest.Mock).mockReset();
+  (mockMain as jest.Mock).mockResolvedValue(EXIT_OK);
+  (mockFlushStdio as jest.Mock).mockReset();
+  (mockFlushStdio as jest.Mock).mockResolvedValue(undefined);
+
+  // jsdom's setTimeout returns a number (no unref()); bootstrap relies on
+  // `setTimeout(...).unref()` to leave the event loop free. Capture the
+  // callback instead of scheduling it, so the exit path is fully controlled.
+  global.setTimeout = ((fn: (...args: unknown[]) => void, ms?: number) => {
+    captured.push({ fn: fn as () => void, ms: ms ?? 0 });
+    return {
+      unref: () => {},
+      ref: () => {},
+      hasRef: () => false,
+    } as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+});
+
+afterEach(() => {
+  global.setTimeout = realSetTimeout;
+  process.exitCode = undefined;
+  jest.restoreAllMocks();
+});
+
+describe('bootstrap entry point', () => {
+  it('【场景】main 正常完成 【目的】验证优雅退出编排 【校验点】main 调用次数/定时器参数/process.exit 【预期】以返回值调度 exit', async () => {
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+    const code = 4;
+    (mockMain as jest.Mock).mockResolvedValue(code);
+
+    jest.isolateModules(() => {
+      require('../bootstrap.ts');
+    });
+    await settle();
+
+    expect(mockMain).toHaveBeenCalledTimes(1);
+    expect(mockMain).toHaveBeenCalledWith();
+    expect(captured).toHaveLength(1);
+    // 默认宽限期：仅在事件循环确实非空时才强制退出。
+    expect(captured[0].ms).toBe(250);
+    expect(process.exitCode).toBeUndefined();
+
+    captured[0].fn();
+    expect(exitSpy).toHaveBeenCalledWith(code);
+  });
+
+  it('【场景】main 抛出 Error 【目的】验证兜底上报与退出码 【校验点】stderr 内容/exitCode/定时器 【预期】99 并调度退出', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+    (mockMain as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    jest.isolateModules(() => {
+      require('../bootstrap.ts');
+    });
+    await settle();
+    await settle();
+
+    expect(errorSpy).toHaveBeenCalledWith('Unexpected error: boom');
+    expect(process.exitCode).toBe(EXIT_UNKNOWN);
+    expect(mockFlushStdio).toHaveBeenCalledTimes(1);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].ms).toBe(250);
+
+    captured[0].fn();
+    expect(exitSpy).toHaveBeenCalledWith(EXIT_UNKNOWN);
+  });
+
+  it('【场景】main 抛出非 Error 值 【目的】验证 messageOf 兜底字符串化 【校验点】stderr 文案 【预期】不崩溃且输出字符串', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (mockMain as jest.Mock).mockRejectedValue('raw string failure');
+
+    jest.isolateModules(() => {
+      require('../bootstrap.ts');
+    });
+    await settle();
+    await settle();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Unexpected error: raw string failure'
+    );
+  });
+
+  it('【场景】flushStdio 挂起未完成 【目的】验证失败兜底先排空 stdio 再调度退出 【校验点】定时器捕获时机/调用顺序 【预期】排空完成后才捕获 exit 定时器', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    let releaseFlush: (value: unknown) => void = () => {};
+    (mockFlushStdio as jest.Mock).mockReturnValue(
+      new Promise((resolve) => {
+        releaseFlush = resolve;
+      })
+    );
+    (mockMain as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    jest.isolateModules(() => {
+      require('../bootstrap.ts');
+    });
+    await settle();
+
+    // flushStdio 尚未完成 → 退出定时器不得提前调度。
+    expect(captured).toHaveLength(0);
+    expect(process.exitCode).toBe(EXIT_UNKNOWN);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+
+    releaseFlush(undefined);
+    await settle();
+    await settle();
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].ms).toBe(250);
+  });
+
+  it('【场景】成功退出也先排空 stdio 外的不确定状态 【目的】确认成功路径不触碰 stderr 【校验点】console.error 未被调用 【预期】静默退出', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (mockMain as jest.Mock).mockResolvedValue(EXIT_OK);
+
+    jest.isolateModules(() => {
+      require('../bootstrap.ts');
+    });
+    await settle();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(mockFlushStdio).not.toHaveBeenCalled();
+  });
+});

--- a/lib/cli/__tests__/cli-args.test.ts
+++ b/lib/cli/__tests__/cli-args.test.ts
@@ -1,0 +1,410 @@
+import {
+  flagValues,
+  hasBareFlag,
+  hasFlag,
+  parseContentSource,
+  parseLimit,
+  parseSingleValueFlag,
+  parseTags,
+  rejectExtraPositionals,
+  takeFirstPositional,
+  tokenize,
+  unknownFlags,
+} from '../cli-args.ts';
+import { UsageError } from '../domain/errors.ts';
+
+describe('flag helpers', () => {
+  it('detects boolean flags', () => {
+    expect(hasFlag(['--json'], 'json')).toBe(true);
+    expect(hasFlag(['--jsonx'], 'json')).toBe(false);
+    expect(hasFlag([], 'json')).toBe(false);
+  });
+
+  // `--json=1` used to be silently ignored (the value form never matched the
+  // bare form), so the user asked for JSON and got tabular output instead.
+  it('treats a valued boolean flag as present', () => {
+    expect(hasFlag(['--json=1'], 'json')).toBe(true);
+    expect(hasFlag(['--include-trashed=true'], 'include-trashed')).toBe(true);
+    expect(hasFlag(['--json=1'], 'limit')).toBe(false);
+  });
+
+  it('collects repeated flags', () => {
+    expect(flagValues(['--file=a', '--file=b'], 'file')).toEqual(['a', 'b']);
+  });
+
+  it('does not read flags from after a "--" terminator', () => {
+    expect(hasFlag(['--', '--json'], 'json')).toBe(false);
+  });
+
+  it('returns an empty list for a repeated flag that is absent', () => {
+    expect(flagValues([], 'file')).toEqual([]);
+    expect(flagValues(['--json'], 'file')).toEqual([]);
+    expect(flagValues(['--', '--file=x'], 'file')).toEqual([]);
+  });
+});
+
+describe('hasBareFlag', () => {
+  it('【场景】裸旗标/带值旗标/缺失 【目的】区分 bare 与 valued 形式 【校验点】布尔返回值 【预期】仅裸旗标为真', () => {
+    expect(hasBareFlag(['--json'], 'json')).toBe(true);
+    expect(hasBareFlag(['--json=1'], 'json')).toBe(false);
+    expect(hasBareFlag(['--limit=5'], 'limit')).toBe(false);
+    expect(hasBareFlag([], 'json')).toBe(false);
+  });
+
+  it('【场景】分隔符之后的旗标 【目的】避免把字面参数当旗标 【校验点】返回值 【预期】忽略', () => {
+    expect(hasBareFlag(['--', '--limit'], 'limit')).toBe(false);
+  });
+});
+
+describe('parseSingleValueFlag', () => {
+  it('【场景】正常取值 【目的】单值旗标取值（含 = 号的值） 【校验点】返回值 【预期】完整值', () => {
+    expect(parseSingleValueFlag(['--output=/tmp/a=b'], 'output', './out')).toBe(
+      '/tmp/a=b'
+    );
+  });
+
+  it('【场景】裸旗标无值 【目的】视为用法错误 【校验点】UsageError 【预期】消息含 requires a value', () => {
+    expect(() => parseSingleValueFlag(['--format'], 'format', 'json')).toThrow(
+      'requires a value'
+    );
+  });
+
+  it('【场景】同一旗标重复 【目的】拒绝歧义 【校验点】UsageError 【预期】消息含 Provide --…= once', () => {
+    expect(() =>
+      parseSingleValueFlag(['--limit=5', '--limit=6'], 'limit', '20')
+    ).toThrow('Provide --limit= once');
+  });
+
+  it('【场景】显式空值 【目的】空值不是请求默认 【校验点】UsageError 【预期】消息含 cannot be empty', () => {
+    expect(() =>
+      parseSingleValueFlag(['--output='], 'output', './out')
+    ).toThrow('cannot be empty');
+  });
+
+  it('【场景】旗标缺省 【目的】返回 undefined 【校验点】返回值 【预期】undefined', () => {
+    expect(parseSingleValueFlag([], 'format', 'json')).toBeUndefined();
+  });
+});
+
+describe('tokenize', () => {
+  it('splits flags from positionals', () => {
+    expect(tokenize(['--json', 'n1', '--limit=2', 'extra'])).toEqual({
+      flags: ['--json', '--limit=2'],
+      positionals: ['n1', 'extra'],
+      hasTerminator: false,
+    });
+  });
+
+  it('treats everything after "--" as a positional', () => {
+    expect(tokenize(['create', '--', '--looks-like-a-flag'])).toEqual({
+      flags: [],
+      positionals: ['create', '--looks-like-a-flag'],
+      hasTerminator: true,
+    });
+  });
+});
+
+describe('parseLimit', () => {
+  it('returns the fallback when the flag is absent', () => {
+    expect(parseLimit([], 20)).toBe(20);
+  });
+
+  it('parses a positive integer', () => {
+    expect(parseLimit(['--limit=5'], 20)).toBe(5);
+  });
+
+  // Previously each of these silently fell back to the default, so
+  // `list --limit=0` printed 20 notes and looked like it had worked.
+  it.each([
+    ['--limit=abc'],
+    ['--limit=0'],
+    ['--limit=-3'],
+    ['--limit='],
+    ['--limit=2.5'],
+  ])('rejects %s as a usage error', (arg) => {
+    let thrown: unknown;
+    try {
+      parseLimit([arg], 20);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(UsageError);
+    expect((thrown as UsageError).code).toBe(1);
+    expect((thrown as UsageError).message).toContain('positive integer');
+  });
+
+  it('rejects a bare --limit because it carries no value', () => {
+    expect(() => parseLimit(['--limit'], 20)).toThrow(
+      '--limit requires a value'
+    );
+  });
+
+  it('rejects a repeated --limit= flag instead of keeping the first value', () => {
+    expect(() => parseLimit(['--limit=5', '--limit=10'], 20)).toThrow(
+      'Provide --limit= once'
+    );
+  });
+
+  it('does not count a --limit after a "--" terminator as a duplicate', () => {
+    expect(parseLimit(['--limit=5', '--', '--limit=10'], 20)).toBe(5);
+  });
+
+  // Number() coerces "0x10" (16), "1e3" (1000), " 5 " (5) and "5.0" (5) into
+  // integers, so `Number.isInteger` alone used to let these through as if the
+  // user had asked for that value. A positive integer is decimal digits only.
+  it.each([
+    ['--limit=0x10'],
+    ['--limit=1e3'],
+    ['--limit= 5 '],
+    ['--limit=5.0'],
+    ['--limit=+7'],
+  ])('rejects %s as a usage error', (arg) => {
+    expect(() => parseLimit([arg], 20)).toThrow(
+      '--limit must be a positive integer'
+    );
+  });
+
+  it('still accepts leading-zero forms it previously accepted', () => {
+    expect(parseLimit(['--limit=007'], 20)).toBe(7);
+  });
+
+  it('ignores a --limit after a "--" terminator', () => {
+    expect(parseLimit(['--', '--limit=5'], 20)).toBe(20);
+  });
+});
+
+describe('unknownFlags', () => {
+  it('accepts declared bare and valued flags', () => {
+    expect(unknownFlags(['--json', '--limit=5'], ['json', 'limit'])).toEqual(
+      []
+    );
+  });
+
+  it('reports a typo instead of ignoring it', () => {
+    expect(unknownFlags(['--limt=5'], ['json', 'limit'])).toEqual(['--limt=5']);
+  });
+
+  it('ignores positionals and anything after "--"', () => {
+    expect(unknownFlags(['n1', '--', '--whatever'], ['json'])).toEqual([]);
+  });
+
+  it('accepts the valued form of a declared flag', () => {
+    expect(unknownFlags(['--json=1'], ['json'])).toEqual([]);
+    expect(unknownFlags(['--limit=5'], ['limit'])).toEqual([]);
+  });
+});
+
+describe('takeFirstPositional', () => {
+  it('finds the positional after leading flags', () => {
+    expect(takeFirstPositional(['--json', 'n1', '--limit=2'])).toEqual({
+      value: 'n1',
+      rest: ['--json', '--limit=2'],
+    });
+  });
+
+  it('finds the positional before trailing flags', () => {
+    expect(takeFirstPositional(['n1', '--json'])).toEqual({
+      value: 'n1',
+      rest: ['--json'],
+    });
+  });
+
+  it('removes only the first positional', () => {
+    expect(takeFirstPositional(['n1', 'content'])).toEqual({
+      value: 'n1',
+      rest: ['content'],
+    });
+  });
+
+  it('reports no value when every argument is a flag', () => {
+    expect(takeFirstPositional(['--json'])).toEqual({ rest: ['--json'] });
+  });
+
+  it('re-inserts the "--" terminator so the remainder re-tokenizes losslessly', () => {
+    expect(takeFirstPositional(['--', 'n1', '--dashed content'])).toEqual({
+      value: 'n1',
+      rest: ['--', '--dashed content'],
+    });
+  });
+
+  it('drops an inert terminator once no literal positional remains', () => {
+    expect(takeFirstPositional(['--json', '--', 'n1'])).toEqual({
+      value: 'n1',
+      rest: ['--json'],
+    });
+  });
+});
+
+describe('parseContentSource', () => {
+  it('accepts a positional', () => {
+    expect(parseContentSource(['hello'], 'create', 'content')).toEqual({
+      content: 'hello',
+      fromFile: false,
+    });
+  });
+
+  it('accepts --content= and --file=', () => {
+    expect(parseContentSource(['--content=x'], 'create', 'content')).toEqual({
+      content: 'x',
+      fromFile: false,
+    });
+    expect(
+      parseContentSource(['--file=/tmp/x'], 'edit', 'new content')
+    ).toEqual({ content: '/tmp/x', fromFile: true });
+  });
+
+  it('rejects zero sources with a usage error (exit 1)', () => {
+    let thrown: unknown;
+    try {
+      parseContentSource([], 'create', 'content');
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(UsageError);
+    expect((thrown as UsageError).code).toBe(1);
+    expect((thrown as UsageError).message).toContain('create requires content');
+  });
+
+  it('rejects more than one source', () => {
+    expect(() =>
+      parseContentSource(['x', '--content=y'], 'edit', 'new content')
+    ).toThrow('Provide the new content once');
+  });
+
+  // `--content=a --content=b` used to keep only "a" and silently throw "b"
+  // away; the same flag twice is almost always a shell-expansion or editing
+  // mistake, and guessing which value won can create the wrong note.
+  it('rejects a repeated --content= flag instead of keeping the first value', () => {
+    expect(() =>
+      parseContentSource(['--content=a', '--content=b'], 'create', 'content')
+    ).toThrow('--content= appears twice');
+  });
+
+  it('rejects a repeated --file= flag instead of keeping the first value', () => {
+    expect(() =>
+      parseContentSource(
+        ['--file=/tmp/a', '--file=/tmp/b'],
+        'create',
+        'content'
+      )
+    ).toThrow('--file= appears twice');
+  });
+
+  // `create hello world` (unquoted) used to keep "hello" and throw the rest
+  // away, silently creating the wrong note.
+  it('rejects unquoted multi-word content instead of dropping words', () => {
+    expect(() =>
+      parseContentSource(['hello', 'world'], 'create', 'content')
+    ).toThrow('quote multi-word content');
+  });
+
+  it('accepts flag-looking content after a "--" terminator', () => {
+    expect(
+      parseContentSource(['--', '--not-a-flag'], 'create', 'content')
+    ).toEqual({ content: '--not-a-flag', fromFile: false });
+  });
+
+  // M-01: everything after `--` is literal by contract, so unquoted multi-word
+  // content there folds into one string instead of tripping the "quote
+  // multi-word" guard (which exists to catch *forgotten* quotes, not explicit
+  // literal intent).
+  it('joins unquoted multi-word content after a "--" terminator', () => {
+    expect(
+      parseContentSource(['--', 'a', 'b', 'c'], 'create', 'content')
+    ).toEqual({ content: 'a b c', fromFile: false });
+  });
+
+  it('still rejects multi-word content before a "--" terminator', () => {
+    expect(() =>
+      parseContentSource(
+        ['hello', 'world', '--', 'literal'],
+        'create',
+        'content'
+      )
+    ).toThrow('quote multi-word content');
+  });
+
+  // `--file=` used to fall through to readContentSource, which reported a
+  // confusing "Cannot read --file=: ENOENT" for a path the user never wrote.
+  it('rejects an empty --content= value instead of treating it as blank text', () => {
+    expect(() =>
+      parseContentSource(['--content='], 'create', 'content')
+    ).toThrow('--content= cannot be empty');
+  });
+
+  it('rejects an empty --file= value instead of attempting to read ""', () => {
+    expect(() =>
+      parseContentSource(['--file='], 'edit', 'new content')
+    ).toThrow('--file= cannot be empty');
+  });
+});
+
+describe('parseTags', () => {
+  it('trims and drops blanks', () => {
+    expect(parseTags(['--tags=a, b ,,c'])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('defaults to an empty list', () => {
+    expect(parseTags([])).toEqual([]);
+  });
+
+  it('collapses a blank-only list to an empty list', () => {
+    expect(parseTags(['--tags= ,  ,'])).toEqual([]);
+  });
+
+  // B.4：空白/逗号 tag 无法被 tag: 查询找回（模式 `[^\s,]+`），是输入错误。
+  it('rejects a tag containing whitespace or a comma', () => {
+    expect(() => parseTags(['--tags=a\nb'])).toThrow('whitespace or a comma');
+    expect(() => parseTags(['--tags=ok,a\rb'])).toThrow(
+      'whitespace or a comma'
+    );
+    // An internal space is a separator in the desktop app, so a value like
+    // `a b` would be created here but never searchable — reject it too.
+    expect(() => parseTags(['--tags=a b'])).toThrow('whitespace or a comma');
+  });
+
+  // B.5：重复 tag 去重，`--tags=a,a` 与 `--tags=a` 是同一笔记。
+  it('de-duplicates repeated tags', () => {
+    expect(parseTags(['--tags=a,a,b,a'])).toEqual(['a', 'b']);
+  });
+
+  // `--tags=a --tags=b` used to keep only the first value; parsing once,
+  // loudly, beats guessing which tag set the user meant.
+  it('rejects a repeated --tags= flag instead of keeping the first value', () => {
+    expect(() => parseTags(['--tags=a', '--tags=b'])).toThrow(
+      'Provide --tags= once'
+    );
+  });
+});
+
+describe('rejectExtraPositionals', () => {
+  it('accepts the expected number of positionals', () => {
+    expect(() => rejectExtraPositionals(['--json'], 'list', 0)).not.toThrow();
+    expect(() =>
+      rejectExtraPositionals(['id', '--json'], 'show', 1)
+    ).not.toThrow();
+  });
+
+  // `show n1 n2` and `list extra` used to silently drop the extra word.
+  it('rejects more positionals than the command takes', () => {
+    expect(() => rejectExtraPositionals(['extra'], 'list', 0)).toThrow(
+      UsageError
+    );
+    expect(() => rejectExtraPositionals(['n1', 'n2'], 'show', 1)).toThrow(
+      'Too many arguments for show'
+    );
+  });
+
+  it('counts arguments after a "--" terminator as positionals', () => {
+    expect(() => rejectExtraPositionals(['--', 'x'], 'list', 0)).toThrow(
+      UsageError
+    );
+  });
+
+  it('counts positionals the caller already consumed', () => {
+    // show consumes the note id (1 positional), so "n2" makes the total 2.
+    expect(() => rejectExtraPositionals(['n2'], 'show', 0, 1)).toThrow(
+      'Too many arguments for show: got 2, expected at most 1'
+    );
+  });
+});

--- a/lib/cli/__tests__/cli-constants.test.ts
+++ b/lib/cli/__tests__/cli-constants.test.ts
@@ -1,0 +1,97 @@
+import {
+  DEFAULT_APP_ID,
+  LIST_DEFAULT_LIMIT,
+  SEARCH_DEFAULT_LIMIT,
+  PREVIEW_WIDTH,
+  FLUSH_GUARD_MS,
+  MAX_PAGES,
+  DEFAULT_TOTAL_TIMEOUT_MS,
+  INDEX_PAGE_SIZE,
+  WRITE_CONCURRENCY,
+  FILENAME_LENGTH,
+  TAG_LINE_LENGTH,
+  BASE_BACKOFF_MS,
+  MAX_BACKOFF_MS,
+  MIN_BACKOFF_MS,
+  MIN_ATTEMPT_TIMEOUT_MS,
+  MAX_CONSECUTIVE_FAILURES,
+  envPositiveInt,
+} from '../cli-constants.ts';
+
+// ---------------------------------------------------------------------------
+// cli-constants：集中管理的魔法数值。纯常量模块，单测聚焦于“合理性不变量”
+// （边界关系 / 正值 / 单调性），防止有人误改导致退避、分页、并发预算错乱。
+// 七大维度：业务规则（数值不变量）/ 资源（无状态）。
+// ---------------------------------------------------------------------------
+
+describe('cli-constants 数值不变量', () => {
+  it('【场景】分页与窗口  【目的】正值一致  【校验点】LIST<SEARCH 默认窗口，页大小大  【预期】>0 且关系成立', () => {
+    expect(LIST_DEFAULT_LIMIT).toBeGreaterThan(0);
+    expect(SEARCH_DEFAULT_LIMIT).toBeGreaterThan(0);
+    expect(INDEX_PAGE_SIZE).toBeGreaterThan(0);
+    expect(LIST_DEFAULT_LIMIT).toBeLessThanOrEqual(SEARCH_DEFAULT_LIMIT);
+  });
+
+  it('【场景】退避曲线  【目的】floor<=base<=ceil  【校验点】单调性  【预期】MIN<=BASE<=MAX 且均为正', () => {
+    expect(MIN_BACKOFF_MS).toBeGreaterThan(0);
+    expect(BASE_BACKOFF_MS).toBeGreaterThan(0);
+    expect(MAX_BACKOFF_MS).toBeGreaterThan(0);
+    expect(MIN_BACKOFF_MS).toBeLessThanOrEqual(BASE_BACKOFF_MS);
+    expect(BASE_BACKOFF_MS).toBeLessThanOrEqual(MAX_BACKOFF_MS);
+  });
+
+  it('【场景】单次尝试最小超时  【目的】不为负/不回退  【校验点】下限约束  【预期】MIN_ATTEMPT_TIMEOUT_MS 在合理范围', () => {
+    expect(MIN_ATTEMPT_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(MIN_ATTEMPT_TIMEOUT_MS).toBeLessThanOrEqual(
+      DEFAULT_TOTAL_TIMEOUT_MS
+    );
+  });
+
+  it('【场景】全局预算与防失控  【目的】总超时远大于单页、最大页数有界  【校验点】量级  【预期】均为正且 MAX_PAGES 有上界', () => {
+    expect(DEFAULT_TOTAL_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(MAX_PAGES).toBeGreaterThan(0);
+    expect(FLUSH_GUARD_MS).toBeGreaterThan(0);
+    expect(MAX_CONSECUTIVE_FAILURES).toBeGreaterThan(0);
+  });
+
+  it('【场景】写入并发与文件名长度  【目的】边界值合理  【校验点】正值  【预期】均为正', () => {
+    expect(WRITE_CONCURRENCY).toBeGreaterThan(0);
+    expect(FILENAME_LENGTH).toBeGreaterThan(0);
+    expect(TAG_LINE_LENGTH).toBeGreaterThan(0);
+    expect(PREVIEW_WIDTH).toBeGreaterThan(0);
+  });
+
+  it('【场景】生产 app id 常量  【目的】与 auth/config 约定一致  【校验点】值  【预期】等于 chalk-bump-f49', () => {
+    expect(DEFAULT_APP_ID).toBe('chalk-bump-f49');
+  });
+});
+
+describe('envPositiveInt', () => {
+  const name = 'SIMPLENOTE_CLI_TEST_ENV';
+
+  afterEach(() => {
+    delete process.env[name];
+  });
+
+  it('returns the value for a positive number', () => {
+    process.env[name] = '150';
+    expect(envPositiveInt(name, 20)).toBe(150);
+  });
+
+  // `Number()` coercion is preserved from the call sites this helper unifies,
+  // so "0x10" behaves the same as it did before the extraction.
+  it('keeps the Number() coercion of the call sites it replaced', () => {
+    process.env[name] = '0x10';
+    expect(envPositiveInt(name, 20)).toBe(16);
+  });
+
+  it.each([['missing'], ['not-a-number'], ['0'], ['-3']])(
+    'falls back when the variable is %s',
+    (raw) => {
+      if (raw !== 'missing') {
+        process.env[name] = raw;
+      }
+      expect(envPositiveInt(name, 20)).toBe(20);
+    }
+  );
+});

--- a/lib/cli/__tests__/command-help.test.ts
+++ b/lib/cli/__tests__/command-help.test.ts
@@ -1,0 +1,113 @@
+import { COMMAND_HELP, renderCommandHelp } from '../command-help.ts';
+import { AUTHENTICATED_COMMANDS } from '../app.ts';
+
+/**
+ * 每个命令帮助必须覆盖的命令与核心旗标。帮助是给人读的（用途/示例/退出码），
+ * 因此这里只锁定关键旗标与命令名，不要求与 app.ts 的 flags 逐字一致；命令集合
+ * 的同步则通过下方案例强制：COMMAND_HELP 的键必须与 AUTHENTICATED_COMMANDS 加
+ * login/logout 完全一致。
+ */
+const EXPECTED_COMMANDS = [
+  'login',
+  'logout',
+  'whoami',
+  'list',
+  'show',
+  'search',
+  'edit',
+  'create',
+  'add',
+  'export',
+];
+
+const EXPECTED_FLAGS: Record<string, string[]> = {
+  login: [],
+  logout: [],
+  whoami: ['--json'],
+  list: ['--limit=N', '--json', '--include-trashed'],
+  show: ['--json'],
+  search: ['--limit=N', '--json', '--include-trashed'],
+  edit: ['--json', '--content=', '--file='],
+  create: ['--tags=a,b', '--json', '--content=', '--file='],
+  add: ['--file=', '--json'],
+  export: ['--format=', '--output='],
+};
+
+describe('command-help 内容', () => {
+  it('【场景】全部命令 【目的】每个命令都有帮助文案  【校验点】键集合  【预期】覆盖 login/logout/全部认证命令', () => {
+    const knownCommands = new Set([
+      ...Object.keys(AUTHENTICATED_COMMANDS),
+      'login',
+      'logout',
+    ]);
+    for (const command of EXPECTED_COMMANDS) {
+      expect(COMMAND_HELP[command]).toBeDefined();
+      expect(knownCommands.has(command)).toBe(true);
+    }
+    // 反向：COMMAND_HELP 不得凭空出现未知命令，避免文档与分发表漂移。
+    for (const key of Object.keys(COMMAND_HELP)) {
+      expect(knownCommands.has(key)).toBe(true);
+    }
+  });
+
+  it('【场景】每命令帮助 【目的】包含用途、核心旗标与退出码说明  【校验点】文案片段  【预期】Usage 行 + 关键旗标 + Exit codes 齐备', () => {
+    for (const command of EXPECTED_COMMANDS) {
+      const help = COMMAND_HELP[command];
+      expect(help).toContain(`Usage: npm run cli -- ${command}`);
+      expect(help).toContain('Exit codes:');
+      for (const flag of EXPECTED_FLAGS[command]) {
+        expect(help).toContain(flag);
+      }
+    }
+  });
+
+  it('【场景】export 帮助 【目的】说明多格式与默认行为  【校验点】文案  【预期】all/json/markdown/zip 与默认输出目录', () => {
+    const help = COMMAND_HELP.export;
+    expect(help).toContain('json, markdown, zip, or all');
+    expect(help).toContain('simplenote-export');
+  });
+
+  it('【场景】add 帮助 【目的】说明幂等行为  【校验点】文案  【预期】提到 idempotent/去重', () => {
+    expect(COMMAND_HELP.add).toContain('Idempotent');
+  });
+
+  it('【场景】add 退出码 【目的】声明 not found/conflict 【校验点】4/5 出现 【预期】add 的部分失败路径真实可达，脚本可按 4/5 分支', () => {
+    expect(COMMAND_HELP.add).toContain('4 not found');
+    expect(COMMAND_HELP.add).toContain('5 conflict');
+  });
+
+  it('【场景】create 退出码 【目的】只列真实可达的退出码 【校验点】不出现 4/5 【预期】create 用随机 UUID 做无版本 POST（note-source versionPath 为空），404/409 分支不可达', () => {
+    expect(COMMAND_HELP.create).not.toContain('4 not found');
+    expect(COMMAND_HELP.create).not.toContain('5 conflict');
+  });
+
+  it('【场景】退出码文档 【目的】帮助只列真实可达的退出码 【校验点】退出码行 【预期】全部命令含 1 usage；logout 不含 3；whoami 不含 3；两者均含 6（全局信号码）', () => {
+    for (const command of EXPECTED_COMMANDS) {
+      expect(COMMAND_HELP[command]).toContain('1 usage');
+    }
+    // 6 aborted is a *global* signal mapping: app.ts main() applies
+    // `lifecycle.aborted() -> EXIT_ABORTED` to every command, and
+    // loadCredentials is an async suspension point, so logout/whoami can exit
+    // 6 too even though their own work has no abortable await. 3 network is
+    // still unreachable: clearCredentials swallows every error and
+    // loadCredentials swallows fs errors.
+    expect(COMMAND_HELP.logout).not.toContain('3 network');
+    expect(COMMAND_HELP.logout).toContain('6 aborted');
+    expect(COMMAND_HELP.whoami).not.toContain('3 network');
+    expect(COMMAND_HELP.whoami).toContain('6 aborted');
+    expect(COMMAND_HELP.whoami).toContain('2 auth');
+  });
+});
+
+describe('renderCommandHelp', () => {
+  it('【场景】已知命令 【目的】返回该命令帮助  【校验点】返回值 【预期】与 COMMAND_HELP 表一致', () => {
+    expect(renderCommandHelp('list')).toBe(COMMAND_HELP.list);
+    expect(renderCommandHelp('login')).toBe(COMMAND_HELP.login);
+  });
+
+  it('【场景】未知命令 【目的】给出纠正提示而非空洞输出  【校验点】返回值 【预期】标注 Unknown command 并指向顶层 help', () => {
+    const rendered = renderCommandHelp('frobnicate');
+    expect(rendered).toContain('Unknown command: frobnicate');
+    expect(rendered).toContain('npm run cli -- help');
+  });
+});

--- a/lib/cli/__tests__/config.test.ts
+++ b/lib/cli/__tests__/config.test.ts
@@ -1,0 +1,374 @@
+jest.mock('fs');
+
+// ---------------------------------------------------------------------------
+// config：lazy 读取仓库根 config.json 的 app_key，并缓存结果；同时导出若干
+// 由环境变量驱动或恒定（生产 app id）的常量。cachedAppKey 是模块级状态，且
+// APP_ID 等常量在模块加载时读取环境变量，因此每个用例通过 jest.isolateModules
+// 重新加载模块以保证相互隔离，并从同一隔离块内取回 AuthError 类用于类型断言
+// （不同 registry 下的同名类 instanceof 会失效）。
+// 七大维度：入参边界 / 分支逻辑 / 异常故障 / 生命周期（缓存）/ 业务规则。
+// ---------------------------------------------------------------------------
+
+type ConfigModule = typeof import('../config.ts');
+type ErrorsModule = typeof import('../domain/errors.ts');
+import * as path from 'path';
+
+// fs mock 实例在 jest.isolateModules 之间共享，调用次数会在用例间累计；
+// 每次清空保证「调用次数」类断言与执行顺序无关。
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+function loadFresh(setup?: (fsMod: { readFileSync: jest.Mock }) => void): {
+  config: ConfigModule;
+  AuthError: ErrorsModule['AuthError'];
+} {
+  let config!: ConfigModule;
+  let AuthError!: ErrorsModule['AuthError'];
+  jest.isolateModules(() => {
+    const fsMod = require('fs');
+    if (setup) setup(fsMod);
+
+    config = require('../config.ts');
+
+    AuthError = require('../domain/errors.ts').AuthError;
+  });
+  return { config, AuthError };
+}
+
+// 在同一隔离块内调用 getAppKey 并捕获异常与 AuthError 类，保证类型身份一致
+// （不同 isolateModules 块会重新实例化 errors.ts，导致 instanceof 失效）。
+function captureGetAppKey(
+  setup: (fsMod: { readFileSync: jest.Mock }) => void
+): { error: unknown; AuthError: ErrorsModule['AuthError'] } {
+  let error: unknown;
+  let AuthError!: ErrorsModule['AuthError'];
+  jest.isolateModules(() => {
+    const fsMod = require('fs');
+    setup(fsMod);
+
+    const config = require('../config.ts');
+
+    AuthError = require('../domain/errors.ts').AuthError;
+    try {
+      config.getAppKey();
+    } catch (e) {
+      error = e;
+    }
+  });
+  return { error, AuthError };
+}
+
+describe('config 常量与环境', () => {
+  afterEach(() => {
+    delete process.env.SIMPLENOTE_APP_ID;
+    delete process.env.SIMPLENOTE_ACCOUNT_BASE;
+  });
+
+  it('【场景】默认 APP_ID / 基址  【目的】CLI 必须打生产 app id  【校验点】常量值  【预期】APP_ID=chalk-bump-f49，API/AUTH 基址正确', () => {
+    const { config } = loadFresh(() => {});
+    expect(config.APP_ID).toBe('chalk-bump-f49');
+    expect(config.API_BASE).toBe('https://api.simperium.com/1');
+    expect(config.AUTH_BASE).toBe('https://auth.simperium.com/1');
+  });
+
+  it('【场景】SIMPLENOTE_APP_ID 覆盖默认  【目的】可切换 app  【校验点】APP_ID 取值  【预期】读环境变量', () => {
+    process.env.SIMPLENOTE_APP_ID = 'custom-app';
+    expect(loadFresh(() => {}).config.APP_ID).toBe('custom-app');
+  });
+
+  it('【场景】SIMPLENOTE_ACCOUNT_BASE 覆盖默认  【目的】可切换账户基址  【校验点】ACCOUNT_BASE  【预期】读环境变量', () => {
+    process.env.SIMPLENOTE_ACCOUNT_BASE = 'https://staging.example/account';
+    expect(loadFresh(() => {}).config.ACCOUNT_BASE).toBe(
+      'https://staging.example/account'
+    );
+  });
+});
+
+describe('getAppKey', () => {
+  afterEach(() => {
+    delete process.env.SIMPLENOTE_APP_ID;
+    delete process.env.SIMPLENOTE_ACCOUNT_BASE;
+    delete process.env.SIMPLENOTE_APP_KEY;
+  });
+
+  it('【场景】SIMPLENOTE_APP_KEY 设置  【目的】生产 app_key 可经环境注入（F-1 根治）  【校验点】返回值/文件读取 【预期】返回 env 值且不读取文件', () => {
+    process.env.SIMPLENOTE_APP_KEY = 'env-provided-key';
+    const { config } = loadFresh((fsMod) => {
+      // env 优先：即便文件读取失败也不该触达文件层。
+      fsMod.readFileSync.mockImplementation(() => {
+        throw new Error('should not be read');
+      });
+    });
+    expect(config.getAppKey()).toBe('env-provided-key');
+    expect(
+      (require('fs') as { readFileSync: jest.Mock }).readFileSync
+    ).not.toHaveBeenCalled();
+  });
+
+  it('【场景】SIMPLENOTE_APP_KEY 为空串  【目的】空值等同未设置  【校验点】返回值 【预期】回退读取 config.json', () => {
+    process.env.SIMPLENOTE_APP_KEY = '';
+    const { config } = loadFresh((fsMod) => {
+      fsMod.readFileSync.mockReturnValue(
+        JSON.stringify({ app_key: 'file-key' })
+      );
+    });
+    expect(config.getAppKey()).toBe('file-key');
+  });
+
+  it('【场景】全部失败  【目的】错误消息引导注入 env  【校验点】消息内容 【预期】含 SIMPLENOTE_APP_KEY 引导', () => {
+    const { error } = captureGetAppKey((fsMod) => {
+      fsMod.readFileSync.mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+    });
+    expect((error as Error).message).toContain('SIMPLENOTE_APP_KEY');
+    expect((error as Error).message).toContain('magic-link');
+  });
+
+  it('【场景】config.json 含合法 app_key  【目的】正常解析  【校验点】返回值  【预期】返回该 key', () => {
+    const { config } = loadFresh((fsMod) => {
+      fsMod.readFileSync.mockReturnValue(
+        JSON.stringify({ app_key: 'secret-key' })
+      );
+    });
+    expect(config.getAppKey()).toBe('secret-key');
+  });
+
+  it('【场景】任一锚点命中即可  【目的】多锚点回退  【校验点】首个失败后续成功  【预期】返回后续锚点的 key', () => {
+    // 测试环境下 __dirname 推导的锚点与 process.cwd() 都解析到仓库根，Set 去重后
+    // 只会剩一个候选，无法复现“首锚失败、次锚成功”的回退。这里临时把 cwd 指到
+    // 另一条不相交的路径，从而让 moduleAnchors() 真实产出两个不同锚点；两个候选
+    // 均在 getAppKey() 调用时实时计算，因此 cwd mock 在调用前就位即可生效。
+    const cwdSpy = jest
+      .spyOn(process, 'cwd')
+      .mockReturnValue('/tmp/alt-cwd-root');
+    try {
+      const { config } = loadFresh((fsMod) => {
+        // 用闭包计数保证“首次失败、其余成功”，不依赖 mockImplementationOnce/Implementation 的排队顺序
+        let calls = 0;
+        fsMod.readFileSync.mockImplementation(() => {
+          calls += 1;
+          if (calls === 1) {
+            throw new Error('ENOENT first anchor');
+          }
+          return JSON.stringify({ app_key: 'fallback-key' });
+        });
+      });
+      expect(config.getAppKey()).toBe('fallback-key');
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  });
+
+  it('【场景】所有锚点均失败  【目的】无配置可优雅失败  【校验点】异常类型/消息/退出码  【预期】抛 AuthError(code 2) 提示无法读取 app_key', () => {
+    const { error, AuthError } = captureGetAppKey((fsMod) => {
+      fsMod.readFileSync.mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+    });
+    expect(error).toBeInstanceOf(AuthError);
+    expect((error as { code: number }).code).toBe(2);
+    expect((error as Error).message).toContain('Cannot read app_key');
+  });
+
+  it('【场景】app_key 缺失或非字符串  【目的】拒绝无效 key  【校验点】异常类型/退出码  【预期】抛 AuthError(code 2)', () => {
+    const a = captureGetAppKey((fsMod) => {
+      fsMod.readFileSync.mockReturnValue(JSON.stringify({ other: 1 }));
+    });
+    expect(a.error).toBeInstanceOf(a.AuthError);
+    expect((a.error as { code: number }).code).toBe(2);
+
+    const b = captureGetAppKey((fsMod) => {
+      fsMod.readFileSync.mockReturnValue(JSON.stringify({ app_key: 7 }));
+    });
+    expect(b.error).toBeInstanceOf(b.AuthError);
+    expect((b.error as { code: number }).code).toBe(2);
+  });
+
+  it('【场景】app_key 为空串  【目的】空串等同缺失  【校验点】异常类型  【预期】抛 AuthError(code 2)', () => {
+    const { error, AuthError } = captureGetAppKey((fsMod) => {
+      fsMod.readFileSync.mockReturnValue(JSON.stringify({ app_key: '' }));
+    });
+    expect(error).toBeInstanceOf(AuthError);
+    expect((error as { code: number }).code).toBe(2);
+  });
+
+  it('【场景】JSON 损坏  【目的】解析失败兜底  【校验点】异常类型  【预期】抛 AuthError(code 2)', () => {
+    const { error, AuthError } = captureGetAppKey((fsMod) => {
+      fsMod.readFileSync.mockReturnValue('{not json');
+    });
+    expect(error).toBeInstanceOf(AuthError);
+    expect((error as { code: number }).code).toBe(2);
+  });
+
+  it('【场景】重复调用  【目的】缓存避免重复 IO  【校验点】readFileSync 调用次数  【预期】仅读取一次', () => {
+    let fsModRef!: { readFileSync: jest.Mock };
+    const { config } = loadFresh((fsMod) => {
+      fsModRef = fsMod;
+      fsMod.readFileSync.mockReturnValue(
+        JSON.stringify({ app_key: 'cached-key' })
+      );
+    });
+    const first = config.getAppKey();
+    const countAfterFirst = fsModRef.readFileSync.mock.calls.length;
+    const second = config.getAppKey();
+    expect(first).toBe('cached-key');
+    expect(second).toBe('cached-key');
+    // 缓存生效：第二次调用不新增任何读盘（含锚点归属探测）。
+    expect(fsModRef.readFileSync.mock.calls.length).toBe(countAfterFirst);
+  });
+});
+
+describe('getVersion', () => {
+  afterEach(() => {
+    delete process.env.SIMPLENOTE_APP_ID;
+    delete process.env.SIMPLENOTE_ACCOUNT_BASE;
+  });
+
+  it('【场景】模块自身 package.json 可读  【目的】--version 报告 CLI 独立版本线（B9）  【校验点】返回值 【预期】与 lib/cli/package.json 的 version 一致', () => {
+    const realFs = jest.requireActual('fs') as typeof import('fs');
+    const { config } = loadFresh((fsMod) => {
+      // 委托给真实 fs，让模块自身 package.json 真实可读。
+      fsMod.readFileSync.mockImplementation(((
+        ...args: Parameters<typeof realFs.readFileSync>
+      ) => realFs.readFileSync(...args)) as never);
+    });
+    const expectedVersion = (require('../package.json') as { version: string })
+      .version;
+    expect(expectedVersion).toBe('0.1.0');
+    expect(config.getVersion()).toBe(expectedVersion);
+  });
+
+  it('【场景】SIMPLENOTE_CLI_VERSION 注入  【目的】构建期版本注入优先于任何文件读取  【校验点】返回值 【预期】返回注入值', () => {
+    process.env.SIMPLENOTE_CLI_VERSION = '9.8.7';
+    try {
+      const { config } = loadFresh(() => {});
+      expect(config.getVersion()).toBe('9.8.7');
+    } finally {
+      delete process.env.SIMPLENOTE_CLI_VERSION;
+    }
+  });
+
+  it('【场景】模块 manifest 优先于仓库根  【目的】模块自身版本线生效  【校验点】返回值 【预期】返回模块 version（0.1.0）而非根版本', () => {
+    const realFs = jest.requireActual('fs') as typeof import('fs');
+    const { config } = loadFresh((fsMod) => {
+      fsMod.readFileSync.mockImplementation(((
+        ...args: Parameters<typeof realFs.readFileSync>
+      ) => realFs.readFileSync(...args)) as never);
+    });
+    expect(config.getVersion()).toBe('0.1.0');
+    expect(config.getVersion()).not.toBe('2.27.1');
+  });
+
+  it('【场景】package.json 不可读  【目的】--version 永不因文件缺失而失败  【校验点】回退值  【预期】返回 CLI_VERSION_FALLBACK', () => {
+    const { config } = loadFresh((fsMod) => {
+      fsMod.readFileSync.mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+    });
+    expect(config.getVersion()).toBe('0.0.0');
+  });
+
+  it('【场景】version 缺失或为空串  【目的】拒绝无效版本字段  【校验点】回退值  【预期】返回 CLI_VERSION_FALLBACK', () => {
+    const a = loadFresh((fsMod) => {
+      fsMod.readFileSync.mockReturnValue(JSON.stringify({ name: 'x' }));
+    });
+    expect(a.config.getVersion()).toBe('0.0.0');
+
+    const b = loadFresh((fsMod) => {
+      fsMod.readFileSync.mockReturnValue(JSON.stringify({ version: '' }));
+    });
+    expect(b.config.getVersion()).toBe('0.0.0');
+  });
+
+  it('【场景】重复调用  【目的】版本缓存避免重复 IO  【校验点】readFileSync 调用次数  【预期】第二次调用不产生新读', () => {
+    let fsModRef!: { readFileSync: jest.Mock };
+    const { config } = loadFresh((fsMod) => {
+      fsModRef = fsMod;
+      fsMod.readFileSync.mockReturnValue(JSON.stringify({ version: '9.9.9' }));
+    });
+    const first = config.getVersion();
+    const countAfterFirst = fsModRef.readFileSync.mock.calls.length;
+    const second = config.getVersion();
+    expect(first).toBe('9.9.9');
+    expect(second).toBe('9.9.9');
+    // 首次调用含锚点探测读（isProjectRoot 每锚点读一次 package.json）；
+    // 缓存命中后第二次调用不产生任何新读。
+    expect(fsModRef.readFileSync.mock.calls.length).toBe(countAfterFirst);
+  });
+});
+
+describe('ancestorAnchors 与 moduleAnchors', () => {
+  it('【场景】从 dist 目录起始 【目的】打包形态（source/dist/SEA）锚点可上溯到仓库根 【校验点】逐级祖先 【预期】dist→cli→lib→仓库根 均被覆盖', () => {
+    const repoRoot = process.cwd();
+    const { config } = loadFresh(() => {});
+    const anchors = config.ancestorAnchors(
+      path.join(repoRoot, 'lib', 'cli', 'dist')
+    );
+    expect(anchors).toContain(path.join(repoRoot, 'lib', 'cli', 'dist'));
+    expect(anchors).toContain(path.join(repoRoot, 'lib', 'cli'));
+    expect(anchors).toContain(path.join(repoRoot, 'lib'));
+    expect(anchors).toContain(repoRoot);
+  });
+
+  it('【场景】moduleAnchors 【目的】以模块目录为起点上溯，并始终含 cwd 兜底 【校验点】锚点集合 【预期】同时含仓库根与 lib/cli', () => {
+    const repoRoot = process.cwd();
+    const { config } = loadFresh(() => {});
+    const anchors = config.moduleAnchors();
+    expect(anchors).toContain(repoRoot);
+    expect(anchors).toContain(path.join(repoRoot, 'lib', 'cli'));
+  });
+
+  it('【场景】默认深度 【目的】锚点数量与顺序固定 【校验点】数组形态 【预期】默认 5 层且逐级为上级目录', () => {
+    const { config } = loadFresh(() => {});
+    const start = path.join(process.cwd(), 'x', 'y', 'z');
+    const anchors = config.ancestorAnchors(start);
+    expect(anchors).toHaveLength(5);
+    expect(anchors[0]).toBe(path.resolve(start));
+    for (let i = 1; i < anchors.length; i += 1) {
+      expect(anchors[i]).toBe(path.dirname(anchors[i - 1]));
+    }
+  });
+
+  // E-5：getAppKey 的锚点链在项目根（package.json name 匹配）停止，不再越过
+  // 项目根捡到无关祖先目录的 config.json app_key（全局安装形态 401 难排查的
+  // 根源）。cwd 本身仍保留为一级兜底。
+  it('【场景】模块锚点遇项目根即停 【目的】E-5 归属校验 【校验点】候选不越项目根 【预期】用项目根 key 且不读项目根之上', () => {
+    const repoRoot = path.resolve(process.cwd());
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue('/tmp/elsewhere');
+    try {
+      const readPaths: string[] = [];
+      const { config } = loadFresh((fsMod) => {
+        fsMod.readFileSync.mockImplementation((filePath: string) => {
+          readPaths.push(filePath);
+          if (filePath.endsWith('package.json')) {
+            // 只有仓库根的 package.json 属于本项目；其余目录（含 lib/cli）
+            // 视为非项目根，验证链真正上溯到仓库根而非中途停止。
+            return JSON.stringify({
+              name:
+                path.resolve(path.dirname(filePath)) === repoRoot
+                  ? 'simplenote'
+                  : 'some-other-package',
+            });
+          }
+          return JSON.stringify({ app_key: 'root-key' });
+        });
+      });
+      expect(config.getAppKey()).toBe('root-key');
+      // 归属校验生效：所有读取路径要么在仓库根子树内，要么属于 cwd 兜底
+      // （mock 到 /tmp/elsewhere）；仓库根之上的任何祖先目录都不允许出现。
+      const cwdPath = '/tmp/elsewhere';
+      for (const p of readPaths) {
+        const resolved = path.resolve(p);
+        const insideRepo =
+          resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
+        const insideCwd =
+          resolved === cwdPath || resolved.startsWith(cwdPath + path.sep);
+        expect(insideRepo || insideCwd).toBe(true);
+      }
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  });
+});

--- a/lib/cli/__tests__/content-input.test.ts
+++ b/lib/cli/__tests__/content-input.test.ts
@@ -1,0 +1,70 @@
+jest.mock('fs/promises', () => ({
+  readFile: jest.fn(),
+}));
+
+import * as fs from 'fs/promises';
+import { readContentSource } from '../content-input.ts';
+import { UsageError } from '../domain/errors.ts';
+
+// ---------------------------------------------------------------------------
+// readContentSource：把解析出的内容源（内联 or --file=）落地为真实文本。
+// --file 读取失败是“命令行错误”，故映射为 UsageError(1) 而非 NetworkError(3)。
+// 七大维度：入参边界 / 分支逻辑 / 异常故障（IO）。
+// ---------------------------------------------------------------------------
+
+describe('readContentSource', () => {
+  beforeEach(() => {
+    (fs.readFile as jest.Mock).mockReset();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('【场景】内联内容（fromFile=false）  【目的】直接返回、零 IO  【校验点】返回值与是否触碰 fs  【预期】返回原内容且 readFile 未被调用', async () => {
+    const out = await readContentSource({
+      content: 'inline text',
+      fromFile: false,
+    });
+    expect(out).toBe('inline text');
+    expect(fs.readFile).not.toHaveBeenCalled();
+  });
+
+  it('【场景】空内联内容  【目的】原样透传  【校验点】返回值  【预期】空串', async () => {
+    const out = await readContentSource({ content: '', fromFile: false });
+    expect(out).toBe('');
+  });
+
+  it('【场景】--file 指向可读文件  【目的】按 utf8 读取  【校验点】读取路径与编码  【预期】返回文件内容', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue('file body\nline2');
+    const out = await readContentSource({
+      content: '/tmp/x.md',
+      fromFile: true,
+    });
+    expect(fs.readFile).toHaveBeenCalledWith('/tmp/x.md', 'utf8');
+    expect(out).toBe('file body\nline2');
+  });
+
+  it('【场景】--file 路径不存在/不可读  【目的】归为 usage 错误  【校验点】异常类型/消息含路径  【预期】抛 UsageError 且消息含路径', async () => {
+    (fs.readFile as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('ENOENT: no such file'), { code: 'ENOENT' })
+    );
+    let thrown: unknown;
+    try {
+      await readContentSource({ content: '/missing/x.md', fromFile: true });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(UsageError);
+    expect((thrown as UsageError).code).toBe(1);
+    expect((thrown as Error).message).toContain('/missing/x.md');
+    expect((thrown as Error).message).toContain('Cannot read --file=');
+  });
+
+  it('【场景】--file 读取抛非 Error 对象  【目的】messageOf 兜底  【校验点】不崩溃  【预期】仍抛 UsageError', async () => {
+    (fs.readFile as jest.Mock).mockRejectedValue('string failure');
+    await expect(
+      readContentSource({ content: '/x', fromFile: true })
+    ).rejects.toBeInstanceOf(UsageError);
+  });
+});

--- a/lib/cli/__tests__/contract/mock-simperium.ts
+++ b/lib/cli/__tests__/contract/mock-simperium.ts
@@ -1,0 +1,234 @@
+// Zero-dependency in-process stand-in for the Simperium REST API, used by the
+// contract tests. Real sockets and real HTTP semantics (status codes, headers,
+// body encoding) on a random loopback port, so the suite runs offline and in
+// CI without a live account.
+//
+// The CLI builds every URL from config.ts constants and egresses exclusively
+// through global.fetch, so the tests only need to (a) run this server on a
+// random loopback port and (b) install a fetch wrapper that rewrites
+// `https://api.simperium.com/**` onto `http://127.0.0.1:{port}/**` while
+// preserving method, headers, body and signal. Any other host is refused so a
+// regression can never leak a real network call from the test run.
+
+import { createServer, request as nodeRequest } from 'node:http';
+import type { ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+export type RequestLog = {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+};
+
+export type IndexPageResponse = {
+  status?: number;
+  body: unknown;
+};
+
+export type GetOptions = {
+  status?: number;
+  version?: number;
+  body: unknown;
+};
+
+export type WriteOptions = {
+  status?: number;
+  version?: number;
+};
+
+export type MockSimperiumServer = {
+  port: number;
+  requests: () => RequestLog[];
+  setIndexPages: (pages: IndexPageResponse[]) => void;
+  setGet: (options: GetOptions) => void;
+  setWrite: (options: WriteOptions) => void;
+  close: () => Promise<void>;
+};
+
+function flattenHeaders(
+  headers: NodeJS.Dict<string | string[] | undefined>
+): Record<string, string> {
+  const flat: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    flat[key] = Array.isArray(value) ? value.join(', ') : String(value ?? '');
+  }
+  return flat;
+}
+
+function sendJson(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  extraHeaders: Record<string, string> = {}
+): void {
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    ...extraHeaders,
+  });
+  res.end(JSON.stringify(body));
+}
+
+/**
+ * Starts a loopback server speaking the subset of the Simperium REST API the
+ * CLI exercises. Each test mutates behaviour through the setter methods; the
+ * index endpoint serves a queue of pages so pagination scenarios can script
+ * a sequence of responses (one 429 then a 200, or two pages with a mark).
+ */
+export async function createMockSimperiumServer(): Promise<MockSimperiumServer> {
+  const logs: RequestLog[] = [];
+  let indexPages: IndexPageResponse[] = [];
+  let getOptions: GetOptions = { body: {} };
+  let writeOptions: WriteOptions = {};
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    logs.push({
+      method: req.method ?? 'GET',
+      url: url.pathname + url.search,
+      headers: flattenHeaders(req.headers),
+    });
+    // Drain the request body so keep-alive connections stay reusable.
+    req.resume();
+
+    if (
+      req.method === 'GET' &&
+      /^\/1\/[^/]+\/note\/index$/.test(url.pathname)
+    ) {
+      const page =
+        indexPages.length > 0 ? indexPages.shift()! : { body: { index: [] } };
+      sendJson(res, page.status ?? 200, page.body);
+      return;
+    }
+    if (
+      req.method === 'GET' &&
+      /^\/1\/[^/]+\/note\/i\/[^/]+$/.test(url.pathname)
+    ) {
+      const headers: Record<string, string> =
+        getOptions.version === undefined
+          ? {}
+          : { 'X-Simperium-Version': String(getOptions.version) };
+      sendJson(res, getOptions.status ?? 200, getOptions.body, headers);
+      return;
+    }
+    if (
+      req.method === 'POST' &&
+      /^\/1\/[^/]+\/note\/i\/[^/]+(\/v\/\d+)?$/.test(url.pathname)
+    ) {
+      const headers: Record<string, string> =
+        writeOptions.version === undefined
+          ? {}
+          : { 'X-Simperium-Version': String(writeOptions.version) };
+      sendJson(res, writeOptions.status ?? 200, {}, headers);
+      return;
+    }
+    sendJson(res, 404, { error: 'contract test: no such route' });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  return {
+    port,
+    requests: () => logs,
+    setIndexPages: (pages) => {
+      indexPages = pages;
+    },
+    setGet: (options) => {
+      getOptions = options;
+    },
+    setWrite: (options) => {
+      writeOptions = options;
+    },
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      ),
+  };
+}
+
+type BufferedHttpResponse = {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+};
+
+/**
+ * A fetch that rewrites `https://api.simperium.com/**` onto the loopback
+ * server and refuses every other host. Implemented with node:http rather than
+ * the global fetch so the contract tests run identically under jsdom (which
+ * ships no fetch) and node.
+ */
+export function createRoutedFetch(port: number): typeof fetch {
+  const routed = async (
+    input: RequestInfo | URL,
+    init?: RequestInit
+  ): Promise<Response> => {
+    const url =
+      input instanceof URL
+        ? input
+        : typeof input === 'string'
+          ? new URL(input)
+          : new URL(input.url);
+    if (url.host !== 'api.simperium.com') {
+      throw new Error(`Contract test refuses to reach host "${url.host}"`);
+    }
+
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const source =
+        init.headers instanceof Headers
+          ? init.headers
+          : new Headers(init.headers as HeadersInit);
+      source.forEach((value, key) => {
+        headers[key] = value;
+      });
+    }
+
+    const response = await new Promise<BufferedHttpResponse>(
+      (resolve, reject) => {
+        const req = nodeRequest(
+          {
+            host: '127.0.0.1',
+            port,
+            path: url.pathname + url.search,
+            method: init?.method ?? 'GET',
+            headers,
+            signal: init?.signal ?? undefined,
+          },
+          (res) => {
+            // setEncoding('utf8') makes data chunks strings, sidestepping the
+            // Buffer<->Uint8Array<ArrayBufferLike> friction between the
+            // installed @types/node and the TypeScript 5.7 generic Uint8Array.
+            let body = '';
+            res.setEncoding('utf8');
+            res.on('data', (chunk) => {
+              body += chunk;
+            });
+            res.on('end', () => {
+              resolve({
+                status: res.statusCode ?? 0,
+                headers: flattenHeaders(res.headers),
+                body,
+              });
+            });
+          }
+        );
+        req.on('error', reject);
+        const body = init?.body;
+        if (body !== undefined && body !== null) {
+          req.write(String(body));
+        }
+        req.end();
+      }
+    );
+
+    return {
+      status: response.status,
+      ok: response.status >= 200 && response.status < 300,
+      headers: new Headers(response.headers),
+      text: async () => response.body,
+      json: async () => JSON.parse(response.body),
+    } as unknown as Response;
+  };
+  return routed as typeof fetch;
+}

--- a/lib/cli/__tests__/contract/note-source.contract.test.ts
+++ b/lib/cli/__tests__/contract/note-source.contract.test.ts
@@ -1,0 +1,134 @@
+// Contract tests for note-source.ts against a real loopback server.
+//
+// These are the module-side delivery for "no CLI E2E in CI": the full
+// createNoteSource -> httpRequest -> fetch -> socket chain runs against an
+// in-process HTTP server speaking Simperium's REST dialect, so HTTP semantics
+// (status codes, headers, body encoding) are exercised for real while the
+// suite stays offline and hermetic.
+
+import {
+  createMockSimperiumServer,
+  createRoutedFetch,
+} from './mock-simperium.ts';
+import type { MockSimperiumServer } from './mock-simperium.ts';
+import { createNoteSource } from '../../note-source.ts';
+import { AuthError, NetworkError, NotFoundError } from '../../domain/errors.ts';
+
+let server: MockSimperiumServer;
+let originalFetch: typeof fetch | undefined;
+
+beforeEach(async () => {
+  originalFetch = global.fetch;
+  server = await createMockSimperiumServer();
+  global.fetch = createRoutedFetch(server.port);
+  // Keep the suite fast: everything here talks to loopback.
+  process.env.SIMPLENOTE_CLI_TIMEOUT_MS = '2000';
+  process.env.SIMPLENOTE_CLI_TOTAL_TIMEOUT_MS = '10000';
+});
+
+afterEach(async () => {
+  delete process.env.SIMPLENOTE_CLI_TIMEOUT_MS;
+  delete process.env.SIMPLENOTE_CLI_TOTAL_TIMEOUT_MS;
+  if (originalFetch === undefined) {
+    delete (global as { fetch?: typeof fetch }).fetch;
+  } else {
+    global.fetch = originalFetch;
+  }
+  await server.close();
+});
+
+function noteData(content: string): Record<string, unknown> {
+  return {
+    content,
+    creationDate: 1700000000,
+    modificationDate: 1700000000,
+    deleted: false,
+    publishURL: '',
+    shareURL: '',
+    systemTags: ['markdown'],
+    tags: ['test'],
+  };
+}
+
+describe('note-source contract', () => {
+  it('follows a two-page index, merges the results and sends the auth header', async () => {
+    server.setIndexPages([
+      {
+        body: { index: [{ id: 'n-1', d: noteData('first') }], mark: 'mark-1' },
+      },
+      { body: { index: [{ id: 'n-2', d: noteData('second') }] } },
+    ]);
+    const source = createNoteSource('token-123');
+
+    const all = await source.find();
+
+    expect(all.map((note) => note.id)).toEqual(['n-1', 'n-2']);
+    expect(all[0].data.content).toBe('first');
+    const indexRequests = server
+      .requests()
+      .filter((request) => request.url.includes('/index'));
+    expect(indexRequests).toHaveLength(2);
+    expect(indexRequests[1].url).toContain('mark=mark-1');
+    for (const request of indexRequests) {
+      expect(request.headers['x-simperium-token']).toBe('token-123');
+    }
+  });
+
+  it('writes against the version read from the last GET', async () => {
+    server.setGet({ body: noteData('old'), version: 7 });
+    server.setWrite({ version: 8 });
+    const source = createNoteSource('token-123');
+
+    const result = await source.update('n-1', 'new text');
+
+    expect(result.version).toBe(8);
+    const writes = server
+      .requests()
+      .filter((request) => request.method === 'POST');
+    expect(writes).toHaveLength(1);
+    expect(writes[0].url).toContain('/v/7');
+  });
+
+  it('maps a write-time 404 to NotFoundError (exit 4), not a network error', async () => {
+    server.setGet({ body: noteData('old'), version: 7 });
+    server.setWrite({ status: 404 });
+    const source = createNoteSource('token-123');
+
+    await expect(source.update('n-1', 'new text')).rejects.toBeInstanceOf(
+      NotFoundError
+    );
+  });
+
+  it('maps a 401 to AuthError (exit 2)', async () => {
+    server.setGet({ body: noteData('x'), status: 401 });
+    const source = createNoteSource('token-123');
+
+    await expect(source.get('n-1')).rejects.toBeInstanceOf(AuthError);
+  });
+
+  it('retries a 429 and succeeds once the server recovers', async () => {
+    server.setIndexPages([{ status: 429, body: {} }, { body: { index: [] } }]);
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+    const source = createNoteSource('token-123');
+
+    try {
+      const all = await source.find();
+      expect(all).toEqual([]);
+    } finally {
+      randomSpy.mockRestore();
+    }
+
+    const indexRequests = server
+      .requests()
+      .filter((request) => request.url.includes('/index'));
+    expect(indexRequests).toHaveLength(2);
+    expect(indexRequests[0].url).not.toContain('mark=');
+  });
+
+  it('rejects a dirty index payload as a NetworkError (exit 3)', async () => {
+    server.setIndexPages([{ body: { index: null } }]);
+    const source = createNoteSource('token-123');
+
+    await expect(source.find()).rejects.toBeInstanceOf(NetworkError);
+  });
+});

--- a/lib/cli/__tests__/create.test.ts
+++ b/lib/cli/__tests__/create.test.ts
@@ -1,0 +1,171 @@
+jest.mock('../note-source.ts', () => ({
+  createNoteSource: jest.fn(),
+}));
+
+jest.mock('fs/promises', () => ({
+  readFile: jest.fn(),
+}));
+
+import * as fs from 'fs/promises';
+import { createNoteSource } from '../note-source.ts';
+import { createCommand, parseCreateOptions } from '../commands/create.ts';
+import type { Credentials } from '../domain/types.ts';
+
+const mockCreate = jest.fn();
+const mockSource = {
+  create: mockCreate,
+};
+
+const credentials: Credentials = {
+  access_token: 'tok',
+  username: 'user@example.com',
+};
+
+describe('parseCreateOptions', () => {
+  it('uses the positional content', () => {
+    expect(parseCreateOptions(['hello world'])).toEqual({
+      content: 'hello world',
+      fromFile: false,
+      tags: [],
+      json: false,
+    });
+  });
+
+  it('parses --content=', () => {
+    expect(parseCreateOptions(['--content=hello'])).toEqual({
+      content: 'hello',
+      fromFile: false,
+      tags: [],
+      json: false,
+    });
+  });
+
+  it('parses --file=', () => {
+    expect(parseCreateOptions(['--file=/tmp/x.md'])).toEqual({
+      content: '/tmp/x.md',
+      fromFile: true,
+      tags: [],
+      json: false,
+    });
+  });
+
+  it('parses --tags and --json', () => {
+    expect(parseCreateOptions(['x', '--tags=a, b ,c', '--json'])).toEqual({
+      content: 'x',
+      fromFile: false,
+      tags: ['a', 'b', 'c'],
+      json: true,
+    });
+  });
+
+  it('throws when no content source is provided', () => {
+    expect(() => parseCreateOptions([])).toThrow('create requires content');
+  });
+
+  it('throws when multiple content sources are provided', () => {
+    expect(() => parseCreateOptions(['x', '--content=y'])).toThrow(
+      'Provide the content once'
+    );
+  });
+
+  it('throws when --tags has no value', () => {
+    // `--tags` without `=` used to fold into an empty array and create a note
+    // with no tags at all, silently dropping the user's intent.
+    expect(() => parseCreateOptions(['x', '--tags'])).toThrow(
+      '--tags requires a value, e.g. --tags=a,b'
+    );
+  });
+
+  it('throws when --file has no value', () => {
+    expect(() => parseCreateOptions(['x', '--file'])).toThrow(
+      '--file requires a value, e.g. --file=notes.json'
+    );
+  });
+});
+
+describe('createCommand', () => {
+  beforeEach(() => {
+    (createNoteSource as jest.Mock).mockReturnValue(mockSource);
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    mockCreate.mockReset();
+  });
+
+  it('creates a note and prints its id', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    await createCommand(credentials, ['hello world']);
+
+    expect(createNoteSource).toHaveBeenCalledWith('tok');
+    expect(mockCreate).toHaveBeenCalledWith({
+      content: 'hello world',
+      tags: [],
+    });
+    expect(logSpy).toHaveBeenCalledWith('n1');
+  });
+
+  it('passes tags through', async () => {
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    await createCommand(credentials, ['x', '--tags=work,home']);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      content: 'x',
+      tags: ['work', 'home'],
+    });
+  });
+
+  it('reads content from a file', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue('file content');
+    mockCreate.mockResolvedValue({ id: 'n1', version: 1 });
+
+    await createCommand(credentials, ['--file=/tmp/x.md']);
+
+    expect(fs.readFile).toHaveBeenCalledWith('/tmp/x.md', 'utf8');
+    expect(mockCreate).toHaveBeenCalledWith({
+      content: 'file content',
+      tags: [],
+    });
+  });
+
+  it('prints JSON output when --json is passed', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockCreate.mockResolvedValue({ id: 'n1', version: 3 });
+
+    await createCommand(credentials, ['x', '--json']);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify({ id: 'n1', version: 3 })
+    );
+  });
+
+  it('rejects blank content', async () => {
+    await expect(createCommand(credentials, ['   '])).rejects.toThrow('blank');
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a bare --tags without touching the network', async () => {
+    await expect(createCommand(credentials, ['x', '--tags'])).rejects.toThrow(
+      '--tags requires a value'
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a bare --file without touching the network', async () => {
+    await expect(createCommand(credentials, ['x', '--file'])).rejects.toThrow(
+      '--file requires a value'
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects when create rejects', async () => {
+    mockCreate.mockRejectedValue(new Error('boom'));
+
+    await expect(createCommand(credentials, ['x'])).rejects.toThrow('boom');
+  });
+});

--- a/lib/cli/__tests__/edit.test.ts
+++ b/lib/cli/__tests__/edit.test.ts
@@ -1,0 +1,150 @@
+jest.mock('../note-source.ts', () => ({
+  createNoteSource: jest.fn(),
+}));
+
+jest.mock('fs/promises', () => ({
+  readFile: jest.fn(),
+}));
+
+import * as fs from 'fs/promises';
+import { createNoteSource } from '../note-source.ts';
+import { editCommand, parseEditOptions } from '../commands/edit.ts';
+import type { Credentials } from '../domain/types.ts';
+
+const mockUpdate = jest.fn();
+const mockSource = {
+  update: mockUpdate,
+};
+
+const credentials: Credentials = {
+  access_token: 'tok',
+  username: 'user@example.com',
+};
+
+describe('parseEditOptions', () => {
+  it('uses the positional content', () => {
+    expect(parseEditOptions(['hello world'])).toEqual({
+      content: 'hello world',
+      fromFile: false,
+      json: false,
+    });
+  });
+
+  it('parses --content=', () => {
+    expect(parseEditOptions(['--content=hello'])).toEqual({
+      content: 'hello',
+      fromFile: false,
+      json: false,
+    });
+  });
+
+  it('parses --file=', () => {
+    expect(parseEditOptions(['--file=/tmp/x.md'])).toEqual({
+      content: '/tmp/x.md',
+      fromFile: true,
+      json: false,
+    });
+  });
+
+  it('detects --json', () => {
+    expect(parseEditOptions(['x', '--json']).json).toBe(true);
+  });
+
+  it('throws when no content source is provided', () => {
+    expect(() => parseEditOptions([])).toThrow('edit requires new content');
+  });
+
+  it('throws when multiple content sources are provided', () => {
+    expect(() => parseEditOptions(['x', '--content=y'])).toThrow(
+      'Provide the new content once'
+    );
+  });
+
+  it('throws a precise message when --content has no value', () => {
+    // A bare `--content` is a forgotten value, not an absent content source;
+    // the error names the flag instead of saying "requires new content".
+    expect(() => parseEditOptions(['n1', '--content'])).toThrow(
+      '--content requires a value, e.g. --content=new content'
+    );
+  });
+
+  it('throws a precise message when --file has no value', () => {
+    expect(() => parseEditOptions(['n1', '--file'])).toThrow(
+      '--file requires a value, e.g. --file=notes.json'
+    );
+  });
+});
+
+describe('editCommand', () => {
+  beforeEach(() => {
+    (createNoteSource as jest.Mock).mockReturnValue(mockSource);
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    mockUpdate.mockReset();
+  });
+
+  it('updates the note content', async () => {
+    mockUpdate.mockResolvedValue({ version: 5 });
+
+    await editCommand(credentials, ['n1', 'new content']);
+
+    expect(createNoteSource).toHaveBeenCalledWith('tok');
+    expect(mockUpdate).toHaveBeenCalledWith('n1', 'new content');
+  });
+
+  it('prints the version in json mode', async () => {
+    mockUpdate.mockResolvedValue({ version: 5 });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await editCommand(credentials, ['n1', 'x', '--json']);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify({ id: 'n1', version: 5 })
+    );
+  });
+
+  it('reads content from a file', async () => {
+    (fs.readFile as jest.Mock).mockResolvedValue('file content');
+    mockUpdate.mockResolvedValue({ version: 2 });
+
+    await editCommand(credentials, ['n1', '--file=/tmp/x.md']);
+
+    expect(fs.readFile).toHaveBeenCalledWith('/tmp/x.md', 'utf8');
+    expect(mockUpdate).toHaveBeenCalledWith('n1', 'file content');
+  });
+
+  it('accepts flags before the note id', async () => {
+    mockUpdate.mockResolvedValue({ version: 5 });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await editCommand(credentials, ['--json', 'n1', 'new content']);
+
+    expect(mockUpdate).toHaveBeenCalledWith('n1', 'new content');
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify({ id: 'n1', version: 5 })
+    );
+  });
+
+  it('throws when the note id is missing', async () => {
+    await expect(editCommand(credentials, [])).rejects.toThrow(
+      'edit requires a note id'
+    );
+  });
+
+  it('rejects blank content', async () => {
+    await expect(editCommand(credentials, ['n1', '   '])).rejects.toThrow(
+      'blank'
+    );
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects when update rejects', async () => {
+    mockUpdate.mockRejectedValue(new Error('boom'));
+
+    await expect(editCommand(credentials, ['n1', 'x'])).rejects.toThrow('boom');
+  });
+});

--- a/lib/cli/__tests__/export-helpers.test.ts
+++ b/lib/cli/__tests__/export-helpers.test.ts
@@ -1,0 +1,706 @@
+import { writeJsonExport, writeMarkdownExport } from '../export-helpers.ts';
+import {
+  addFilename,
+  appendTags,
+  prepareNotes,
+  toUniqueNames,
+  type PreparedNote,
+} from '../export-naming.ts';
+import type { ExportNote } from '../vendor/export/types.ts';
+import type * as T from '../vendor/types.ts';
+import { CliError, AbortedError } from '../domain/errors.ts';
+import { setExternalAbortSignal } from '../infra/http.ts';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Minimal ExportNote factory: no tags, so appendTags leaves content untouched
+// and the filename is derived purely from the first non-blank line.
+function note(content: string): ExportNote {
+  return {
+    content,
+    collaboratorEmails: [],
+    creationDate: 0,
+    id: 'x' as T.EntityId,
+    modificationDate: 0,
+    tags: [],
+  };
+}
+
+describe('prepareNotes filename de-duplication', () => {
+  it('leaves a unique filename without a suffix', () => {
+    const prepared = prepareNotes([note('Solo')]);
+    expect(prepared[0].fileName).toBe('Solo');
+  });
+
+  // The previous toUniqueNames double-counted the base name on the first
+  // occurrence (1 -> 2), so the second duplicate read 2 and produced
+  // "Meeting (2)" — skipping "(1)" entirely. The sequence is now consecutive.
+  it('numbers duplicate filenames consecutively from (1)', () => {
+    const prepared = prepareNotes([
+      note('Meeting notes\nbody'),
+      note('Meeting notes\nother'),
+      note('Meeting notes\nthird'),
+    ]);
+    expect(prepared.map((p) => p.fileName)).toEqual([
+      'Meeting notes',
+      'Meeting notes (1)',
+      'Meeting notes (2)',
+    ]);
+  });
+
+  // An input whose own first line already looks like "Meeting (1)" must not
+  // collide with the generated "(1)" from an earlier duplicate: the probe
+  // pushes it forward instead of overwriting the existing file.
+  it('does not collide when an input name already ends with (n)', () => {
+    const prepared = prepareNotes([
+      note('Meeting'),
+      note('Meeting'),
+      note('Meeting (1)'),
+    ]);
+    const names = prepared.map((p) => p.fileName);
+    expect(new Set(names).size).toBe(3);
+    expect(names).toContain('Meeting');
+    expect(names).toContain('Meeting (1)');
+  });
+
+  // 分支逻辑：命名去重的 while 探测路径——第二个重复名生成的 "(1)" 恰被一个
+  // 独立输入占用时，必须继续递增到 "(2)"，而不是覆盖既有文件名。
+  it('pushes past a generated (n) that is already taken by an input', () => {
+    const prepared = prepareNotes([
+      note('Meeting'),
+      note('Meeting (1)'),
+      note('Meeting'),
+    ]);
+    expect(prepared.map((p) => p.fileName)).toEqual([
+      'Meeting',
+      'Meeting (1)',
+      'Meeting (2)',
+    ]);
+  });
+
+  // H-01: case-insensitive file systems (Windows/macOS) write "Meeting" and
+  // "meeting" to the same path; writeFile's default 'w' flag would silently
+  // overwrite one note with the other unless the de-dup key is case-folded.
+  it('case-folds de-duplication so case-insensitive file systems cannot overwrite', () => {
+    const prepared = prepareNotes([note('Meeting'), note('meeting')]);
+    expect(prepared.map((p) => p.fileName)).toEqual(['Meeting', 'meeting (1)']);
+  });
+
+  // N-4：markdown 与 zip 对同一批笔记各跑一次 prepareNotes；memoize 后同一
+  // 数组引用第二次调用命中缓存（format=all 时 4 次调用降为 2 次计算）。
+  it('【场景】同一数组两次 prepareNotes 【目的】N-4 memoize 【校验点】引用相等/不同数组不串扰 【预期】同引用、各自独立', () => {
+    const notes = [note('Same title')];
+    const first = prepareNotes(notes);
+    expect(prepareNotes(notes)).toBe(first);
+    // 内容相同但引用不同的数组不命中缓存，各自计算。
+    expect(prepareNotes([note('Same title')])).not.toBe(first);
+  });
+});
+
+describe('addFilename', () => {
+  it('【场景】取首行非空文本  【目的】文件名来源  【校验点】首行  【预期】返回首行', () => {
+    expect(addFilename(note('Hello\nworld')).fileName).toBe('Hello');
+  });
+
+  it('【场景】CRLF 首行  【目的】跨平台一致性  【校验点】首行  【预期】剥离 \\r 后取 Title（生产链路已先 normalizeLineBreak，此处为等价性验证）', () => {
+    expect(addFilename(note('\r\nTitle\nbody')).fileName).toBe('Title');
+  });
+
+  it('【场景】前导空行  【目的】跳过空白  【校验点】首个非空行  【预期】返回真实标题', () => {
+    expect(addFilename(note('\n\n  \nReal title')).fileName).toBe('Real title');
+  });
+
+  it('【场景】全为空  【目的】兜底  【校验点】回退名  【预期】untitled', () => {
+    expect(addFilename(note('   \n\n')).fileName).toBe('untitled');
+  });
+
+  it('【场景】含非法文件名字符  【目的】sanitize  【校验点】不含路径分隔符  【预期】安全名', () => {
+    expect(addFilename(note('a/b:c')).fileName).not.toContain('/');
+  });
+
+  it('【场景】首行超长  【目的】截断  【校验点】长度上限  【预期】不超过 FILENAME_LENGTH', () => {
+    expect(
+      addFilename(note('x'.repeat(100))).fileName.length
+    ).toBeLessThanOrEqual(40);
+  });
+
+  it('【场景】截断边界落在代理对中间  【目的】不产生孤立代理  【校验点】末尾无孤立高代理  【预期】回退一位保留完整字符', () => {
+    const out = addFilename(note('a'.repeat(39) + '😀\nbody'));
+    const last = out.fileName.charCodeAt(out.fileName.length - 1);
+    expect(out.fileName.length).toBeLessThanOrEqual(40);
+    expect(last >= 0xd800 && last <= 0xdfff).toBe(false);
+    expect(out.fileName).toBe('a'.repeat(39));
+  });
+});
+
+describe('appendTags', () => {
+  it('【场景】无标签  【目的】原样返回  【校验点】引用相等且内容不变  【预期】返回同一对象', () => {
+    const n = note('body');
+    expect(appendTags(n)).toBe(n);
+  });
+
+  it('【场景】单个短标签  【目的】追加 Tags 块  【校验点】内容含 Tags 与标签  【预期】保留正文并追加', () => {
+    const out = appendTags({ ...note('body'), tags: ['work'] as T.TagName[] });
+    expect(out.content).toContain('Tags:');
+    expect(out.content).toContain('work');
+    expect(out.content.startsWith('body')).toBe(true);
+  });
+
+  it('【场景】大量标签  【目的】按宽度换行  【校验点】多行缩进  【预期】超过一行', () => {
+    const tags = Array.from({ length: 30 }, (_, i) => `tag-${i}` as T.TagName);
+    const out = appendTags({ ...note('body'), tags });
+    const tagLines = out.content
+      .split('\n')
+      .filter((line) => line.startsWith('  '));
+    expect(tagLines.length).toBeGreaterThan(1);
+    expect(out.content).toContain('Tags:');
+  });
+
+  // C.3：空/空白/含换行 tag 必须被过滤，不能进入导出文件（含换行 tag 会
+  // 破坏 markdown 格式，且 tag: 模式 `[^\s,]+` 永远搜不到它）。
+  it('【场景】脏标签（空/空白/含换行） 【目的】过滤不进入导出 【校验点】仅干净标签输出 【预期】脏标签被剔除', () => {
+    const out = appendTags({
+      ...note('body'),
+      tags: ['', '  ', 'work', 'a\nb'] as T.TagName[],
+    });
+    expect(out.content).toContain('Tags:');
+    expect(out.content).toContain('work');
+    expect(out.content).not.toContain('a\nb');
+    const tagLines = out.content
+      .split('\n')
+      .filter((line) => line.startsWith('  '));
+    expect(tagLines).toEqual(['  work']);
+  });
+
+  it('【场景】全脏标签 【目的】等价于无标签 【校验点】引用相等 【预期】返回原对象不加 Tags 区', () => {
+    const n = { ...note('body'), tags: ['', '\nx'] as T.TagName[] };
+    expect(appendTags(n)).toBe(n);
+  });
+});
+
+describe('toUniqueNames', () => {
+  const base: PreparedNote = { ...note('Title'), fileName: 'Title' };
+
+  it('【场景】首次出现  【目的】基础名  【校验点】不追加后缀  【预期】原文件名', () => {
+    const acc: [PreparedNote[], Map<string, number>] = [[], new Map()];
+    const [notes] = toUniqueNames(acc, base);
+    expect(notes[0].fileName).toBe('Title');
+  });
+
+  it('【场景】第二次重复  【目的】顺序编号  【校验点】后缀 (1)  【预期】Title (1)', () => {
+    const acc: [PreparedNote[], Map<string, number>] = [[], new Map()];
+    toUniqueNames(acc, base);
+    const [notes] = toUniqueNames(acc, { ...base });
+    expect(notes[1].fileName).toBe('Title (1)');
+  });
+
+  it('【场景】输入名已含 (n)  【目的】不冲突  【校验点】探测后推  【预期】保留生成 (1) 并将输入名标为 (1) (1)', () => {
+    const acc: [PreparedNote[], Map<string, number>] = [[], new Map()];
+    toUniqueNames(acc, base);
+    toUniqueNames(acc, { ...base });
+    const [notes] = toUniqueNames(acc, { ...base, fileName: 'Title (1)' });
+    const names = notes.map((n) => n.fileName);
+    expect(names).toContain('Title (1)');
+    // The user-supplied "Title (1)" is distinguished from the generated one by
+    // appending another suffix, never by reusing "(1)" or jumping to "(2)".
+    expect(names).toContain('Title (1) (1)');
+    expect(new Set(names).size).toBe(3);
+  });
+});
+
+function noteWithId(content: string, id: string): ExportNote {
+  return {
+    ...note(content),
+    id: id as T.EntityId,
+  };
+}
+
+describe('writeJsonExport', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'simplenote-json-'));
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  it('【场景】常规导出 【目的】验证 JSON 发布与 staging 清理 【校验点】文件内容/无 .part 残留 【预期】缩进 JSON 且干净落盘', async () => {
+    const grouped = {
+      activeNotes: [noteWithId('a', 'n1')],
+      trashedNotes: [noteWithId('t', 'n2')],
+    };
+
+    await writeJsonExport(grouped, tmpDir);
+
+    const raw = await fs.readFile(path.join(tmpDir, 'notes.json'), 'utf8');
+    expect(JSON.parse(raw)).toEqual(grouped);
+    expect(
+      (await fs.readdir(tmpDir)).filter((name) => name.endsWith('.part'))
+    ).toEqual([]);
+  });
+
+  it('【场景】新写入失败 【目的】验证失败回滚与旧文件保留 【校验点】notes.json 旧内容/无 staging 残留 【预期】旧文件原样保留', async () => {
+    const target = path.join(tmpDir, 'notes.json');
+    await fs.writeFile(target, '{"previous":true}', 'utf8');
+    const writeFile = jest
+      .spyOn(fs, 'writeFile')
+      .mockRejectedValue(new Error('ENOSPC: no space left on device'));
+
+    await expect(
+      writeJsonExport(
+        { activeNotes: [noteWithId('a', 'n1')], trashedNotes: [] },
+        tmpDir
+      )
+    ).rejects.toThrow('ENOSPC');
+    writeFile.mockRestore();
+
+    expect(await fs.readFile(target, 'utf8')).toBe('{"previous":true}');
+    expect(
+      (await fs.readdir(tmpDir)).filter((name) => name.endsWith('.part'))
+    ).toEqual([]);
+  });
+
+  it('【场景】上次运行遗留 staging/backup 【目的】验证启动清理 【校验点】残留被移除且新文件生成 【预期】孤本删除、notes.json 产出', async () => {
+    const orphan = path.join(tmpDir, '.notes.json.999.deadbeef.part');
+    const orphanBackup = path.join(tmpDir, '.notes.json.999.deadbeef.bak');
+    await fs.writeFile(orphan, 'half a file', 'utf8');
+    await fs.writeFile(orphanBackup, 'old backup', 'utf8');
+
+    await writeJsonExport({ activeNotes: [], trashedNotes: [] }, tmpDir);
+
+    await expect(fs.access(orphan)).rejects.toBeTruthy();
+    await expect(fs.access(orphanBackup)).rejects.toBeTruthy();
+    await expect(
+      fs.access(path.join(tmpDir, 'notes.json'))
+    ).resolves.toBeUndefined();
+  });
+
+  // B.7：isStagingOf 只识别自有 pid.hex 中段格式；同名前缀的用户文件即使
+  // 带 .part/.bak 后缀也绝不能被视为残留去删除或恢复。
+  it('【场景】同名前缀用户文件 【目的】谓词收紧后不误伤用户文件 【校验点】用户 .part/.bak 保留 【预期】两文件原样存在', async () => {
+    const userPart = path.join(tmpDir, '.notes.json.my-notes.part');
+    const userBackup = path.join(tmpDir, '.notes.json.my-notes.bak');
+    await fs.writeFile(userPart, 'user data', 'utf8');
+    await fs.writeFile(userBackup, 'user data', 'utf8');
+
+    await writeJsonExport({ activeNotes: [], trashedNotes: [] }, tmpDir);
+
+    await expect(fs.access(userPart)).resolves.toBeUndefined();
+    await expect(fs.access(userBackup)).resolves.toBeUndefined();
+  });
+
+  // C.1：崩溃窗口（target 缺失 + backup 唯一副本）下，sweepStale 必须把
+  // backup 恢复为 target 而不是删除 —— 旧实现删掉 .bak 会永久丢失最后一份
+  // 完好导出。这里让新导出构建失败，验证恢复的旧导出在失败后仍被保留。
+  it('【场景】崩溃窗口残留（target 缺失 + backup 唯一副本） 【目的】恢复而非删除最后完好导出 【校验点】notes.json 内容 【预期】旧导出被恢复且在后续失败后保留', async () => {
+    const orphan = path.join(tmpDir, '.notes.json.999.deadbeef.part');
+    const orphanBackup = path.join(tmpDir, '.notes.json.999.deadbeef.bak');
+    await fs.writeFile(orphan, 'half a file', 'utf8');
+    await fs.writeFile(orphanBackup, 'old backup', 'utf8');
+
+    const writeFile = jest
+      .spyOn(fs, 'writeFile')
+      .mockRejectedValue(new Error('ENOSPC: no space left on device'));
+    await expect(
+      writeJsonExport(
+        { activeNotes: [noteWithId('a', 'n1')], trashedNotes: [] },
+        tmpDir
+      )
+    ).rejects.toThrow('ENOSPC');
+    writeFile.mockRestore();
+
+    // backup 被 rename 回 notes.json（而非删除），构建失败后旧导出仍在。
+    expect(await fs.readFile(path.join(tmpDir, 'notes.json'), 'utf8')).toBe(
+      'old backup'
+    );
+    await expect(fs.access(orphan)).rejects.toBeTruthy();
+    await expect(fs.access(orphanBackup)).rejects.toBeTruthy();
+  });
+
+  it('【场景】commit 完成态残留（target 存在 + backup） 【目的】backup 为冗余可清理 【校验点】backup 删除、导出成功 【预期】仅 target 保留', async () => {
+    await fs.writeFile(path.join(tmpDir, 'notes.json'), 'new export', 'utf8');
+    const orphanBackup = path.join(tmpDir, '.notes.json.999.deadbeef.bak');
+    await fs.writeFile(orphanBackup, 'old backup', 'utf8');
+
+    await writeJsonExport(
+      { activeNotes: [noteWithId('a', 'n1')], trashedNotes: [] },
+      tmpDir
+    );
+
+    await expect(fs.access(orphanBackup)).rejects.toBeTruthy();
+    expect(
+      JSON.parse(await fs.readFile(path.join(tmpDir, 'notes.json'), 'utf8'))
+    ).toEqual({ activeNotes: [noteWithId('a', 'n1')], trashedNotes: [] });
+  });
+
+  it('【场景】仅 staging 残留 【目的】清理不误伤现有 target 【校验点】.part 删除、导出正常 【预期】清理成功', async () => {
+    const orphan = path.join(tmpDir, '.notes.json.888.abcdef01.part');
+    await fs.writeFile(orphan, 'half a file', 'utf8');
+
+    await writeJsonExport({ activeNotes: [], trashedNotes: [] }, tmpDir);
+
+    await expect(fs.access(orphan)).rejects.toBeTruthy();
+    await expect(
+      fs.access(path.join(tmpDir, 'notes.json'))
+    ).resolves.toBeUndefined();
+  });
+
+  // B.7：多次崩溃会留下多个 .bak，恢复必须选 mtime 最新的那一个，而不是
+  // readdir 顺序里的第一个。
+  it('【场景】多 backup 残留 【目的】恢复最新的 backup 【校验点】notes.json 内容 【预期】mtime 最新的被恢复', async () => {
+    const older = path.join(tmpDir, '.notes.json.111.aabbccdd.bak');
+    const newer = path.join(tmpDir, '.notes.json.222.eeff0011.bak');
+    await fs.writeFile(older, 'older backup', 'utf8');
+    await fs.writeFile(newer, 'newer backup', 'utf8');
+    const past = new Date('2020-01-01T00:00:00Z');
+    const recent = new Date('2024-01-01T00:00:00Z');
+    await fs.utimes(older, past, past);
+    await fs.utimes(newer, recent, recent);
+
+    const writeFile = jest
+      .spyOn(fs, 'writeFile')
+      .mockRejectedValue(new Error('ENOSPC: no space left on device'));
+    await expect(
+      writeJsonExport(
+        { activeNotes: [noteWithId('a', 'n1')], trashedNotes: [] },
+        tmpDir
+      )
+    ).rejects.toThrow('ENOSPC');
+    writeFile.mockRestore();
+
+    expect(await fs.readFile(path.join(tmpDir, 'notes.json'), 'utf8')).toBe(
+      'newer backup'
+    );
+  });
+
+  // E1：本地写失败（权限、输出路径是文件、磁盘满）必须包成指向输出目录的
+  // 类型化错误，而不是上抛裸 EACCES/ENOENT——后者经 exitCodeFor 显示为网络
+  // 失败，用户无从区分是磁盘问题还是网络问题。
+  it('【场景】mkdir 失败 【目的】E1 本地写失败包错 【校验点】CliError code 3 + 消息含路径 【预期】类型化错误且路径可见', async () => {
+    const mkdir = jest
+      .spyOn(fs, 'mkdir')
+      .mockRejectedValue(new Error('EACCES: permission denied'));
+    const thrown = await writeJsonExport(
+      { activeNotes: [], trashedNotes: [] },
+      tmpDir
+    ).catch((error) => error);
+    mkdir.mockRestore();
+
+    expect(thrown).toBeInstanceOf(CliError);
+    expect((thrown as CliError).code).toBe(3);
+    expect(thrown.message).toContain(tmpDir);
+    expect(thrown.message).toContain('EACCES');
+  });
+
+  // E3：同一文件系统粒度内生成的两个 backup（mtime 相等）必须确定地恢复
+  // 同一个，而不是依赖 readdir 的任意顺序——两次扫描同一目录必须同结果。
+  it('【场景】两 backup mtime 相等 【目的】E3 确定性 tie-break 【校验点】notes.json 内容 【预期】名较大者被恢复', async () => {
+    const a = path.join(tmpDir, '.notes.json.111.aabbccdd.bak');
+    const b = path.join(tmpDir, '.notes.json.222.eeff0011.bak');
+    await fs.writeFile(a, 'backup A', 'utf8');
+    await fs.writeFile(b, 'backup B', 'utf8');
+    const same = new Date('2024-06-01T12:00:00Z');
+    await fs.utimes(a, same, same);
+    await fs.utimes(b, same, same);
+
+    const writeFile = jest
+      .spyOn(fs, 'writeFile')
+      .mockRejectedValue(new Error('ENOSPC: no space left on device'));
+    await expect(
+      writeJsonExport(
+        { activeNotes: [noteWithId('a', 'n1')], trashedNotes: [] },
+        tmpDir
+      )
+    ).rejects.toThrow('ENOSPC');
+    writeFile.mockRestore();
+
+    expect(await fs.readFile(path.join(tmpDir, 'notes.json'), 'utf8')).toBe(
+      'backup B'
+    );
+  });
+
+  // E3：恢复 backup 失败是数据恢复事件（用户唯一的旧导出留在 .bak 里），
+  // 必须 stderr 可见并指明位置，而不是淹没在 debug 日志里。
+  it('【场景】恢复 backup 失败 【目的】E3 告警可见 【校验点】console.error 调用 【预期】含 backup 与 target 路径', async () => {
+    const orphanBackup = path.join(tmpDir, '.notes.json.999.deadbeef.bak');
+    await fs.writeFile(orphanBackup, 'last good export', 'utf8');
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const rename = jest
+      .spyOn(fs, 'rename')
+      .mockRejectedValue(new Error('EACCES: permission denied'));
+
+    const writeFile = jest
+      .spyOn(fs, 'writeFile')
+      .mockRejectedValue(new Error('ENOSPC: no space left on device'));
+    await expect(
+      writeJsonExport(
+        { activeNotes: [noteWithId('a', 'n1')], trashedNotes: [] },
+        tmpDir
+      )
+    ).rejects.toThrow('ENOSPC');
+    writeFile.mockRestore();
+    rename.mockRestore();
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0][0]).toContain(orphanBackup);
+    expect(errorSpy.mock.calls[0][0]).toContain(
+      path.join(tmpDir, 'notes.json')
+    );
+    errorSpy.mockRestore();
+  });
+
+  // F-11：commitAll 回滚期间的 rename 失败过去被静默吞掉——磁盘可能停在
+  // "部分新部分旧"的混合状态而用户毫不知情，唯一的旧导出还留在 .bak 里。
+  // 与 sweepStale 的恢复失败一样是数据恢复事件，必须 stderr 可见并指明
+  // backup 位置，同时原错误仍按原路径抛出。
+  it('【场景】回滚恢复失败 【目的】F-11 告警可见 【校验点】console.error + 主错误 【预期】告警含 target 路径且 EEXIST 仍抛出', async () => {
+    // 第一次成功导出，留下旧 notes.json 供回滚恢复。
+    await writeJsonExport(
+      { activeNotes: [noteWithId('old', 'n0')], trashedNotes: [] },
+      tmpDir
+    );
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    // 第一次 rename（target -> backup）成功；此后（staging -> target，以及
+    // 回滚中的 backup -> target）全部失败。
+    const rename = jest
+      .spyOn(fs, 'rename')
+      .mockImplementationOnce(() => Promise.resolve())
+      .mockRejectedValue(new Error('EEXIST: file already exists'));
+
+    await expect(
+      writeJsonExport(
+        { activeNotes: [noteWithId('new', 'n1')], trashedNotes: [] },
+        tmpDir
+      )
+    ).rejects.toThrow('EEXIST');
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0][0]).toContain('rollback could not restore');
+    expect(errorSpy.mock.calls[0][0]).toContain(
+      path.join(tmpDir, 'notes.json')
+    );
+    rename.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  // B-5：export 本地阶段的中断没有在途 fetch 可取消，必须按 artifact 检查
+  // 进程级信号并转成 AbortedError —— 中断从"静默完成、exit 0"变为"exit 6"。
+  it('【场景】本地写阶段收到中断信号 【目的】B-5 abort 传播 【校验点】异常类型/无产出 【预期】AbortedError 且不产出 notes.json', async () => {
+    const controller = new AbortController();
+    setExternalAbortSignal(controller.signal);
+    controller.abort();
+
+    const thrown = await writeJsonExport(
+      { activeNotes: [noteWithId('a', 'n1')], trashedNotes: [] },
+      tmpDir
+    ).catch((error) => error);
+    setExternalAbortSignal(null);
+
+    expect(thrown).toBeInstanceOf(AbortedError);
+    await expect(
+      fs.access(path.join(tmpDir, 'notes.json'))
+    ).rejects.toBeTruthy();
+  });
+
+  // 入参边界：sweepStale 只识别自有 staging/backup 命名（pid.hex 中段），
+  // 目录里的普通无后缀文件必须原样保留，不能因不含目标后缀之外的形态被误判。
+  it('【场景】目录含普通文件 【目的】sweepStale 不误删无后缀文件 【校验点】random.txt 保留 【预期】普通文件原样存在', async () => {
+    const userFile = path.join(tmpDir, 'random.txt');
+    await fs.writeFile(userFile, 'data', 'utf8');
+    const orphan = path.join(tmpDir, '.notes.json.999.deadbeef.part');
+    await fs.writeFile(orphan, 'half a file', 'utf8');
+
+    await writeJsonExport({ activeNotes: [], trashedNotes: [] }, tmpDir);
+
+    await expect(fs.access(userFile)).resolves.toBeUndefined();
+    await expect(fs.access(orphan)).rejects.toBeTruthy();
+  });
+
+  // 异常故障：清理目录不可读时 sweepStale 必须静默放弃（best-effort 契约），
+  // 导出主流程照常完成，而不是被 EACCES 打断。
+  it('【场景】目录不可读 【目的】清理失败不阻断导出 【校验点】导出完成 【预期】正常产出 notes.json', async () => {
+    const readdir = jest
+      .spyOn(fs, 'readdir')
+      .mockRejectedValue(new Error('EACCES: permission denied'));
+
+    try {
+      await writeJsonExport({ activeNotes: [], trashedNotes: [] }, tmpDir);
+    } finally {
+      readdir.mockRestore();
+    }
+
+    await expect(
+      fs.access(path.join(tmpDir, 'notes.json'))
+    ).resolves.toBeUndefined();
+  });
+
+  // 异常故障：备份重命名被拒绝（非"无旧文件"）属于真实 IO 故障，必须向上
+  // 抛出，而不是被当作"首次导出没有旧文件"静默吞掉。
+  it('【场景】备份重命名被拒绝 【目的】非 ENOENT 错误向上抛 【校验点】异常 【预期】EACCES 抛出', async () => {
+    await fs.writeFile(path.join(tmpDir, 'notes.json'), 'old', 'utf8');
+    const rename = jest
+      .spyOn(fs, 'rename')
+      .mockRejectedValue(new Error('EACCES: permission denied'));
+
+    try {
+      await expect(
+        writeJsonExport(
+          { activeNotes: [noteWithId('a', 'n1')], trashedNotes: [] },
+          tmpDir
+        )
+      ).rejects.toThrow('EACCES');
+    } finally {
+      rename.mockRestore();
+    }
+  });
+
+  // 异常故障：回滚阶段删除半成品失败时，主错误照常抛出、告警走 stderr 可见
+  // （包含 target 路径），不留静默的部分删除状态。commitAll 内 staging -> target
+  // 发布失败才会进入回滚（writeJson 阶段失败时 backups 为空，无回滚可走）。
+  it('【场景】回滚清理失败 【目的】告警可见且不吞主错误 【校验点】console.error 含 target 【预期】告警 + EEXIST 抛出', async () => {
+    await writeJsonExport(
+      { activeNotes: [noteWithId('old', 'n0')], trashedNotes: [] },
+      tmpDir
+    );
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    // 第一次 rename（target -> backup）成功入 backups；staging -> target 与
+    // 回滚的 backup -> target 全部失败。
+    const rename = jest
+      .spyOn(fs, 'rename')
+      .mockImplementationOnce(() => Promise.resolve())
+      .mockRejectedValue(new Error('EEXIST: file already exists'));
+    const rm = jest
+      .spyOn(fs, 'rm')
+      .mockRejectedValue(new Error('EACCES: permission denied'));
+
+    let warnings: string[];
+    try {
+      await expect(
+        writeJsonExport(
+          { activeNotes: [noteWithId('new', 'n1')], trashedNotes: [] },
+          tmpDir
+        )
+      ).rejects.toThrow('EEXIST');
+      warnings = errorSpy.mock.calls.map((call) => String(call[0]));
+    } finally {
+      rename.mockRestore();
+      rm.mockRestore();
+      errorSpy.mockRestore();
+    }
+
+    expect(
+      warnings.some((message) => message.includes('rollback could not remove'))
+    ).toBe(true);
+  });
+});
+
+describe('writeMarkdownExport', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'simplenote-md-'));
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  it('【场景】活动与回收站笔记分流 【目的】验证双目录发布 【校验点】active/trash 目录文件名 【预期】各归其位', async () => {
+    const grouped = {
+      activeNotes: [noteWithId('Active title\nbody', 'n1')],
+      trashedNotes: [noteWithId('Trash title', 'n2')],
+    };
+
+    await writeMarkdownExport(grouped, tmpDir);
+
+    expect(await fs.readdir(path.join(tmpDir, 'active'))).toEqual([
+      'Active title.md',
+    ]);
+    expect(await fs.readdir(path.join(tmpDir, 'trash'))).toEqual([
+      'Trash title.md',
+    ]);
+  });
+
+  it('【场景】目标目录已有旧导出 【目的】验证整目录替换而非合并 【校验点】残留文件 【预期】旧文件消失', async () => {
+    const activeDir = path.join(tmpDir, 'active');
+    await fs.mkdir(activeDir, { recursive: true });
+    await fs.writeFile(path.join(activeDir, 'ghost.md'), 'stale', 'utf8');
+
+    await writeMarkdownExport(
+      { activeNotes: [noteWithId('Fresh', 'n1')], trashedNotes: [] },
+      tmpDir
+    );
+
+    expect(await fs.readdir(activeDir)).toEqual(['Fresh.md']);
+  });
+
+  it('【场景】大量同标题笔记 【目的】验证并发分区写入与命名去重 【校验点】文件数与唯一性 【预期】40 个互不覆盖文件', async () => {
+    const notes = Array.from({ length: 40 }, (_, i) =>
+      noteWithId(`Same title ${i % 2}`, `id-${i}`)
+    );
+
+    await writeMarkdownExport({ activeNotes: notes, trashedNotes: [] }, tmpDir);
+
+    const files = await fs.readdir(path.join(tmpDir, 'active'));
+    expect(files.length).toBe(40);
+    expect(new Set(files).size).toBe(40);
+  });
+
+  it('【场景】成功导出后 【目的】验证无 staging/backup 残留 【校验点】根目录 .part/.bak 【预期】无', async () => {
+    await writeMarkdownExport(
+      { activeNotes: [noteWithId('a', 'n1')], trashedNotes: [] },
+      tmpDir
+    );
+
+    expect(
+      (await fs.readdir(tmpDir)).filter(
+        (name) => name.endsWith('.part') || name.endsWith('.bak')
+      )
+    ).toEqual([]);
+  });
+
+  // 生命周期/时序：本地写盘阶段的 Ctrl-C 必须在每个文件之间被感知（而不是
+  // 等到整个 artifact 写完后才检查）——中断落在多文件 markdown 导出中途时，
+  // 已写文件保留、剩余文件停止、整体抛 AbortedError。
+  it('【场景】导出中途收到中断 【目的】逐文件中止检查 【校验点】异常类型 【预期】AbortedError', async () => {
+    const controller = new AbortController();
+    setExternalAbortSignal(controller.signal);
+    const realWriteFile = fs.writeFile.bind(fs);
+    const writeFile = jest.spyOn(fs, 'writeFile').mockImplementation((async (
+      ...args: unknown[]
+    ) => {
+      controller.abort();
+      await realWriteFile(
+        args[0] as Parameters<typeof fs.writeFile>[0],
+        args[1] as Parameters<typeof fs.writeFile>[1],
+        args[2] as Parameters<typeof fs.writeFile>[2]
+      );
+    }) as unknown as typeof fs.writeFile);
+
+    try {
+      const thrown = await writeMarkdownExport(
+        {
+          activeNotes: [noteWithId('a', 'n1'), noteWithId('b', 'n2')],
+          trashedNotes: [],
+        },
+        tmpDir
+      ).catch((error) => error);
+
+      expect(thrown).toBeInstanceOf(AbortedError);
+    } finally {
+      writeFile.mockRestore();
+      setExternalAbortSignal(null);
+    }
+  });
+});

--- a/lib/cli/__tests__/export-publish.test.ts
+++ b/lib/cli/__tests__/export-publish.test.ts
@@ -1,0 +1,31 @@
+jest.mock('../vendor/export/to-zip.ts', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+import noteExportToZip from '../vendor/export/to-zip.ts';
+import { writeZipExport } from '../export-helpers.ts';
+import { NetworkError } from '../domain/errors.ts';
+import type { GroupedExportNotes } from '../vendor/export/types.ts';
+
+const grouped: GroupedExportNotes = { activeNotes: [], trashedNotes: [] };
+
+// writeZipExport only touches the file system after the archive is built, so a
+// null/undefined zip (generation failed upstream) must surface as a NetworkError
+// before any staging write happens. These cases are not exercised by the
+// command-level export tests, which always supply a working zip double.
+describe('writeZipExport', () => {
+  it('【场景】zip 生成为 null  【目的】上游失败兜底  【校验点】异常类型  【预期】抛 NetworkError', async () => {
+    (noteExportToZip as jest.Mock).mockResolvedValue(null);
+    await expect(writeZipExport(grouped, '/tmp/out')).rejects.toBeInstanceOf(
+      NetworkError
+    );
+  });
+
+  it('【场景】zip 生成为 undefined  【目的】上游失败兜底  【校验点】异常类型  【预期】抛 NetworkError', async () => {
+    (noteExportToZip as jest.Mock).mockResolvedValue(undefined);
+    await expect(writeZipExport(grouped, '/tmp/out')).rejects.toBeInstanceOf(
+      NetworkError
+    );
+  });
+});

--- a/lib/cli/__tests__/export-to-zip.test.ts
+++ b/lib/cli/__tests__/export-to-zip.test.ts
@@ -1,0 +1,93 @@
+jest.mock('jszip', () => {
+  class MockJSZip {
+    files: Array<{ name: string; content: string; opts?: unknown }> = [];
+    file(name: string, content: string, opts?: unknown) {
+      this.files.push({ name, content, opts });
+      return this;
+    }
+  }
+  return { __esModule: true, default: MockJSZip };
+});
+
+import noteExportToZip from '../vendor/export/to-zip.ts';
+import type { ExportNote, GroupedExportNotes } from '../vendor/export/types.ts';
+import type * as T from '../vendor/types.ts';
+
+// Minimal ExportNote factory. `lastModified` is not part of ExportNote; it is
+// carried through from the note source and read by the zip writer via its
+// ZipNote cast, so it is supplied here to pin the date option.
+function note(
+  content: string,
+  lastModified = '2024-01-01T00:00:00.000Z'
+): ExportNote & { lastModified: string } {
+  return {
+    content,
+    collaboratorEmails: [],
+    creationDate: 0,
+    id: `id-${content}` as T.EntityId,
+    lastModified,
+    modificationDate: 0,
+    tags: [],
+  };
+}
+
+type CapturedZip = {
+  files: Array<{ name: string; content: string; opts?: { date?: Date } }>;
+};
+
+describe('noteExportToZip', () => {
+  it('【场景】活动与回收站分流 【目的】验证 zip 条目路径与 trash/ 前缀 【校验点】文件名列表 【预期】source/notes.json 在前，活动笔记在后，回收站带 trash/ 前缀', async () => {
+    const grouped: GroupedExportNotes = {
+      activeNotes: [note('Active title\nbody')],
+      trashedNotes: [note('Trash title')],
+    };
+
+    const zip = (await noteExportToZip(grouped)) as unknown as CapturedZip;
+
+    expect(zip.files.map((file) => file.name)).toEqual([
+      'source/notes.json',
+      'Active title.txt',
+      'trash/Trash title.txt',
+    ]);
+  });
+
+  it('【场景】同标题笔记 【目的】复用 export-naming 去重（R4）【校验点】条目名 【预期】同标题按 (n) 编号互不覆盖', async () => {
+    const grouped: GroupedExportNotes = {
+      activeNotes: [note('Meeting'), note('Meeting')],
+      trashedNotes: [],
+    };
+
+    const zip = (await noteExportToZip(grouped)) as unknown as CapturedZip;
+
+    expect(zip.files.map((file) => file.name)).toEqual([
+      'source/notes.json',
+      'Meeting.txt',
+      'Meeting (1).txt',
+    ]);
+  });
+
+  it('【场景】导出失败 【目的】验证构造错误向上传播而非被 catch 吞掉 【校验点】rejects 【预期】调用方沿既有错误处理链分类（H-03）', async () => {
+    const grouped: GroupedExportNotes = {
+      activeNotes: [note('a')],
+      trashedNotes: [],
+    };
+    const jszipMock = require('jszip') as { default: new () => unknown };
+    const original = jszipMock.default;
+    class ExplodingZip {
+      constructor() {
+        throw new Error('zip build failed');
+      }
+    }
+    (jszipMock as { default: new () => unknown }).default = ExplodingZip;
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await expect(noteExportToZip(grouped)).rejects.toThrow(
+        'zip build failed'
+      );
+      expect(logSpy).not.toHaveBeenCalled();
+    } finally {
+      (jszipMock as { default: new () => unknown }).default = original;
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/lib/cli/__tests__/export.test.ts
+++ b/lib/cli/__tests__/export.test.ts
@@ -1,0 +1,468 @@
+jest.mock('../note-source.ts', () => ({
+  createNoteSource: jest.fn(),
+}));
+
+jest.mock('../vendor/export/to-zip.ts', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+import { promises as fs } from 'fs';
+import { Readable } from 'stream';
+import * as os from 'os';
+import * as path from 'path';
+import { createNoteSource } from '../note-source.ts';
+import noteExportToZip from '../vendor/export/to-zip.ts';
+import { exportCommand, parseExportOptions } from '../commands/export.ts';
+import type { Credentials } from '../domain/types.ts';
+import type * as T from '../vendor/types.ts';
+
+const mockFind = jest.fn();
+const mockSource = {
+  find: mockFind,
+};
+
+const credentials: Credentials = {
+  access_token: 'tok',
+  username: 'user@example.com',
+};
+
+const sampleNote: T.Note = {
+  content: '# Active Note\n\nbody',
+  creationDate: 1700000000,
+  modificationDate: 1700000001,
+  systemTags: ['markdown'],
+  tags: ['work'] as T.TagName[],
+  deleted: false,
+};
+
+const trashedNote: T.Note = {
+  content: 'trashed note',
+  creationDate: 1690000000,
+  modificationDate: 1690000001,
+  systemTags: [],
+  tags: [],
+  deleted: true,
+};
+
+// The archive is streamed to disk rather than buffered in memory, so the
+// double has to hand back a fresh readable stream on every call.
+const mockZip = {
+  generateNodeStream: jest.fn(() => Readable.from(['zip-bytes'])),
+};
+
+describe('parseExportOptions', () => {
+  it('defaults to all formats and the simplenote-export directory', () => {
+    const opts = parseExportOptions([]);
+    expect(opts.format).toBe('all');
+    expect(opts.outputDir).toBe(path.resolve('simplenote-export'));
+  });
+
+  it('parses a single format and custom output dir', () => {
+    const opts = parseExportOptions(['--format=json', '--output=/tmp/out']);
+    expect(opts.format).toBe('json');
+    expect(opts.outputDir).toBe('/tmp/out');
+  });
+
+  // Falling back to "all" turned `--format=exe` into a full export the user
+  // never asked for, silently writing three artefacts instead of failing.
+  it('rejects an unknown format', () => {
+    expect(() => parseExportOptions(['--format=exe'])).toThrow(
+      '--format must be one of'
+    );
+  });
+
+  it('rejects an empty --format or --output rather than guessing', () => {
+    expect(() => parseExportOptions(['--format='])).toThrow(
+      '--format cannot be empty'
+    );
+    expect(() => parseExportOptions(['--output='])).toThrow(
+      '--output cannot be empty'
+    );
+  });
+
+  it('rejects a repeated --format= or --output= flag instead of keeping the first value', () => {
+    expect(() => parseExportOptions(['--format=json', '--format=zip'])).toThrow(
+      'Provide --format= once'
+    );
+    expect(() =>
+      parseExportOptions(['--output=/tmp/a', '--output=/tmp/b'])
+    ).toThrow('Provide --output= once');
+  });
+
+  it('keeps "=" inside an output path', () => {
+    expect(parseExportOptions(['--output=/tmp/a=b']).outputDir).toBe(
+      '/tmp/a=b'
+    );
+  });
+
+  it('rejects a stray positional argument', () => {
+    expect(() => parseExportOptions(['extra'])).toThrow(
+      'Too many arguments for export'
+    );
+  });
+});
+
+/**
+ * Delete a scratch directory without ever failing the test.
+ *
+ * Teardown is not an assertion: some environments wrap `fs.rm` (recycle-bin
+ * shims, read-only mounts, antivirus locks) and reject even though every
+ * assertion already passed. Letting that bubble up turns a green test red for
+ * reasons that have nothing to do with the code under test.
+ */
+async function removeQuietly(dir: string): Promise<void> {
+  try {
+    await fs.rm(dir, { recursive: true, force: true });
+  } catch {
+    // Best effort — the OS reclaims the temp directory anyway.
+  }
+}
+
+/**
+ * Waits until no staging directory remains under `dir`.
+ *
+ * The markdown writer publishes the active and trash directories in parallel
+ * (`Promise.all`), so when the active side fails the rejection surfaces while
+ * the sibling trash publish may still be mid-flight. Polling for the ".part"
+ * artefacts to disappear makes the assertion race-free without slowing the
+ * happy path.
+ */
+async function waitForNoPart(dir: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (!(await fs.readdir(dir)).some((name) => name.endsWith('.part'))) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+describe('exportCommand', () => {
+  // A unique directory per test keeps the runs independent and, unlike a fixed
+  // folder under the repo root, never leaves artefacts in the working tree.
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'simplenote-cli-export-'));
+    (createNoteSource as jest.Mock).mockReturnValue(mockSource);
+    (noteExportToZip as jest.Mock).mockResolvedValue(mockZip);
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    mockFind.mockReset();
+    (noteExportToZip as jest.Mock).mockClear();
+    await removeQuietly(tmpDir);
+  });
+
+  it('writes notes.json with the expected structure', async () => {
+    mockFind.mockResolvedValue([
+      { id: 'n1', data: sampleNote },
+      { id: 'n2', data: trashedNote },
+    ]);
+
+    await exportCommand(credentials, ['--format=json', `--output=${tmpDir}`]);
+
+    const raw = await fs.readFile(path.join(tmpDir, 'notes.json'), 'utf8');
+    const parsed = JSON.parse(raw) as {
+      activeNotes: Array<{ id: string; content: string }>;
+      trashedNotes: Array<{ id: string }>;
+    };
+    expect(parsed.activeNotes).toHaveLength(1);
+    expect(parsed.activeNotes[0].id).toBe('n1');
+    expect(parsed.activeNotes[0].content).toContain('# Active Note');
+    expect(parsed.trashedNotes).toHaveLength(1);
+    expect(parsed.trashedNotes[0].id).toBe('n2');
+    expect(createNoteSource).toHaveBeenCalledWith('tok');
+  });
+
+  it('writes markdown files under active/ and trash/', async () => {
+    mockFind.mockResolvedValue([
+      { id: 'n1', data: sampleNote },
+      { id: 'n2', data: trashedNote },
+    ]);
+
+    await exportCommand(credentials, [
+      '--format=markdown',
+      `--output=${tmpDir}`,
+    ]);
+
+    const activeFiles = await fs.readdir(path.join(tmpDir, 'active'));
+    const trashFiles = await fs.readdir(path.join(tmpDir, 'trash'));
+    expect(activeFiles.length).toBe(1);
+    expect(activeFiles[0]).toMatch(/\.md$/);
+    expect(trashFiles.length).toBe(1);
+  });
+
+  it('removes stale markdown from a previous export into the same directory', async () => {
+    // A note that existed at export time but has since been deleted (or whose
+    // first line changed) must not survive as a ghost .md in the next export.
+    const activeDir = path.join(tmpDir, 'active');
+    const trashDir = path.join(tmpDir, 'trash');
+    await fs.mkdir(activeDir, { recursive: true });
+    await fs.mkdir(trashDir, { recursive: true });
+    await fs.writeFile(path.join(activeDir, 'ghost.md'), 'stale', 'utf8');
+    await fs.writeFile(path.join(trashDir, 'ghost.md'), 'stale', 'utf8');
+
+    mockFind.mockResolvedValue([{ id: 'n1', data: sampleNote }]);
+
+    await exportCommand(credentials, [
+      '--format=markdown',
+      `--output=${tmpDir}`,
+    ]);
+
+    const activeFiles = await fs.readdir(activeDir);
+    const trashFiles = await fs.readdir(trashDir);
+    expect(activeFiles).toHaveLength(1);
+    expect(activeFiles[0]).not.toBe('ghost.md');
+    expect(trashFiles).toHaveLength(0);
+  });
+
+  it('appends tags to markdown content', async () => {
+    mockFind.mockResolvedValue([{ id: 'n1', data: sampleNote }]);
+
+    await exportCommand(credentials, [
+      '--format=markdown',
+      `--output=${tmpDir}`,
+    ]);
+
+    const [file] = await fs.readdir(path.join(tmpDir, 'active'));
+    const content = await fs.readFile(
+      path.join(tmpDir, 'active', file),
+      'utf8'
+    );
+    expect(content).toContain('Tags:');
+    expect(content).toContain('work');
+  });
+
+  it('writes a zip archive via noteExportToZip', async () => {
+    mockFind.mockResolvedValue([{ id: 'n1', data: sampleNote }]);
+
+    await exportCommand(credentials, ['--format=zip', `--output=${tmpDir}`]);
+
+    expect(noteExportToZip).toHaveBeenCalled();
+    const bytes = await fs.readFile(path.join(tmpDir, 'notes.zip'));
+    expect(bytes.toString()).toBe('zip-bytes');
+  });
+
+  it('writes all formats when format=all', async () => {
+    mockFind.mockResolvedValue([{ id: 'n1', data: sampleNote }]);
+
+    await exportCommand(credentials, [`--output=${tmpDir}`]);
+
+    expect(
+      await fs.readFile(path.join(tmpDir, 'notes.json'), 'utf8')
+    ).toBeTruthy();
+    expect(await fs.readdir(path.join(tmpDir, 'active'))).toHaveLength(1);
+    expect(await fs.readFile(path.join(tmpDir, 'notes.zip'))).toBeTruthy();
+  });
+
+  it('rejects when find rejects', async () => {
+    mockFind.mockRejectedValue(new Error('boom'));
+
+    await expect(exportCommand(credentials, ['--format=json'])).rejects.toThrow(
+      'boom'
+    );
+  });
+
+  it('leaves no staging artefacts behind on a successful export', async () => {
+    mockFind.mockResolvedValue([{ id: 'n1', data: sampleNote }]);
+
+    await exportCommand(credentials, [`--output=${tmpDir}`]);
+
+    const entries = await fs.readdir(tmpDir);
+    expect(entries.filter((name) => name.endsWith('.part'))).toEqual([]);
+    expect(entries.sort()).toEqual([
+      'active',
+      'notes.json',
+      'notes.zip',
+      'trash',
+    ]);
+  });
+
+  // `export` exists so the user has a copy of their notes, so a failed run
+  // must never be worse than not running it at all. The markdown writer used
+  // to delete active/ and trash/ *before* writing: a failure left neither the
+  // new export nor the previous one.
+  it('keeps the previous markdown export when the new one fails', async () => {
+    const activeDir = path.join(tmpDir, 'active');
+    await fs.mkdir(activeDir, { recursive: true });
+    await fs.writeFile(path.join(activeDir, 'previous.md'), 'good', 'utf8');
+
+    mockFind.mockResolvedValue([{ id: 'n1', data: sampleNote }]);
+    const writeFile = jest
+      .spyOn(fs, 'writeFile')
+      .mockRejectedValue(new Error('ENOSPC: no space left on device'));
+
+    await expect(
+      exportCommand(credentials, ['--format=markdown', `--output=${tmpDir}`])
+    ).rejects.toThrow('ENOSPC');
+    writeFile.mockRestore();
+
+    // The concurrent trash publish may still be settling when the active one
+    // fails; wait for it before asserting there is no orphaned staging.
+    await waitForNoPart(tmpDir);
+
+    // The old export is still there, and no staging directory was orphaned.
+    expect(await fs.readdir(activeDir)).toEqual(['previous.md']);
+    expect(
+      (await fs.readdir(tmpDir)).filter((name) => name.endsWith('.part'))
+    ).toEqual([]);
+  });
+
+  // The active/ and trash/ halves are one export, so a failure in one half
+  // must not swap in the other. When the trash build fails, the old code had
+  // already replaced active/ with the new generation, leaving a brand-new
+  // active/ next to a stale trash/ — two generations mixed in one export.
+  it('keeps both halves of a previous markdown export when either half fails', async () => {
+    const activeDir = path.join(tmpDir, 'active');
+    const trashDir = path.join(tmpDir, 'trash');
+    await fs.mkdir(activeDir, { recursive: true });
+    await fs.mkdir(trashDir, { recursive: true });
+    await fs.writeFile(path.join(activeDir, 'old.md'), 'old-active', 'utf8');
+    await fs.writeFile(path.join(trashDir, 'old.md'), 'old-trash', 'utf8');
+
+    mockFind.mockResolvedValue([
+      { id: 'n1', data: sampleNote },
+      { id: 'n2', data: trashedNote },
+    ]);
+
+    // Only the trash half fails (its note's file name is derived from the
+    // content's first line, "trashed note"). The active half builds fine —
+    // exactly the setup that used to leave a half-swapped export behind.
+    const writeFile = jest
+      .spyOn(fs, 'writeFile')
+      .mockImplementation(async (file: unknown, ..._rest: unknown[]) => {
+        if (String(file).endsWith('trashed note.md')) {
+          throw new Error('ENOSPC: no space left on device');
+        }
+      });
+
+    await expect(
+      exportCommand(credentials, ['--format=markdown', `--output=${tmpDir}`])
+    ).rejects.toThrow('ENOSPC');
+    writeFile.mockRestore();
+
+    await waitForNoPart(tmpDir);
+
+    // Neither half was swapped: the old export survives intact instead of a
+    // new active/ sitting next to the previous trash/.
+    expect(await fs.readdir(activeDir)).toEqual(['old.md']);
+    expect(await fs.readdir(trashDir)).toEqual(['old.md']);
+  });
+
+  // R3: the two renames are one transaction. Even when the *build* succeeds,
+  // a failed install of the trash half (a rename error, not a build error)
+  // must roll the already-installed active half back — never a new active/
+  // beside a missing trash/.
+  it('restores both markdown halves when a commit-phase rename fails', async () => {
+    const activeDir = path.join(tmpDir, 'active');
+    const trashDir = path.join(tmpDir, 'trash');
+    await fs.mkdir(activeDir, { recursive: true });
+    await fs.mkdir(trashDir, { recursive: true });
+    await fs.writeFile(path.join(activeDir, 'old.md'), 'old-active', 'utf8');
+    await fs.writeFile(path.join(trashDir, 'old.md'), 'old-trash', 'utf8');
+
+    mockFind.mockResolvedValue([{ id: 'n1', data: sampleNote }]);
+
+    const originalRename = fs.rename;
+    const rename = jest
+      .spyOn(fs, 'rename')
+      .mockImplementation(async (from: unknown, to: unknown) => {
+        // Fail only the swap of the trash *staging* into place. Backups and
+        // rollback restores move non-.part paths, so they must not be caught.
+        if (String(from).endsWith('.part') && String(to).endsWith('trash')) {
+          throw new Error('EPERM: rename failed');
+        }
+        return originalRename(from as string, to as string);
+      });
+
+    await expect(
+      exportCommand(credentials, ['--format=markdown', `--output=${tmpDir}`])
+    ).rejects.toThrow('EPERM');
+    rename.mockRestore();
+
+    // Both halves were rolled back to the previous export, and no staging or
+    // backup artefact was orphaned.
+    expect(await fs.readdir(activeDir)).toEqual(['old.md']);
+    expect(await fs.readdir(trashDir)).toEqual(['old.md']);
+    expect(
+      (await fs.readdir(tmpDir)).filter(
+        (name) => name.endsWith('.part') || name.endsWith('.bak')
+      )
+    ).toEqual([]);
+  });
+
+  // R2: `format=all` commits every format as one unit. When the zip install
+  // fails, the already-committed notes.json and active/ must be rolled back,
+  // so the output never mixes a new generation with an old one.
+  it('rolls back every format when one commit fails in format=all', async () => {
+    const activeDir = path.join(tmpDir, 'active');
+    await fs.mkdir(activeDir, { recursive: true });
+    await fs.writeFile(path.join(activeDir, 'old.md'), 'old', 'utf8');
+    await fs.writeFile(
+      path.join(tmpDir, 'notes.json'),
+      '{"previous":true}',
+      'utf8'
+    );
+
+    mockFind.mockResolvedValue([{ id: 'n1', data: sampleNote }]);
+
+    const originalRename = fs.rename;
+    const rename = jest
+      .spyOn(fs, 'rename')
+      .mockImplementation(async (from: unknown, to: unknown) => {
+        // Fail only the zip install; backups and the other formats proceed.
+        if (String(to).endsWith('notes.zip')) {
+          throw new Error('EPERM: rename failed');
+        }
+        return originalRename(from as string, to as string);
+      });
+
+    await expect(
+      exportCommand(credentials, [`--output=${tmpDir}`])
+    ).rejects.toThrow('EPERM');
+    rename.mockRestore();
+
+    // notes.json and active/ were committed before zip; both rolled back.
+    expect(await fs.readFile(path.join(tmpDir, 'notes.json'), 'utf8')).toBe(
+      '{"previous":true}'
+    );
+    expect(await fs.readdir(activeDir)).toEqual(['old.md']);
+    expect(
+      (await fs.readdir(tmpDir)).filter(
+        (name) => name.endsWith('.part') || name.endsWith('.bak')
+      )
+    ).toEqual([]);
+  });
+
+  it('keeps the previous notes.json when the new one fails', async () => {
+    const target = path.join(tmpDir, 'notes.json');
+    await fs.writeFile(target, '{"previous":true}', 'utf8');
+
+    mockFind.mockResolvedValue([{ id: 'n1', data: sampleNote }]);
+    const writeFile = jest
+      .spyOn(fs, 'writeFile')
+      .mockRejectedValue(new Error('ENOSPC: no space left on device'));
+
+    await expect(
+      exportCommand(credentials, ['--format=json', `--output=${tmpDir}`])
+    ).rejects.toThrow('ENOSPC');
+    writeFile.mockRestore();
+
+    expect(await fs.readFile(target, 'utf8')).toBe('{"previous":true}');
+  });
+
+  // Staging a killed run (SIGKILL, power loss) cannot clean up after itself,
+  // so the next export sweeps what it recognizes as its own leftovers.
+  it('sweeps staging left by a killed run', async () => {
+    const orphan = path.join(tmpDir, '.notes.json.999.deadbeef.part');
+    await fs.writeFile(orphan, 'half a file', 'utf8');
+    mockFind.mockResolvedValue([{ id: 'n1', data: sampleNote }]);
+
+    await exportCommand(credentials, ['--format=json', `--output=${tmpDir}`]);
+
+    await expect(fs.access(orphan)).rejects.toBeTruthy();
+  });
+});

--- a/lib/cli/__tests__/list.test.ts
+++ b/lib/cli/__tests__/list.test.ts
@@ -1,0 +1,261 @@
+jest.mock('../note-source.ts', () => ({
+  createNoteSource: jest.fn(),
+}));
+
+import { createNoteSource } from '../note-source.ts';
+import { listCommand, parseListOptions } from '../commands/list.ts';
+import type { Credentials } from '../domain/types.ts';
+
+const mockFind = jest.fn();
+const mockSource = {
+  find: mockFind,
+};
+
+/**
+ * A mock `find` that honours the source contract: trash is dropped at the
+ * page boundary unless `includeTrashed` is set. The real source does this in
+ * note-source.ts, so command-level tests exercise it through a faithful stub
+ * rather than relying on a second, command-level filter.
+ */
+function mockFindFiltering(
+  notes: Array<{ id: string; data: Record<string, unknown> }>
+) {
+  mockFind.mockImplementation(
+    ({ includeTrashed }: { includeTrashed?: boolean }) =>
+      Promise.resolve(
+        notes.filter(
+          (note) =>
+            includeTrashed ||
+            (note.data.deleted !== true && note.data.deleted !== 1)
+        )
+      )
+  );
+}
+
+const credentials: Credentials = {
+  access_token: 'tok',
+  username: 'user@example.com',
+};
+
+describe('parseListOptions', () => {
+  it('defaults to 20 items, non-json output and no trash', () => {
+    expect(parseListOptions([])).toEqual({
+      limit: 20,
+      json: false,
+      includeTrashed: false,
+    });
+  });
+
+  it('parses a custom limit and json flag', () => {
+    expect(parseListOptions(['--limit=5', '--json'])).toEqual({
+      limit: 5,
+      json: true,
+      includeTrashed: false,
+    });
+  });
+
+  // Falling back to 20 made `list --limit=abc` look successful while ignoring
+  // what the user asked for.
+  it('rejects an invalid limit instead of silently using the default', () => {
+    expect(() => parseListOptions(['--limit=abc'])).toThrow(
+      '--limit must be a positive integer'
+    );
+  });
+
+  it('opts back into the trash with --include-trashed', () => {
+    expect(parseListOptions(['--include-trashed']).includeTrashed).toBe(true);
+  });
+
+  it('rejects a stray positional argument', () => {
+    expect(() => parseListOptions(['extra'])).toThrow(
+      'Too many arguments for list'
+    );
+  });
+});
+
+describe('listCommand', () => {
+  beforeEach(() => {
+    (createNoteSource as jest.Mock).mockReturnValue(mockSource);
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    mockFind.mockReset();
+  });
+
+  it('prints notes as JSON when --json is passed', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockFind.mockResolvedValue([
+      { id: 'n1', data: { content: 'hello world', modificationDate: 123 } },
+      { id: 'n2', data: { content: 'second note', modificationDate: 456 } },
+    ]);
+
+    await listCommand(credentials, ['--json', '--limit=2']);
+
+    // Newest first: the index arrives in storage order, the command sorts it.
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify(
+        [
+          { id: 'n2', data: { content: 'second note', modificationDate: 456 } },
+          { id: 'n1', data: { content: 'hello world', modificationDate: 123 } },
+        ],
+        null,
+        2
+      )
+    );
+    expect(createNoteSource).toHaveBeenCalledWith('tok');
+  });
+
+  it('returns the most recently modified notes, not the first N stored', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockFind.mockResolvedValue([
+      { id: 'oldest', data: { content: 'a', modificationDate: 1 } },
+      { id: 'newest', data: { content: 'b', modificationDate: 9 } },
+      { id: 'middle', data: { content: 'c', modificationDate: 5 } },
+    ]);
+
+    await listCommand(credentials, ['--json', '--limit=2']);
+
+    const parsed = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(parsed.map((item) => item.id)).toEqual(['newest', 'middle']);
+  });
+
+  it('does not mutate the array returned by the source', async () => {
+    const notes = [
+      { id: 'a', data: { content: 'a', modificationDate: 1 } },
+      { id: 'b', data: { content: 'b', modificationDate: 2 } },
+    ];
+    mockFind.mockResolvedValue(notes);
+
+    await listCommand(credentials, ['--json']);
+
+    expect(notes.map((note) => note.id)).toEqual(['a', 'b']);
+  });
+
+  it('prints a tab-separated table when json is not requested', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockFind.mockResolvedValue([
+      { id: 'n1', data: { content: 'line1\nline2', modificationDate: 123 } },
+    ]);
+
+    await listCommand(credentials, ['--limit=10']);
+
+    expect(logSpy).toHaveBeenCalledWith('n1\t123\tline1 line2');
+  });
+
+  // 入参边界：非 JSON 输出下 data 可缺省 content/modificationDate（例如索引
+  // 返回不含正文的占位对象）。`data?.content ?? ''` 与 `?? ''` 必须落到空串
+  // 分支而非抛错，预览行退化为仅 id。
+  it('prints an empty preview when a note has no content or date', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockFind.mockResolvedValue([{ id: 'n1', data: {} }]);
+
+    await listCommand(credentials, ['--limit=10']);
+
+    expect(logSpy).toHaveBeenCalledWith('n1\t\t');
+  });
+
+  // B.3：预览截断落在 surrogate pair 中间时，回退一位码元，避免孤立高代理
+  // 乱码。59 个 BMP 字符 + emoji 使第 60 个码元恰为高代理。
+  it('does not split a surrogate pair when truncating the preview', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockFind.mockResolvedValue([
+      {
+        id: 'n1',
+        data: { content: 'a'.repeat(59) + '\u{1F600}', modificationDate: 1 },
+      },
+    ]);
+
+    await listCommand(credentials, ['--limit=10']);
+
+    const row = logSpy.mock.calls[0][0] as string;
+    const content = row.split('\t')[2];
+    // The cut would have landed on the emoji's high surrogate; the guard steps
+    // back one code unit so no dangling surrogate is printed.
+    expect(content).toBe('a'.repeat(59));
+    expect(content).not.toMatch(/[\uD800-\uDBFF]$/);
+  });
+
+  // B.3：tab 是列分隔符、\r 会覆盖终端，内容里的这两种字符必须被抹掉。
+  it('strips tab and carriage return from cell content', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockFind.mockResolvedValue([
+      { id: 'n1', data: { content: 'a\tb\rc', modificationDate: 1 } },
+    ]);
+
+    await listCommand(credentials, ['--limit=10']);
+
+    expect(logSpy).toHaveBeenCalledWith('n1\t1\ta bc');
+  });
+
+  it('respects the limit option', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockFind.mockResolvedValue([
+      { id: 'a', data: { content: 'a', modificationDate: 1 } },
+      { id: 'b', data: { content: 'b', modificationDate: 2 } },
+      { id: 'c', data: { content: 'c', modificationDate: 3 } },
+    ]);
+
+    await listCommand(credentials, ['--json', '--limit=2']);
+
+    const output = logSpy.mock.calls.map((call) => call[0]);
+    const parsed = JSON.parse(output[0]) as Array<{ id: string }>;
+    expect(parsed).toHaveLength(2);
+  });
+
+  it('hides trashed notes so the default page is actionable', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockFindFiltering([
+      { id: 'live', data: { content: 'a', modificationDate: 1 } },
+      {
+        id: 'gone',
+        data: { content: 'b', modificationDate: 9, deleted: true },
+      },
+      // Simperium types `deleted` as boolean | 0 | 1, so 1 must count too.
+      {
+        id: 'gone-numeric',
+        data: { content: 'c', modificationDate: 8, deleted: 1 },
+      },
+    ]);
+
+    await listCommand(credentials, ['--json']);
+
+    const parsed = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(parsed.map((item) => item.id)).toEqual(['live']);
+  });
+
+  it('keeps trashed notes when --include-trashed is passed', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockFindFiltering([
+      { id: 'live', data: { content: 'a', modificationDate: 1 } },
+      {
+        id: 'gone',
+        data: { content: 'b', modificationDate: 9, deleted: true },
+      },
+    ]);
+
+    await listCommand(credentials, ['--json', '--include-trashed']);
+
+    const parsed = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(parsed.map((item) => item.id)).toEqual(['gone', 'live']);
+  });
+
+  it('does not mutate the source array when including the trash', async () => {
+    const notes = [
+      { id: 'a', data: { content: 'a', modificationDate: 1 } },
+      { id: 'b', data: { content: 'b', modificationDate: 2 } },
+    ];
+    mockFind.mockResolvedValue(notes);
+
+    await listCommand(credentials, ['--json', '--include-trashed']);
+
+    expect(notes.map((note) => note.id)).toEqual(['a', 'b']);
+  });
+
+  it('rejects when the source rejects', async () => {
+    mockFind.mockRejectedValue(new Error('boom'));
+
+    await expect(listCommand(credentials, [])).rejects.toThrow('boom');
+  });
+});

--- a/lib/cli/__tests__/logging.test.ts
+++ b/lib/cli/__tests__/logging.test.ts
@@ -1,0 +1,53 @@
+import { debug, isVerbose, setVerbose } from '../logging.ts';
+
+describe('logging (verbose diagnostics)', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    setVerbose(false);
+  });
+
+  afterEach(() => {
+    setVerbose(false);
+    jest.restoreAllMocks();
+  });
+
+  it('【场景】verbose 关闭 【目的】诊断默认静默  【校验点】console.error 调用 【预期】debug 不输出任何内容', () => {
+    debug('HTTP GET https://example.test/x');
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(isVerbose()).toBe(false);
+  });
+
+  it('【场景】setVerbose(true) 后 【目的】诊断走 stderr 且带 [cli] 前缀  【校验点】console.error 入参 【预期】完整前缀行输出', () => {
+    setVerbose(true);
+
+    debug('HTTP GET https://example.test/x');
+
+    expect(isVerbose()).toBe(true);
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[cli] HTTP GET https://example.test/x'
+    );
+  });
+
+  it('【场景】setVerbose(false) 复位后 【目的】开关可逆、无状态泄漏  【校验点】console.error 调用 【预期】再次静默', () => {
+    setVerbose(true);
+    setVerbose(false);
+
+    debug('should be swallowed');
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('【场景】多次 debug 调用 【目的】逐条输出互不覆盖  【校验点】调用次数与内容 【预期】每条均完整输出', () => {
+    setVerbose(true);
+
+    debug('first');
+    debug('second');
+
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenNthCalledWith(1, '[cli] first');
+    expect(errorSpy).toHaveBeenNthCalledWith(2, '[cli] second');
+  });
+});

--- a/lib/cli/__tests__/note-source.test.ts
+++ b/lib/cli/__tests__/note-source.test.ts
@@ -1,0 +1,869 @@
+import { createNoteSource } from '../note-source.ts';
+import {
+  AuthError,
+  ConflictError,
+  NetworkError,
+  NotFoundError,
+} from '../domain/errors.ts';
+import type * as T from '../vendor/types.ts';
+
+const token = 'tok-123';
+
+// infra/http.ts buffers the body with a single `text()` read inside the
+// request deadline, so the double has to expose `text`, not `json`.
+function mockResponse(
+  status: number,
+  body: unknown,
+  versionHeader?: string
+): Response {
+  const headers = new Headers();
+  if (versionHeader !== undefined) {
+    headers.set('X-Simperium-Version', versionHeader);
+  }
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    text: async () => JSON.stringify(body),
+    headers,
+  } as unknown as Response;
+}
+
+describe('createNoteSource', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.SIMPLENOTE_CLI_TIMEOUT_MS;
+  });
+
+  it('maps the index entries (id, d) to (id, data)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(200, {
+        index: [{ id: 'n1', d: { content: 'hello' } }],
+      })
+    );
+
+    const notes = await createNoteSource(token).find();
+
+    // Boundary normalization fills the fields the payload did not carry, so
+    // downstream consumers (export, search previews) can rely on the shape.
+    expect(notes).toEqual([
+      {
+        id: 'n1',
+        data: {
+          content: 'hello',
+          creationDate: 0,
+          modificationDate: 0,
+          deleted: false,
+          systemTags: [],
+          tags: [],
+        },
+      },
+    ]);
+    // objectContaining, not an exact match: every request now also carries an
+    // AbortSignal from the shared timeout wrapper.
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/note/index?data=true'),
+      expect.objectContaining({ headers: { 'X-Simperium-Token': token } })
+    );
+    const init = (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  // A corrupt or partially-written index row has no data blob. `search` and
+  // `export` dereference `entry.d` freely, so it is dropped at the boundary
+  // instead of crashing a command halfway through.
+  it('skips index entries whose data blob is missing', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(200, {
+        index: [
+          { id: 'n1', d: { content: 'hello' } },
+          { id: 'broken', d: null },
+          { id: 'missing' },
+        ],
+      })
+    );
+
+    const notes = await createNoteSource(token).find();
+
+    expect(notes.map((note) => note.id)).toEqual(['n1']);
+  });
+
+  // `list`/`search`/`add` only work with the live working set. Passing
+  // `includeTrashed: false` must drop trashed records at the page boundary,
+  // before they are retained in memory, instead of fetching and discarding
+  // them downstream. The `deleted` flag arrives as `boolean | 0 | 1`, so both
+  // spellings are exercised.
+  it('drops trashed entries when asked not to include them', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(200, {
+        index: [
+          { id: 'live', d: { content: 'a', deleted: false } },
+          { id: 'gone-bool', d: { content: 'b', deleted: true } },
+          { id: 'gone-num', d: { content: 'c', deleted: 1 } },
+        ],
+      })
+    );
+
+    const notes = await createNoteSource(token).find({ includeTrashed: false });
+
+    expect(notes.map((note) => note.id)).toEqual(['live']);
+  });
+
+  // The default and the explicit opt-in both keep trashed records, which the
+  // markdown/zip/json export needs for its trash/ half.
+  it('keeps trashed entries by default and on explicit opt-in', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(200, {
+        index: [
+          { id: 'live', d: { content: 'a' } },
+          { id: 'gone', d: { content: 'b', deleted: true } },
+        ],
+      })
+    );
+
+    const byDefault = await createNoteSource(token).find();
+    const optedIn = await createNoteSource(token).find({
+      includeTrashed: true,
+    });
+
+    expect(byDefault.map((note) => note.id)).toEqual(['live', 'gone']);
+    expect(optedIn.map((note) => note.id)).toEqual(['live', 'gone']);
+  });
+
+  // A dirty record is *repaired*, not dropped and not passed through: the
+  // export path (`note.systemTags.includes`) and search previews used to crash
+  // with a TypeError that surfaced as a bogus "network error" exit code.
+  it('repairs index entries whose fields are unusable', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(200, {
+        index: [
+          { id: 'no-system-tags', d: { content: 'a' } },
+          {
+            id: 'bad-fields',
+            d: { content: 'b', tags: 'work', systemTags: null, deleted: 1 },
+          },
+          {
+            id: 'string-dates',
+            d: { content: 'c', creationDate: 'soon', modificationDate: 'x' },
+          },
+          { id: 'unknown-fields', d: { content: 'd', futureField: { x: 1 } } },
+          { id: 'not-an-object', d: 'garbage' },
+        ],
+      })
+    );
+
+    const notes = await createNoteSource(token).find();
+    const byId = new Map(notes.map((note) => [note.id, note.data]));
+
+    expect(byId.get('no-system-tags')).toMatchObject({
+      content: 'a',
+      systemTags: [],
+      tags: [],
+    });
+    expect(byId.get('bad-fields')).toMatchObject({
+      tags: [],
+      systemTags: [],
+      deleted: true,
+    });
+    expect(byId.get('string-dates')).toMatchObject({
+      creationDate: 0,
+      modificationDate: 0,
+    });
+    // Fields this CLI does not model round-trip untouched (an edit POST must
+    // not strip future API additions).
+    expect(byId.get('unknown-fields')).toMatchObject({
+      futureField: { x: 1 },
+    });
+    // A payload with no usable record at all follows the drop rule.
+    expect(byId.has('not-an-object')).toBe(false);
+  });
+
+  it('treats a single-note payload with no usable record as not found', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(mockResponse(200, 'garbage'));
+
+    await expect(createNoteSource(token).get('n1')).resolves.toBeUndefined();
+  });
+
+  // One request per 1000 notes instead of per 100: the default page size meant
+  // a 5000-note account paid 50 sequential round trips just to run `list`.
+  it('asks for a full page of index entries', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(200, { index: [] })
+    );
+
+    await createNoteSource(token).find();
+
+    expect(String((global.fetch as jest.Mock).mock.calls[0][0])).toContain(
+      'limit=1000'
+    );
+  });
+
+  it('follows the mark for paginated indexes', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse(200, {
+          index: [{ id: 'a', d: { content: 'A' } }],
+          mark: 'next-page',
+        })
+      )
+      .mockResolvedValueOnce(
+        mockResponse(200, {
+          index: [{ id: 'b', d: { content: 'B' } }],
+        })
+      );
+
+    const notes = await createNoteSource(token).find();
+
+    expect(notes.map((n) => n.id)).toEqual(['a', 'b']);
+    const calls = fetchMock.mock.calls.map((call) => String(call[0]));
+    expect(calls[1]).toContain('mark=next-page');
+  });
+
+  // The transport only guarantees the body parsed as JSON. A 200 whose shape
+  // is wrong (captive portal, misconfigured proxy, an API change) used to
+  // reach `for (const entry of page.index)` and throw a raw
+  // "page.index is not iterable" — exit 99 with a stack trace instead of the
+  // network error the CLI knows how to report.
+  describe('index payload boundaries', () => {
+    it.each([
+      ['an empty object', {}],
+      ['a null index', { index: null }],
+      ['a non-array index', { index: { 0: { id: 'a' } } }],
+      ['a bare array', [{ id: 'a', d: {} }]],
+      ['a bare string', 'not json shaped like an index'],
+      ['null', null],
+    ])('rejects %s as a network error, not a TypeError', async (_, body) => {
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse(200, body));
+
+      const find = createNoteSource(token).find();
+
+      await expect(find).rejects.toBeInstanceOf(NetworkError);
+      await expect(find).rejects.toThrow('unexpected payload');
+    });
+
+    it('drops entries that carry no usable id instead of failing the run', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockResponse(200, {
+          index: [
+            null,
+            'nonsense',
+            { d: { content: 'no id' } },
+            { id: '', d: { content: 'empty id' } },
+            { id: 42, d: { content: 'numeric id' } },
+            { id: 'ok', d: { content: 'keep me' } },
+          ],
+        })
+      );
+
+      const notes = await createNoteSource(token).find();
+
+      expect(notes.map((n) => n.id)).toEqual(['ok']);
+    });
+
+    // A non-string mark matched neither `page.mark === mark` nor the
+    // `Set<string>` of seen marks, so both loop terminators missed it and a
+    // server echoing objects paged all the way to MAX_PAGES.
+    it('stops paginating on a mark it cannot follow', async () => {
+      const fetchMock = global.fetch as jest.Mock;
+      fetchMock.mockResolvedValue(
+        mockResponse(200, {
+          index: [{ id: 'a', d: { content: 'A' } }],
+          mark: { not: 'a cursor' },
+        })
+      );
+
+      const notes = await createNoteSource(token).find();
+
+      expect(notes.map((n) => n.id)).toEqual(['a']);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('follows a numeric mark by normalizing it to a string', async () => {
+      const fetchMock = global.fetch as jest.Mock;
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, { index: [{ id: 'a', d: {} }], mark: 7 })
+        )
+        .mockResolvedValueOnce(
+          mockResponse(200, { index: [{ id: 'b', d: {} }] })
+        );
+
+      const notes = await createNoteSource(token).find();
+
+      expect(notes.map((n) => n.id)).toEqual(['a', 'b']);
+      expect(String(fetchMock.mock.calls[1][0])).toContain('mark=7');
+    });
+  });
+
+  // `--help` advertises SIMPLENOTE_CLI_TIMEOUT_MS as *the* per-request
+  // timeout, but the paged fetch used to build its per-attempt budget from
+  // DEFAULT_TIMEOUT_MS, so the variable was a no-op on list/search/export --
+  // the exact commands slow enough to need it.
+  it('honours SIMPLENOTE_CLI_TIMEOUT_MS on a paged index fetch', async () => {
+    process.env.SIMPLENOTE_CLI_TIMEOUT_MS = '40';
+    (global.fetch as jest.Mock).mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            const error = new Error('aborted');
+            error.name = 'AbortError';
+            reject(error);
+          });
+        })
+    );
+
+    const started = Date.now();
+    await expect(createNoteSource(token).find()).rejects.toThrow(
+      'timed out after 40ms'
+    );
+    // Without the fix this waits out DEFAULT_TIMEOUT_MS (15s) per attempt.
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
+  it('throws Unauthorized on 401', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(401, { error: 'unauthorized' })
+    );
+
+    await expect(createNoteSource(token).find()).rejects.toThrow(
+      'Unauthorized: invalid access token'
+    );
+  });
+
+  it('returns undefined for a missing note', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(404, { error: 'not found' })
+    );
+
+    const note = await createNoteSource(token).get('nope');
+
+    expect(note).toBeUndefined();
+  });
+
+  it('fetches a single note by id', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(200, { content: 'single' })
+    );
+
+    const note = await createNoteSource(token).get('n1');
+
+    expect(note).toEqual({
+      id: 'n1',
+      data: {
+        content: 'single',
+        creationDate: 0,
+        modificationDate: 0,
+        deleted: false,
+        systemTags: [],
+        tags: [],
+      },
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/note/i/n1'),
+      expect.objectContaining({ headers: { 'X-Simperium-Token': token } })
+    );
+  });
+
+  // The GET response carries the object version in an X-Simperium-Version
+  // header. It is the base the next write must be computed against (`/v/{v}`),
+  // so an edit merges with — instead of clobbering — concurrent changes.
+  it('captures the version header when fetching a single note', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(200, { content: 'v4' }, '4')
+    );
+
+    const note = await createNoteSource(token).get('n1');
+
+    expect(note).toMatchObject({ id: 'n1', version: 4 });
+    expect(note?.data.content).toBe('v4');
+  });
+
+  it('throws a generic error for other statuses', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(500, { error: 'server' })
+    );
+
+    await expect(createNoteSource(token).find()).rejects.toThrow(
+      'Simperium API error: HTTP 500'
+    );
+  });
+
+  it('updates a note with merged fields and returns the new version', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse(
+          200,
+          {
+            content: 'old',
+            creationDate: 100,
+            modificationDate: 101,
+            deleted: false,
+            systemTags: ['markdown'],
+            tags: ['work'],
+            publishURL: 'https://x',
+          },
+          '4'
+        )
+      )
+      .mockResolvedValueOnce(mockResponse(200, {}, '7'));
+
+    const result = await createNoteSource(token).update('n1', 'new content');
+
+    expect(result).toEqual({ version: 7 });
+    const postCall = fetchMock.mock.calls[1];
+    // 版本头 '4' 使 POST 走 /v/4 合并写（与"posts against the read version"
+    // 用例一致）；正文仍携带合并后的完整字段。
+    expect(String(postCall[0])).toContain('/note/i/n1/v/4?ccid=');
+    expect((postCall[1] as RequestInit).method).toBe('POST');
+    const body = JSON.parse((postCall[1] as RequestInit).body as string);
+    expect(body.content).toBe('new content');
+    expect(body.publishURL).toBe('https://x');
+    expect(body.tags).toEqual(['work']);
+    expect(typeof body.modificationDate).toBe('number');
+  });
+
+  // An edit must carry the version it read, so the server treats the change
+  // as an increment from that base and merges concurrent edits per field
+  // instead of clobbering them with the stale full body.
+  it('posts against the read version so concurrent edits merge', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse(200, { content: 'old', deleted: false }, '4')
+      )
+      .mockResolvedValueOnce(mockResponse(200, {}, '5'));
+
+    const result = await createNoteSource(token).update('n1', 'new');
+
+    expect(result).toEqual({ version: 5 });
+    expect(String(fetchMock.mock.calls[1][0])).toContain(
+      '/note/i/n1/v/4?ccid='
+    );
+  });
+
+  // R2-1：版本头缺失（代理/网关剥离 X-Simperium-Version）时 get 返回无
+  // version 的 note；update 若继续 POST 会是盲写（versionPath=''），并发合并
+  // 保护静默失效——显式 ConflictError 而不是悄悄覆盖。
+  it('refuses a blind update when the version header is missing', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(200, { content: 'old', deleted: false })
+    );
+
+    await expect(createNoteSource(token).update('n1', 'x')).rejects.toThrow(
+      'Cannot safely update note n1'
+    );
+    // 只有 GET，没有后续 POST。
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // A versioned write can land a 404 when the object was deleted concurrently
+  // ("specified object version does not exist"). It is a not-found — exit 4 —
+  // not a network fault (exit 3).
+  it('classifies a 404 on the update POST as not-found', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse(200, { content: 'old', deleted: false }, '4')
+      )
+      .mockResolvedValueOnce(mockResponse(404, { error: 'gone' }));
+
+    let thrown: unknown;
+    try {
+      await createNoteSource(token).update('n1', 'new');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(NotFoundError);
+    expect((thrown as NotFoundError).code).toBe(4);
+  });
+
+  it('throws Note not found when the note does not exist', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(404, { error: 'not found' })
+    );
+
+    await expect(createNoteSource(token).update('nope', 'x')).rejects.toThrow(
+      'Note not found: nope'
+    );
+  });
+
+  it('throws when the note is trashed', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(200, {
+        content: 'old',
+        creationDate: 100,
+        modificationDate: 101,
+        deleted: true,
+        systemTags: [],
+        tags: [],
+      })
+    );
+
+    await expect(createNoteSource(token).update('n1', 'x')).rejects.toThrow(
+      'Note is in the trash: n1'
+    );
+  });
+
+  it('throws Unauthorized when the update POST is rejected', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse(
+          200,
+          {
+            content: 'old',
+            creationDate: 100,
+            modificationDate: 101,
+            deleted: false,
+            systemTags: [],
+            tags: [],
+          },
+          '4'
+        )
+      )
+      .mockResolvedValueOnce(mockResponse(401, { error: 'unauthorized' }));
+
+    await expect(createNoteSource(token).update('n1', 'x')).rejects.toThrow(
+      'Unauthorized: invalid access token'
+    );
+  });
+
+  // The write already succeeded server-side. Throwing here used to make the
+  // command look failed, and the natural user response -- run it again --
+  // produced a second note. The GET carries a version (normal read); it is the
+  // POST response's missing version header that degrades to 0.
+  it('reports version 0 rather than failing a write that already landed', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse(
+          200,
+          {
+            content: 'old',
+            creationDate: 100,
+            modificationDate: 101,
+            deleted: false,
+            systemTags: [],
+            tags: [],
+          },
+          '4'
+        )
+      )
+      .mockResolvedValueOnce(mockResponse(200, {}));
+
+    await expect(createNoteSource(token).update('n1', 'x')).resolves.toEqual({
+      version: 0,
+    });
+  });
+
+  it('creates a note with defaults and returns its id and version', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValueOnce(mockResponse(200, {}, '1'));
+
+    const result = await createNoteSource(token).create({
+      content: 'hello',
+      tags: ['work'] as T.TagName[],
+    });
+
+    expect(result).toEqual({ id: expect.any(String), version: 1 });
+    const postCall = fetchMock.mock.calls[0];
+    expect(String(postCall[0])).toContain('/note/i/');
+    expect(String(postCall[0])).toContain('?ccid=');
+    expect((postCall[1] as RequestInit).method).toBe('POST');
+    const body = JSON.parse((postCall[1] as RequestInit).body as string);
+    expect(body.content).toBe('hello');
+    expect(body.deleted).toBe(false);
+    expect(body.systemTags).toEqual(['markdown']);
+    expect(body.tags).toEqual(['work']);
+    expect(typeof body.creationDate).toBe('number');
+    expect(typeof body.modificationDate).toBe('number');
+  });
+
+  it('creates a note with a custom system tag set', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValueOnce(mockResponse(200, {}, '2'));
+
+    await createNoteSource(token).create({
+      content: 'x',
+      systemTags: [],
+    });
+
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0][1] as RequestInit).body as string
+    );
+    expect(body.systemTags).toEqual([]);
+  });
+
+  it('throws Unauthorized when the create POST is rejected', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(401, { error: 'unauthorized' })
+    );
+
+    await expect(
+      createNoteSource(token).create({ content: 'x' })
+    ).rejects.toThrow('Unauthorized: invalid access token');
+  });
+
+  describe('error classification', () => {
+    async function capture(run: () => Promise<unknown>): Promise<unknown> {
+      try {
+        await run();
+        return undefined;
+      } catch (error) {
+        return error;
+      }
+    }
+
+    it('maps 401 to an auth error (exit 2), not a network error', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse(401, {}));
+
+      const error = await capture(() => createNoteSource(token).find());
+
+      expect(error).toBeInstanceOf(AuthError);
+      expect((error as AuthError).code).toBe(2);
+    });
+
+    it('maps a server error to a network error (exit 3)', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse(500, {}));
+
+      const error = await capture(() => createNoteSource(token).find());
+
+      expect(error).toBeInstanceOf(NetworkError);
+      expect((error as NetworkError).code).toBe(3);
+    });
+
+    it('maps a missing note to a not-found error (exit 4)', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse(404, {}));
+
+      const error = await capture(() =>
+        createNoteSource(token).update('nope', 'x')
+      );
+
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect((error as NotFoundError).code).toBe(4);
+    });
+
+    // 403 is what Simperium returns for a token that is valid but no longer
+    // authorized. Falling through to the generic branch reported it as exit 3
+    // ("network"), so scripts retried instead of prompting for a new login.
+    it('maps 403 to an auth error (exit 2)', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse(403, {}));
+
+      const error = await capture(() => createNoteSource(token).find());
+
+      expect(error).toBeInstanceOf(AuthError);
+      expect((error as AuthError).code).toBe(2);
+    });
+
+    it.each([409, 412])(
+      'maps a rejected write (HTTP %i) to a conflict error (exit 5)',
+      async (status) => {
+        (global.fetch as jest.Mock).mockResolvedValue(mockResponse(status, {}));
+
+        const error = await capture(() =>
+          createNoteSource(token).create({ content: 'x' })
+        );
+
+        expect(error).toBeInstanceOf(ConflictError);
+        expect((error as ConflictError).code).toBe(5);
+      }
+    );
+
+    it('names rate limiting explicitly on a 429', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(mockResponse(429, {}));
+
+      const error = await capture(() =>
+        createNoteSource(token).create({ content: 'x' })
+      );
+
+      expect(error).toBeInstanceOf(NetworkError);
+      expect((error as NetworkError).message).toContain('Too many requests');
+    });
+
+    it('maps a trashed note to a conflict error (exit 5)', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockResponse(200, { content: 'old', deleted: true, tags: [] })
+      );
+
+      const error = await capture(() =>
+        createNoteSource(token).update('n1', 'x')
+      );
+
+      expect(error).toBeInstanceOf(ConflictError);
+      expect((error as ConflictError).code).toBe(5);
+    });
+  });
+
+  it('never replays a write, so a note cannot be created twice', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(mockResponse(503, {}));
+
+    await expect(
+      createNoteSource(token).create({ content: 'x' })
+    ).rejects.toThrow('HTTP 503');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a throttled read instead of failing outright', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(mockResponse(503, {}))
+      .mockResolvedValueOnce(mockResponse(200, { index: [] }));
+
+    await expect(createNoteSource(token).find()).resolves.toEqual([]);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops paginating when the server repeats a mark', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse(200, { index: [{ id: 'a', d: {} }], mark: 'm1' })
+      )
+      .mockResolvedValueOnce(
+        mockResponse(200, { index: [{ id: 'b', d: {} }], mark: 'm2' })
+      )
+      .mockResolvedValueOnce(
+        mockResponse(200, { index: [{ id: 'c', d: {} }], mark: 'm1' })
+      );
+
+    const notes = await createNoteSource(token).find();
+
+    expect(notes.map((note) => note.id)).toEqual(['a', 'b', 'c']);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  // B.4：分页窗口内同 id 重复出现（snapshot 漂移）时只保留首页首次出现的
+  // 那条，避免 list/search 输出重复行。
+  it('drops a duplicate id across pages, first page wins', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse(200, {
+          index: [{ id: 'a', d: { content: 'first' } }],
+          mark: 'm1',
+        })
+      )
+      .mockResolvedValueOnce(
+        mockResponse(200, {
+          index: [
+            { id: 'a', d: { content: 'second' } },
+            { id: 'b', d: {} },
+          ],
+          mark: 'm2',
+        })
+      )
+      .mockResolvedValueOnce(mockResponse(200, { index: [], mark: 'm1' }));
+
+    const notes = await createNoteSource(token).find();
+
+    expect(notes.map((note) => note.id)).toEqual(['a', 'b']);
+    expect(notes[0].data.content).toBe('first');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  describe('total pagination time budget', () => {
+    let now: number;
+    let nowSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      now = 1_000_000;
+      nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+    });
+
+    afterEach(() => {
+      nowSpy.mockRestore();
+      delete process.env.SIMPLENOTE_CLI_TOTAL_TIMEOUT_MS;
+    });
+
+    it('【场景】整轮分页超过总量预算 【目的】验证 SIMPLENOTE_CLI_TOTAL_TIMEOUT_MS 生效 【校验点】异常类型/文案/请求次数 【预期】NetworkError 且不再发起请求', async () => {
+      process.env.SIMPLENOTE_CLI_TOTAL_TIMEOUT_MS = '100';
+      const fetchMock = global.fetch as jest.Mock;
+      fetchMock.mockImplementation(() => {
+        // 第一页正常完成；随后把时钟推进到截止时间之后，
+        // 第二轮迭代应在再次请求前触发预算保护。
+        now += 500;
+        return Promise.resolve(
+          mockResponse(200, {
+            index: [{ id: 'a', d: { content: 'A' } }],
+            mark: 'm1',
+          })
+        );
+      });
+
+      let thrown: unknown;
+      try {
+        await createNoteSource(token).find();
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(NetworkError);
+      expect((thrown as NetworkError).message).toContain('total time budget');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('【场景】服务端返回空字符串 mark 【目的】验证空 mark 视为分页终止 【校验点】结果与请求次数 【预期】单次请求且返回全部笔记', async () => {
+      const fetchMock = global.fetch as jest.Mock;
+      fetchMock.mockResolvedValue(
+        mockResponse(200, {
+          index: [{ id: 'a', d: { content: 'A' } }],
+          mark: '',
+        })
+      );
+
+      const notes = await createNoteSource(token).find();
+
+      expect(notes.map((note) => note.id)).toEqual(['a']);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('【场景】deleted 字段为数值 1 【目的】验证数值型回收站标记同样拦截 【校验点】异常类型/退出码/文案 【预期】ConflictError code 5', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockResponse(200, { content: 'old', deleted: 1, tags: [] })
+    );
+
+    let thrown: unknown;
+    try {
+      await createNoteSource(token).update('n1', 'x');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ConflictError);
+    expect((thrown as ConflictError).code).toBe(5);
+    expect((thrown as ConflictError).message).toContain('trash');
+  });
+
+  it('【场景】单条笔记拉取返回 403 【目的】验证 403 归类认证错误 【校验点】异常类型与退出码 【预期】AuthError code 2', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(mockResponse(403, {}));
+
+    let thrown: unknown;
+    try {
+      await createNoteSource(token).get('n1');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(AuthError);
+    expect((thrown as AuthError).code).toBe(2);
+  });
+
+  it('【场景】新建笔记时间戳 【目的】验证创建/修改时间一致 【校验点】请求体字段 【预期】creationDate === modificationDate', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValueOnce(mockResponse(200, {}, '1'));
+
+    await createNoteSource(token).create({ content: 'x' });
+
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0][1] as RequestInit).body as string
+    );
+    expect(typeof body.creationDate).toBe('number');
+    expect(body.creationDate).toBe(body.modificationDate);
+  });
+});

--- a/lib/cli/__tests__/search.test.ts
+++ b/lib/cli/__tests__/search.test.ts
@@ -1,0 +1,384 @@
+jest.mock('../note-source.ts', () => ({
+  createNoteSource: jest.fn(),
+}));
+
+import { createNoteSource } from '../note-source.ts';
+import { searchCommand, parseSearchOptions } from '../commands/search.ts';
+import { createBoundedCache } from '../vendor/note-utils.ts';
+import type { Credentials } from '../domain/types.ts';
+import type { BucketObject } from '../vendor/types.ts';
+import type * as T from '../vendor/types.ts';
+
+const mockFind = jest.fn();
+const mockSource = {
+  find: mockFind,
+};
+
+const credentials: Credentials = {
+  access_token: 'tok',
+  username: 'user@example.com',
+};
+
+function note(
+  id: string,
+  content: string,
+  modificationDate = 0,
+  tags: string[] = []
+): BucketObject<T.Note> {
+  return {
+    id,
+    data: {
+      content,
+      creationDate: modificationDate,
+      deleted: false,
+      modificationDate,
+      tags: tags as T.TagName[],
+      systemTags: [],
+    },
+  };
+}
+
+describe('parseSearchOptions', () => {
+  it('defaults to 50 items, non-json output and no trash', () => {
+    expect(parseSearchOptions([])).toEqual({
+      limit: 50,
+      json: false,
+      includeTrashed: false,
+    });
+  });
+
+  it('parses a custom limit and json flag', () => {
+    expect(parseSearchOptions(['--limit=10', '--json'])).toEqual({
+      limit: 10,
+      json: true,
+      includeTrashed: false,
+    });
+  });
+
+  it('rejects an invalid limit instead of silently using the default', () => {
+    expect(() => parseSearchOptions(['--limit=abc'])).toThrow(
+      '--limit must be a positive integer'
+    );
+  });
+
+  // `search "a" "b"` used to search for "a" and silently drop "b".
+  it('rejects more than one query positional', () => {
+    expect(() => parseSearchOptions(['b'])).toThrow(
+      'Too many arguments for search'
+    );
+  });
+});
+
+describe('searchCommand', () => {
+  beforeEach(() => {
+    (createNoteSource as jest.Mock).mockReturnValue(mockSource);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    mockFind.mockReset();
+  });
+
+  it('returns only notes whose content matches all terms', async () => {
+    mockFind.mockResolvedValue([
+      note('n1', 'alpha beta gamma'),
+      note('n2', 'alpha only'),
+      note('n3', 'beta gamma'),
+    ]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await searchCommand(credentials, ['alpha beta', '--json']);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(output.map((item) => item.id)).toEqual(['n1']);
+  });
+
+  it('sorts results by modificationDate descending', async () => {
+    mockFind.mockResolvedValue([
+      note('old', 'needle', 100),
+      note('mid', 'needle', 200),
+      note('new', 'needle', 300),
+    ]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await searchCommand(credentials, ['needle', '--json']);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(output.map((item) => item.id)).toEqual(['new', 'mid', 'old']);
+  });
+
+  it('skips trashed notes unless asked for them', async () => {
+    const trashed = note('gone', 'needle', 300);
+    trashed.data.deleted = true;
+    const all = [note('live', 'needle', 100), trashed];
+    // Contract-faithful stub: the real source drops trash at the page boundary
+    // in `find`, so the command receives it already filtered.
+    mockFind.mockImplementation(
+      ({ includeTrashed }: { includeTrashed?: boolean }) =>
+        Promise.resolve(all.filter((n) => includeTrashed || !n.data.deleted))
+    );
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await searchCommand(credentials, ['needle', '--json']);
+    expect(
+      (JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>).map(
+        (item) => item.id
+      )
+    ).toEqual(['live']);
+
+    logSpy.mockClear();
+    await searchCommand(credentials, ['needle', '--json', '--include-trashed']);
+    expect(
+      (JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>).map(
+        (item) => item.id
+      )
+    ).toEqual(['gone', 'live']);
+  });
+
+  it('respects tag: filters', async () => {
+    mockFind.mockResolvedValue([
+      note('t1', 'needle', 1, ['work']),
+      note('t2', 'needle', 2, ['home']),
+    ]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await searchCommand(credentials, ['needle tag:work', '--json']);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(output.map((item) => item.id)).toEqual(['t1']);
+  });
+
+  // B1-6：TAG: 前缀与 tag 值侧一致地大小写不敏感；旧实现前缀大小写敏感，
+  // "TAG:work" 静默退化为对字面文本的全文搜索。
+  it('matches a case-insensitive tag: prefix', async () => {
+    mockFind.mockResolvedValue([
+      note('t1', 'needle', 1, ['work']),
+      note('t2', 'needle', 2, ['home']),
+    ]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await searchCommand(credentials, ['needle TAG:work', '--json']);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(output.map((item) => item.id)).toEqual(['t1']);
+  });
+
+  // N-3：macOS 存 NFD（e + combining accent）、Win/Linux 存 NFC 的标签必须
+  // 互相命中——create/add 存储、add 指纹与 tag: 检索都做 NFC 归一。
+  it('matches a tag stored in NFD against an NFC tag: query', async () => {
+    mockFind.mockResolvedValue([
+      note('t1', 'needle', 1, ['cafe\u0301']), // NFD: café
+      note('t2', 'needle', 2, ['unrelated']),
+    ]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await searchCommand(credentials, ['needle tag:caf\u00e9', '--json']); // NFC
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(output.map((item) => item.id)).toEqual(['t1']);
+  });
+
+  // B1-2：单查询词 ≥31 字符时 leadingChars 为负，拼出非法量词 {0,-N} 会让
+  // new RegExp 抛 SyntaxError（旧实现误报为网络错误 exit 3）。
+  it('does not crash on a single term longer than 30 chars', async () => {
+    const longWord = 'a'.repeat(40);
+    mockFind.mockResolvedValue([
+      note('n1', `${longWord} inside`),
+      note('n2', 'unrelated'),
+    ]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await expect(
+      searchCommand(credentials, [longWord, '--json'])
+    ).resolves.toBeUndefined();
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(output.map((item) => item.id)).toEqual(['n1']);
+  });
+
+  it('matches tags and content case-insensitively', async () => {
+    mockFind.mockResolvedValue([
+      note('t1', 'Needle in a haystack', 1, ['Work']),
+      note('t2', 'needle', 2, ['home']),
+    ]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await searchCommand(credentials, ['NEEDLE tag:WORK', '--json']);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(output.map((item) => item.id)).toEqual(['t1']);
+  });
+
+  // The tag filter and the content term are AND-ed: a note that matches only
+  // one of them must not appear, which is the case a tag *or* a term test alone
+  // never exercises.
+  it('requires both the tag and the content term to match (AND)', async () => {
+    mockFind.mockResolvedValue([
+      note('hit', 'needle here', 3, ['work']),
+      note('tagOnly', 'nothing relevant', 2, ['work']),
+      note('termOnly', 'needle here', 1, ['home']),
+    ]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await searchCommand(credentials, ['needle tag:work', '--json']);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(output.map((item) => item.id)).toEqual(['hit']);
+  });
+
+  // A note with no tags at all can never satisfy a `tag:` filter. This pins
+  // the short-circuit in createMatcher: the fast path must reject untagged
+  // notes without building a Set, and must not fall through to the content
+  // match as if the tag filter had not been asked for.
+  it('excludes notes without tags from a tag: query even if content matches', async () => {
+    mockFind.mockResolvedValue([
+      note('tagged', 'needle here', 3, ['work']),
+      note('untagged', 'needle here', 2),
+    ]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await searchCommand(credentials, ['needle tag:work', '--json']);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(output.map((item) => item.id)).toEqual(['tagged']);
+  });
+
+  // Terms come straight from the shell, so a query like `a+b` or `c(1)` must be
+  // matched literally instead of being compiled as a regular expression.
+  it('treats regex metacharacters in a query as literal text', async () => {
+    mockFind.mockResolvedValue([
+      note('lit', 'costs a+b dollars', 1),
+      note('other', 'costs ab dollars', 2),
+    ]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await searchCommand(credentials, ['a+b', '--json']);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(output.map((item) => item.id)).toEqual(['lit']);
+  });
+
+  it('respects the limit option', async () => {
+    mockFind.mockResolvedValue([
+      note('a', 'x', 3),
+      note('b', 'x', 2),
+      note('c', 'x', 1),
+    ]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await searchCommand(credentials, ['x', '--json', '--limit=2']);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(output).toHaveLength(2);
+  });
+
+  it('prints a tab-separated row in non-json mode', async () => {
+    mockFind.mockResolvedValue([note('n1', '# Title\nbody', 123)]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await searchCommand(credentials, ['Title']);
+
+    const row = logSpy.mock.calls[0][0] as string;
+    expect(row).toContain('n1');
+    expect(row).toContain('123');
+    expect(row).toContain('Title');
+  });
+
+  // B.3：tab 是列分隔符、\r 覆盖终端，标题/预览里的这两种字符必须被抹掉。
+  it('strips tab and carriage return from title and preview', async () => {
+    mockFind.mockResolvedValue([note('n1', 'Title\tX\rY\nbody', 123)]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await searchCommand(credentials, ['Title']);
+
+    const row = logSpy.mock.calls[0][0] as string;
+    // Tab in the title cell became a space and the CR was dropped entirely;
+    // the only remaining tabs are the column separators.
+    expect(row).toContain('Title XY');
+    expect(row).not.toContain('\r');
+  });
+
+  it('accepts flags before the query', async () => {
+    mockFind.mockResolvedValue([note('n1', 'needle', 1), note('n2', 'other')]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await searchCommand(credentials, ['--json', '--limit=5', 'needle']);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(output.map((item) => item.id)).toEqual(['n1']);
+  });
+
+  it('does not leak regex state between tag: queries', async () => {
+    mockFind.mockResolvedValue([
+      note('t1', 'needle', 1, ['work']),
+      note('t2', 'needle', 2, ['home']),
+    ]);
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await searchCommand(credentials, ['needle tag:work', '--json']);
+    await searchCommand(credentials, ['needle tag:work', '--json']);
+
+    const first = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    const second = JSON.parse(logSpy.mock.calls[1][0]) as Array<{ id: string }>;
+    expect(second.map((item) => item.id)).toEqual(first.map((i) => i.id));
+    expect(second.map((item) => item.id)).toEqual(['t1']);
+  });
+
+  it('throws when no query is provided', async () => {
+    await expect(searchCommand(credentials, [])).rejects.toThrow(
+      'search requires a query'
+    );
+  });
+
+  it('rejects a whitespace-only query without touching the network', async () => {
+    await expect(searchCommand(credentials, ['   '])).rejects.toThrow(
+      'search requires a query'
+    );
+    expect(mockFind).not.toHaveBeenCalled();
+  });
+
+  // 分支逻辑：纯 `tag:` 过滤（查询无词项）时 createMatcher 的词项正则集为
+  // 空，必须命中「恒匹配」快捷路径而不是误判为全部不匹配；只有标签达标才
+  // 进入结果集。
+  it('filters by tags alone when the query has no search terms', async () => {
+    mockFind.mockResolvedValue([
+      note('t1', 'content', 1, ['work']),
+      note('t2', 'content', 2, ['home']),
+    ]);
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await searchCommand(credentials, ['tag:work', '--json']);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]) as Array<{ id: string }>;
+    expect(output.map((item) => item.id)).toEqual(['t1']);
+  });
+
+  it('rejects when find rejects', async () => {
+    mockFind.mockRejectedValue(new Error('boom'));
+
+    await expect(searchCommand(credentials, ['x'])).rejects.toThrow('boom');
+  });
+});
+
+describe('createBoundedCache', () => {
+  it('evicts the oldest insertion once the cap is exceeded', () => {
+    const cache = createBoundedCache<number>(2);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBe(2);
+    expect(cache.get('c')).toBe(3);
+  });
+
+  it('keeps every entry while under the cap and returns set values', () => {
+    const cache = createBoundedCache<number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+
+    expect(cache.get('a')).toBe(1);
+    expect(cache.get('b')).toBe(2);
+    expect(cache.get('missing')).toBeUndefined();
+  });
+});

--- a/lib/cli/__tests__/show.test.ts
+++ b/lib/cli/__tests__/show.test.ts
@@ -1,0 +1,127 @@
+jest.mock('../note-source.ts', () => ({
+  createNoteSource: jest.fn(),
+}));
+
+import { createNoteSource } from '../note-source.ts';
+import { showCommand } from '../commands/show.ts';
+import type { Credentials } from '../domain/types.ts';
+
+const mockGet = jest.fn();
+const mockSource = {
+  get: mockGet,
+};
+
+const credentials: Credentials = {
+  access_token: 'tok',
+  username: 'user@example.com',
+};
+
+describe('showCommand', () => {
+  beforeEach(() => {
+    (createNoteSource as jest.Mock).mockReturnValue(mockSource);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    mockGet.mockReset();
+  });
+
+  it('prints the note content as markdown text', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockGet.mockResolvedValue({
+      id: 'n1',
+      data: { content: '# Title\n\nbody text' },
+    });
+
+    await showCommand(credentials, ['n1']);
+
+    expect(logSpy).toHaveBeenCalledWith('# Title\n\nbody text');
+    expect(mockGet).toHaveBeenCalledWith('n1');
+  });
+
+  it('prints the full object as JSON when --json is passed', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const note = { id: 'n1', data: { content: 'x' } };
+    mockGet.mockResolvedValue(note);
+
+    await showCommand(credentials, ['n1', '--json']);
+
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(note, null, 2));
+  });
+
+  it('accepts the note id after a flag', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const note = { id: 'n1', data: { content: 'x' } };
+    mockGet.mockResolvedValue(note);
+
+    await showCommand(credentials, ['--json', 'n1']);
+
+    expect(mockGet).toHaveBeenCalledWith('n1');
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(note, null, 2));
+  });
+
+  it('throws when no note id is provided', async () => {
+    await expect(showCommand(credentials, [])).rejects.toThrow(
+      'show requires a note id'
+    );
+  });
+
+  it('throws when the note does not exist', async () => {
+    mockGet.mockResolvedValue(null);
+
+    await expect(showCommand(credentials, ['nope'])).rejects.toThrow(
+      'Note not found: nope'
+    );
+  });
+
+  // `show n1 n2` used to fetch n1 and silently ignore n2.
+  it('rejects a second positional argument', async () => {
+    await expect(showCommand(credentials, ['n1', 'n2'])).rejects.toThrow(
+      'Too many arguments for show'
+    );
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the source rejects', async () => {
+    mockGet.mockRejectedValue(new Error('boom'));
+
+    await expect(showCommand(credentials, ['n1'])).rejects.toThrow('boom');
+  });
+
+  it('【场景】展示回收站内笔记（非 JSON 模式） 【目的】验证垃圾箱告警 【校验点】stderr 告警与 stdout 正文 【预期】告警+内容均输出', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockGet.mockResolvedValue({
+      id: 'n1',
+      data: { content: 'x', deleted: true },
+    });
+
+    await showCommand(credentials, ['n1']);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Warning: this note is in the trash.'
+    );
+    expect(logSpy).toHaveBeenCalledWith('x');
+  });
+
+  it('【场景】展示回收站笔记且 --json 【目的】验证机器可读输出不被告警污染 【校验点】stderr 【预期】无告警', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockGet.mockResolvedValue({
+      id: 'n1',
+      data: { content: 'x', deleted: 1 },
+    });
+
+    await showCommand(credentials, ['n1', '--json']);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('【场景】笔记无 content 字段 【目的】验证空内容兜底 【校验点】stdout 【预期】输出空行', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockGet.mockResolvedValue({ id: 'n1', data: {} });
+
+    await showCommand(credentials, ['n1']);
+
+    expect(logSpy).toHaveBeenCalledWith('');
+  });
+});

--- a/lib/cli/__tests__/store.test.ts
+++ b/lib/cli/__tests__/store.test.ts
@@ -1,0 +1,272 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// `store.ts` derives STORE_DIR at module load, so the fake home has to be
+// resolved inside the factory — a module-scope const would still be in its
+// temporal dead zone when the hoisted import of `../store.ts` runs.
+// The directory lives under the OS temp folder (not the repo) and is keyed by
+// pid so concurrent jest workers cannot clobber each other.
+jest.mock('os', () => {
+  const actual = jest.requireActual('os') as typeof import('os');
+  const nodePath = jest.requireActual('path') as typeof import('path');
+  const home = nodePath.join(
+    actual.tmpdir(),
+    `simplenote-cli-home-${process.pid}`
+  );
+  return { ...actual, homedir: () => home };
+});
+
+import {
+  clearCredentials,
+  loadCredentials,
+  saveCredentials,
+  STORE_DIR,
+  CRED_FILE,
+} from '../store.ts';
+import { EXIT_NETWORK } from '../domain/errors.ts';
+
+const TEST_HOME = os.homedir();
+
+const ORIGINAL_PLATFORM = Object.getOwnPropertyDescriptor(process, 'platform');
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+}
+
+describe('store', () => {
+  beforeAll(() => {
+    // The permission check is a no-op on the real (Windows) host, so pin the
+    // suite to a POSIX platform and let individual cases opt into win32.
+    setPlatform('linux');
+  });
+
+  afterAll(async () => {
+    if (ORIGINAL_PLATFORM) {
+      Object.defineProperty(process, 'platform', ORIGINAL_PLATFORM);
+    }
+    // Teardown must never fail the suite: sandboxes that wrap `fs.rm`
+    // (recycle-bin shims, locked files) would otherwise turn passing tests red.
+    try {
+      await fs.rm(TEST_HOME, { recursive: true, force: true });
+    } catch {
+      // Best effort — the OS reclaims its temp directory anyway.
+    }
+  });
+
+  it('saves credentials under the expected store directory', async () => {
+    await saveCredentials({
+      access_token: 'tok',
+      username: 'user@example.com',
+    });
+
+    expect(STORE_DIR).toBe(path.join(TEST_HOME, '.simplenote-cli'));
+    expect(CRED_FILE).toBe(
+      path.join(TEST_HOME, '.simplenote-cli', 'credentials.json')
+    );
+
+    const raw = await fs.readFile(CRED_FILE, 'utf8');
+    expect(JSON.parse(raw)).toEqual({
+      access_token: 'tok',
+      username: 'user@example.com',
+    });
+  });
+
+  it('round-trips credentials through save and load', async () => {
+    await saveCredentials({ access_token: 'tok-2', username: 'a@b.com' });
+    const loaded = await loadCredentials();
+    expect(loaded).toEqual({ access_token: 'tok-2', username: 'a@b.com' });
+  });
+
+  it('returns null when no credentials exist', async () => {
+    await clearCredentials();
+    expect(await loadCredentials()).toBeNull();
+  });
+
+  it('returns null when the stored file is malformed', async () => {
+    await fs.mkdir(STORE_DIR, { recursive: true });
+    await fs.writeFile(CRED_FILE, 'not-json{', 'utf8');
+    expect(await loadCredentials()).toBeNull();
+  });
+
+  it('clears credentials idempotently', async () => {
+    await saveCredentials({ access_token: 'tok', username: 'u@x.com' });
+    await clearCredentials();
+    await clearCredentials();
+    expect(await loadCredentials()).toBeNull();
+  });
+
+  // A file that exists but is not two strings is corrupt, not "logged out".
+  // The old truthiness check let a number through into an auth header, where
+  // it came back as an opaque 401 instead of the warning below.
+  it.each([
+    ['a non-string token', { access_token: 12345, username: 'u@x.com' }],
+    ['a missing username', { access_token: 'tok' }],
+    ['an empty token', { access_token: '', username: 'u@x.com' }],
+    ['a top-level null', null],
+    ['a top-level array', [{ access_token: 'tok', username: 'u@x.com' }]],
+  ])('warns and reports logged-out for %s', async (_, stored) => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await fs.mkdir(STORE_DIR, { recursive: true });
+    await fs.writeFile(CRED_FILE, JSON.stringify(stored), 'utf8');
+
+    expect(await loadCredentials()).toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('corrupt'));
+    errorSpy.mockRestore();
+  });
+
+  async function tempFiles(): Promise<string[]> {
+    const names = await fs.readdir(STORE_DIR);
+    return names.filter((name) => name.endsWith('.tmp'));
+  }
+
+  it('leaves no temp file behind on a successful save', async () => {
+    await saveCredentials({ access_token: 'tok', username: 'u@x.com' });
+    expect(await tempFiles()).toEqual([]);
+  });
+
+  // Only the rename used to be cleaned up, so a failed *write* leaked one
+  // 0600 file holding a live token on every attempt.
+  it('leaves no temp file behind when the write cannot be published', async () => {
+    await clearCredentials();
+    // A directory where the credentials file belongs makes rename fail on
+    // every platform without needing permission tricks.
+    await fs.mkdir(CRED_FILE, { recursive: true });
+    try {
+      await expect(
+        saveCredentials({ access_token: 'tok', username: 'u@x.com' })
+      ).rejects.toMatchObject({
+        code: EXIT_NETWORK,
+        message: expect.stringContaining('Could not persist credentials'),
+      });
+      expect(await tempFiles()).toEqual([]);
+    } finally {
+      await fs.rm(CRED_FILE, { recursive: true, force: true });
+    }
+  });
+
+  // Logout has to mean "no token is left on disk", including one leaked by an
+  // older build that used a fixed temp filename.
+  it('sweeps a stray temp file on logout', async () => {
+    await fs.mkdir(STORE_DIR, { recursive: true });
+    const stale = `${CRED_FILE}.tmp`;
+    await fs.writeFile(stale, '{"access_token":"leaked"}', 'utf8');
+
+    await clearCredentials();
+
+    await expect(fs.access(stale)).rejects.toBeTruthy();
+  });
+
+  // 异常故障：store 目录不可读时 logout 的临时文件清扫是 best-effort——
+  // 清理失败必须静默放弃（否则 logout 本身会被 EACCES 变成错误），凭据清理照常。
+  it('tolerates an unreadable store directory on logout', async () => {
+    const readdir = jest
+      .spyOn(fs, 'readdir')
+      .mockRejectedValue(new Error('EACCES: permission denied'));
+
+    try {
+      await clearCredentials();
+    } finally {
+      readdir.mockRestore();
+    }
+  });
+
+  describe('warnIfCredentialFileIsGroupReadable (POSIX)', () => {
+    beforeEach(() => {
+      setPlatform('linux');
+    });
+
+    // Real chmod is a no-op on the Windows test host, so stat is mocked to
+    // return an explicit mode instead of relying on the filesystem.
+    async function loadWithMode(
+      mode: number
+    ): Promise<ReturnType<typeof jest.spyOn>> {
+      await saveCredentials({ access_token: 'tok', username: 'u@x.com' });
+      return jest.spyOn(fs, 'stat').mockResolvedValue({
+        mode,
+      } as Awaited<ReturnType<typeof fs.stat>>);
+    }
+
+    it('stays silent when the credentials file mode is 0600', async () => {
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const statSpy = await loadWithMode(0o100600);
+      try {
+        expect(await loadCredentials()).toEqual({
+          access_token: 'tok',
+          username: 'u@x.com',
+        });
+        expect(errorSpy).not.toHaveBeenCalled();
+      } finally {
+        statSpy.mockRestore();
+        errorSpy.mockRestore();
+      }
+    });
+
+    it('warns with the chmod 600 fix when the mode is 0644', async () => {
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const statSpy = await loadWithMode(0o100644);
+      try {
+        await loadCredentials();
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Warning: credentials file')
+        );
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('mode 0644')
+        );
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('chmod 600')
+        );
+      } finally {
+        statSpy.mockRestore();
+        errorSpy.mockRestore();
+      }
+    });
+
+    it('skips the check on Windows', async () => {
+      await saveCredentials({ access_token: 'tok', username: 'u@x.com' });
+      setPlatform('win32');
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const statSpy = jest.spyOn(fs, 'stat');
+      try {
+        expect(await loadCredentials()).toEqual({
+          access_token: 'tok',
+          username: 'u@x.com',
+        });
+        expect(statSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+      } finally {
+        setPlatform('linux');
+        statSpy.mockRestore();
+        errorSpy.mockRestore();
+      }
+    });
+
+    it('stays silent when stat fails', async () => {
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const statSpy = jest
+        .spyOn(fs, 'stat')
+        .mockRejectedValue(new Error('EACCES'));
+      try {
+        expect(await loadCredentials()).toEqual({
+          access_token: 'tok',
+          username: 'u@x.com',
+        });
+        expect(errorSpy).not.toHaveBeenCalled();
+      } finally {
+        statSpy.mockRestore();
+        errorSpy.mockRestore();
+      }
+    });
+  });
+});

--- a/lib/cli/__tests__/whoami.test.ts
+++ b/lib/cli/__tests__/whoami.test.ts
@@ -1,0 +1,58 @@
+import { whoamiCommand } from '../commands/whoami.ts';
+import { UsageError } from '../domain/errors.ts';
+import type { Credentials } from '../domain/types.ts';
+
+// ---------------------------------------------------------------------------
+// whoami：打印已登录用户名。极简命令，但直接单测可锁定其输出契约与越参校验。
+// 七大维度：入参边界 / 分支逻辑 / 异常故障。
+// ---------------------------------------------------------------------------
+
+const credentials: Credentials = {
+  access_token: 'tok',
+  username: 'user@example.com',
+};
+
+describe('whoamiCommand', () => {
+  let logSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('【场景】默认输出  【目的】打印纯用户名  【校验点】stdout 内容  【预期】仅打印用户名', async () => {
+    await whoamiCommand(credentials, []);
+    expect(logSpy).toHaveBeenCalledWith('user@example.com');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('【场景】--json 输出  【目的】结构化输出供脚本解析  【校验点】JSON 形状  【预期】{ username }', async () => {
+    await whoamiCommand(credentials, ['--json']);
+    expect(JSON.parse(logSpy.mock.calls[0][0] as string)).toEqual({
+      username: 'user@example.com',
+    });
+  });
+
+  it('【场景】存在多余位置参数  【目的】拒绝 typo  【校验点】异常类型/退出码  【预期】抛 UsageError(code 1)', async () => {
+    let thrown: unknown;
+    try {
+      await whoamiCommand(credentials, ['extra']);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(UsageError);
+    expect((thrown as UsageError).code).toBe(1);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('【场景】--json 与多余参数  【目的】越参优先于正常输出  【校验点】不打印用户名  【预期】抛 UsageError', async () => {
+    await expect(
+      whoamiCommand(credentials, ['--json', 'extra'])
+    ).rejects.toBeInstanceOf(UsageError);
+  });
+});

--- a/lib/cli/app.ts
+++ b/lib/cli/app.ts
@@ -1,0 +1,574 @@
+// The CLI application: argv -> command dispatch -> exit code.
+//
+// `bootstrap.ts` is only the executable shim. Everything that decides *what
+// happens* lives here so it can be unit tested: importing this module has no
+// side effects, while importing bootstrap.ts runs the whole CLI.
+//
+// Layering (top to bottom; each layer depends only on layers below it):
+//
+//   app.ts                 process lifecycle, dispatch, exit codes, signals
+//   commands/*.ts          one user-facing verb each, argv -> output
+//   auth.ts                login flows (password, magic-link request/code)
+//   export-helpers.ts      export staging/commit/rollback transaction
+//   export-naming.ts       pure export file-name pipeline
+//   note-source.ts         Simperium bucket operations
+//   content-input.ts       --file= reading
+//   cli-args.ts            argv parsing primitives
+//   command-help.ts        per-command help text
+//   store.ts               credential persistence (atomic write, permissions)
+//   config.ts              app key / version resolution
+//   logging.ts             debug output
+//   infra/http.ts          the single fetch egress (timeout, retry, cancellation)
+//   domain/*.ts            pure types, sorting, trash rules, tags, top-k,
+//                          error taxonomy
+//   vendor/*.ts            desktop-app mirrors (read-mostly). Two known runtime
+//                          back-references exist and are recorded debt:
+//                          `vendor/export/to-zip.ts -> export-naming.ts` and
+//                          `vendor/export/export-notes.ts -> domain/trash`
+//                          (import without .ts extension); see D-2 in the
+//                          analysis plan.
+
+import { createInterface } from 'readline/promises';
+import { stdin as input, stdout as output } from 'process';
+import { completeLogin, login, requestLoginEmail } from './auth.ts';
+import type { Credentials } from './domain/types.ts';
+import { clearCredentials, loadCredentials, saveCredentials } from './store.ts';
+import { listCommand } from './commands/list.ts';
+import { showCommand } from './commands/show.ts';
+import { searchCommand } from './commands/search.ts';
+import { exportCommand } from './commands/export.ts';
+import { editCommand } from './commands/edit.ts';
+import { createCommand } from './commands/create.ts';
+import { addCommand } from './commands/add.ts';
+import { whoamiCommand } from './commands/whoami.ts';
+import {
+  hasFlag,
+  rejectExtraPositionals,
+  tokenize,
+  unknownFlags,
+} from './cli-args.ts';
+import { setExternalAbortSignal } from './infra/http.ts';
+import { getVersion } from './config.ts';
+import { renderCommandHelp } from './command-help.ts';
+import { isVerbose, setVerbose } from './logging.ts';
+import { FLUSH_GUARD_MS } from './cli-constants.ts';
+import {
+  AbortedError,
+  AuthError,
+  CliError,
+  EXIT_ABORTED,
+  EXIT_OK,
+  UsageError,
+  exitCodeFor,
+  messageOf,
+} from './domain/errors.ts';
+
+// Re-exported so bootstrap.ts keeps a single import surface for the entry
+// point while the implementation lives with the rest of the error taxonomy.
+export { messageOf };
+
+export const HELP = `Usage: npm run cli -- <command> [args]
+
+Commands:
+  login                          Log in (password via SIMPLENOTE_PASSWORD, or magic-link code prompt)
+  logout                         Remove stored credentials
+  whoami [--json]                Print the logged-in username
+  list [--limit=N] [--json]      List note summaries, most recently modified first
+  show <id> [--json]             Show a single note's content
+  search "<query>" [--limit=N] [--json]   Search note contents (supports tag: filters)
+                                 list/search skip the trash; add --include-trashed to keep it
+  edit <id> "<content>" [--json] Replace a note's content (also --content= or --file=)
+  create "<content>" [--tags=a,b] [--json]  Create a note (also --content= or --file=)
+  add --file=notes.json [--json]            Create multiple notes from a JSON array file (idempotent)
+  export [--format=all|json|markdown|zip] [--output=DIR]  Export notes
+
+Flags may appear before or after positional arguments. Use \`--\` to stop flag
+parsing, e.g. \`create -- "--not-a-flag"\`.
+
+-v, --version                         Print the CLI version and exit
+-h, --help                            Show this help; use \`cli <command> --help\` for a command's details
+    --verbose                         Print request-level diagnostics to stderr (or set SIMPLENOTE_CLI_DEBUG=1)
+
+Machine output (--json) goes to stdout; diagnostics and progress go to stderr.
+
+Piping --json: npm prints its own banner to stdout, which corrupts the payload.
+Use \`npm run --silent cli -- list --json\` (or call bin/simplenote-cli.js directly).
+
+Environment:
+  SIMPLENOTE_USER, SIMPLENOTE_PASSWORD   Credentials for \`login\`
+  SIMPLENOTE_APP_KEY                     Override the app_key used for password login (falls back to config.json)
+  SIMPLENOTE_CLI_TIMEOUT_MS              Per-request timeout (default 15000); the leftover budget of a paged fetch is floored at 1000ms
+  SIMPLENOTE_CLI_TOTAL_TIMEOUT_MS        Budget for a whole paged fetch (default 120000)
+  SIMPLENOTE_CLI_DEBUG                   Set to 1 to enable --verbose diagnostics
+
+Exit codes:
+  0 ok  1 usage  2 auth  3 network  4 not found  5 conflict  6 aborted  7 partial  99 unexpected`;
+
+type CommandHandler = (
+  credentials: Credentials,
+  args: string[]
+) => Promise<void>;
+
+type CommandSpec = {
+  /** Prefix for the stderr line when this command fails. */
+  label: string;
+  /** Flag names this command understands, without the leading `--`. */
+  flags: readonly string[];
+  run: CommandHandler;
+};
+
+// A table instead of a switch: adding a command no longer means duplicating a
+// try/catch, an exit code and a usage pre-check that could drift out of sync
+// with the command module's own validation.
+//
+// `flags` is the single source of truth for what each verb accepts. Declaring
+// it here (rather than only inside the command) is what lets the dispatcher
+// reject `list --limt=5` before any network call happens.
+export const AUTHENTICATED_COMMANDS: Record<string, CommandSpec> = {
+  list: {
+    label: 'List failed',
+    flags: ['limit', 'json', 'include-trashed', 'verbose'],
+    run: listCommand,
+  },
+  show: {
+    label: 'Show failed',
+    flags: ['json', 'verbose'],
+    run: showCommand,
+  },
+  search: {
+    label: 'Search failed',
+    flags: ['limit', 'json', 'include-trashed', 'verbose'],
+    run: searchCommand,
+  },
+  edit: {
+    label: 'Edit failed',
+    flags: ['json', 'content', 'file', 'verbose'],
+    run: editCommand,
+  },
+  create: {
+    label: 'Create failed',
+    flags: ['json', 'tags', 'content', 'file', 'verbose'],
+    run: createCommand,
+  },
+  add: {
+    label: 'Add failed',
+    flags: ['json', 'file', 'verbose'],
+    run: addCommand,
+  },
+  export: {
+    label: 'Export failed',
+    flags: ['format', 'output', 'verbose'],
+    run: exportCommand,
+  },
+  whoami: {
+    label: 'Whoami failed',
+    flags: ['json', 'verbose'],
+    run: whoamiCommand,
+  },
+};
+
+/**
+ * Rejects flags the command does not understand.
+ *
+ * Silently ignoring `--limt=5` meant the user got the default 20 notes and no
+ * hint that the run did not do what they asked. Unknown flags are a usage
+ * error, checked before credentials are loaded so the failure is instant.
+ */
+export function validateFlags(
+  command: string,
+  allowed: readonly string[],
+  args: string[]
+): void {
+  const unknown = unknownFlags(args, [...allowed]);
+  if (unknown.length === 0) {
+    return;
+  }
+  throw new UsageError(
+    `Unknown flag${unknown.length > 1 ? 's' : ''} for ${command}: ${unknown.join(
+      ', '
+    )}. Accepted: ${allowed.map((flag) => `--${flag}`).join(', ') || '(none)'}`
+  );
+}
+
+/**
+ * Re-labels a command failure while preserving its exit code.
+ *
+ * Classification is by type, not by string matching. The previous
+ * `message.startsWith('Note not found')` check meant renaming an error message
+ * silently changed the process exit code.
+ */
+export function labelled(error: unknown, label: string): CliError {
+  const relabelled = new CliError(
+    exitCodeFor(error),
+    `${label}: ${messageOf(error)}`
+  );
+  if (error instanceof Error && error.stack) {
+    relabelled.stack = error.stack;
+  }
+  return relabelled;
+}
+
+async function requireCredentials(): Promise<Credentials> {
+  const credentials = await loadCredentials();
+  if (!credentials) {
+    throw new AuthError(
+      'Not logged in. Run: npm run cli -- login (with SIMPLENOTE_USER / SIMPLENOTE_PASSWORD set)'
+    );
+  }
+  return credentials;
+}
+
+async function promptCode(
+  username: string,
+  signal?: AbortSignal
+): Promise<string> {
+  const rl = createInterface({ input, output });
+  try {
+    return await rl.question(
+      `Verification code sent to ${username}. Enter the 6-character code: `,
+      // Without the signal a Ctrl-C at the prompt left the readline interface
+      // owning stdin, so the process kept running with nothing to do.
+      signal ? { signal } : {}
+    );
+  } catch (error) {
+    if ((error as { name?: string })?.name === 'AbortError') {
+      throw new AbortedError('Login cancelled');
+    }
+    throw error;
+  } finally {
+    rl.close();
+  }
+}
+
+async function obtainCredentials(
+  username: string,
+  signal?: AbortSignal
+): Promise<Credentials> {
+  const password = process.env.SIMPLENOTE_PASSWORD;
+  // A blank-but-set variable fails exactly like a missing one: a whitespace-
+  // only password is not a password, and sending it would just earn a 401 the
+  // user cannot distinguish from a genuinely wrong one. The *value* is passed
+  // through untrimmed — a real password may legitimately contain leading or
+  // trailing spaces — only the blank check trims.
+  if (password !== undefined && password.trim().length > 0) {
+    return login(username, password);
+  }
+  if (password !== undefined) {
+    console.error(
+      'SIMPLENOTE_PASSWORD is blank; falling back to magic-link login.'
+    );
+  }
+  // The magic-link prompt needs a real terminal. With stdin piped (or already
+  // closed) readline's question either resolves an empty line — burning a
+  // single-use code against the server — or never settles and hangs the CLI.
+  // Failing fast here is cheaper and clearer than either outcome, and it does
+  // not waste the code-request email.
+  if (!process.stdin.isTTY) {
+    throw new UsageError(
+      'Magic-link login requires an interactive terminal. Set SIMPLENOTE_PASSWORD for non-interactive login.'
+    );
+  }
+  await requestLoginEmail(username);
+  const code = await promptCode(username, signal);
+  return completeLogin(username, code);
+}
+
+/**
+ * Interactive or env-driven login.
+ *
+ * Note what is *not* here any more: the old version wrapped every failure in
+ * `AuthError`, so a DNS outage and a keychain write failure both told the user
+ * their password was wrong and exited 2. Errors now keep the code their own
+ * layer assigned (auth 2 / network 3 / aborted 6), and persisting the token is
+ * outside the authentication step because it is a different failure mode.
+ */
+export async function doLogin(signal?: AbortSignal): Promise<void> {
+  // Trimmed so a blank-but-set variable fails exactly like a missing one: the
+  // auth layer normalizes downstream, and a whitespace-only value would
+  // otherwise be sent to the server as an empty username (or waste a code
+  // email on the magic-link path).
+  const username = process.env.SIMPLENOTE_USER?.trim();
+  if (!username) {
+    throw new AuthError(
+      'Login requires a non-blank SIMPLENOTE_USER environment variable'
+    );
+  }
+
+  const credentials = await obtainCredentials(username, signal);
+  await saveCredentials(credentials);
+  console.error(`Logged in as ${credentials.username}`);
+}
+
+/**
+ * True when the args ask for a command's help.
+ *
+ * Uses tokenize's own classification: `--help` is a flag, so it always means
+ * help; `-h` is a single-dash arg that tokenize treats as a positional, so it
+ * only means help when it is the *only* positional. Anything after `--` is
+ * literal content and must not trigger help (`create -- "-h"` writes the text
+ * "-h"), and a content/query argument next to `-h` means the flag is data
+ * (`edit <id> "-h"` writes "-h"; `search "foo" -h` is not help, though search
+ * then rejects the extra positional and asks for one quoted query string).
+ */
+function wantsHelp(rest: string[]): boolean {
+  const { flags, positionals, hasTerminator } = tokenize(rest);
+  if (hasTerminator) {
+    return false;
+  }
+  if (flags.includes('--help')) {
+    return true;
+  }
+  return positionals.length === 1 && positionals[0] === '-h';
+}
+
+export async function run(argv: string[], signal?: AbortSignal): Promise<void> {
+  const [command, ...rest] = argv;
+
+  // `--verbose` is global: accepted by every command and also enabled from the
+  // environment. Set before any dispatch so the HTTP layer's diagnostics are
+  // live from the first fetch.
+  setVerbose(
+    process.env.SIMPLENOTE_CLI_DEBUG === '1' || hasFlag(argv, 'verbose')
+  );
+
+  if (
+    command === undefined ||
+    command === 'help' ||
+    command === '--help' ||
+    command === '-h'
+  ) {
+    console.error(HELP);
+    return;
+  }
+
+  if (command === '--version' || command === '-v') {
+    console.log(getVersion());
+    return;
+  }
+
+  // `--help`/`-h` on a known command prints that command's own help and exits
+  // before credentials are loaded or the network is touched. An unknown
+  // command with `--help` still fails as an unknown command below.
+  if (
+    command === 'login' ||
+    command === 'logout' ||
+    AUTHENTICATED_COMMANDS[command]
+  ) {
+    if (wantsHelp(rest)) {
+      console.error(renderCommandHelp(command));
+      return;
+    }
+  }
+
+  if (command === 'login' || command === 'logout') {
+    validateFlags(command, ['verbose'], rest);
+    rejectExtraPositionals(rest, command, 0);
+    try {
+      if (command === 'login') {
+        await doLogin(signal);
+        return;
+      }
+      await clearCredentials();
+      console.error('Logged out');
+      return;
+    } catch (error) {
+      throw labelled(
+        error,
+        command === 'login' ? 'Login failed' : 'Logout failed'
+      );
+    }
+  }
+
+  const spec = AUTHENTICATED_COMMANDS[command];
+  if (!spec) {
+    throw new UsageError(
+      `Unknown command: ${command}. Run: npm run cli -- help`
+    );
+  }
+
+  // Argv problems are reported before the network is touched, so a typo costs
+  // a millisecond instead of a round trip plus a misleading result.
+  validateFlags(command, spec.flags, rest);
+
+  const credentials = await requireCredentials();
+  try {
+    await spec.run(credentials, rest);
+  } catch (error) {
+    throw labelled(error, spec.label);
+  }
+}
+
+/**
+ * Waits for buffered stdio to reach the OS before the process dies.
+ *
+ * When stdout is a pipe, Node's writes are asynchronous. Exiting straight
+ * after console.log() therefore truncated `--json` payloads, which is exactly
+ * the case a script consumes. The unref'd guard keeps a broken pipe from
+ * hanging the CLI forever.
+ */
+function drain(stream: NodeJS.WriteStream): Promise<void> {
+  return new Promise((resolve) => {
+    if (
+      stream.writableEnded ||
+      stream.destroyed ||
+      stream.writableLength === 0
+    ) {
+      resolve();
+      return;
+    }
+    stream.write('', () => resolve());
+  });
+}
+
+export function flushStdio(): Promise<unknown> {
+  const guard = new Promise<void>((resolve) => {
+    setTimeout(resolve, FLUSH_GUARD_MS).unref();
+  });
+  return Promise.race([
+    Promise.all([drain(process.stdout), drain(process.stderr)]),
+    guard,
+  ]);
+}
+
+/**
+ * `npm run cli -- list | head -3` closes the pipe early. Without this the CLI
+ * dies with an unhandled EPIPE stack trace instead of exiting quietly.
+ *
+ * It must not *invent* a success either: the previous `process.exit(0)` here
+ * turned "auth failed, and the reader hung up" into exit 0, so `set -e`
+ * pipelines happily continued on a failed command.
+ */
+// The guard is process-global state, so registering it must be idempotent:
+// every repeat call used to attach another pair of 'error' listeners, and a
+// process that runs main() more than once (test harnesses, embedded use)
+// would accumulate handlers until Node warns about a possible listener leak.
+let brokenPipeGuardInstalled = false;
+
+export function ignoreBrokenPipe(): void {
+  if (brokenPipeGuardInstalled) {
+    return;
+  }
+  brokenPipeGuardInstalled = true;
+  for (const stream of [process.stdout, process.stderr]) {
+    stream.on('error', (error: NodeJS.ErrnoException) => {
+      if (error.code !== 'EPIPE') {
+        return;
+      }
+      process.exitCode ??= EXIT_OK;
+      stream.destroy();
+    });
+  }
+}
+
+export type Lifecycle = {
+  /** Aborts in-flight work when the user interrupts the CLI. */
+  signal: AbortSignal;
+  aborted: () => boolean;
+  dispose: () => void;
+};
+
+/**
+ * Turns SIGINT/SIGTERM into a cooperative cancellation.
+ *
+ * Before this, Ctrl-C during `export` killed the process mid-write and left a
+ * half-written file with no message; a paged `list` kept its socket open until
+ * the OS reaped it. The signal is handed to infra/http so the in-flight fetch
+ * aborts, and a second interrupt is treated as "I mean it" and exits at once.
+ */
+export function installSignalHandlers(): Lifecycle {
+  const controller = new AbortController();
+  let signalled = false;
+
+  const onSignal = (): void => {
+    if (signalled) {
+      // The graceful unwind is not making progress and the user asked twice.
+      process.exit(EXIT_ABORTED);
+    }
+    signalled = true;
+    controller.abort();
+  };
+
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
+  // Windows Ctrl-Break. Without a handler the process is killed by the default
+  // action before stdio can flush; with one it cooperates like Ctrl-C.
+  // (POSIX ignores SIGBREAK, so registering it there is harmless.)
+  process.on('SIGBREAK', onSignal);
+  setExternalAbortSignal(controller.signal);
+
+  return {
+    signal: controller.signal,
+    aborted: () => signalled,
+    dispose: () => {
+      process.off('SIGINT', onSignal);
+      process.off('SIGTERM', onSignal);
+      process.off('SIGBREAK', onSignal);
+      setExternalAbortSignal(null);
+    },
+  };
+}
+
+/**
+ * Runs the CLI and resolves with the exit code.
+ *
+ * `process.exitCode` is set rather than calling `process.exit()`, so Node is
+ * allowed to finish flushing stdio on its own; the caller decides when (and
+ * whether) to force the process down.
+ */
+export async function main(
+  argv: string[] = process.argv.slice(2)
+): Promise<number> {
+  ignoreBrokenPipe();
+  const lifecycle = installSignalHandlers();
+
+  let code = EXIT_OK;
+  try {
+    await run(argv, lifecycle.signal);
+  } catch (error) {
+    // An interrupted run reports "aborted" (6) regardless of which layer
+    // noticed first — an aborted fetch surfacing as a network error would
+    // otherwise be indistinguishable from a real outage.
+    code = lifecycle.aborted() ? EXIT_ABORTED : exitCodeFor(error);
+    console.error(lifecycle.aborted() ? 'Aborted' : messageOf(error));
+    // An unexpected (non-CliError) failure keeps its network-ish exit code so
+    // the public contract is untouched, but --verbose still exposes the stack
+    // so a real bug is not silently disguised as an outage.
+    if (
+      !lifecycle.aborted() &&
+      isVerbose() &&
+      error instanceof Error &&
+      error.stack
+    ) {
+      console.error(error.stack);
+    }
+  }
+  // A Ctrl-C that lands while no fetch is in flight (the local phase — export
+  // writing files, login persisting credentials, any command's console output)
+  // does not make run() throw: the command simply completes. Map it to aborted
+  // here, the single point every command and every phase converges on.
+  if (lifecycle.aborted()) {
+    code = EXIT_ABORTED;
+  }
+
+  process.exitCode = code;
+  try {
+    await flushStdio();
+  } finally {
+    // The handlers stay installed through the drain: without them a Ctrl-C in
+    // this window hits Node's default handler and kills the process before
+    // stdout finishes writing, truncating a piped --json payload. A first
+    // interrupt here only aborts an already-finished run; a second one still
+    // means "I mean it" and exits at once.
+    lifecycle.dispose();
+  }
+  // A first Ctrl-C during the flush window sets the flag but leaves `code` as
+  // the command computed — re-check after the drain so an interrupted run
+  // still reports "aborted" (6) per the public contract. The command itself
+  // already finished and its output was flushed, so this only changes the
+  // exit code, never the data.
+  if (lifecycle.aborted()) {
+    code = EXIT_ABORTED;
+    process.exitCode = EXIT_ABORTED;
+  }
+  return code;
+}

--- a/lib/cli/auth.ts
+++ b/lib/cli/auth.ts
@@ -1,0 +1,156 @@
+import { ACCOUNT_BASE, AUTH_BASE, APP_ID, getAppKey } from './config.ts';
+import { httpRequest } from './infra/http.ts';
+import { AuthError, RateLimitError, UsageError } from './domain/errors.ts';
+import type { Credentials } from './domain/types.ts';
+
+export const RATE_LIMIT_MESSAGE =
+  'Too many login requests in a short time. Wait a few minutes and try again.';
+
+function toErrorMessage(status: number, body: string): string {
+  if (status === 429) {
+    return `${RATE_LIMIT_MESSAGE} (HTTP 429)`;
+  }
+  return `HTTP ${status}: ${body}`;
+}
+
+/**
+ * Classifies a non-OK auth response: a 429 is a throttle, not a bad
+ * credential — it keeps the network exit code (3) and its own class so CI
+ * that treats exit 2 as "wrong password" does not misreport a rate limit.
+ * Everything else stays AuthError (exit 2).
+ */
+function throwAuthError(status: number, message: string): never {
+  if (status === 429) {
+    throw new RateLimitError(message);
+  }
+  throw new AuthError(message);
+}
+
+// Login is never retried: `authorize` counts against a rate limit and
+// `complete-login` burns a single-use code, so a replay would turn a slow
+// network into a locked-out account.
+const NO_RETRY = { retries: 0 } as const;
+
+export async function login(
+  username: string,
+  password: string
+): Promise<Credentials> {
+  // Normalized the same way requestLoginEmail/completeLogin normalize, so the
+  // authorize request body and the stored username are byte-identical no
+  // matter which flow produced the login (password vs magic-link) and whoami
+  // prints the same address either way.
+  const normalizedUsername = username.trim().toLowerCase();
+  const res = await httpRequest(
+    `${AUTH_BASE}/${APP_ID}/authorize/`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Simperium-API-Key': getAppKey(),
+      },
+      body: JSON.stringify({ username: normalizedUsername, password }),
+    },
+    { ...NO_RETRY, label: 'Auth request' }
+  );
+
+  if (!res.ok) {
+    // A 401 here means the app credentials (app_key) or the password were
+    // rejected. Both look identical from the outside, so point the user at
+    // the flow that sidesteps password auth entirely rather than leaving them
+    // to guess which input was wrong.
+    const guidance =
+      res.status === 401
+        ? ' If password login keeps failing, use magic-link login instead (unset SIMPLENOTE_PASSWORD).'
+        : '';
+    throwAuthError(
+      res.status,
+      `Auth failed: ${toErrorMessage(res.status, await res.text())}${guidance}`
+    );
+  }
+
+  const body = (await res.json()) as Partial<Credentials>;
+  if (!body.access_token || !body.username) {
+    throw new AuthError('Auth response malformed');
+  }
+
+  return { access_token: body.access_token, username: normalizedUsername };
+}
+
+export async function requestLoginEmail(username: string): Promise<void> {
+  const res = await httpRequest(
+    `${ACCOUNT_BASE}/request-login`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        username: username.trim().toLowerCase(),
+        request_source: 'electron',
+      }),
+    },
+    { ...NO_RETRY, label: 'Request login' }
+  );
+
+  if (!res.ok) {
+    throwAuthError(
+      res.status,
+      `Request login failed: ${toErrorMessage(res.status, await res.text())}`
+    );
+  }
+}
+
+export async function completeLogin(
+  username: string,
+  code: string
+): Promise<Credentials> {
+  // An empty code must never reach the server: it burns a single-use code and
+  // comes back as an unhelpful 400. With piped stdin the prompt can hand us
+  // an empty line instead of a real code, so this is the guard of last resort.
+  // Codes are copied out of an email, so they routinely arrive with stray
+  // spaces or newlines (e.g. "12 345"). Strip all whitespace before sending,
+  // otherwise the server rejects a well-intended code with a 400 the user
+  // cannot distinguish from a genuinely wrong one.
+  const normalized = code.replace(/\s+/g, '');
+  if (normalized.length === 0) {
+    throw new UsageError(
+      'Login code is empty. Re-run login and enter the 6-character code sent to your email.'
+    );
+  }
+  const res = await httpRequest(
+    `${ACCOUNT_BASE}/complete-login`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        username: username.trim().toLowerCase(),
+        auth_code: normalized.toUpperCase(),
+      }),
+    },
+    { ...NO_RETRY, label: 'Complete login' }
+  );
+
+  if (!res.ok) {
+    // A failed code is single-use, so guide the user to request a fresh one.
+    // 429 is a throttle (rate limit), not a wrong code — telling the user to
+    // re-run immediately would only deepen the lockout, so skip the guidance.
+    const guidance =
+      res.status === 429
+        ? ''
+        : ' Re-run `npm run cli -- login` to send a new code.';
+    throwAuthError(
+      res.status,
+      `Complete login failed: ${toErrorMessage(res.status, await res.text())}${guidance}`
+    );
+  }
+
+  const body = (await res.json()) as { sync_token?: string };
+  if (!body.sync_token) {
+    throw new AuthError('Complete login response malformed');
+  }
+
+  // Normalize the same way `requestLoginEmail` does, so the stored username is
+  // exactly the address the server sent the code to.
+  return {
+    access_token: body.sync_token,
+    username: username.trim().toLowerCase(),
+  };
+}

--- a/lib/cli/bootstrap.ts
+++ b/lib/cli/bootstrap.ts
@@ -1,0 +1,35 @@
+// Executable entry point. Importing this file runs the CLI, so it stays as
+// thin as possible — all behaviour lives in `app.ts`, which is importable
+// without side effects and therefore testable.
+
+import { flushStdio, main, messageOf } from './app.ts';
+import { EXIT_UNKNOWN } from './domain/errors.ts';
+
+/**
+ * Lets the event loop close the process on its own, with a bounded fallback.
+ *
+ * `process.exitCode` alone is the correct way to finish: Node exits once the
+ * loop is empty, after stdio has drained, so nothing can truncate a `--json`
+ * payload. The catch is that Node's global fetch parks HTTP/1.1 sockets in a
+ * keep-alive pool for a few seconds, which would leave the shell waiting on a
+ * CLI that has nothing left to do.
+ *
+ * The timer is unref'd, so when the loop is already idle it never fires and
+ * the process exits immediately. It only fires when something *is* still
+ * holding the loop open — at which point stdio is long since flushed and
+ * forcing the exit is safe.
+ */
+function exitWhenIdle(code: number, graceMs = 250): void {
+  setTimeout(() => process.exit(code), graceMs).unref();
+}
+
+main()
+  .then(exitWhenIdle)
+  .catch(async (error) => {
+    // Reaching here means the error escaped main()'s own handling, i.e. a bug
+    // in the CLI rather than a failed operation.
+    console.error(`Unexpected error: ${messageOf(error)}`);
+    process.exitCode = EXIT_UNKNOWN;
+    await flushStdio();
+    exitWhenIdle(EXIT_UNKNOWN);
+  });

--- a/lib/cli/cli-args.ts
+++ b/lib/cli/cli-args.ts
@@ -1,0 +1,343 @@
+// Shared argv primitives.
+//
+// Every command used to re-implement flag scanning by hand. That duplication
+// is why `show --json <id>` parsed `--json` as the note id, and why `create`
+// and `edit` carried two near-identical copies of the same content-source
+// rules. Parsing lives here once; commands only describe what they need.
+
+import { UsageError } from './domain/errors.ts';
+import { normalizeTags } from './domain/tags.ts';
+import type { ContentSource } from './domain/types.ts';
+
+export type TokenizedArgs = {
+  /** `--name=value` / `--flag` arguments (post-`--` args are excluded). */
+  flags: string[];
+  /** Everything that is not a flag, including anything after a `--` terminator. */
+  positionals: string[];
+  /** True when a `--` terminator was present (flags after it are positionals). */
+  hasTerminator: boolean;
+};
+
+/**
+ * Splits argv into flags and positionals, honoring a `--` terminator.
+ *
+ * Without this, `create "hello world"` (two shell words) or
+ * `create -- "--heading"` (content that looks like a flag) cannot be told
+ * apart from real flags. Flags are scanned only from `flags`, so a positional
+ * that happens to start with `--` is never misread as an option.
+ */
+export function tokenize(args: string[]): TokenizedArgs {
+  const flags: string[] = [];
+  const positionals: string[] = [];
+  let hasTerminator = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--') {
+      hasTerminator = true;
+      // Everything after `--` is a literal positional, even if it starts with `--`.
+      for (let j = i + 1; j < args.length; j++) {
+        positionals.push(args[j]);
+      }
+      break;
+    }
+    if (arg.startsWith('--')) {
+      flags.push(arg);
+    } else {
+      positionals.push(arg);
+    }
+  }
+
+  return { flags, positionals, hasTerminator };
+}
+
+/**
+ * After a `--` terminator every word is a literal positional (tokenize
+ * guarantees it), so unquoted multi-word content is one string there — the
+ * whole point of the escape hatch. Words before `--` keep the "quote
+ * multi-word" error, so a forgotten quote still cannot silently drop data.
+ */
+function mergeTerminatedPositionals(
+  args: string[],
+  positionals: string[]
+): string[] {
+  const terminatorIndex = args.indexOf('--');
+  if (terminatorIndex === -1) {
+    return positionals;
+  }
+  const beforeCount = args
+    .slice(0, terminatorIndex)
+    .filter((arg) => !arg.startsWith('--')).length;
+  const after = positionals.slice(beforeCount);
+  return after.length <= 1
+    ? positionals
+    : [...positionals.slice(0, beforeCount), after.join(' ')];
+}
+
+/** Flags only — ignores anything after a `--` terminator. */
+function flagsOf(args: string[]): string[] {
+  return tokenize(args).flags;
+}
+
+/**
+ * True when `--name` was given in any form: bare (`--json`) or valued
+ * (`--json=1`). Booleans only care about presence; treating `--json=1` as
+ * absent used to silently drop the JSON request and print tabular output with
+ * no hint that the flag was ignored.
+ */
+export function hasFlag(args: string[], name: string): boolean {
+  return flagsOf(args).some(
+    (arg) => arg === `--${name}` || arg.startsWith(`--${name}=`)
+  );
+}
+
+/**
+ * True only when `--name` appears as a bare flag (no `=value`). A flag that
+ * expects a value but got none is a usage error, not a silent fallback to the
+ * default, so `list --limit` (forgetting the `=N`) no longer quietly returns
+ * 20 notes.
+ */
+export function hasBareFlag(args: string[], name: string): boolean {
+  return flagsOf(args).includes(`--${name}`);
+}
+
+export function flagValues(args: string[], name: string): string[] {
+  const prefix = `--${name}=`;
+  return flagsOf(args)
+    .filter((arg) => arg.startsWith(prefix))
+    .map((arg) => arg.slice(prefix.length));
+}
+
+/**
+ * The "exactly one `--name=value`" rule shared by every single-valued flag.
+ *
+ * Collapses the three checks each command used to repeat by hand — a bare flag
+ * (no `=`), the same flag given twice, and an explicit-but-empty value — into
+ * one helper. Returns the value, or `undefined` when the flag is absent. Uses
+ * `flagValues`, which slices instead of splitting on `=`, so values that
+ * themselves contain `=` (paths, base64) survive intact. `example` only shapes
+ * the error messages (`--format requires a value, e.g. --format=json`), so a
+ * command keeps its own wording without re-implementing the checks.
+ */
+export function parseSingleValueFlag(
+  args: string[],
+  name: string,
+  example: string
+): string | undefined {
+  if (hasBareFlag(args, name)) {
+    throw new UsageError(
+      `--${name} requires a value, e.g. --${name}=${example}`
+    );
+  }
+  const values = flagValues(args, name);
+  if (values.length > 1) {
+    throw new UsageError(`Provide --${name}= once (e.g. --${name}=${example})`);
+  }
+  const raw = values[0];
+  if (raw === '') {
+    throw new UsageError(`--${name} cannot be empty`);
+  }
+  return raw;
+}
+
+/**
+ * `--limit=N`. Absent -> fallback. Anything that is not a positive integer
+ * (0, negatives, decimals, hex, garbage) is a usage error rather than a silent
+ * fallback, so `list --limit=abc` no longer quietly returns the default.
+ */
+export function parseLimit(args: string[], fallback: number): number {
+  if (hasBareFlag(args, 'limit')) {
+    throw new UsageError('--limit requires a value, e.g. --limit=20');
+  }
+
+  const values = flagValues(args, 'limit');
+  if (values.length > 1) {
+    throw new UsageError('Provide --limit= once (e.g. --limit=20)');
+  }
+  const raw = values[0];
+  if (raw === undefined) {
+    return fallback;
+  }
+  // Number() also coerces "0x10" (16), "1e3" (1000), " 5 " (5) and "5.0" (5)
+  // into integers, so those used to slip past `Number.isInteger`. A positive
+  // integer has exactly the shape of decimal digits with a non-zero total.
+  if (!/^\d+$/.test(raw) || Number(raw) <= 0) {
+    throw new UsageError(`--limit must be a positive integer, got: ${raw}`);
+  }
+  return Number(raw);
+}
+
+/**
+ * Pulls the first non-flag argument out of argv and returns everything else
+ * untouched, so `edit --json <id> "text"` and `edit <id> "text" --json` are
+ * equivalent instead of the former silently using `--json` as the id.
+ *
+ * `rest` is re-assembled so that tokenizing it again yields the same
+ * classification. `edit`/`show`/`search` parse in two phases (take the id,
+ * then parse the remainder), and dropping the `--` terminator here meant the
+ * second phase re-read post-terminator words as flags:
+ *
+ *   edit -- <id> "--dashed content"
+ *     -> rest ["--dashed content"] -> re-tokenized as a *flag*
+ *     -> "edit requires new content", i.e. the documented `--` escape hatch
+ *        was unusable for every verb that takes a leading positional.
+ *
+ * Re-inserting the terminator makes the round-trip lossless.
+ */
+export function takeFirstPositional(args: string[]): {
+  value?: string;
+  rest: string[];
+} {
+  const { positionals, flags, hasTerminator } = tokenize(args);
+  if (positionals.length === 0) {
+    return { rest: flags };
+  }
+  const [value, ...restPositionals] = positionals;
+  // The terminator is only needed while literal positionals remain; without
+  // any it would be inert noise in the returned argv.
+  const separator = hasTerminator && restPositionals.length > 0 ? ['--'] : [];
+  return { value, rest: [...flags, ...separator, ...restPositionals] };
+}
+
+/**
+ * The "exactly one of positional / --content= / --file=" rule shared by
+ * `create` and `edit`. `verb` and `noun` keep each command's wording.
+ */
+export function parseContentSource(
+  args: string[],
+  verb: string,
+  noun: string
+): ContentSource {
+  // A bare `--content`/`--file` (no `=value`) is a forgotten value, not an
+  // absent flag: reporting "requires new content" would send the user chasing
+  // the wrong fix. Error with the precise message instead, like the other
+  // single-valued flags do.
+  if (hasBareFlag(args, 'content')) {
+    throw new UsageError(`--content requires a value, e.g. --content=${noun}`);
+  }
+  if (hasBareFlag(args, 'file')) {
+    throw new UsageError('--file requires a value, e.g. --file=notes.json');
+  }
+  const { positionals, hasTerminator } = tokenize(args);
+  const contentFlags = flagValues(args, 'content');
+  const fileFlags = flagValues(args, 'file');
+  const contentFlag = contentFlags[0];
+  const fileFlag = fileFlags[0];
+
+  // The same flag twice silently kept only its first value, so
+  // `create --content=a --content=b` created note "a" and threw "b" away.
+  // Erroring (like add does for --file) is safer than guessing which one won.
+  if (contentFlags.length > 1) {
+    throw new UsageError(`Provide the ${noun} once (--content= appears twice)`);
+  }
+  if (fileFlags.length > 1) {
+    throw new UsageError(`Provide the ${noun} once (--file= appears twice)`);
+  }
+
+  // An explicit-but-empty value is a mistake, not a request to read a blank
+  // string: `--file=` used to fall through to `readContentSource`, which
+  // reported "Cannot read --file=: ENOENT" for a path the user never wrote.
+  if (contentFlag === '') {
+    throw new UsageError(`--content= cannot be empty (provide ${noun})`);
+  }
+  if (fileFlag === '') {
+    throw new UsageError('--file= cannot be empty (provide a path)');
+  }
+
+  // A single positional is the content. More than one means the user forgot to
+  // quote multi-word content; erroring is safer than silently dropping every
+  // word but the first (which would lose data on `create a b`). After a `--`
+  // terminator, though, every word is explicitly literal, so they fold into
+  // one content string (`create -- a b` === `create "a b"`).
+  const effectivePositionals = hasTerminator
+    ? mergeTerminatedPositionals(args, positionals)
+    : positionals;
+  if (effectivePositionals.length > 1) {
+    throw new UsageError(`Provide the ${noun} once (quote multi-word ${noun})`);
+  }
+  const positional = effectivePositionals[0];
+
+  const provided = [positional, contentFlag, fileFlag].filter(
+    (value) => value !== undefined
+  );
+
+  if (provided.length === 0) {
+    throw new UsageError(
+      `${verb} requires ${noun} (positional, --content=, or --file=)`
+    );
+  }
+  if (provided.length > 1) {
+    throw new UsageError(
+      `Provide the ${noun} once (positional, --content=, or --file=)`
+    );
+  }
+
+  if (fileFlag !== undefined) {
+    return { content: fileFlag, fromFile: true };
+  }
+  if (contentFlag !== undefined) {
+    return { content: contentFlag, fromFile: false };
+  }
+  return { content: positional as string, fromFile: false };
+}
+
+/** Comma-separated `--tags=a,b,c`, trimmed, de-blanked, de-duplicated. */
+export function parseTags(args: string[]): string[] {
+  // `--tags` without `=value` used to fold into an empty array and create a
+  // note with no tags at all, silently dropping the user's intent.
+  if (hasBareFlag(args, 'tags')) {
+    throw new UsageError('--tags requires a value, e.g. --tags=a,b');
+  }
+  const tags = flagValues(args, 'tags');
+  if (tags.length > 1) {
+    throw new UsageError('Provide --tags= once (e.g. --tags=a,b)');
+  }
+  const raw = tags[0];
+  if (raw === undefined) {
+    return [];
+  }
+  return normalizeTags(raw.split(','), '--tags=');
+}
+
+/**
+ * Returns the flags in `args` that are not in `allowed` (e.g. `["--limt"]`).
+ * Used by the dispatcher so a typo like `list --limt=5` fails loudly instead of
+ * silently falling back to the default.
+ */
+export function unknownFlags(args: string[], allowed: string[]): string[] {
+  const allowedSet = new Set(allowed.map((name) => `--${name}`));
+  return flagsOf(args).filter((flag) => {
+    // `--json` / `--include-trashed` are bare flags; `--limit=5` carries a value.
+    const base = flag.includes('=') ? flag.slice(0, flag.indexOf('=')) : flag;
+    return !allowedSet.has(base);
+  });
+}
+
+/**
+ * Errors when the command was handed more positional arguments than it takes.
+ *
+ * `show n1 n2` used to ignore `n2` and `list extra` ignored `extra` entirely;
+ * a stray argument is almost always a typo or an unquoted multi-word value,
+ * so it is a usage error rather than silent data loss.
+ *
+ * `consumed` is the number of positionals the caller already removed from
+ * `args` (via `takeFirstPositional`) and is added to both sides of the
+ * comparison. `show n1 n2` is checked *after* the id is taken, so without it
+ * the message read "got 1, expected at most 0" for a command the user handed
+ * two arguments and that legitimately accepts one.
+ */
+export function rejectExtraPositionals(
+  args: string[],
+  command: string,
+  max: number,
+  consumed = 0
+): void {
+  const { positionals } = tokenize(args);
+  const got = positionals.length + consumed;
+  const allowed = max + consumed;
+  if (got > allowed) {
+    throw new UsageError(
+      `Too many arguments for ${command}: got ${got}, expected at most ${allowed}`
+    );
+  }
+}

--- a/lib/cli/cli-constants.ts
+++ b/lib/cli/cli-constants.ts
@@ -1,0 +1,86 @@
+// Single home for the magic values scattered through the CLI.
+//
+// Previously each file hard-coded its own literals (20, 50, 60, 2000, 16,
+// 40, 75, ...) with no name and no explanation of why that number. Centralizing
+// them makes the limits discoverable and the reasoning auditable. Every module
+// that needs a constant imports it directly (http, export-helpers, config,
+// note-source, export-naming, app, commands/list, commands/search,
+// commands/add, ...); nothing re-exports this module.
+
+/** Simplenote production app id (magic-link tokens are issued against it). */
+export const DEFAULT_APP_ID = 'chalk-bump-f49';
+
+/** Default result window for `list`. */
+export const LIST_DEFAULT_LIMIT = 20;
+
+/** Version reported by `--version` when the repo root package.json is unreadable. */
+export const CLI_VERSION_FALLBACK = '0.0.0';
+
+/** Default result window for `search`. */
+export const SEARCH_DEFAULT_LIMIT = 50;
+
+/** Preview width (characters) used by the non-JSON `list` output. */
+export const PREVIEW_WIDTH = 60;
+
+/** Grace period to drain stdio before giving up (milliseconds). */
+export const FLUSH_GUARD_MS = 2_000;
+
+/** Hard cap on index pagination rounds before we give up (anti-runaway). */
+export const MAX_PAGES = 1_000;
+
+/** Wall-clock budget for a whole command (pagination, retries included). */
+export const DEFAULT_TOTAL_TIMEOUT_MS = 120_000;
+
+/** Page size requested from the Simperium index to limit round-trips. */
+export const INDEX_PAGE_SIZE = 1_000;
+
+/** Bounded fan-out when writing exported note files. */
+export const WRITE_CONCURRENCY = 16;
+
+/** Bounded fan-out when importing notes from a file (`add --file=`). */
+export const IMPORT_CONCURRENCY = 8;
+
+/** Truncated length of a note's first line, used as a file name. */
+export const FILENAME_LENGTH = 40;
+
+/** Maximum line length before a tag list wraps to a new line. */
+export const TAG_LINE_LENGTH = 75;
+
+/** Exponential backoff bounds (full jitter, AWS Architecture Blog). */
+export const BASE_BACKOFF_MS = 300;
+export const MAX_BACKOFF_MS = 4_000;
+
+// Retry-After is the server's explicit instruction and is honored far above
+// the local backoff cap — but still bounded, so a hostile or buggy
+// "Retry-After: 86400" cannot park the CLI for a day. Abort and deadlineAt
+// stay authoritative and can interrupt the wait at any time.
+export const MAX_RETRY_AFTER_MS = 30_000;
+/** Floor so a "backoff" is never a zero-delay immediate retry. */
+export const MIN_BACKOFF_MS = 50;
+
+/**
+ * Floor for a single attempt's deadline when an overall budget is nearly spent.
+ * Without it, the last attempt of a long pagination run would be handed a
+ * negative timeout and abort before the socket was even opened.
+ */
+export const MIN_ATTEMPT_TIMEOUT_MS = 1_000;
+
+/**
+ * Consecutive failures tolerated by a batch command before it stops.
+ * A whole import failing one note at a time is slower and noisier than
+ * failing fast once the backend is clearly unavailable.
+ */
+export const MAX_CONSECUTIVE_FAILURES = 5;
+
+/**
+ * Reads a positive-integer environment variable, falling back when it is
+ * absent or not a positive number.
+ *
+ * `Number()` coercion is kept deliberately (so "15", " 15 " and "0x10" behave
+ * exactly as the call sites relied on before this helper existed); only the
+ * duplicated parsing is being unified.
+ */
+export function envPositiveInt(name: string, fallback: number): number {
+  const raw = Number(process.env[name]);
+  return Number.isFinite(raw) && raw > 0 ? raw : fallback;
+}

--- a/lib/cli/command-help.ts
+++ b/lib/cli/command-help.ts
@@ -1,0 +1,128 @@
+/**
+ * Per-command help for `cli <command> --help`.
+ *
+ * This is static text, deliberately written out rather than generated from
+ * AUTHENTICATED_COMMANDS: it exists for *humans* who do not have the source
+ * open, so it reads like a manual page instead of a serialized flag table.
+ * Keep the flags lists in sync with app.ts — the command-help test locks both.
+ *
+ * Global flags (`--verbose`, `--json` where applicable) are not re-listed per
+ * command; `cli --help` documents them once.
+ */
+
+export const COMMAND_HELP: Record<string, string> = {
+  login: `Usage: npm run cli -- login
+
+Log in. Credentials come from SIMPLENOTE_USER (required) and SIMPLENOTE_PASSWORD
+(password login), or a magic-link verification code prompt when no password is
+set. Stored credentials are kept in ~/.simplenote-cli/credentials.json.
+
+Flags: (none besides the global --verbose)
+
+Exit codes: 0 ok | 1 usage | 2 auth | 3 network | 6 aborted`,
+
+  logout: `Usage: npm run cli -- logout
+
+Remove the stored credentials.
+
+Flags: (none besides the global --verbose)
+
+Exit codes: 0 ok | 1 usage | 6 aborted`,
+
+  whoami: `Usage: npm run cli -- whoami [--json]
+
+Print the logged-in username.
+
+Flags:
+  --json     Print a JSON object instead of a bare username
+
+Exit codes: 0 ok | 1 usage | 2 auth | 6 aborted`,
+
+  list: `Usage: npm run cli -- list [--limit=N] [--json] [--include-trashed]
+
+List note summaries, most recently modified first. Trashed notes are skipped
+unless --include-trashed is given.
+
+Flags:
+  --limit=N            Max results (default 20)
+  --json               Print machine-readable JSON
+  --include-trashed    Keep trashed notes in the result
+
+Exit codes: 0 ok | 1 usage | 2 auth | 3 network | 6 aborted`,
+
+  show: `Usage: npm run cli -- show <id> [--json]
+
+Show a single note's content.
+
+Flags:
+  --json     Print machine-readable JSON
+
+Exit codes: 0 ok | 1 usage | 2 auth | 3 network | 4 not found | 6 aborted`,
+
+  search: `Usage: npm run cli -- search "<query>" [--limit=N] [--json] [--include-trashed]
+
+Search note contents; supports tag: filters (e.g. "tag:recipes pasta").
+Trashed notes are skipped unless --include-trashed is given.
+
+Flags:
+  --limit=N            Max results (default 50)
+  --json               Print machine-readable JSON
+  --include-trashed    Keep trashed notes in the result
+
+Exit codes: 0 ok | 1 usage | 2 auth | 3 network | 6 aborted`,
+
+  edit: `Usage: npm run cli -- edit <id> "<content>" [--json]
+
+Replace a note's content. The new content can also come from --content= or
+--file= instead of the second positional argument.
+
+Flags:
+  --json               Print machine-readable JSON
+  --content=<text>     New content (alternative to the positional argument)
+  --file=<path>        Read new content from a file
+
+Exit codes: 0 ok | 1 usage | 2 auth | 3 network | 4 not found | 5 conflict | 6 aborted`,
+
+  create: `Usage: npm run cli -- create "<content>" [--tags=a,b] [--json]
+
+Create a note. The content can also come from --content= or --file= instead of
+the positional argument.
+
+Flags:
+  --tags=a,b           Comma-separated tags to attach
+  --json               Print machine-readable JSON
+  --content=<text>     Note content (alternative to the positional argument)
+  --file=<path>        Read note content from a file
+
+Exit codes: 0 ok | 1 usage | 2 auth | 3 network | 6 aborted`,
+
+  add: `Usage: npm run cli -- add --file=notes.json [--json]
+
+Create multiple notes from a JSON array file. Idempotent: notes whose content
+already exists (by hash) are skipped rather than duplicated.
+
+Flags:
+  --file=<path>        JSON array file to import (required)
+  --json               Print machine-readable JSON
+
+Exit codes: 0 ok | 1 usage | 2 auth | 3 network | 4 not found | 5 conflict | 6 aborted | 7 partial`,
+
+  export: `Usage: npm run cli -- export [--format=all|json|markdown|zip] [--output=DIR]
+
+Export notes. all (the default) writes json, markdown and zip. A single format
+writes only that one.
+
+Flags:
+  --format=<fmt>       json, markdown, zip, or all (default all)
+  --output=<dir>       Target directory (default ./simplenote-export)
+
+Exit codes: 0 ok | 1 usage | 2 auth | 3 network | 6 aborted`,
+};
+
+/** Renders a command's help text, or an error marker for unknown commands. */
+export function renderCommandHelp(command: string): string {
+  return (
+    COMMAND_HELP[command] ??
+    `Unknown command: ${command}. Run: npm run cli -- help`
+  );
+}

--- a/lib/cli/commands/add.ts
+++ b/lib/cli/commands/add.ts
@@ -1,0 +1,431 @@
+import { createHash } from 'crypto';
+import type { Credentials } from '../domain/types.ts';
+import { createNoteSource } from '../note-source.ts';
+import type { NewNote, NoteSource } from '../domain/types.ts';
+import { hasFlag, parseSingleValueFlag } from '../cli-args.ts';
+import { readContentSource } from '../content-input.ts';
+import { isTrashed } from '../domain/trash.ts';
+import { normalizeTags } from '../domain/tags.ts';
+import {
+  IMPORT_CONCURRENCY,
+  MAX_CONSECUTIVE_FAILURES,
+} from '../cli-constants.ts';
+import {
+  UsageError,
+  PartialError,
+  AbortedError,
+  AuthError,
+  CliError,
+  RateLimitError,
+  exitCodeFor,
+  messageOf,
+} from '../domain/errors.ts';
+
+export type AddOptions = {
+  file: string;
+  json: boolean;
+};
+
+export function parseAddOptions(args: string[]): AddOptions {
+  // parseSingleValueFlag covers the bare/duplicate/empty cases with the same
+  // messages as every other single-valued flag; only the "required" rule is
+  // add-specific and stays here.
+  const file = parseSingleValueFlag(args, 'file', 'notes.json');
+  if (file === undefined) {
+    throw new UsageError(
+      'add requires --file=notes.json (JSON array of {content, tags?})'
+    );
+  }
+  return { file, json: hasFlag(args, 'json') };
+}
+
+type AddEntry = { content: string; tags?: string[] };
+
+// Stable fingerprint for idempotent import: identical content + same tag set
+// (order-normalized) must collide, so re-running an import file skips notes
+// that already exist instead of creating duplicates.
+function fingerprint(note: {
+  content?: string;
+  tags?: readonly string[];
+}): string {
+  // Tags are trimmed, de-duplicated and case-folded on both sides of the
+  // comparison. Import-file tags were already cleaned by parseNotesFile; tags
+  // read back from the server may carry stray whitespace (e.g. desktop-created
+  // tags), duplicates, or casing differences — search matches tags
+  // case-insensitively, so the fingerprint must agree or "work" vs "WORK"
+  // silently re-imports a duplicate. Content is line-break-normalized: an
+  // export round-trip (normalizeLineBreak -> CRLF) followed by an import (LF)
+  // must still dedup. Both are also Unicode-normalized (NFC): macOS writes NFD
+  // and Windows/Linux write NFC, so "café" exported on one platform must
+  // collide with the same text typed on the other — otherwise a cross-platform
+  // round-trip silently duplicates the note.
+  const tags = [
+    ...new Set(
+      [...(note.tags ?? [])].map((tag) =>
+        tag.trim().toLowerCase().normalize('NFC')
+      )
+    ),
+  ]
+    .sort()
+    .join(',');
+  const content = (note.content ?? '').replace(/\r\n/g, '\n').normalize('NFC');
+  return createHash('sha1').update(`${content}\u0000${tags}`).digest('hex');
+}
+
+function parseNotesFile(raw: string): AddEntry[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new UsageError('Invalid JSON in the notes file');
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new UsageError('The notes file must contain a non-empty JSON array');
+  }
+  return parsed.map((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new UsageError(`Notes file entry ${index} is not an object`);
+    }
+    const content = (entry as { content?: unknown }).content;
+    if (typeof content !== 'string' || content.trim().length === 0) {
+      throw new UsageError(
+        `Notes file entry ${index} has no non-blank content`
+      );
+    }
+    const tags = (entry as { tags?: unknown }).tags;
+    let parsedTags: string[] | undefined;
+    if (tags !== undefined) {
+      if (!Array.isArray(tags) || tags.some((tag) => typeof tag !== 'string')) {
+        throw new UsageError(`Notes file entry ${index} has invalid tags`);
+      }
+      // Same normalization as parseTags: trim, drop blanks, reject line breaks,
+      // drop duplicates — so empty/duplicate tags are never uploaded and the
+      // dedup fingerprint agrees with `create --tags=`.
+      parsedTags = normalizeTags(tags as string[], `notes file entry ${index}`);
+    }
+    return { content, tags: parsedTags };
+  });
+}
+
+/**
+ * Why the batch ended. Naming the four endings is what keeps the reporting and
+ * the exit-code decision from re-deriving them from flag combinations: each
+ * one means something different to the user (the server is down / your token
+ * expired / you pressed Ctrl-C / we got to the end) and each needs its own
+ * line of output.
+ */
+type StopReason =
+  | 'complete'
+  | 'consecutive-failures'
+  | 'rate-limited'
+  | 'auth'
+  | 'aborted';
+
+type ImportOutcome = {
+  created: Array<{ index: number; id: string; version: number }>;
+  // Skipped entries carry only their index: dedup keys off the fingerprint,
+  // and echoing the full content doubled the report size on a re-import.
+  skipped: Array<{ index: number }>;
+  failures: Array<{ index: number; error: string }>;
+  stopReason: StopReason;
+  /**
+   * Rethrown by the caller *after* the report is printed, so the exit code
+   * still names the real cause (2 auth / 6 aborted) while the ids of the
+   * notes that did land are not swallowed with it.
+   */
+  terminalError?: CliError;
+  /** First per-item failure, used to pick an exit code when nothing worked. */
+  firstFailure?: unknown;
+};
+
+/**
+ * Errors that make every remaining entry futile.
+ *
+ * A bad token can never fix itself mid-run, and a Ctrl-C is the user telling
+ * us to stop. Both used to fall through to the generic failure path (only
+ * `AuthError` was special-cased), so an interrupt turned into a burst of
+ * MAX_CONSECUTIVE_FAILURES doomed requests — each one rejected instantly by
+ * the transport's cancellation pre-check — followed by a "Stopped early after
+ * 5 consecutive failures" that blamed the server for the user's own Ctrl-C.
+ */
+function terminalStop(error: unknown): StopReason | undefined {
+  if (error instanceof AuthError) {
+    return 'auth';
+  }
+  if (error instanceof AbortedError) {
+    return 'aborted';
+  }
+  // A 429 is the server asking us to slow down: on a write path with no
+  // retries (duplicate-note safety) every further entry will be refused too,
+  // so stop on the first one instead of five doomed attempts. The report
+  // names the real cause rather than "backend unavailable".
+  if (error instanceof RateLimitError) {
+    return 'rate-limited';
+  }
+  return undefined;
+}
+
+async function importNotes(
+  source: NoteSource,
+  entries: AddEntry[],
+  existingFingerprints: Set<string>
+): Promise<ImportOutcome> {
+  const created: ImportOutcome['created'] = [];
+  const skipped: ImportOutcome['skipped'] = [];
+  const failures: ImportOutcome['failures'] = [];
+  let firstFailure: unknown;
+  let consecutiveFailures = 0;
+  let stopReason: StopReason = 'complete';
+  let terminalError: CliError | undefined;
+
+  // Serializes entries that share a fingerprint. The concurrent pool must not
+  // create two notes with identical content at the same time — the serial
+  // implementation could not either, because the first create completed
+  // before the second entry was even looked at. Each follower awaits its
+  // key's previous result: a success dedups it, a plain failure lets it try,
+  // a terminal stop stands it down.
+  const pending: Map<string, Promise<'ok' | 'failed'>> = new Map();
+  // Shared cursor: every worker grabs the next index in one synchronous step,
+  // so no two workers can claim the same entry.
+  let cursor = 0;
+
+  const stopped = () => stopReason !== 'complete';
+
+  async function processEntry(index: number): Promise<void> {
+    const entry = entries[index];
+    // Hashed once per entry. The fingerprint is a SHA-1 over the full note
+    // body, and it used to be recomputed for the dedup insert right after the
+    // dedup lookup — doubling the hashing cost of every large import.
+    const key = fingerprint(entry);
+    if (existingFingerprints.has(key)) {
+      skipped.push({ index });
+      return;
+    }
+
+    // The chain, not a fan-out. The old code let every follower await the same
+    // `prior` promise; when the predecessor failed, two followers both fell
+    // through and created concurrently — three identical entries with the
+    // first one failing produced *two* duplicates on the server. Chaining the
+    // new attempt onto the key's current tail makes W3's create run only after
+    // W2's attempt settles: a success dedups it, a failure lets it try, a stop
+    // stands it down — exactly like the serial loop.
+    const prior = pending.get(key) ?? Promise.resolve('failed' as const);
+    const attempt = prior.then(
+      async (priorResult): Promise<'ok' | 'failed'> => {
+        // The predecessor (or an earlier link in the chain) already created
+        // this key, so this entry is a duplicate of a note that landed.
+        if (priorResult === 'ok' || existingFingerprints.has(key)) {
+          skipped.push({ index });
+          return 'ok';
+        }
+        // A terminal stop (auth/aborted) or the consecutive-failure stop stands
+        // this entry down too, mirroring the serial `break`.
+        if (stopped()) {
+          return 'failed';
+        }
+        try {
+          const { id, version } = await source.create(entry as NewNote);
+          created.push({ index, id, version });
+          // Guards against duplicates *within* one import file, not just against
+          // notes that already existed on the server.
+          existingFingerprints.add(key);
+          // A success is evidence the backend is healthy, so the streak of
+          // failures no longer says "the server is down".
+          consecutiveFailures = 0;
+          return 'ok';
+        } catch (error) {
+          const terminal = terminalStop(error);
+          if (terminal) {
+            stopReason = terminal;
+            terminalError = error as CliError;
+            return 'failed';
+          }
+          if (firstFailure === undefined) {
+            firstFailure = error;
+          }
+          // `messageOf` rather than `error.message`: a rejection that is not an
+          // Error (a string throw, a plain object from a stray library) rendered
+          // as `undefined` in the failure list, which told the user nothing.
+          failures.push({ index, error: messageOf(error) });
+          // A burst of consecutive failures means the backend is unavailable (or
+          // the token is bad in a way auth detection missed). Grinding through
+          // the rest one-by-one only delays the error the user is waiting for and
+          // hammers a server that is already struggling. A skip does not reset
+          // the streak: a skip is not evidence the backend is healthy, it never
+          // touched the network.
+          if (++consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+            stopReason = 'consecutive-failures';
+          }
+          return 'failed';
+        }
+      }
+    );
+    // Register the chain tail before anyone else reads the key: a follower
+    // that reads `pending.get(key)` now awaits this full operation.
+    pending.set(key, attempt);
+    await attempt;
+    // Release the chain once it has fully settled. Only the *tail* may be
+    // removed: deleting an intermediate link — one a follower already chained
+    // onto — would let that follower's create race a later one. If we are not
+    // the tail, a follower has registered behind us and the check below leaves
+    // the map untouched; after settlement the existingFingerprints guard is
+    // authoritative either way. This keeps a large import's map from growing
+    // linearly with the number of distinct fingerprints it has seen.
+    if (pending.get(key) === attempt) {
+      pending.delete(key);
+    }
+  }
+
+  async function worker(): Promise<void> {
+    while (!stopped()) {
+      const index = cursor++;
+      if (index >= entries.length) {
+        return;
+      }
+      await processEntry(index);
+    }
+  }
+
+  const poolSize = Math.min(IMPORT_CONCURRENCY, entries.length);
+  await Promise.all(Array.from({ length: poolSize }, () => worker()));
+
+  // Completion order is nondeterministic under concurrency; restore the input
+  // order the serial implementation guaranteed so reports (and the json
+  // arrays) stay stable and the index column keeps pointing at the file.
+  created.sort((a, b) => a.index - b.index);
+  skipped.sort((a, b) => a.index - b.index);
+  failures.sort((a, b) => a.index - b.index);
+
+  return {
+    created,
+    skipped,
+    failures,
+    stopReason,
+    terminalError,
+    firstFailure,
+  };
+}
+
+/** The single sentence explaining an early stop, or nothing for a full run. */
+function stopNotice(reason: StopReason, unattempted: number): string | null {
+  const tail = `${unattempted} note(s) not attempted`;
+  switch (reason) {
+    case 'consecutive-failures':
+      return `Stopped early after ${MAX_CONSECUTIVE_FAILURES} consecutive failures; ${tail}`;
+    case 'rate-limited':
+      return `Rate limited (HTTP 429); ${tail}`;
+    case 'auth':
+      return `Stopped: the session is no longer valid; ${tail}`;
+    case 'aborted':
+      return `Interrupted; ${tail}`;
+    case 'complete':
+      return null;
+  }
+}
+
+function reportOutcome(
+  outcome: ImportOutcome,
+  total: number,
+  json: boolean
+): void {
+  const { created, skipped, failures, stopReason } = outcome;
+  // Notes that were never attempted because the batch stopped early. Computed
+  // once so the JSON and human-readable outputs cannot disagree.
+  const unattempted = total - created.length - skipped.length - failures.length;
+
+  if (json) {
+    console.log(
+      JSON.stringify(
+        {
+          created,
+          skipped,
+          failures,
+          stoppedEarly: stopReason !== 'complete',
+          stopReason,
+          unattempted,
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  for (const item of created) {
+    console.log(item.id);
+  }
+  if (skipped.length > 0) {
+    console.error(`Skipped ${skipped.length} existing note(s) (idempotent)`);
+  }
+  if (failures.length > 0) {
+    console.error(`Created ${created.length}, failed ${failures.length}`);
+    for (const failure of failures) {
+      console.error(`  [${failure.index}] ${failure.error}`);
+    }
+  } else {
+    console.error(`Created ${created.length} note(s)`);
+  }
+  const notice = stopNotice(stopReason, unattempted);
+  if (notice) {
+    console.error(notice);
+  }
+}
+
+/** The error this run should exit with, or `undefined` if it went fine. */
+function outcomeError(
+  outcome: ImportOutcome,
+  total: number
+): CliError | undefined {
+  // A terminal cause outranks the partial tally: "log in again" (2) and
+  // "aborted" (6) are more actionable than "7 of 900 failed".
+  if (outcome.terminalError) {
+    return outcome.terminalError;
+  }
+  const { failures, firstFailure } = outcome;
+  if (failures.length === 0) {
+    return undefined;
+  }
+  const summary = `${failures.length} of ${total} notes failed to create`;
+  // When nothing succeeded, the exit code should reflect the actual failure
+  // (e.g. a network error -> 3) rather than always being "partial" (7).
+  if (failures.length === total && firstFailure !== undefined) {
+    return new CliError(exitCodeFor(firstFailure), summary);
+  }
+  return new PartialError(summary);
+}
+
+export async function addCommand(
+  credentials: Credentials,
+  args: string[]
+): Promise<void> {
+  const { file, json } = parseAddOptions(args);
+  const raw = await readContentSource({ content: file, fromFile: true });
+  const entries = parseNotesFile(raw);
+
+  const source = createNoteSource(credentials.access_token);
+  // Trashed notes are excluded on purpose: a note the user deleted must be
+  // importable again, otherwise the dedup would permanently block re-adding
+  // it. `isTrashed` is the single convention for reading the `deleted` flag
+  // (boolean | 0 | 1); hand-rolled truthiness checks drifted apart before.
+  // find() already normalized every record, so `note.data` is always present.
+  // The option below also drops trashed records at the page boundary; the
+  // explicit filter stays as defence in depth for callers that stub the
+  // source.
+  const existing = await source.find({ includeTrashed: false });
+  const existingFingerprints = new Set(
+    existing
+      .filter((note) => !isTrashed(note.data))
+      .map((note) => fingerprint(note.data))
+  );
+
+  const outcome = await importNotes(source, entries, existingFingerprints);
+  // Reported before the throw, always. An import that dies on entry 400 has
+  // already created 399 notes server-side; throwing without printing their
+  // ids leaves the user with no record of what landed.
+  reportOutcome(outcome, entries.length, json);
+
+  const error = outcomeError(outcome, entries.length);
+  if (error) {
+    throw error;
+  }
+}

--- a/lib/cli/commands/create.ts
+++ b/lib/cli/commands/create.ts
@@ -1,0 +1,48 @@
+import type { Credentials } from '../domain/types.ts';
+import { createNoteSource } from '../note-source.ts';
+import { hasFlag, parseContentSource, parseTags } from '../cli-args.ts';
+import { readContentSource } from '../content-input.ts';
+import { UsageError } from '../domain/errors.ts';
+import type * as T from '../vendor/types.ts';
+
+export type CreateOptions = {
+  content: string;
+  fromFile: boolean;
+  tags: string[];
+  json: boolean;
+};
+
+export function parseCreateOptions(args: string[]): CreateOptions {
+  const { content, fromFile } = parseContentSource(args, 'create', 'content');
+  return {
+    content,
+    fromFile,
+    tags: parseTags(args),
+    json: hasFlag(args, 'json'),
+  };
+}
+
+export async function createCommand(
+  credentials: Credentials,
+  args: string[]
+): Promise<void> {
+  const { content: raw, fromFile, tags, json } = parseCreateOptions(args);
+  const content = await readContentSource({ content: raw, fromFile });
+
+  if (content.trim().length === 0) {
+    throw new UsageError('Refusing to create a note with blank content');
+  }
+
+  const source = createNoteSource(credentials.access_token);
+  const { id, version } = await source.create({
+    content,
+    tags: tags as T.TagName[],
+  });
+
+  if (json) {
+    console.log(JSON.stringify({ id, version }));
+  } else {
+    console.log(id);
+    console.error(`Created note ${id} (version ${version})`);
+  }
+}

--- a/lib/cli/commands/edit.ts
+++ b/lib/cli/commands/edit.ts
@@ -1,0 +1,50 @@
+import type { Credentials } from '../domain/types.ts';
+import { createNoteSource } from '../note-source.ts';
+import {
+  hasFlag,
+  parseContentSource,
+  takeFirstPositional,
+} from '../cli-args.ts';
+import { readContentSource } from '../content-input.ts';
+import { UsageError } from '../domain/errors.ts';
+
+export type EditOptions = {
+  content: string;
+  fromFile: boolean;
+  json: boolean;
+};
+
+export function parseEditOptions(args: string[]): EditOptions {
+  const { content, fromFile } = parseContentSource(args, 'edit', 'new content');
+  return { content, fromFile, json: hasFlag(args, 'json') };
+}
+
+export async function editCommand(
+  credentials: Credentials,
+  args: string[]
+): Promise<void> {
+  // The note id is the first non-flag argument; everything else (including
+  // flags that appeared before it) is the content source.
+  const { value: noteId, rest } = takeFirstPositional(args);
+  if (!noteId) {
+    throw new UsageError('edit requires a note id: edit <id> "<content>"');
+  }
+
+  const { content: raw, fromFile, json } = parseEditOptions(rest);
+  const content = await readContentSource({ content: raw, fromFile });
+
+  if (content.trim().length === 0) {
+    throw new UsageError(
+      'Refusing to replace note content with blank text. Delete the note from the desktop app or web app instead.'
+    );
+  }
+
+  const source = createNoteSource(credentials.access_token);
+  const { version } = await source.update(noteId, content);
+
+  if (json) {
+    console.log(JSON.stringify({ id: noteId, version }));
+  } else {
+    console.error(`Updated note ${noteId} (version ${version})`);
+  }
+}

--- a/lib/cli/commands/export.ts
+++ b/lib/cli/commands/export.ts
@@ -1,0 +1,101 @@
+import * as path from 'path';
+import type { Credentials } from '../domain/types.ts';
+import { createNoteSource } from '../note-source.ts';
+import exportNotes from '../vendor/export/export-notes.ts';
+import { writeExportBundle, type ExportFormat } from '../export-helpers.ts';
+import { parseSingleValueFlag, rejectExtraPositionals } from '../cli-args.ts';
+import { UsageError } from '../domain/errors.ts';
+import type { GroupedExportNotes } from '../vendor/export/types.ts';
+import type * as T from '../vendor/types.ts';
+
+export type ExportFormats = ExportFormat | 'all';
+
+export type ExportOptions = {
+  format: ExportFormats;
+  outputDir: string;
+};
+
+const FORMATS: ReadonlySet<string> = new Set([
+  'json',
+  'markdown',
+  'zip',
+  'all',
+]);
+
+export function parseExportOptions(args: string[]): ExportOptions {
+  // `export` takes no positional arguments; a stray word is a typo.
+  rejectExtraPositionals(args, 'export', 0);
+  // parseSingleValueFlag handles the "bare flag / repeated / empty value"
+  // checks for both flags; value-domain validation stays here (FORMATS is
+  // export-specific). An explicit but empty value (or a bare flag with no
+  // value) is a mistake, not a request for the default.
+  const formatRaw = parseSingleValueFlag(args, 'format', 'json');
+  let format: ExportFormats = 'all';
+  if (formatRaw !== undefined) {
+    if (!FORMATS.has(formatRaw)) {
+      throw new UsageError(
+        `--format must be one of: ${[...FORMATS].join(', ')}`
+      );
+    }
+    format = formatRaw as ExportFormats;
+  }
+
+  const outputRaw = parseSingleValueFlag(args, 'output', './out');
+  const outputDir = outputRaw ?? path.resolve('simplenote-export');
+  return { format, outputDir };
+}
+
+/**
+ * What each format tells the user afterwards.
+ *
+ * The publishing itself is transactional — `writeExportBundle` stages every
+ * selected format and commits them as one unit — so per-format "write" hooks
+ * here would break the all-or-nothing guarantee. Only the success message
+ * stays per format.
+ */
+const DESCRIBERS: ReadonlyArray<{
+  format: ExportFormat;
+  describe: (outputDir: string) => string;
+}> = [
+  {
+    format: 'json',
+    describe: (dir) => `notes.json -> ${path.join(dir, 'notes.json')}`,
+  },
+  {
+    format: 'markdown',
+    describe: (dir) => `markdown -> ${path.join(dir, 'active', '*.md')}`,
+  },
+  {
+    format: 'zip',
+    describe: (dir) => `notes.zip -> ${path.join(dir, 'notes.zip')}`,
+  },
+];
+
+export async function exportCommand(
+  credentials: Credentials,
+  args: string[]
+): Promise<void> {
+  const { format, outputDir } = parseExportOptions(args);
+  const source = createNoteSource(credentials.access_token);
+  const results = await source.find();
+  // `find()` already guarantees unique ids (first page wins), so this Map is
+  // a lookup structure, not a dedup pass. Built with a loop rather than
+  // `new Map(results.map(...))` to skip an intermediate array of pairs.
+  const notesMap = new Map<T.EntityId, T.Note>();
+  for (const result of results) {
+    notesMap.set(result.id as T.EntityId, result.data);
+  }
+
+  const grouped: GroupedExportNotes = await exportNotes(notesMap);
+
+  const selected: ExportFormat[] =
+    format === 'all' ? ['json', 'markdown', 'zip'] : [format];
+  await writeExportBundle(selected, grouped, outputDir);
+
+  for (const item of DESCRIBERS) {
+    if (!selected.includes(item.format)) {
+      continue;
+    }
+    console.error(`Exported ${item.describe(outputDir)}`);
+  }
+}

--- a/lib/cli/commands/list.ts
+++ b/lib/cli/commands/list.ts
@@ -1,0 +1,60 @@
+import type { Credentials } from '../domain/types.ts';
+import { createNoteSource } from '../note-source.ts';
+import { hasFlag, parseLimit, rejectExtraPositionals } from '../cli-args.ts';
+import { byModificationDateDesc } from '../domain/sort.ts';
+import { topBy } from '../domain/top.ts';
+import { LIST_DEFAULT_LIMIT, PREVIEW_WIDTH } from '../cli-constants.ts';
+
+export type ListOptions = {
+  limit: number;
+  json: boolean;
+  includeTrashed: boolean;
+};
+
+export function parseListOptions(args: string[]): ListOptions {
+  // `list` takes no positional arguments; a stray word is a typo, not input.
+  rejectExtraPositionals(args, 'list', 0);
+  return {
+    limit: parseLimit(args, LIST_DEFAULT_LIMIT),
+    json: hasFlag(args, 'json'),
+    includeTrashed: hasFlag(args, 'include-trashed'),
+  };
+}
+
+export async function listCommand(
+  credentials: Credentials,
+  args: string[]
+): Promise<void> {
+  const { limit, json, includeTrashed } = parseListOptions(args);
+  const source = createNoteSource(credentials.access_token);
+  // Trashed notes are dropped at the page boundary, not fetched and filtered
+  // out here. The default view is the live working set, so fetching the trash
+  // is pure waste for the common case.
+  const results = await source.find({ includeTrashed });
+
+  // Simperium's index returns objects in storage order, not recency order.
+  // Slicing it directly showed the *oldest* notes, which is the opposite of
+  // what "the first 20 notes" means to a user and inconsistent with `search`.
+  // Trash was already dropped at the page boundary by `find({ includeTrashed })`.
+  const top = topBy(results, limit, byModificationDateDesc);
+
+  if (json) {
+    console.log(JSON.stringify(top, null, 2));
+  } else {
+    for (const result of top) {
+      const raw = (result.data?.content ?? '')
+        .replace(/\r/g, '')
+        .replace(/\n/g, ' ')
+        .replace(/\t/g, ' ')
+        .slice(0, PREVIEW_WIDTH);
+      // A lone high surrogate at the cut point means the slice split a
+      // surrogate pair, leaving a dangling half that renders as mojibake.
+      // The export side guards the same way when truncating file names.
+      const code = raw.charCodeAt(raw.length - 1);
+      const content = code >= 0xd800 && code <= 0xdbff ? raw.slice(0, -1) : raw;
+      console.log(
+        [result.id, result.data?.modificationDate ?? '', content].join('\t')
+      );
+    }
+  }
+}

--- a/lib/cli/commands/search.ts
+++ b/lib/cli/commands/search.ts
@@ -1,0 +1,144 @@
+import type { Credentials } from '../domain/types.ts';
+import { createNoteSource } from '../note-source.ts';
+import { getTerms, tagPattern } from '../vendor/filter-notes.ts';
+import { noteTitleAndPreview } from '../vendor/note-utils.ts';
+import { escapeRegExp } from 'lodash';
+import {
+  hasFlag,
+  parseLimit,
+  rejectExtraPositionals,
+  takeFirstPositional,
+} from '../cli-args.ts';
+import { byModificationDateDesc } from '../domain/sort.ts';
+import { topBy } from '../domain/top.ts';
+import { UsageError } from '../domain/errors.ts';
+import { SEARCH_DEFAULT_LIMIT } from '../cli-constants.ts';
+import type * as T from '../vendor/types.ts';
+
+export type SearchOptions = {
+  limit: number;
+  json: boolean;
+  includeTrashed: boolean;
+};
+
+export function parseSearchOptions(args: string[]): SearchOptions {
+  // `search` takes exactly one (quoted) query; more words are a typo.
+  // The query itself was already taken by the caller, hence `consumed: 1`.
+  rejectExtraPositionals(args, 'search', 0, 1);
+  return {
+    limit: parseLimit(args, SEARCH_DEFAULT_LIMIT),
+    json: hasFlag(args, 'json'),
+    includeTrashed: hasFlag(args, 'include-trashed'),
+  };
+}
+
+// `tagPattern` is rebuilt per call, so the /g regex has no stale lastIndex
+// between calls. The desktop app and the CLI share the same source so they
+// always agree on what counts as a `tag:` filter.
+function extractTags(query: string): string[] {
+  // `toLowerCase()` (not `toLocaleLowerCase`) keeps matching locale-independent:
+  // under e.g. the Turkish locale `toLocaleLowerCase` folds `I`/`i` and `k`/`K`
+  // differently than ASCII, which would silently break `tag:WORK` matching.
+  // NFC first so a tag: query typed on one platform matches a note whose tag
+  // was stored in the other platform's encoding (macOS NFD vs Win/Linux NFC).
+  return [...query.matchAll(tagPattern())].map((match) =>
+    match[1].normalize('NFC').toLowerCase()
+  );
+}
+
+type Matcher = (note: T.Note) => boolean;
+
+/**
+ * Per-query setup: lower-case the terms and pre-compile one case-insensitive
+ * regex per term (no per-note string copy, no per-note toLocaleLowerCase of
+ * the whole body). Tags are matched case-insensitively and checked first,
+ * because a `tag:` filter usually eliminates most notes cheaply.
+ */
+function createMatcher(terms: string[], tags: string[]): Matcher {
+  const termRegexes = terms.map((term) => new RegExp(escapeRegExp(term), 'i'));
+  const wantedTags = new Set(tags);
+
+  return (note: T.Note): boolean => {
+    // Cheap path: a tag filter alone rejects the overwhelming majority of
+    // notes without ever touching the (possibly large) content string.
+    if (wantedTags.size > 0) {
+      // No tags at all cannot satisfy any `tag:` filter. Short-circuiting
+      // here avoids building an empty Set per note, which is the common case
+      // for a library-wide scan and used to allocate one Set for every note.
+      if (!note.tags || note.tags.length === 0) {
+        return false;
+      }
+      // Lower-cased once per note so `tag:Work` also matches a `work` tag,
+      // and NFC-normalized so a note tagged on macOS (NFD) matches a query
+      // typed on Windows/Linux (NFC) — the same normalization create/add
+      // store and the fingerprint in add.ts use.
+      const noteTags = new Set(
+        note.tags.map((tag) => tag.normalize('NFC').toLowerCase())
+      );
+      for (const tag of wantedTags) {
+        if (!noteTags.has(tag)) {
+          return false;
+        }
+      }
+    }
+    if (termRegexes.length === 0) {
+      return true;
+    }
+    const content = note.content ?? '';
+    return termRegexes.every((re) => re.test(content));
+  };
+}
+
+export async function searchCommand(
+  credentials: Credentials,
+  args: string[]
+): Promise<void> {
+  const { value: query, rest } = takeFirstPositional(args);
+  if (!query || query.trim().length === 0) {
+    throw new UsageError(
+      'search requires a query: npm run cli -- search "<query>"'
+    );
+  }
+
+  const { limit, json, includeTrashed } = parseSearchOptions(rest);
+  const matches = createMatcher(getTerms(query), extractTags(query));
+
+  const source = createNoteSource(credentials.access_token);
+  // Same boundary opt-out as `list`: a query runs against the live working
+  // set, so trashed records never need to cross the wire into memory.
+  const results = await source.find({ includeTrashed });
+  const hits = topBy(
+    results.filter((result) => matches(result.data)),
+    limit,
+    byModificationDateDesc
+  );
+
+  if (json) {
+    const output = hits.map((result) => {
+      const { title, preview } = noteTitleAndPreview(result.data, query);
+      return {
+        id: result.id,
+        title,
+        preview,
+        modificationDate: result.data.modificationDate,
+      };
+    });
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    for (const result of hits) {
+      const { title, preview } = noteTitleAndPreview(result.data, query);
+      // Tab is the column separator and \r overwrites the terminal, so both
+      // are stripped from cell text (preview keeps its intentional \n breaks).
+      console.log(
+        [
+          result.id,
+          result.data.modificationDate ?? '',
+          title.replace(/\t/g, ' ').replace(/\r/g, ''),
+          preview.replace(/\t/g, ' ').replace(/\r/g, ''),
+        ]
+          .join('\t')
+          .trimEnd()
+      );
+    }
+  }
+}

--- a/lib/cli/commands/show.ts
+++ b/lib/cli/commands/show.ts
@@ -1,0 +1,52 @@
+import type { Credentials } from '../domain/types.ts';
+import { createNoteSource } from '../note-source.ts';
+import {
+  hasFlag,
+  rejectExtraPositionals,
+  takeFirstPositional,
+} from '../cli-args.ts';
+import { isTrashed } from '../domain/trash.ts';
+import { NotFoundError, UsageError } from '../domain/errors.ts';
+
+export type ShowOptions = {
+  json: boolean;
+};
+
+export function parseShowOptions(args: string[]): ShowOptions {
+  // `show` takes exactly one id; anything beyond it is a typo, not input.
+  // `args` here is the remainder *after* the id was taken, so the id is
+  // declared as already consumed to keep the error message honest
+  // ("got 2, expected at most 1" rather than "got 1, expected at most 0").
+  rejectExtraPositionals(args, 'show', 0, 1);
+  return { json: hasFlag(args, 'json') };
+}
+
+export async function showCommand(
+  credentials: Credentials,
+  args: string[]
+): Promise<void> {
+  // First non-flag argument, so `show --json <id>` works the same as
+  // `show <id> --json` instead of treating `--json` as the note id.
+  const { value: noteId, rest } = takeFirstPositional(args);
+  if (!noteId) {
+    throw new UsageError('show requires a note id: npm run cli -- show <id>');
+  }
+
+  const { json } = parseShowOptions(rest);
+  const source = createNoteSource(credentials.access_token);
+  const note = await source.get(noteId);
+
+  if (!note) {
+    throw new NotFoundError(`Note not found: ${noteId}`);
+  }
+
+  if (!json && isTrashed(note.data)) {
+    console.error('Warning: this note is in the trash.');
+  }
+
+  if (json) {
+    console.log(JSON.stringify(note, null, 2));
+  } else {
+    console.log(note.data?.content ?? '');
+  }
+}

--- a/lib/cli/commands/whoami.ts
+++ b/lib/cli/commands/whoami.ts
@@ -1,0 +1,24 @@
+import type { Credentials } from '../domain/types.ts';
+import { hasFlag, rejectExtraPositionals } from '../cli-args.ts';
+
+/**
+ * Prints the logged-in username.
+ *
+ * Trivial, and it used to be written inline in app.ts's dispatch table for
+ * exactly that reason. That made app.ts the one place that was both the
+ * dispatcher *and* a command implementation: it had to import `hasFlag` and
+ * `rejectExtraPositionals` — argv primitives no other part of app.ts needs —
+ * and `whoami` was the only verb with no module to hold its tests. Size is
+ * not what decides which layer a thing belongs to.
+ */
+export async function whoamiCommand(
+  credentials: Credentials,
+  args: string[]
+): Promise<void> {
+  rejectExtraPositionals(args, 'whoami', 0);
+  if (hasFlag(args, 'json')) {
+    console.log(JSON.stringify({ username: credentials.username }));
+    return;
+  }
+  console.log(credentials.username);
+}

--- a/lib/cli/config.ts
+++ b/lib/cli/config.ts
@@ -1,0 +1,245 @@
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import { AuthError } from './domain/errors.ts';
+import { CLI_VERSION_FALLBACK, DEFAULT_APP_ID } from './cli-constants.ts';
+
+// Simplenote production app id. The desktop app's config.json ships a
+// development app (history-analyst-dad), but magic-link tokens are issued
+// against the production app, so the CLI must talk to the production app id.
+// The default is the single source of truth shared with cli-constants.ts.
+export const APP_ID: string = process.env.SIMPLENOTE_APP_ID ?? DEFAULT_APP_ID;
+
+export const API_BASE = 'https://api.simperium.com/1';
+export const AUTH_BASE = 'https://auth.simperium.com/1';
+
+// Where the magic-link endpoints live. Kept here so the whole CLI has exactly
+// one place that knows about Simplenote hosts.
+export const ACCOUNT_BASE =
+  process.env.SIMPLENOTE_ACCOUNT_BASE ?? 'https://app.simplenote.com/account';
+
+/**
+ * config.json lives at the repository root. Resolving it from the CLI's own
+ * location first means the CLI works from any working directory; previously
+ * the key was read relative to process.cwd(), so running the CLI from a
+ * subdirectory silently produced an empty key and password login failed with
+ * an opaque HTTP 401.
+ *
+ * The module can be executed in four shapes, each with a different `__dirname`:
+ *  - source via tsx/jest: `lib/cli/` (config.ts is compiled in place);
+ *  - bundled dist/cli.js: `lib/cli/dist/`;
+ *  - SEA exe: inside the bundled copy, same as above;
+ *  - ESM (tsx, the real CLI): `__dirname` is undefined, but the CLI always
+ *    runs through bin/simplenote-cli.js, whose directory sits one level below
+ *    the repo root.
+ * A fixed `../..` depth cannot cover all four (bundled builds need three
+ * levels to reach the root), so `moduleAnchors` walks upward from the module
+ * directory until depth is exhausted. `process.cwd()` stays as a fallback
+ * (npm run cli runs from the package root).
+ *
+ * Exported so `getVersion()` can resolve the same repo root for the version
+ * read; both uses want "the root of the project this CLI was installed from".
+ */
+export const MAX_ANCHOR_DEPTH = 5;
+
+/** `startDir` plus its ancestors, `depth` levels deep (including `startDir`). */
+export function ancestorAnchors(
+  startDir: string,
+  depth: number = MAX_ANCHOR_DEPTH
+): string[] {
+  const dirs: string[] = [];
+  let dir = path.resolve(startDir);
+  for (let i = 0; i < depth; i += 1) {
+    dirs.push(dir);
+    dir = path.dirname(dir);
+  }
+  return dirs;
+}
+
+export function moduleAnchors(): string[] {
+  const anchors: string[] = [];
+  if (typeof __dirname === 'string') {
+    anchors.push(...ancestorAnchors(__dirname));
+  } else if (typeof process.argv[1] === 'string') {
+    anchors.push(...ancestorAnchors(path.dirname(process.argv[1])));
+  }
+  anchors.push(process.cwd());
+  return [...new Set(anchors)];
+}
+
+// The repository root's package.json name — the marker that says "this anchor
+// belongs to this project". getAppKey stops its upward anchor walk here so a
+// config.json from an unrelated ancestor directory is never picked up as the
+// app_key source (a global install run from an arbitrary directory used to
+// reach arbitrarily far up the tree, and a stray config.json anywhere above
+// silently won). Must match the repo root's `package.json` "name" field
+// exactly ("simplenote" — not the folder name "simplenote-electron").
+const PROJECT_NAME = 'simplenote';
+
+/** True when `dir` carries this project's package.json. */
+function isProjectRoot(dir: string): boolean {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(path.join(dir, 'package.json'), 'utf8')
+    ) as { name?: unknown };
+    return typeof pkg.name === 'string' && pkg.name === PROJECT_NAME;
+  } catch {
+    // No package.json (or unreadable): not a project root, keep walking.
+    return false;
+  }
+}
+
+/**
+ * The module anchor chain, truncated at the first project root (see
+ * `isProjectRoot`), with `process.cwd()` kept as a one-level fallback
+ * candidate. Inside the project the cwd is already in the module chain
+ * (Set-deduplicated in moduleAnchors); an explicit run elsewhere still honors
+ * a config/manifest in the current directory. Shared by getAppKey (config.json
+ * candidates) and getVersion (manifest candidates) so neither ever walks past
+ * the repository root into unrelated ancestor directories.
+ */
+function projectBoundedAnchors(): string[] {
+  const cwd = process.cwd();
+  const anchors: string[] = [];
+  let projectRootReached = false;
+  for (const anchor of moduleAnchors()) {
+    if (projectRootReached && anchor !== cwd) {
+      continue;
+    }
+    anchors.push(anchor);
+    if (!projectRootReached && isProjectRoot(anchor)) {
+      projectRootReached = true;
+    }
+  }
+  return anchors;
+}
+
+/**
+ * Config candidates for getAppKey: one `config.json` path per bounded anchor
+ * (see `projectBoundedAnchors`), so a config.json from an unrelated ancestor
+ * directory is never consulted.
+ */
+function candidateConfigPaths(): Array<{ anchor: string; configPath: string }> {
+  return projectBoundedAnchors().map((anchor) => ({
+    anchor,
+    configPath: path.resolve(anchor, 'config.json'),
+  }));
+}
+
+let cachedAppKey: string | undefined;
+
+/**
+ * Read lazily, not at module load: only password login needs the key, and a
+ * missing config.json must not break `list`/`show`/`export`, which
+ * authenticate with a stored token.
+ *
+ * `SIMPLENOTE_APP_KEY` wins over config.json, mirroring how `APP_ID` takes
+ * `SIMPLENOTE_APP_ID` first. This is the injection channel for a production
+ * app key: the repo's own config.json ships a *development* app key, so
+ * password login fails with an opaque 401 when the CLI talks to the
+ * production app id. An env-provided key sidesteps that without touching the
+ * file (which is shared with the desktop app and must not be rewritten).
+ */
+export function getAppKey(): string {
+  if (cachedAppKey !== undefined) {
+    return cachedAppKey;
+  }
+
+  const envKey = process.env.SIMPLENOTE_APP_KEY;
+  if (typeof envKey === 'string' && envKey.length > 0) {
+    cachedAppKey = envKey;
+    return cachedAppKey;
+  }
+
+  const attempts: string[] = [];
+  for (const { configPath } of candidateConfigPaths()) {
+    try {
+      const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as {
+        app_key?: unknown;
+      };
+      if (typeof parsed.app_key === 'string' && parsed.app_key.length > 0) {
+        cachedAppKey = parsed.app_key;
+        return cachedAppKey;
+      }
+      attempts.push(`${configPath}: no non-empty "app_key"`);
+    } catch (error) {
+      attempts.push(`${configPath}: ${(error as Error).message}`);
+    }
+  }
+
+  throw new AuthError(
+    `Cannot read app_key for password login. Set SIMPLENOTE_APP_KEY or provide ` +
+      `a config.json with an "app_key". Tried:\n  ${attempts.join(
+        '\n  '
+      )}\nUse magic-link login instead (unset SIMPLENOTE_PASSWORD).`
+  );
+}
+
+let cachedVersion: string | undefined;
+
+/**
+ * Manifests the CLI version can come from, in priority order:
+ *
+ *  1. the module's own package.json (lib/cli/package.json) — the CLI's
+ *     independent version line;
+ *  2. the repo root package.json — historical fallback (the desktop app's
+ *     version), kept so a copy of the module without its own manifest still
+ *     reports something truthful;
+ *  3. `CLI_VERSION_FALLBACK` when neither is readable.
+ *
+ * `lib/cli/package.json` resolves differently per module system: `__dirname`
+ * points at it under CommonJS (jest), while the tsx runtime runs through
+ * bin/simplenote-cli.js whose parent is the repo root — so the module manifest
+ * is derived from the same anchors `getAppKey` uses.
+ */
+function versionCandidatePaths(): string[] {
+  const candidates: string[] = [];
+  if (typeof __dirname === 'string') {
+    candidates.push(path.resolve(__dirname, 'package.json'));
+  }
+  for (const anchor of projectBoundedAnchors()) {
+    candidates.push(path.resolve(anchor, 'lib', 'cli', 'package.json'));
+    candidates.push(path.resolve(anchor, 'package.json'));
+  }
+  return [...new Set(candidates)];
+}
+
+/**
+ * The CLI version. Priority:
+ *
+ *  1. `SIMPLENOTE_CLI_VERSION`, the build-time stamp baked in by esbuild
+ *     (`scripts/build.mjs`). A packaged copy — dist/cli.js, the SEA exe —
+ *     reports the version it was built from even with no manifest next to it.
+ *  2. The module's own package.json, then the repo root, then
+ *     `CLI_VERSION_FALLBACK` (runtime reads for source/test runs).
+ *
+ * The read is lazy so a missing/unreadable manifest never breaks `--version`;
+ * it falls back instead of failing.
+ */
+export function getVersion(): string {
+  if (cachedVersion !== undefined) {
+    return cachedVersion;
+  }
+
+  const baked = process.env.SIMPLENOTE_CLI_VERSION;
+  if (typeof baked === 'string' && baked.length > 0) {
+    cachedVersion = baked;
+    return cachedVersion;
+  }
+
+  for (const candidate of versionCandidatePaths()) {
+    try {
+      const parsed = JSON.parse(readFileSync(candidate, 'utf8')) as {
+        version?: unknown;
+      };
+      if (typeof parsed.version === 'string' && parsed.version.length > 0) {
+        cachedVersion = parsed.version;
+        return cachedVersion;
+      }
+    } catch {
+      // Not this candidate; try the next one before giving up.
+    }
+  }
+
+  cachedVersion = CLI_VERSION_FALLBACK;
+  return cachedVersion;
+}

--- a/lib/cli/content-input.ts
+++ b/lib/cli/content-input.ts
@@ -1,0 +1,27 @@
+import * as fs from 'fs/promises';
+import { messageOf, UsageError } from './domain/errors.ts';
+import type { ContentSource } from './domain/types.ts';
+
+/**
+ * Resolves a parsed content source to actual text.
+ *
+ * A missing or unreadable `--file=` is a mistake in the command line, not a
+ * transport failure, so it surfaces as a usage error (exit 1) rather than
+ * being lumped in with network errors (exit 3).
+ */
+export async function readContentSource(
+  source: ContentSource
+): Promise<string> {
+  if (!source.fromFile) {
+    return source.content;
+  }
+  try {
+    return await fs.readFile(source.content, 'utf8');
+  } catch (error) {
+    // messageOf instead of `(error as Error).message`: a non-Error rejection
+    // (string throws, plain objects) would otherwise render as "undefined".
+    throw new UsageError(
+      `Cannot read --file=${source.content}: ${messageOf(error)}`
+    );
+  }
+}

--- a/lib/cli/domain/__tests__/errors.test.ts
+++ b/lib/cli/domain/__tests__/errors.test.ts
@@ -1,0 +1,136 @@
+import {
+  UsageError,
+  AuthError,
+  NetworkError,
+  RateLimitError,
+  NotFoundError,
+  ConflictError,
+  AbortedError,
+  PartialError,
+  CliError,
+  exitCodeFor,
+  messageOf,
+  EXIT_OK,
+  EXIT_ARG,
+  EXIT_AUTH,
+  EXIT_NETWORK,
+  EXIT_NOT_FOUND,
+  EXIT_CONFLICT,
+  EXIT_ABORTED,
+  EXIT_PARTIAL,
+  EXIT_UNKNOWN,
+} from '../errors.ts';
+
+describe('CliError exit-code mapping', () => {
+  it('maps each typed error to its declared exit code', () => {
+    expect(new UsageError('x').code).toBe(EXIT_ARG);
+    expect(new AuthError('x').code).toBe(2);
+    expect(new NetworkError('x').code).toBe(EXIT_NETWORK);
+    // RateLimitError inherits NetworkError's exit code but is its own class
+    // so batch callers can tell "rate limited" from "backend down".
+    expect(new RateLimitError('x').code).toBe(EXIT_NETWORK);
+    expect(new NotFoundError('x').code).toBe(4);
+    expect(new ConflictError('x').code).toBe(5);
+    expect(new AbortedError('x').code).toBe(6);
+    expect(new PartialError('x').code).toBe(EXIT_PARTIAL);
+  });
+
+  it('exitCodeFor returns the CliError code', () => {
+    expect(exitCodeFor(new UsageError('u'))).toBe(EXIT_ARG);
+    expect(exitCodeFor(new PartialError('p'))).toBe(EXIT_PARTIAL);
+  });
+
+  it('exitCodeFor falls back to network (3) for untyped errors', () => {
+    expect(exitCodeFor(new Error('boom'))).toBe(EXIT_NETWORK);
+    expect(exitCodeFor('string')).toBe(EXIT_NETWORK);
+  });
+
+  it('typed errors are instances of CliError', () => {
+    expect(new UsageError('x')).toBeInstanceOf(CliError);
+    expect(new PartialError('x')).toBeInstanceOf(CliError);
+  });
+});
+
+describe('CliError identity and Error semantics', () => {
+  it('【场景】new.target 全部分支 【目的】验证子类命名 【校验点】name 属性 【预期】等于具体子类名', () => {
+    expect(new UsageError('x').name).toBe('UsageError');
+    expect(new AuthError('x').name).toBe('AuthError');
+    expect(new NetworkError('x').name).toBe('NetworkError');
+    expect(new RateLimitError('x').name).toBe('RateLimitError');
+    expect(new NotFoundError('x').name).toBe('NotFoundError');
+    expect(new ConflictError('x').name).toBe('ConflictError');
+    expect(new AbortedError('x').name).toBe('AbortedError');
+    expect(new PartialError('x').name).toBe('PartialError');
+    expect(new CliError(0, 'x').name).toBe('CliError');
+  });
+
+  it('【场景】构造 Error 基类 【目的】验证 instanceof/message/stack 【校验点】继承关系与字段 【预期】真 Error 且带栈', () => {
+    const error = new UsageError('bad args');
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe('bad args');
+    expect(typeof error.stack).toBe('string');
+  });
+
+  it('【场景】code 与 message 分离 【目的】验证退出码独立承载 【校验点】code/message 双字段 【预期】互不混淆', () => {
+    const error = new NetworkError('network down');
+    expect(error.code).toBe(EXIT_NETWORK);
+    expect(error.message).toBe('network down');
+  });
+
+  it('【场景】全量常量取值 【目的】防止退出码冲突 【校验点】九枚常量互不相同 【预期】无重复', () => {
+    const codes = [
+      EXIT_OK,
+      EXIT_ARG,
+      EXIT_AUTH,
+      EXIT_NETWORK,
+      EXIT_NOT_FOUND,
+      EXIT_CONFLICT,
+      EXIT_ABORTED,
+      EXIT_PARTIAL,
+      EXIT_UNKNOWN,
+    ];
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+});
+
+describe('messageOf', () => {
+  it('【场景】Error 输入 【目的】验证取 .message 【校验点】返回值 【预期】等于 message 字段', () => {
+    expect(messageOf(new Error('boom'))).toBe('boom');
+    expect(messageOf(new CliError(3, 'net'))).toBe('net');
+  });
+
+  it('【场景】非 Error 输入 【目的】验证兜底字符串化不崩溃 【校验点】string/number/boolean/null/undefined/object 【预期】String() 语义', () => {
+    expect(messageOf('oops')).toBe('oops');
+    expect(messageOf(42)).toBe('42');
+    expect(messageOf(false)).toBe('false');
+    expect(messageOf(null)).toBe('null');
+    expect(messageOf(undefined)).toBe('undefined');
+    expect(messageOf({ a: 1 })).toBe('[object Object]');
+  });
+});
+
+describe('exitCodeFor fallback', () => {
+  it('【场景】全量 CliError 子类 【目的】验证每类错误映射声明码 【校验点】code 【预期】与常量一致', () => {
+    expect(exitCodeFor(new UsageError('x'))).toBe(EXIT_ARG);
+    expect(exitCodeFor(new AuthError('x'))).toBe(EXIT_AUTH);
+    expect(exitCodeFor(new NetworkError('x'))).toBe(EXIT_NETWORK);
+    expect(exitCodeFor(new RateLimitError('x'))).toBe(EXIT_NETWORK);
+    expect(exitCodeFor(new NotFoundError('x'))).toBe(EXIT_NOT_FOUND);
+    expect(exitCodeFor(new ConflictError('x'))).toBe(EXIT_CONFLICT);
+    expect(exitCodeFor(new AbortedError('x'))).toBe(EXIT_ABORTED);
+    expect(exitCodeFor(new PartialError('x'))).toBe(EXIT_PARTIAL);
+  });
+
+  it('【场景】非 CliError 输入 【目的】验证缺省兜底退出码 【校验点】Error/string/number/null/undefined/object 【预期】一律网络码 3', () => {
+    expect(exitCodeFor(new Error('x'))).toBe(EXIT_NETWORK);
+    expect(exitCodeFor('oops')).toBe(EXIT_NETWORK);
+    expect(exitCodeFor(42)).toBe(EXIT_NETWORK);
+    expect(exitCodeFor(null)).toBe(EXIT_NETWORK);
+    expect(exitCodeFor(undefined)).toBe(EXIT_NETWORK);
+    expect(exitCodeFor({ x: 1 })).toBe(EXIT_NETWORK);
+  });
+
+  it('【场景】CliError 直接实例 【目的】验证携带显式 code 【校验点】返回值 【预期】等于构造时传入的码', () => {
+    expect(exitCodeFor(new CliError(9, 'custom'))).toBe(9);
+  });
+});

--- a/lib/cli/domain/__tests__/note.test.ts
+++ b/lib/cli/domain/__tests__/note.test.ts
@@ -1,0 +1,191 @@
+import { sanitizeNote } from '../note.ts';
+import type * as T from '../../vendor/types.ts';
+
+// ---------------------------------------------------------------------------
+// sanitizeNote：系统边界（Simperium index/get 返回）的归一化。
+//
+// 下游消费者（vendor 的 export-notes / note-utils）直接解引用
+// note.systemTags.includes / note.content.split，脏记录会让 export/search
+// 以 TypeError 崩溃并伪装成“网络错误”退出。这里一次性把边界数据修成稳定形状。
+//
+// 七大维度覆盖：入参边界 / 分支逻辑 / 异常故障 / 业务规则 / 资源（无状态纯函数）。
+// ---------------------------------------------------------------------------
+
+describe('sanitizeNote 入参边界', () => {
+  it('【场景】原始数据为 null  【目的】无可用记录  【校验点】返回 undefined  【预期】不崩溃、返回 undefined', () => {
+    expect(sanitizeNote(null)).toBeUndefined();
+  });
+
+  it('【场景】原始数据 undefined  【目的】缺失记录  【校验点】返回 undefined  【预期】undefined', () => {
+    expect(sanitizeNote(undefined)).toBeUndefined();
+  });
+
+  it('【场景】原始数据是数组（非对象）  【目的】拒绝非对象载荷  【校验点】返回 undefined  【预期】undefined', () => {
+    expect(sanitizeNote([{ content: 'x' }])).toBeUndefined();
+  });
+
+  it('【场景】原始数据是字符串/数字  【目的】拒绝标量载荷  【校验点】返回 undefined  【预期】undefined', () => {
+    expect(sanitizeNote('garbage' as unknown)).toBeUndefined();
+    expect(sanitizeNote(42 as unknown)).toBeUndefined();
+  });
+});
+
+describe('sanitizeNote 字段归一化（分支逻辑）', () => {
+  it('【场景】content 缺失或非字符串  【目的】安全默认值  【校验点】content 为空串  【预期】content 为 ""', () => {
+    expect(sanitizeNote({})?.content).toBe('');
+    expect(sanitizeNote({ content: 123 } as unknown)?.content).toBe('');
+    expect(sanitizeNote({ content: null })?.content).toBe('');
+  });
+
+  it('【场景】content 为正常字符串  【目的】原样保留  【校验点】返回值  【预期】content 透传', () => {
+    expect(sanitizeNote({ content: 'hello\nworld' })?.content).toBe(
+      'hello\nworld'
+    );
+  });
+
+  it('【场景】creationDate 为字符串化日期或 NaN  【目的】防 NaN 污染比较  【校验点】epoch 落地为 0  【预期】creationDate===0', () => {
+    expect(
+      sanitizeNote({ content: 'x', creationDate: 'soon' })?.creationDate
+    ).toBe(0);
+    expect(
+      sanitizeNote({ content: 'x', creationDate: NaN })?.creationDate
+    ).toBe(0);
+    expect(
+      sanitizeNote({ content: 'x', creationDate: Infinity })?.creationDate
+    ).toBe(0);
+  });
+
+  it('【场景】modificationDate 为合法数字  【目的】保留可信时间戳  【校验点】原值  【预期】modificationDate 透传', () => {
+    expect(
+      sanitizeNote({ content: 'x', modificationDate: 1700000001 })
+        ?.modificationDate
+    ).toBe(1700000001);
+  });
+
+  it('【场景】时间戳超出 Date 可表示范围  【目的】防 RangeError 击穿导出  【校验点】epoch 落地为 0  【预期】越界值归 0，边界值保留', () => {
+    expect(
+      sanitizeNote({ content: 'x', creationDate: 1e20 })?.creationDate
+    ).toBe(0);
+    expect(
+      sanitizeNote({ content: 'x', creationDate: -1e20 })?.creationDate
+    ).toBe(0);
+    expect(
+      sanitizeNote({ content: 'x', modificationDate: 9e12 })?.modificationDate
+    ).toBe(0);
+    expect(
+      sanitizeNote({ content: 'x', creationDate: 8.64e12 })?.creationDate
+    ).toBe(8.64e12);
+    expect(
+      sanitizeNote({ content: 'x', creationDate: -8.64e12 })?.creationDate
+    ).toBe(-8.64e12);
+  });
+
+  it('【场景】deleted 为布尔/0/1 多种表示  【目的】统一布尔约定  【校验点】Boolean() 包裹  【预期】1 与 true 都视为已删', () => {
+    expect(sanitizeNote({ content: 'x', deleted: true })?.deleted).toBe(true);
+    expect(sanitizeNote({ content: 'x', deleted: false })?.deleted).toBe(false);
+    expect(sanitizeNote({ content: 'x', deleted: 1 })?.deleted).toBe(true);
+    expect(sanitizeNote({ content: 'x', deleted: 0 })?.deleted).toBe(false);
+    expect(sanitizeNote({ content: 'x' })?.deleted).toBe(false);
+  });
+
+  it('【场景】deleted 为契约外字符串 "false"/"0"  【目的】拒绝字符串真值误判  【校验点】不视为已删  【预期】Boolean() 曾把 "false"/"0" 转 true，现按契约只认 true/1', () => {
+    expect(sanitizeNote({ content: 'x', deleted: 'false' })?.deleted).toBe(
+      false
+    );
+    expect(sanitizeNote({ content: 'x', deleted: '0' })?.deleted).toBe(false);
+    expect(sanitizeNote({ content: 'x', deleted: 'true' })?.deleted).toBe(
+      false
+    );
+    expect(sanitizeNote({ content: 'x', deleted: '1' })?.deleted).toBe(false);
+  });
+
+  it('【场景】systemTags 非数组/含非字符串  【目的】只保留字符串标签  【校验点】过滤后数组  【预期】非数组→[]，脏元素被剔除', () => {
+    expect(
+      sanitizeNote({ content: 'x', systemTags: 'markdown' } as unknown)
+        ?.systemTags
+    ).toEqual([]);
+    expect(
+      sanitizeNote({
+        content: 'x',
+        systemTags: ['markdown', 7, null],
+      } as unknown)?.systemTags
+    ).toEqual(['markdown']);
+    expect(sanitizeNote({ content: 'x' })?.systemTags).toEqual([]);
+  });
+
+  it('【场景】tags 非数组/含非字符串  【目的】只保留字符串标签  【校验点】过滤后数组  【预期】非数组→[]，脏元素被剔除', () => {
+    expect(
+      sanitizeNote({ content: 'x', tags: 'work' } as unknown)?.tags
+    ).toEqual([]);
+    expect(
+      sanitizeNote({ content: 'x', tags: ['work', 9, 'home'] } as unknown)?.tags
+    ).toEqual(['work', 'home']);
+    expect(sanitizeNote({ content: 'x' })?.tags).toEqual([]);
+  });
+});
+
+describe('sanitizeNote 业务规则：未知字段保留与完整形状', () => {
+  it('【场景】API 未来新增字段  【目的】edit POST 不丢字段  【校验点】未知字段原样往返  【预期】futureField 留存', () => {
+    const out = sanitizeNote({
+      content: 'x',
+      futureField: { nested: 1 },
+      another: 'kept',
+    });
+    expect((out as Record<string, unknown>).futureField).toEqual({ nested: 1 });
+    expect((out as Record<string, unknown>).another).toBe('kept');
+  });
+
+  it('【场景】完整合法记录  【目的】端到端形状一致  【校验点】全部字段  【预期】与桌面端期望形状吻合', () => {
+    const raw = {
+      content: 'body',
+      creationDate: 100,
+      modificationDate: 200,
+      deleted: false,
+      systemTags: ['markdown'],
+      tags: ['work'],
+      publishURL: 'https://x',
+    };
+    const out = sanitizeNote(raw) as T.Note;
+    expect(out.content).toBe('body');
+    expect(out.creationDate).toBe(100);
+    expect(out.modificationDate).toBe(200);
+    expect(out.deleted).toBe(false);
+    expect(out.systemTags).toEqual(['markdown']);
+    expect(out.tags).toEqual(['work']);
+    expect(out.publishURL).toBe('https://x');
+  });
+
+  it('【场景】脏记录同时有多处问题  【目的】一次修复而非崩溃  【校验点】逐项修复  【预期】字符串日期/非数组标签/1-deleted 全部归位', () => {
+    const out = sanitizeNote({
+      content: 'b',
+      creationDate: 'soon',
+      modificationDate: 'x',
+      deleted: 1,
+      systemTags: null,
+      tags: 'work',
+    });
+    expect(out?.creationDate).toBe(0);
+    expect(out?.modificationDate).toBe(0);
+    expect(out?.deleted).toBe(true);
+    expect(out?.systemTags).toEqual([]);
+    expect(out?.tags).toEqual([]);
+  });
+});
+
+describe('sanitizeNote 异常故障：顶层对象一律归一再返回', () => {
+  // 注意：drop 规则（返回 undefined）只在 find() 对 entry.d 调用时生效，
+  // sanitizeNote 本身对“顶层就是个对象”的情况总是返回一个归一化记录，
+  // 把脏字段修复成中性默认值，而不是整条丢弃。
+  it('【场景】顶层对象但字段全脏  【目的】修复而非丢弃  【校验点】返回归一化记录  【预期】返回对象，content 回退为空串', () => {
+    const out = sanitizeNote({ id: 'x', d: 'garbage' } as unknown);
+    expect(out).toBeDefined();
+    expect(out?.content).toBe('');
+  });
+
+  it('【场景】对象仅含 null data  【目的】修复而非丢弃  【校验点】返回对象  【预期】返回带中性默认值的记录', () => {
+    const out = sanitizeNote({ d: null } as unknown);
+    expect(out).toBeDefined();
+    expect(out?.tags).toEqual([]);
+    expect(out?.systemTags).toEqual([]);
+  });
+});

--- a/lib/cli/domain/__tests__/sort.test.ts
+++ b/lib/cli/domain/__tests__/sort.test.ts
@@ -1,0 +1,199 @@
+import { byModificationDateDesc } from '../sort.ts';
+import type { BucketObject } from '../../vendor/types.ts';
+import type * as T from '../../vendor/types.ts';
+
+// ---------------------------------------------------------------------------
+// byModificationDateDesc：list/search 共用的“最近优先”排序。
+//
+// timestampOf 用 Number()+isFinite 守卫，避免 NaN 比较让 sort 实现定义化
+// （V8 会停止交换），从而打乱整张列表。七大维度：入参边界 / 分支 / 异常故障。
+// ---------------------------------------------------------------------------
+
+type Note = BucketObject<T.Note>;
+
+function note(id: string, modificationDate?: number): Note {
+  return {
+    id,
+    data: {
+      content: id,
+      creationDate: 0,
+      modificationDate: (modificationDate ?? 0) as T.SecondsEpoch,
+      deleted: false,
+      systemTags: [],
+      tags: [],
+    },
+  };
+}
+
+describe('byModificationDateDesc 入参边界', () => {
+  it('【场景】单条记录  【目的】不崩溃  【校验点】返回自身  【预期】顺序不变', () => {
+    const arr = [note('only', 5)];
+    expect([...arr].sort(byModificationDateDesc)).toEqual(arr);
+  });
+
+  it('【场景】空数组  【目的】不崩溃  【校验点】返回空  【预期】[]', () => {
+    expect([].sort(byModificationDateDesc)).toEqual([]);
+  });
+
+  it('【场景】modificationDate 缺失（undefined）  【目的】降级为 0 排末尾  【校验点】该记录排最后  【预期】undefined 的排在最末', () => {
+    const arr = [
+      note('old', 10),
+      {
+        id: 'no-date',
+        data: {
+          content: 'x',
+          creationDate: 0,
+          deleted: false,
+          systemTags: [],
+          tags: [],
+        },
+      } as unknown as Note,
+      note('new', 20),
+    ];
+    const sorted = [...arr].sort(byModificationDateDesc);
+    expect(sorted[0].id).toBe('new');
+    expect(sorted[sorted.length - 1].id).toBe('no-date');
+  });
+
+  it('【场景】modificationDate 为字符串化日期  【目的】降级为 0  【校验点】不污染排序  【预期】排末尾', () => {
+    const arr = [
+      {
+        id: 'str',
+        data: {
+          content: 'x',
+          creationDate: 0,
+          modificationDate: 'soon' as unknown as number,
+          deleted: false,
+          systemTags: [],
+          tags: [],
+        },
+      },
+      note('real', 3),
+    ];
+    const sorted = [...arr].sort(byModificationDateDesc);
+    expect(sorted[0].id).toBe('real');
+    expect(sorted[1].id).toBe('str');
+  });
+
+  it('【场景】modificationDate 为 NaN  【目的】降级为 0  【校验点】不污染排序  【预期】排末尾', () => {
+    const arr = [
+      {
+        id: 'nan',
+        data: {
+          content: 'x',
+          creationDate: 0,
+          modificationDate: NaN,
+          deleted: false,
+          systemTags: [],
+          tags: [],
+        },
+      },
+      note('real', 7),
+    ];
+    const sorted = [...arr].sort(byModificationDateDesc);
+    expect(sorted[0].id).toBe('real');
+    expect(sorted[1].id).toBe('nan');
+  });
+
+  it('【场景】modificationDate 为负数  【目的】仍为有限数  【校验点】参与比较  【预期】负数排在正常正数之前但晚于更大负数', () => {
+    const arr = [note('a', -5), note('b', 5), note('c', 0)];
+    const sorted = [...arr].sort(byModificationDateDesc);
+    expect(sorted.map((n) => n.id)).toEqual(['b', 'c', 'a']);
+  });
+});
+
+describe('byModificationDateDesc 分支逻辑与业务规则', () => {
+  it('【场景】正常多记录  【目的】最新优先  【校验点】降序  【预期】由新到旧', () => {
+    const arr = [note('old', 1), note('new', 9), note('mid', 5)];
+    expect([...arr].sort(byModificationDateDesc).map((n) => n.id)).toEqual([
+      'new',
+      'mid',
+      'old',
+    ]);
+  });
+
+  it('【场景】两条修改时间相等  【目的】稳定排序（V8 稳定）  【校验点】原顺序保持  【预期】相对顺序不变', () => {
+    const arr = [note('first', 5), note('second', 5), note('third', 5)];
+    expect([...arr].sort(byModificationDateDesc).map((n) => n.id)).toEqual([
+      'first',
+      'second',
+      'third',
+    ]);
+  });
+
+  it('【场景】全部缺失时间  【目的】全部降级为 0  【校验点】顺序稳定  【预期】保持原顺序', () => {
+    const arr = [note('a'), note('b'), note('c')];
+    expect([...arr].sort(byModificationDateDesc).map((n) => n.id)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  it('【场景】混合可信与脏时间戳  【目的】脏值不越位  【校验点】可信记录正确降序  【预期】脏值沉底', () => {
+    const arr = [
+      note('real-new', 100),
+      {
+        id: 'nan',
+        data: {
+          content: 'x',
+          creationDate: 0,
+          modificationDate: NaN,
+          deleted: false,
+          systemTags: [],
+          tags: [],
+        },
+      },
+      note('real-old', 1),
+      {
+        id: 'str',
+        data: {
+          content: 'x',
+          creationDate: 0,
+          modificationDate: 'x' as unknown as number,
+          deleted: false,
+          systemTags: [],
+          tags: [],
+        },
+      },
+    ];
+    const sorted = [...arr].sort(byModificationDateDesc);
+    expect(sorted.map((n) => n.id)).toEqual([
+      'real-new',
+      'real-old',
+      'nan',
+      'str',
+    ]);
+  });
+
+  it('【场景】比较器符号正确  【目的】a 较旧→a 排在 b 后（正）  【校验点】返回值  【预期】byModificationDateDesc(旧,新)>0，反之<0，相等为0', () => {
+    // byModificationDateDesc(a,b) = timestampOf(b) - timestampOf(a)
+    expect(byModificationDateDesc(note('a', 1), note('b', 2))).toBeGreaterThan(
+      0
+    );
+    expect(byModificationDateDesc(note('a', 2), note('b', 1))).toBeLessThan(0);
+    expect(byModificationDateDesc(note('a', 3), note('b', 3))).toBe(0);
+  });
+
+  it('【场景】极端时间戳（±1e12） 【目的】三态比较顺序确定，不受减法溢出影响 【校验点】降序 【预期】正值在前', () => {
+    const arr = [note('neg', -1e12), note('pos', 1e12), note('zero', 0)];
+    expect([...arr].sort(byModificationDateDesc).map((n) => n.id)).toEqual([
+      'pos',
+      'zero',
+      'neg',
+    ]);
+  });
+
+  it('【场景】契约外超大时间戳 【目的】不产生 NaN 排序 【校验点】顺序确定 【预期】有限值降序', () => {
+    const arr = [
+      note('huge', Number.MAX_VALUE),
+      note('normal', 5),
+      note('low', 1),
+    ];
+    expect([...arr].sort(byModificationDateDesc).map((n) => n.id)).toEqual([
+      'huge',
+      'normal',
+      'low',
+    ]);
+  });
+});

--- a/lib/cli/domain/__tests__/tags.test.ts
+++ b/lib/cli/domain/__tests__/tags.test.ts
@@ -1,0 +1,56 @@
+import { normalizeTags } from '../tags.ts';
+import { UsageError } from '../errors.ts';
+
+// ---------------------------------------------------------------------------
+// tags 规范化：create --tags / add --file 的标签是系统边界输入。空白或逗号
+// 标签会被拒收（tag: 查询的 [^\s,]+ 永远匹配不到它，且与桌面端分隔符语义
+// 冲突）；空白标签跳过；重复标签去重；NFC 折叠保证跨平台同一标签。
+// 七大维度：入参边界 / 分支逻辑 / 异常故障 / 业务规则 / 资源（不改入参）。
+// ---------------------------------------------------------------------------
+
+describe('normalizeTags 入参边界与分支', () => {
+  it('【场景】合法标签 【目的】trim + 保序 【校验点】返回数组 【预期】trim 后按原序', () => {
+    expect(normalizeTags([' Work ', 'home'], 'note')).toEqual(['Work', 'home']);
+  });
+
+  it('【场景】纯空白标签 【目的】跳过空标签而非报错 【校验点】结果 【预期】被剔除', () => {
+    expect(normalizeTags(['', '   ', 'ok'], 'note')).toEqual(['ok']);
+  });
+
+  it('【场景】全部空白 【目的】空输入等价 【校验点】结果 【预期】空数组', () => {
+    expect(normalizeTags([' ', '  '], 'note')).toEqual([]);
+    expect(normalizeTags([], 'note')).toEqual([]);
+  });
+
+  it('【场景】空入参数组 【目的】无标签创建合法 【校验点】结果 【预期】空数组且不抛错', () => {
+    expect(normalizeTags([], 'create --tags')).toEqual([]);
+  });
+
+  it('【场景】非法标签（内部空格） 【目的】边界拒收 【校验点】异常类型与消息 【预期】UsageError 且消息含序号与来源', () => {
+    expect(() => normalizeTags(['a', 'b c'], 'create --tags')).toThrow(
+      UsageError
+    );
+    expect(() => normalizeTags(['a', 'b c'], 'create --tags')).toThrow(
+      'Tag 2 for create --tags contains whitespace or a comma'
+    );
+  });
+
+  it('【场景】非法标签（逗号） 【目的】与 tag: 查询模式一致 【校验点】异常消息 【预期】UsageError', () => {
+    expect(() => normalizeTags(['a,b'], 'add --file')).toThrow(
+      'Tag 1 for add --file contains whitespace or a comma'
+    );
+  });
+
+  it('【场景】重复标签 【目的】去重保证幂等 【校验点】结果 【预期】仅保留首次出现', () => {
+    expect(normalizeTags(['a', 'a', 'b', 'a'], 'note')).toEqual(['a', 'b']);
+  });
+
+  it('【场景】NFD 与 NFC 同标签 【目的】跨平台折叠 【校验点】结果 【预期】折叠为 NFC 形式且去重', () => {
+    // 'e\u0301'（e + combining acute）normalize('NFC') 后为 '\u00e9'。
+    expect(normalizeTags(['\u00e9', 'e\u0301'], 'note')).toEqual(['\u00e9']);
+  });
+
+  it('【场景】大小写差异 【目的】标签大小写敏感语义保持 【校验点】结果 【预期】不折叠大小写', () => {
+    expect(normalizeTags(['Work', 'work'], 'note')).toEqual(['Work', 'work']);
+  });
+});

--- a/lib/cli/domain/__tests__/top.test.ts
+++ b/lib/cli/domain/__tests__/top.test.ts
@@ -1,0 +1,87 @@
+import { topBy } from '../top.ts';
+import { byModificationDateDesc } from '../sort.ts';
+import type { BucketObject } from '../../vendor/types.ts';
+import type * as T from '../../vendor/types.ts';
+
+// A number comparator with a clear "newest first" sign convention, matching
+// byModificationDateDesc (comparator(a, b) < 0 => a comes first).
+const desc = (a: number, b: number) => b - a;
+
+describe('topBy 入参边界', () => {
+  it('limit <= 0 返回空数组', () => {
+    expect(topBy([1, 2, 3], 0, desc)).toEqual([]);
+    expect(topBy([1, 2, 3], -1, desc)).toEqual([]);
+  });
+
+  it('非整数 limit（NaN/小数）返回空数组而不是静默退化', () => {
+    expect(topBy([1, 2, 3], NaN, desc)).toEqual([]);
+    expect(topBy([1, 2, 3], 2.5, desc)).toEqual([]);
+  });
+
+  it('空输入返回空数组', () => {
+    expect(topBy([], 5, desc)).toEqual([]);
+  });
+
+  it('limit >= 长度返回全排序', () => {
+    expect(topBy([3, 1, 2], 3, desc)).toEqual([3, 2, 1]);
+    expect(topBy([3, 1, 2], 99, desc)).toEqual([3, 2, 1]);
+  });
+});
+
+describe('topBy 结果等价于 sort + slice', () => {
+  it('小 k 二分插入与全排序一致', () => {
+    const items = [3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9];
+    expect(topBy(items, 5, desc)).toEqual([...items].sort(desc).slice(0, 5));
+  });
+
+  it('重复值保持与稳定排序相同的相对顺序', () => {
+    // sort 是稳定的：相等的 5 保持它们的输入顺序。
+    const items = [5, 3, 5, 1, 5];
+    expect(topBy(items, 5, desc)).toEqual([...items].sort(desc));
+    expect(topBy(items, 3, desc)).toEqual([...items].sort(desc).slice(0, 3));
+  });
+
+  it('大 k 回退全排序（结果一致）', () => {
+    const items = Array.from({ length: 300 }, (_, i) => (i * 7919) % 101);
+    expect(topBy(items, 100, desc)).toEqual(
+      [...items].sort(desc).slice(0, 100)
+    );
+  });
+});
+
+describe('topBy 与 byModificationDateDesc 集成', () => {
+  function note(id: string, modificationDate: number): BucketObject<T.Note> {
+    return {
+      id,
+      data: {
+        content: id,
+        creationDate: modificationDate as T.SecondsEpoch,
+        modificationDate: modificationDate as T.SecondsEpoch,
+        deleted: false,
+        systemTags: [],
+        tags: [],
+      },
+    };
+  }
+
+  it('最新优先 top-k 与全排序一致', () => {
+    const notes = [
+      note('old', 1),
+      note('new', 9),
+      note('mid-a', 5),
+      note('mid-b', 5),
+      note('ancient', 0),
+    ];
+    expect(topBy(notes, 3, byModificationDateDesc)).toEqual(
+      [...notes].sort(byModificationDateDesc).slice(0, 3)
+    );
+  });
+
+  it('相同修改时间的笔记保持输入顺序（稳定性）', () => {
+    const notes = [note('first', 5), note('second', 5), note('third', 5)];
+    expect(topBy(notes, 2, byModificationDateDesc).map((n) => n.id)).toEqual([
+      'first',
+      'second',
+    ]);
+  });
+});

--- a/lib/cli/domain/__tests__/trash.test.ts
+++ b/lib/cli/domain/__tests__/trash.test.ts
@@ -1,0 +1,49 @@
+import { isTrashed } from '../trash.ts';
+import type * as T from '../../vendor/types.ts';
+
+// ---------------------------------------------------------------------------
+// trash 规则：Simperium 的 deleted 为 boolean | 0 | 1，且 list/search 必须把
+// 回收站排除在工作集之外（除非显式 opt-in）。
+// 七大维度：入参边界 / 分支逻辑 / 业务规则 / 资源（不改动入参）。
+// ---------------------------------------------------------------------------
+
+type Wrapped = { data: T.Note };
+
+function wrap(deleted: unknown, extra: Partial<T.Note> = {}): Wrapped {
+  return {
+    data: {
+      content: 'x',
+      creationDate: 0,
+      modificationDate: 0,
+      deleted: deleted as T.Note['deleted'],
+      systemTags: [],
+      tags: [],
+      ...extra,
+    },
+  };
+}
+
+describe('isTrashed 入参边界与分支', () => {
+  it('【场景】未删除（false/0/缺失）  【目的】布尔约定  【校验点】false  【预期】均视为未删', () => {
+    expect(isTrashed(wrap(false).data)).toBe(false);
+    expect(isTrashed(wrap(0).data)).toBe(false);
+    expect(isTrashed(wrap(undefined).data)).toBe(false);
+  });
+
+  it('【场景】已删（true/1）  【目的】覆盖 0|1|true 全部表示  【校验点】true  【预期】均视为已删', () => {
+    expect(isTrashed(wrap(true).data)).toBe(true);
+    expect(isTrashed(wrap(1).data)).toBe(true);
+  });
+
+  it('【场景】note 为 undefined  【目的】空指针保护  【校验点】安全返回 false  【预期】false', () => {
+    expect(isTrashed(undefined)).toBe(false);
+    expect(isTrashed(null as unknown as T.Note | undefined)).toBe(false);
+  });
+
+  it('【场景】契约外真值（字符串/越界数字）  【目的】与 note.ts 边界归一化一致  【校验点】不视为已删  【预期】"false"/"0"/"yes"/2 均按未删', () => {
+    expect(isTrashed(wrap('false' as unknown).data)).toBe(false);
+    expect(isTrashed(wrap('0' as unknown).data)).toBe(false);
+    expect(isTrashed(wrap('yes' as unknown).data)).toBe(false);
+    expect(isTrashed(wrap(2).data)).toBe(false);
+  });
+});

--- a/lib/cli/domain/errors.ts
+++ b/lib/cli/domain/errors.ts
@@ -1,0 +1,106 @@
+// Typed CLI errors. Each carries the process exit code it should map to,
+// so every command shares one error -> exit-code rule instead of ad-hoc
+// string matching in bootstrap.ts.
+//
+// Mapping:
+//   0 ok | 1 usage | 2 auth | 3 network | 4 not found
+//   5 conflict | 6 aborted | 7 partial (batch partial failure) | 99 unknown
+
+export const EXIT_OK = 0;
+export const EXIT_ARG = 1;
+export const EXIT_AUTH = 2;
+export const EXIT_NETWORK = 3;
+export const EXIT_NOT_FOUND = 4;
+export const EXIT_CONFLICT = 5;
+export const EXIT_ABORTED = 6;
+export const EXIT_PARTIAL = 7;
+export const EXIT_UNKNOWN = 99;
+
+export class CliError extends Error {
+  readonly code: number;
+  constructor(code: number, message: string) {
+    super(message);
+    // `new.target` is the concrete subclass being constructed, so an
+    // AbortedError reports itself as "AbortedError" in logs, stack traces and
+    // `util.inspect` output. Hard-coding 'CliError' made every typed error
+    // indistinguishable once it left the throw site: a crash report showed
+    // `CliError: Request aborted` with no hint of which class (and therefore
+    // which exit code) was involved.
+    this.name = new.target.name;
+    this.code = code;
+  }
+}
+
+export class UsageError extends CliError {
+  constructor(message: string) {
+    super(EXIT_ARG, message);
+  }
+}
+
+export class AuthError extends CliError {
+  constructor(message: string) {
+    super(EXIT_AUTH, message);
+  }
+}
+
+export class NetworkError extends CliError {
+  constructor(message: string) {
+    super(EXIT_NETWORK, message);
+  }
+}
+
+/**
+ * HTTP 429: the server asked us to slow down. Keeps the network exit code (3)
+ * but is its own class so batch callers can tell "rate limited" from "the
+ * backend is down" — grinding through doomed retries against a limiter is
+ * what the consecutive-failure stop exists to prevent.
+ */
+export class RateLimitError extends NetworkError {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class NotFoundError extends CliError {
+  constructor(message: string) {
+    super(EXIT_NOT_FOUND, message);
+  }
+}
+
+export class ConflictError extends CliError {
+  constructor(message: string) {
+    super(EXIT_CONFLICT, message);
+  }
+}
+
+export class AbortedError extends CliError {
+  constructor(message: string) {
+    super(EXIT_ABORTED, message);
+  }
+}
+
+export class PartialError extends CliError {
+  constructor(message: string) {
+    super(EXIT_PARTIAL, message);
+  }
+}
+
+/**
+ * Renders any thrown value as a human-readable string. Values that are not
+ * `Error` instances (string throws, plain objects, null) are stringified so a
+ * `throw 'oops'` never surfaces as `[object Object]`.
+ *
+ * Centralized here so the dispatch layer (app.ts) and the transport layer
+ * (infra/http.ts) share one definition instead of each carrying a private
+ * copy that could drift apart.
+ */
+export function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// A non-CliError is treated as a network/operational failure, preserving the
+// prior behavior where every unclassified error mapped to exit 3.
+export function exitCodeFor(error: unknown): number {
+  if (error instanceof CliError) return error.code;
+  return EXIT_NETWORK;
+}

--- a/lib/cli/domain/note.ts
+++ b/lib/cli/domain/note.ts
@@ -1,0 +1,73 @@
+// Boundary normalization for note payloads arriving from the Simperium API.
+//
+// "Parse, don't validate": the index/get endpoints are the system boundary,
+// and everything downstream of `note-source.ts` — including the vendored
+// helpers under `vendor/` (`vendor/export/export-notes.ts`,
+// `vendor/note-utils.ts`) — was written against the desktop bucket's
+// guaranteed shape. Those consumers
+// dereference `note.systemTags.includes(...)` and `note.content.split(...)`
+// without guards, so a single dirty record (missing `systemTags`, a non-array
+// `tags`, a stringified date) crashed `export`/`search` with a TypeError that
+// surfaced as exit 3 ("network error") instead of a usable result.
+//
+// Normalizing here — once, at the boundary — means no consumer needs its own
+// defensive copy of these rules, and user data is never silently dropped:
+// fields we cannot trust are reset to a neutral default, the note itself is
+// kept, and unknown extra fields round-trip untouched (an `edit` POST must
+// not strip fields this CLI does not know about).
+
+import type * as T from '../vendor/types.ts';
+
+function asString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+// Largest epoch-seconds a Date can represent (ECMA-262 TimeClip, ±8.64e15 ms).
+// `new Date(x * 1000).toISOString()` throws RangeError beyond that, so a
+// corrupt out-of-range timestamp would take the whole export down with it.
+const MAX_EPOCH_SECONDS = 8.64e12;
+
+function asEpoch(value: unknown): T.SecondsEpoch {
+  // A corrupt record can carry a stringified date or NaN; both poison
+  // `Date(... * 1000)` in the export path and comparators downstream.
+  const num = Number(value);
+  return Number.isFinite(num) && Math.abs(num) <= MAX_EPOCH_SECONDS ? num : 0;
+}
+
+function asStringArray<S extends string>(value: unknown): S[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is S => typeof item === 'string');
+}
+
+/**
+ * Normalizes one raw note payload.
+ *
+ * Returns `undefined` only when there is no usable record at all (the data
+ * blob is absent or not an object) — the same drop rule `find()` already
+ * applied to `null`/`undefined` entries, extended to non-object payloads.
+ */
+export function sanitizeNote(raw: unknown): T.Note | undefined {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return undefined;
+  }
+  const note = raw as Record<string, unknown>;
+
+  return {
+    // Unknown fields first: anything this CLI does not model (future API
+    // additions) is preserved so update() round-trips it back to the server.
+    ...(note as Partial<T.Note>),
+    content: asString(note.content),
+    creationDate: asEpoch(note.creationDate),
+    modificationDate: asEpoch(note.modificationDate),
+    // Simperium types `deleted` as `boolean | 0 | 1`. Only those four values
+    // (plus a missing flag) are trusted: `Boolean()` coerces out-of-contract
+    // payloads such as the string "false" or "0" to `true`, silently flipping
+    // a live note into the trash — which drops it from list/search, routes it
+    // into the trash/ export half, and blocks edits with "in the trash".
+    deleted: note.deleted === true || note.deleted === 1,
+    systemTags: asStringArray<T.SystemTag>(note.systemTags),
+    tags: asStringArray<T.TagName>(note.tags),
+  };
+}

--- a/lib/cli/domain/sort.ts
+++ b/lib/cli/domain/sort.ts
@@ -1,0 +1,33 @@
+import type { BucketObject } from '../vendor/types.ts';
+import type * as T from '../vendor/types.ts';
+
+/**
+ * A comparable timestamp, or 0 when the note has none we can trust.
+ *
+ * `?? 0` only guards `null`/`undefined`. The API has also been seen returning
+ * a stringified date, and a corrupt record can carry `NaN`; both produce NaN
+ * comparisons, and a comparator that returns NaN makes the sort order
+ * implementation-defined (V8 simply stops swapping), so a single bad note
+ * scrambles the whole list.
+ */
+function timestampOf(note: BucketObject<T.Note>): number {
+  const raw = Number(note.data?.modificationDate);
+  return Number.isFinite(raw) ? raw : 0;
+}
+
+/**
+ * Newest first. Shared by `list` and `search` so both commands agree on what
+ * "most recent" means, and so a missing modificationDate sorts last instead of
+ * corrupting the ordering of everything around it.
+ */
+export function byModificationDateDesc(
+  a: BucketObject<T.Note>,
+  b: BucketObject<T.Note>
+): number {
+  // Three-way comparison, not a subtraction: the difference of two extreme
+  // timestamps can exceed Number precision (or overflow to Infinity), and a
+  // comparator that returns NaN makes the sort order implementation-defined.
+  const tb = timestampOf(b);
+  const ta = timestampOf(a);
+  return tb > ta ? 1 : tb < ta ? -1 : 0;
+}

--- a/lib/cli/domain/tags.ts
+++ b/lib/cli/domain/tags.ts
@@ -1,0 +1,43 @@
+// Tag normalization shared by `create --tags=` and `add --file=`.
+//
+// Tags are user input at a system boundary. A tag carrying whitespace or a
+// comma is rejected outright: the `tag:` query's pattern is `[^\s,]+`, which
+// can never match such a tag, so it would be created and then be
+// un-searchable forever. This also matches the desktop app, where whitespace
+// and commas are tag *separators* and the importer strips them — a value like
+// `a b` cannot exist as one tag there. (A line break additionally breaks the
+// exported markdown by injecting a new line into the `Tags:` block.) All of
+// these are a usage error, not data. Duplicates are dropped so `--tags=a,a`
+// is the same note as `--tags=a` and the dedup fingerprint cannot tell them
+// apart.
+import { UsageError } from './errors.ts';
+
+const INVALID = /[\s,]/;
+
+export function normalizeTags(
+  tags: readonly string[],
+  where: string
+): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  tags.forEach((raw, index) => {
+    // NFC-normalized so a tag created on macOS (NFD) and one typed on
+    // Windows/Linux (NFC) are the same tag: the dedup fingerprint in add.ts
+    // and the tag: search both normalize, so the stored value must too.
+    const tag = raw.trim().normalize('NFC');
+    if (tag.length === 0) {
+      return;
+    }
+    if (INVALID.test(tag)) {
+      throw new UsageError(
+        `Tag ${index + 1} for ${where} contains whitespace or a comma`
+      );
+    }
+    if (seen.has(tag)) {
+      return;
+    }
+    seen.add(tag);
+    result.push(tag);
+  });
+  return result;
+}

--- a/lib/cli/domain/top.ts
+++ b/lib/cli/domain/top.ts
@@ -1,0 +1,50 @@
+// Bounded top-k selection, shared by `list` and `search`.
+//
+// Both commands sort the *whole* result set only to keep the first `limit`
+// entries — O(n log n) for what is usually k = 20 or 50. For small k we keep
+// a bounded sorted window and binary-insert each item, giving O(n·k) array
+// moves with a tiny constant; for larger k (or when k covers the whole list)
+// we fall back to a full sort, where the O(n log n) comparison cost is cheaper
+// than O(n·k) splice moves.
+
+/** Above this many kept entries the splice cost outruns a full sort. */
+const TOP_K_THRESHOLD = 64;
+
+export function topBy<T>(
+  items: readonly T[],
+  limit: number,
+  comparator: (a: T, b: T) => number
+): T[] {
+  // NaN and fractional limits would silently fall through to the insertion
+  // branch (`NaN > limit` and `top.length > NaN` are both false), returning
+  // the whole list without error. Defensive guard only — the CLI callers
+  // (list/search) already validate via parseLimit.
+  if (!Number.isInteger(limit) || limit <= 0) {
+    return [];
+  }
+  if (limit >= items.length || limit > TOP_K_THRESHOLD) {
+    return [...items].sort(comparator).slice(0, limit);
+  }
+
+  const top: T[] = [];
+  for (const item of items) {
+    // First index where `item` sorts before `top[mid]`. Equal elements fall
+    // through the `else` branch (insert after equals), preserving the stable
+    // order that `Array.prototype.sort` guarantees.
+    let lo = 0;
+    let hi = top.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (comparator(item, top[mid]) < 0) {
+        hi = mid;
+      } else {
+        lo = mid + 1;
+      }
+    }
+    top.splice(lo, 0, item);
+    if (top.length > limit) {
+      top.pop();
+    }
+  }
+  return top;
+}

--- a/lib/cli/domain/trash.ts
+++ b/lib/cli/domain/trash.ts
@@ -1,0 +1,13 @@
+import type * as T from '../vendor/types.ts';
+
+/**
+ * Simperium types `deleted` as `boolean | 0 | 1`. Only those four values
+ * (plus a missing flag) are trusted: `Boolean()` coerces out-of-contract
+ * payloads such as the string "false" or "0" to `true`, silently flipping a
+ * live note into the trash — which drops it from list/search, routes it into
+ * the trash/ export half, and blocks edits with "in the trash". The strict
+ * comparison is the same contract `sanitizeNote` applies at the boundary.
+ */
+export function isTrashed(note: T.Note | undefined): boolean {
+  return note?.deleted === true || note?.deleted === 1;
+}

--- a/lib/cli/domain/types.ts
+++ b/lib/cli/domain/types.ts
@@ -1,0 +1,53 @@
+// Shared domain shapes for the CLI.
+//
+// These used to be scattered across auth.ts (Credentials), note-source.ts
+// (NoteSource, NewNote) and cli-args.ts (ContentSource). Pulling them here
+// gives one home for the vocabulary the whole module speaks and removes the
+// inverted dependency where store.ts (a persistence layer) imported a type
+// from auth.ts (a network layer).
+
+import type { BucketObject } from '../vendor/types.ts';
+import type * as T from '../vendor/types.ts';
+
+export interface Credentials {
+  access_token: string;
+  username: string;
+}
+
+export type NewNote = {
+  content: string;
+  tags?: T.TagName[];
+  systemTags?: T.SystemTag[];
+};
+
+export type FindOptions = {
+  /**
+   * Whether the index fetch should keep trashed notes. Defaults to `true`.
+   *
+   * `list`/`search`/`add` only ever work with live notes, so letting them
+   * pass `false` drops trashed records at the page boundary: they are never
+   * parsed, retained in memory or re-filtered downstream. `export` needs both
+   * halves and keeps the default.
+   */
+  includeTrashed?: boolean;
+};
+
+export type NoteSource = {
+  find(options?: FindOptions): Promise<BucketObject<T.Note>[]>;
+  /**
+   * A note plus the version the server attached to this read. `version` is
+   * the base a subsequent `update` should be computed against (`/v/{v}`), so
+   * concurrent edits to other fields merge instead of being clobbered. It is
+   * absent when the read carried no usable version header.
+   */
+  get(
+    id: string
+  ): Promise<(BucketObject<T.Note> & { version?: number }) | undefined>;
+  update(id: string, content: string): Promise<{ version: number }>;
+  create(note: NewNote): Promise<{ id: string; version: number }>;
+};
+
+export type ContentSource = {
+  content: string;
+  fromFile: boolean;
+};

--- a/lib/cli/export-helpers.ts
+++ b/lib/cli/export-helpers.ts
@@ -1,0 +1,487 @@
+import { promises as fs, createWriteStream } from 'fs';
+import { randomBytes } from 'crypto';
+import { pipeline } from 'stream/promises';
+import * as path from 'path';
+import noteExportToZip from './vendor/export/to-zip.ts';
+import type { GroupedExportNotes } from './vendor/export/types.ts';
+import { debug } from './logging.ts';
+import { isExternalAborted } from './infra/http.ts';
+import {
+  AbortedError,
+  CliError,
+  EXIT_NETWORK,
+  NetworkError,
+  messageOf,
+} from './domain/errors.ts';
+import { WRITE_CONCURRENCY } from './cli-constants.ts';
+import { prepareNotes, type PreparedNote } from './export-naming.ts';
+
+// --------------------------------------------------------------------------
+// Publishing. Every artifact is written to a private staging path first, and
+// the whole export is swapped in as one unit at the end.
+//
+// `export` exists so the user has a copy of their notes, which makes a
+// half-finished run the one outcome it must never produce. The previous code
+// wrote every artifact in place: a Ctrl-C, a full disk or a crash mid-write
+// truncated `notes.json`/`notes.zip` on top of the last good export, and the
+// markdown writer went further by deleting `active/` and `trash/` *before*
+// writing, so a failure left the user with neither the new export nor the old
+// one.
+//
+// The current flow is two phases:
+//   1. Build every selected format into staging (the expensive part — content
+//      generation, zip compression). A failure here removes the staging and
+//      leaves the previous export untouched.
+//   2. Commit all staged artifacts as one transaction: each old artifact is
+//      renamed aside to a backup, the staging is renamed into place, and any
+//      failure rolls the already-committed ones back. Only when every target
+//      is swapped are the backups deleted.
+//
+// That makes `format=all` atomic across formats (json/zip/markdown never mix
+// generations) and closes the markdown writer's two-rename window where a
+// crash between the active/ and trash/ swaps lost one half.
+//
+// NOT supported: concurrent `export` runs targeting the same output directory.
+// sweepStale identifies leftovers purely by the staging/backup name pattern,
+// so it cannot tell a live process's staging from a crashed run's, and two
+// commitAll transactions racing on the same target can undo each other's
+// backup restores.
+// --------------------------------------------------------------------------
+
+const STAGING_SUFFIX = '.part';
+const BACKUP_SUFFIX = '.bak';
+
+/** Recognizable, collision-proof sibling path for staging. */
+function stagingPath(target: string): string {
+  const unique = `${process.pid}.${randomBytes(4).toString('hex')}`;
+  return path.join(
+    path.dirname(target),
+    `.${path.basename(target)}.${unique}${STAGING_SUFFIX}`
+  );
+}
+
+/** Sibling path the previous artifact is parked at during the commit. */
+function backupPath(target: string): string {
+  const unique = `${process.pid}.${randomBytes(4).toString('hex')}`;
+  return path.join(
+    path.dirname(target),
+    `.${path.basename(target)}.${unique}${BACKUP_SUFFIX}`
+  );
+}
+
+/** Every staging/backup path this module can produce for `target`. */
+function isStagingOf(name: string, target: string): boolean {
+  const base = `.${path.basename(target)}.`;
+  if (!name.startsWith(base)) {
+    return false;
+  }
+  const rest = name.slice(base.length);
+  const suffix = rest.endsWith(STAGING_SUFFIX)
+    ? STAGING_SUFFIX
+    : rest.endsWith(BACKUP_SUFFIX)
+      ? BACKUP_SUFFIX
+      : null;
+  if (suffix === null) {
+    return false;
+  }
+  // stagingPath/backupPath embed `${pid}.${hex}`. A user file that merely
+  // shares the prefix and the .part/.bak suffix is not ours and must never be
+  // swept or restored over.
+  return /^\d+\.[0-9a-f]{8}$/.test(rest.slice(0, -suffix.length));
+}
+
+/**
+ * Removes staging/backups left by a run that was killed outright (SIGKILL,
+ * power loss), which the failure paths below cannot clean up themselves.
+ * Best-effort: housekeeping must never fail an export.
+ *
+ * Backups are treated as data, not garbage. commitAll parks the previous
+ * artifact aside (`target -> backup`) before moving the staging into place;
+ * a process killed in that window leaves the target missing and the backup
+ * holding the *last good export*. Deleting it — the previous behaviour —
+ * permanently lost the only copy. So a backup with a missing target is
+ * renamed back into place; only when the target already exists is the backup
+ * (now redundant) deleted.
+ */
+async function sweepStale(target: string): Promise<void> {
+  const parent = path.dirname(target);
+  let names: string[];
+  try {
+    names = await fs.readdir(parent);
+  } catch {
+    return;
+  }
+  const leftovers = names.filter((name) => isStagingOf(name, target));
+  if (leftovers.length === 0) {
+    return;
+  }
+
+  // Staging is always garbage: a build either finished (and was renamed away)
+  // or was abandoned. Delete unconditionally, before any restore.
+  await Promise.all(
+    leftovers
+      .filter((name) => name.endsWith(STAGING_SUFFIX))
+      .map((name) =>
+        fs
+          .rm(path.join(parent, name), { recursive: true, force: true })
+          .catch(() => {})
+      )
+  );
+
+  const backups = leftovers.filter((name) => name.endsWith(BACKUP_SUFFIX));
+  if (backups.length === 0) {
+    return;
+  }
+
+  let targetExists = true;
+  try {
+    await fs.access(target);
+  } catch {
+    targetExists = false;
+  }
+
+  if (!targetExists) {
+    // A crash between `rename(target -> backup)` and `rename(staging ->
+    // target)` leaves the target missing while the backup holds the last good
+    // export. Restore the *newest* backup (several crashes can leave several);
+    // the older ones are superseded generations.
+    const newest = await newestBackup(parent, backups);
+    try {
+      await fs.rename(path.join(parent, newest), target);
+      targetExists = true;
+    } catch (error) {
+      // Best-effort: a failed restore must not block the export. Leave the
+      // backup in place (target still missing, so it is not swept) and tell
+      // the user where the last good export is. This is a data-recovery event
+      // the user can act on, so it is visible (stderr), not a debug line.
+      console.error(
+        `Warning: export recovery failed — could not restore ${path.join(parent, newest)} over ${target}: ${messageOf(error)}. ` +
+          'The last good export is still at that backup path; copy it back manually.'
+      );
+    }
+  }
+
+  // Now that the target exists (either it already did, or we just restored a
+  // backup into it), every remaining backup is a superseded generation.
+  if (targetExists) {
+    await Promise.all(
+      backups.map((name) =>
+        fs
+          .rm(path.join(parent, name), { recursive: true, force: true })
+          .catch(() => {})
+      )
+    );
+  }
+}
+
+/** Picks the most recently modified backup, the closest to "last good". */
+async function newestBackup(
+  parent: string,
+  backups: string[]
+): Promise<string> {
+  let newest = backups[0];
+  let newestTime = -Infinity;
+  for (const name of backups) {
+    try {
+      const stat = await fs.stat(path.join(parent, name));
+      // Deterministic tie-break on equal mtime (the file system can report
+      // the same timestamp for two backups written within its granularity):
+      // the lexically larger name wins. The backup name's `${pid}.${hex}`
+      // middle makes this *not* a time ordering — pid varies in length and
+      // the hex is random — but it does make "which backup" repeatable for
+      // the same directory, which is all a tie-break needs.
+      if (
+        stat.mtimeMs > newestTime ||
+        (stat.mtimeMs === newestTime && name > newest)
+      ) {
+        newestTime = stat.mtimeMs;
+        newest = name;
+      }
+    } catch {
+      // Vanished mid-scan; keep the current pick.
+    }
+  }
+  return newest;
+}
+
+/** One on-disk artifact of an export, in its staging form. */
+type StagedArtifact = {
+  /** Final location the staging path will be swapped into. */
+  target: string;
+  /** Path `build` must write; unique per attempt, never the live target. */
+  staging: string;
+  /** Writes `staging`; must not touch `target`. */
+  build: (staging: string) => Promise<void>;
+};
+
+export type ExportFormat = 'json' | 'markdown' | 'zip';
+
+/**
+ * The artifacts one export request produces. json/zip are single files;
+ * markdown is the active/ + trash/ pair (the two halves of one format).
+ */
+function collectArtifacts(
+  formats: readonly ExportFormat[],
+  grouped: GroupedExportNotes,
+  outputDir: string
+): StagedArtifact[] {
+  const artifacts: StagedArtifact[] = [];
+
+  if (formats.includes('json')) {
+    const target = path.join(outputDir, 'notes.json');
+    artifacts.push({
+      target,
+      staging: stagingPath(target),
+      build: (staging) =>
+        fs.writeFile(staging, JSON.stringify(grouped, null, 2), 'utf8'),
+    });
+  }
+
+  if (formats.includes('zip')) {
+    const target = path.join(outputDir, 'notes.zip');
+    artifacts.push({
+      target,
+      staging: stagingPath(target),
+      build: async (staging) => {
+        const zip = await noteExportToZip(grouped);
+        if (!zip) {
+          throw new NetworkError('Failed to generate zip archive');
+        }
+        // Streamed to disk rather than assembled in memory: for large accounts
+        // the in-memory archive peaks at several times the source size and can
+        // exceed Node's buffer limit.
+        await pipeline(
+          zip.generateNodeStream({
+            type: 'nodebuffer',
+            streamFiles: true,
+            compression: 'DEFLATE',
+          }),
+          createWriteStream(staging)
+        );
+      },
+    });
+  }
+
+  if (formats.includes('markdown')) {
+    const activeDir = path.join(outputDir, 'active');
+    const trashDir = path.join(outputDir, 'trash');
+    artifacts.push({
+      target: activeDir,
+      staging: stagingPath(activeDir),
+      build: (staging) =>
+        writeNotesToDir(staging, prepareNotes(grouped.activeNotes)),
+    });
+    artifacts.push({
+      target: trashDir,
+      staging: stagingPath(trashDir),
+      build: (staging) =>
+        writeNotesToDir(staging, prepareNotes(grouped.trashedNotes)),
+    });
+  }
+
+  return artifacts;
+}
+
+/**
+ * Best-effort removal of every staging path. Used by both the rollback path
+ * (commitAll) and the phase-one failure path (writeExportBundle); a leftover
+ * staging is swept by the next run anyway, so failures here are swallowed.
+ */
+function removeStaging(artifacts: StagedArtifact[]): Promise<void> {
+  return Promise.all(
+    artifacts.map((a) =>
+      fs.rm(a.staging, { recursive: true, force: true }).catch(() => {})
+    )
+  ).then(() => undefined);
+}
+
+/**
+ * Swaps every staging path into place as one unit, rolling back on failure.
+ *
+ * `rename` cannot overwrite a *directory* on any platform, and cannot
+ * overwrite an existing file on Windows, so each old artifact is first moved
+ * aside to a backup; the staging then moves into the now-free slot. If any
+ * rename fails, previously committed artifacts are removed and their backups
+ * restored, leaving the last good export exactly as it was.
+ */
+async function commitAll(artifacts: StagedArtifact[]): Promise<void> {
+  const backups: Array<{ target: string; backup: string }> = [];
+  try {
+    for (const { target, staging } of artifacts) {
+      const backup = backupPath(target);
+      try {
+        await fs.rename(target, backup);
+        backups.push({ target, backup });
+      } catch (error) {
+        // No previous artifact (first export): the slot is already free.
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw error;
+        }
+      }
+      await fs.rename(staging, target);
+    }
+  } catch (error) {
+    for (const { target, backup } of backups.reverse()) {
+      await fs
+        .rm(target, { recursive: true, force: true })
+        .catch((e) =>
+          console.error(
+            `Warning: rollback could not remove the partial export at ${target}: ${messageOf(e)}`
+          )
+        );
+      await fs
+        .rename(backup, target)
+        .catch((e) =>
+          console.error(
+            `Warning: rollback could not restore ${backup} over ${target}: ${messageOf(e)}. ` +
+              'The previous export is still at that backup path; copy it back manually.'
+          )
+        );
+    }
+    await removeStaging(artifacts);
+    throw error;
+  }
+  // Success: delete the backups so the output directory holds only the new
+  // export. Best-effort — a leftover is swept by the next run.
+  await Promise.all(
+    backups.map(({ backup }) =>
+      fs.rm(backup, { recursive: true, force: true }).catch(() => {})
+    )
+  );
+}
+
+/**
+ * Stages every requested format, then commits them all together.
+ *
+ * Formats that are part of one `export` invocation are committed as one
+ * transaction, so a failure can never leave a mix of old and new artifacts
+ * on disk. Single-format writers below are thin wrappers over this.
+ */
+export async function writeExportBundle(
+  formats: readonly ExportFormat[],
+  grouped: GroupedExportNotes,
+  outputDir: string
+): Promise<void> {
+  const artifacts = collectArtifacts(formats, grouped, outputDir);
+  debug(`export: staging ${artifacts.length} artifact(s) in ${outputDir}`);
+
+  // Phase one: build everything in staging. The directory creation is part of
+  // the phase, not a pre-step, so a local filesystem failure (permissions,
+  // full disk, a path that exists as a file) is wrapped here rather than
+  // surfacing as a bare EACCES/ENOENT. sweepStale is best-effort and never
+  // throws, so folding it into the phase is safe.
+  //
+  // Sequential on purpose — the zip builder holds its archive in memory while
+  // streaming, and running writers concurrently would multiply peak memory
+  // for no wall-clock gain on an I/O-bound, single-directory workload.
+  try {
+    await fs.mkdir(outputDir, { recursive: true });
+
+    // Sweep leftovers from a killed run before touching anything this run owns.
+    await Promise.all(artifacts.map((artifact) => sweepStale(artifact.target)));
+
+    for (const artifact of artifacts) {
+      // An interrupt during the local phase has no fetch in flight to cancel,
+      // so check the process signal per artifact and turn it into the same
+      // AbortedError the fetch path throws. Without this a Ctrl-C mid-export
+      // ran the whole staging/commit to completion and exited 0.
+      if (isExternalAborted()) {
+        throw new AbortedError('Export was cancelled');
+      }
+      await artifact.build(artifact.staging);
+    }
+    debug(
+      `export: staging complete, committing ${artifacts.length} artifact(s)`
+    );
+  } catch (error) {
+    await removeStaging(artifacts);
+    // A local write failure is wrapped as a typed error pointing at the export
+    // directory, so it reads as a disk problem, not a network one. Errors that
+    // already carry a code (zip generation -> NetworkError, an abort from a
+    // future signal check -> AbortedError) keep their own semantics.
+    if (error instanceof CliError) {
+      throw error;
+    }
+    throw new CliError(
+      EXIT_NETWORK,
+      `Failed to write export at ${outputDir}: ${messageOf(error)}`
+    );
+  }
+
+  // Phase two: swap everything in as one unit, with backup/rollback.
+  await commitAll(artifacts);
+}
+
+/**
+ * Single-format writers. Thin wrappers over `writeExportBundle` — the
+ * production dispatch (`commands/export.ts`) calls `writeExportBundle`
+ * directly; these three exist so the tests can exercise one format in
+ * isolation. Not part of the public command surface; kept for test
+ * compatibility, not as a general API.
+ */
+export async function writeJsonExport(
+  grouped: GroupedExportNotes,
+  outputDir: string
+): Promise<void> {
+  await writeExportBundle(['json'], grouped, outputDir);
+}
+
+export async function writeZipExport(
+  grouped: GroupedExportNotes,
+  outputDir: string
+): Promise<void> {
+  await writeExportBundle(['zip'], grouped, outputDir);
+}
+
+/**
+ * Writes notes to `dir` with a bounded number of in-flight writes. A fixed pool
+ * of workers keeps the disk busy without opening one descriptor per note (EMFILE)
+ * or stalling on the single slowest file in a fence-style batch.
+ *
+ * Each worker is handed a *disjoint* slice of the notes (index modulo pool size)
+ * rather than sharing a mutable `cursor` that every worker increments. Sharing
+ * the cursor is the classic "shared counter across concurrent tasks" anti-pattern:
+ * it relies on the increment happening to be atomic between awaits, which is
+ * fragile and unreadable. Partitioned slices are obviously correct and need no
+ * coordination.
+ */
+async function writeNotesToDir(
+  dir: string,
+  notes: PreparedNote[]
+): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+  if (notes.length === 0) {
+    return;
+  }
+
+  const poolSize = Math.min(WRITE_CONCURRENCY, notes.length);
+  const chunks: PreparedNote[][] = Array.from({ length: poolSize }, () => []);
+  notes.forEach((note, index) => {
+    chunks[index % poolSize].push(note);
+  });
+
+  await Promise.all(
+    chunks.map(async (chunk) => {
+      for (const note of chunk) {
+        // Per-file interrupt check (same AbortedError the per-artifact check
+        // throws): a large markdown export of thousands of files must not keep
+        // writing after Ctrl-C until the next artifact boundary.
+        if (isExternalAborted()) {
+          throw new AbortedError('Export was cancelled');
+        }
+        await fs.writeFile(
+          path.join(dir, `${note.fileName}.md`),
+          note.content,
+          'utf8'
+        );
+      }
+    })
+  );
+}
+
+export async function writeMarkdownExport(
+  grouped: GroupedExportNotes,
+  outputDir: string
+): Promise<void> {
+  await writeExportBundle(['markdown'], grouped, outputDir);
+}

--- a/lib/cli/export-naming.ts
+++ b/lib/cli/export-naming.ts
@@ -1,0 +1,171 @@
+import sanitize from 'sanitize-filename';
+import type { ExportNote } from './vendor/export/types.ts';
+import { FILENAME_LENGTH, TAG_LINE_LENGTH } from './cli-constants.ts';
+
+export type PreparedNote = ExportNote & { fileName: string };
+
+/**
+ * Derives a file name from the note's first non-empty, sanitized line.
+ *
+ * The old code expressed this as
+ * `[...].concat('untitled').shift()!` — an obscure idiom that relied on the
+ * trailing sentinel to guarantee a non-null value. Written out it is simply
+ * "first good line, else 'untitled'", which is what the readable form below
+ * says.
+ */
+export const addFilename = (note: ExportNote): PreparedNote => {
+  // Walk the lines until the first one survives `sanitize`, then stop. The
+  // previous chain sanitized *every* line before searching for the first
+  // non-empty result, so a 10k-line note ran sanitize-filename's regex work
+  // on all 10k lines just to use the first. A line can only be sanitized to
+  // empty (e.g. "///"), so the walk cannot short-circuit on the raw text.
+  // An indexOf walk instead of split('\n') keeps the whole content from being
+  // materialized into a line array before the first candidate is found.
+  let fileName: string | undefined;
+  const content = note.content;
+  let searchFrom = 0;
+  for (;;) {
+    const newline = content.indexOf('\n', searchFrom);
+    const line =
+      newline === -1
+        ? content.slice(searchFrom)
+        : content.slice(searchFrom, newline);
+    const candidate = sanitize(line.trim());
+    if (candidate.length > 0) {
+      fileName = candidate;
+      break;
+    }
+    if (newline === -1) {
+      break;
+    }
+    searchFrom = newline + 1;
+  }
+
+  return {
+    ...note,
+    fileName: truncateFileName(fileName ?? 'untitled', FILENAME_LENGTH),
+  };
+};
+
+const isHighSurrogate = (code: number) => 0xd800 <= code && code <= 0xdbff;
+
+function truncateFileName(name: string, max: number): string {
+  if (name.length <= max) {
+    return name;
+  }
+  // A lone high surrogate at the cut point means the slice split a surrogate
+  // pair, leaving a dangling half that is an invalid filename on every OS.
+  const cut = name.slice(0, max);
+  return isHighSurrogate(cut.charCodeAt(cut.length - 1))
+    ? cut.slice(0, -1)
+    : cut;
+}
+
+export const appendTags = (note: ExportNote): ExportNote => {
+  if (!note.tags || note.tags.length === 0) {
+    return note;
+  }
+
+  // Drop tags that cannot survive the round-trip: a blank tag adds nothing,
+  // and a tag containing a line break would inject extra lines into the
+  // exported file (breaking the markdown) and is unsearchable anyway — the
+  // tag: pattern matches `[^\s,]+`, so whitespace-bearing tags can never be
+  // found again after export.
+  const cleanTags = note.tags.filter(
+    (tag) => !/[\r\n]/.test(tag) && tag.trim().length > 0
+  );
+  if (cleanTags.length === 0) {
+    return note;
+  }
+
+  // Accumulate into a mutable array (the reduce used to rebuild `lines` on
+  // every iteration, an O(n^2) copy for notes with many tags).
+  const lines: string[] = [];
+  let currentLine = '';
+  for (const tag of cleanTags) {
+    const candidate =
+      currentLine.length === 0 ? tag.trim() : `${currentLine}, ${tag.trim()}`;
+    if (candidate.length > TAG_LINE_LENGTH && currentLine.length > 0) {
+      lines.push(currentLine);
+      currentLine = tag.trim();
+    } else {
+      currentLine = candidate;
+    }
+  }
+  if (currentLine.length > 0) {
+    lines.push(currentLine);
+  }
+
+  // No leading ", " can exist: every line above either starts with a fresh
+  // `tag.trim()` (empty accumulator) or a joined continuation — the builder
+  // never emits a dangling comma, so a defensive replace would be dead code.
+  return {
+    ...note,
+    content: `${note.content}\n\nTags:\n  ${lines.join('\n  ')}`,
+  };
+};
+
+/**
+ * Reduce step that de-duplicates file names.
+ *
+ * Appends to the accumulator instead of rebuilding it (`[...notes, note]`),
+ * which turned preparing N notes into O(N^2) array copies: 5k notes meant
+ * ~12.5M element copies before a single byte was written.
+ *
+ * The generated name itself is registered back into `nameCounts`, and we probe
+ * forward until we find a free slot, so inputs like
+ * ["Meeting", "Meeting", "Meeting (1)"] cannot collide on "Meeting (1)".
+ */
+export const toUniqueNames = (
+  acc: [PreparedNote[], Map<string, number>],
+  note: PreparedNote
+): [PreparedNote[], Map<string, number>] => {
+  const [notes, nameCounts] = acc;
+
+  // Keys are case-folded: on case-insensitive file systems (Windows, macOS)
+  // "Meeting" and "meeting" write to the same path, and writeFile's default
+  // 'w' flag would silently overwrite one note with the other.
+  const norm = (name: string) => name.toLowerCase();
+  let count = nameCounts.get(norm(note.fileName)) ?? 0;
+  let fileName = count > 0 ? `${note.fileName} (${count})` : note.fileName;
+  while (fileName !== note.fileName && nameCounts.has(norm(fileName))) {
+    count += 1;
+    fileName = `${note.fileName} (${count})`;
+  }
+
+  nameCounts.set(norm(note.fileName), count + 1);
+  if (fileName !== note.fileName) {
+    nameCounts.set(norm(fileName), (nameCounts.get(norm(fileName)) ?? 0) + 1);
+  }
+  notes.push({ ...note, fileName });
+  return acc;
+};
+
+/**
+ * De-duplicates and names a batch of notes.
+ *
+ * Memoized per input array identity: export's markdown and zip artefacts pass
+ * the same `grouped.activeNotes`/`trashedNotes` references, so without this the
+ * whole appendTags + addFilename + toUniqueNames pipeline ran twice per half
+ * (4 times for `format=all`). The function is deterministic, and no caller
+ * mutates the returned array, so a WeakMap keyed by the input reference is
+ * safe — within one process there is exactly one export run per batch.
+ *
+ * Contract: the returned array is shared with the cache — callers MUST treat
+ * it as read-only (no push/sort/in-place element mutation), otherwise a later
+ * memo hit returns a corrupted batch.
+ */
+const preparedCache = new WeakMap<ExportNote[], PreparedNote[]>();
+
+export const prepareNotes = (notes: ExportNote[]): PreparedNote[] => {
+  const cached = preparedCache.get(notes);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const [prepared] = notes.reduce<[PreparedNote[], Map<string, number>]>(
+    (acc, note) => toUniqueNames(acc, addFilename(appendTags(note))),
+    [[], new Map()]
+  );
+  preparedCache.set(notes, prepared);
+  return prepared;
+};

--- a/lib/cli/infra/__tests__/http.test.ts
+++ b/lib/cli/infra/__tests__/http.test.ts
@@ -1,0 +1,526 @@
+import {
+  httpRequest,
+  isExternalAborted,
+  retryAfterMs,
+  setExternalAbortSignal,
+  DEFAULT_TIMEOUT_MS,
+} from '../http.ts';
+import { AbortedError, NetworkError } from '../../domain/errors.ts';
+import { MAX_BACKOFF_MS, MAX_RETRY_AFTER_MS } from '../../cli-constants.ts';
+import { setVerbose } from '../../logging.ts';
+
+function response(
+  status: number,
+  init: { body?: string; headers?: Record<string, string> } = {}
+): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: new Headers(init.headers ?? {}),
+    text: () => Promise.resolve(init.body ?? ''),
+  } as unknown as Response;
+}
+
+describe('httpRequest', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    setExternalAbortSignal(null);
+    setVerbose(false);
+    delete process.env.SIMPLENOTE_CLI_TIMEOUT_MS;
+    delete process.env.SIMPLENOTE_CLI_DEBUG;
+  });
+
+  it('【场景】verbose 开启时重试路径 【目的】诊断日志覆盖请求/状态/退避 【校验点】console.error 内容 【预期】含 [cli] 前缀与 backoff 信息，stdout 不受影响', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    setVerbose(true);
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(response(503))
+      .mockResolvedValueOnce(response(200));
+
+    const res = await httpRequest('https://example.test/x', {}, { retries: 2 });
+
+    expect(res.status).toBe(200);
+    const calls = errorSpy.mock.calls.map((call) => String(call[0]));
+    expect(
+      calls.some((line) =>
+        line.includes('[cli] HTTP GET https://example.test/x')
+      )
+    ).toBe(true);
+    expect(
+      calls.some((line) => line.includes('HTTP 503 https://example.test/x'))
+    ).toBe(true);
+    expect(
+      calls.some((line) => line.includes('is retryable; backing off'))
+    ).toBe(true);
+    expect(
+      calls.some((line) => line.includes('HTTP 200 https://example.test/x'))
+    ).toBe(true);
+  });
+
+  it('【场景】verbose 关闭 【目的】诊断默认静默、行为零侵入 【校验点】console.error 调用 【预期】无 [cli] 输出', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (global.fetch as jest.Mock).mockResolvedValue(response(200));
+
+    await httpRequest('https://example.test/x', {}, { retries: 1 });
+
+    expect(
+      errorSpy.mock.calls.some((call) => String(call[0]).startsWith('[cli]'))
+    ).toBe(false);
+  });
+
+  it('attaches an abort signal to every request', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(response(200));
+
+    await httpRequest('https://example.test/x', { method: 'GET' });
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect((init as RequestInit).method).toBe('GET');
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('instructs fetch to reject redirects instead of following them', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(response(200));
+
+    await httpRequest('https://example.test/x', {});
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect((init as RequestInit).redirect).toBe('error');
+  });
+
+  // 入参边界：`Retry-After` 既非 delay-seconds 也非可解析日期（如 `abc`）
+  // 时必须回落本地退避（null），而不是把 NaN 当退避时长写进 setTimeout。
+  it('falls back to local backoff when Retry-After is unparseable', () => {
+    expect(
+      retryAfterMs(new Headers({ 'retry-after': 'not-a-date' }))
+    ).toBeNull();
+  });
+
+  // 异常故障：防御性兜底——mock 出的 Response 缺 `text` 方法时按空 body
+  // 处理，而不是 TypeError 打断重试/分页。
+  it('tolerates a response object without a text method', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      status: 200,
+      ok: true,
+      headers: new Headers(),
+    } as unknown as Response);
+
+    const res = await httpRequest('https://example.test/x');
+
+    expect(await res.text()).toBe('');
+  });
+
+  // 异常故障：fetch 以 AbortError 拒绝但没有任何信号中止（模拟底层实现把
+  // 故障包装成 AbortError）——按「取消」分类（exit 6），而不是超时或传输错。
+  it('reports a plain AbortError rejection as a cancellation', async () => {
+    const error = new Error('boom');
+    error.name = 'AbortError';
+    (global.fetch as jest.Mock).mockRejectedValue(error);
+
+    await expect(
+      httpRequest('https://example.test/x', {}, { retries: 1 })
+    ).rejects.toThrow('was cancelled');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // 时序/资源：可重试状态在手、但退避会把整体预算拖过 deadline——再开一次
+  // 请求已知无法完成，必须立即交出最后的状态错误而不是白等一程退避。
+  it('gives up on a retryable response when the backoff would outrun the budget', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      response(503, { headers: { 'retry-after': '30' } })
+    );
+
+    await expect(
+      httpRequest(
+        'https://example.test/x',
+        {},
+        { retries: 3, deadlineAt: Date.now() + 20 }
+      )
+    ).rejects.toThrow('failed: HTTP 503');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // 时序/资源：transport 错误同样受整体预算约束——剩余预算不足时停止重试，
+  // 交出已捕获的传输错误而不是继续开新 socket。
+  it('stops retrying a transport error once the budget is exhausted', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('ECONNRESET'));
+
+    await expect(
+      httpRequest(
+        'https://example.test/x',
+        {},
+        { retries: 3, deadlineAt: Date.now() + 20 }
+      )
+    ).rejects.toThrow('ECONNRESET');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts and reports a timeout when the request outlives the deadline', async () => {
+    (global.fetch as jest.Mock).mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            const error = new Error('aborted');
+            error.name = 'AbortError';
+            reject(error);
+          });
+        })
+    );
+
+    const promise = httpRequest(
+      'https://example.test/x',
+      {},
+      { timeoutMs: 20 }
+    );
+
+    await expect(promise).rejects.toThrow('timed out after 20ms');
+    await expect(promise).rejects.toBeInstanceOf(NetworkError);
+  });
+
+  it('does not retry by default', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(response(503));
+
+    const res = await httpRequest('https://example.test/x');
+
+    expect(res.status).toBe(503);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a retryable status and returns the eventual success', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(response(503))
+      .mockResolvedValueOnce(response(200));
+
+    const res = await httpRequest('https://example.test/x', {}, { retries: 2 });
+
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a plain 500, which is rarely transient', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(response(500));
+
+    const res = await httpRequest('https://example.test/x', {}, { retries: 2 });
+
+    expect(res.status).toBe(500);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after the retry budget and surfaces the last status', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(response(429));
+
+    const res = await httpRequest('https://example.test/x', {}, { retries: 2 });
+
+    // The final attempt is returned rather than thrown, so the caller keeps
+    // ownership of status-to-error mapping.
+    expect(res.status).toBe(429);
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries transport errors and wraps a terminal one as NetworkError', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('ECONNRESET'));
+
+    await expect(
+      httpRequest('https://example.test/x', {}, { retries: 1, label: 'Read' })
+    ).rejects.toThrow('Read failed: ECONNRESET');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('honours SIMPLENOTE_CLI_TIMEOUT_MS and falls back to the default', async () => {
+    (global.fetch as jest.Mock).mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            const error = new Error('aborted');
+            error.name = 'AbortError';
+            reject(error);
+          });
+        })
+    );
+
+    process.env.SIMPLENOTE_CLI_TIMEOUT_MS = '15';
+    await expect(httpRequest('https://example.test/x')).rejects.toThrow(
+      'timed out after 15ms'
+    );
+
+    process.env.SIMPLENOTE_CLI_TIMEOUT_MS = 'not-a-number';
+    await expect(
+      httpRequest('https://example.test/x', {}, { timeoutMs: 5 })
+    ).rejects.toThrow('timed out after 5ms');
+    expect(DEFAULT_TIMEOUT_MS).toBe(15_000);
+  });
+
+  // The body is read inside the deadline and handed back buffered, so a caller
+  // can never be left holding an unconsumed stream (which pins a socket) and a
+  // server that sends headers then stalls the body still times out.
+  it('returns the body already buffered', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      response(200, { body: '{"a":1}' })
+    );
+
+    const res = await httpRequest('https://example.test/x');
+
+    expect(await res.json()).toEqual({ a: 1 });
+    expect(await res.text()).toBe('{"a":1}');
+  });
+
+  it('times out when the body never finishes arriving', async () => {
+    (global.fetch as jest.Mock).mockImplementation(
+      (_url: string, init: RequestInit) =>
+        Promise.resolve({
+          status: 200,
+          ok: true,
+          headers: new Headers(),
+          text: () =>
+            new Promise((_resolve, reject) => {
+              init.signal?.addEventListener('abort', () => {
+                const error = new Error('aborted');
+                error.name = 'AbortError';
+                reject(error);
+              });
+            }),
+        })
+    );
+
+    await expect(
+      httpRequest('https://example.test/x', {}, { timeoutMs: 20 })
+    ).rejects.toThrow('timed out after 20ms');
+  });
+
+  it('consumes a retryable response body so the socket is released', async () => {
+    const text = jest.fn().mockResolvedValue('slow down');
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        status: 503,
+        ok: false,
+        headers: new Headers(),
+        text,
+      })
+      .mockResolvedValueOnce(response(200));
+
+    await httpRequest('https://example.test/x', {}, { retries: 1 });
+
+    expect(text).toHaveBeenCalledTimes(1);
+  });
+
+  // A retryable response in hand *and* an interrupt is a cancellation, not a
+  // network fault: add.ts's batch loop must stop instead of counting the
+  // interrupted attempt as a failure, and the CLI must print "cancelled".
+  // Regression: this used to throw the NetworkError for the HTTP status.
+  it('reports a cancellation when the signal fires with a retryable response in hand', async () => {
+    const controller = new AbortController();
+    setExternalAbortSignal(controller.signal);
+    (global.fetch as jest.Mock).mockResolvedValue({
+      status: 503,
+      ok: false,
+      headers: new Headers({ 'retry-after': '0.05' }),
+      text: async () => {
+        controller.abort();
+        return 'slow down';
+      },
+    });
+
+    await expect(
+      httpRequest('https://example.test/x', {}, { retries: 3 })
+    ).rejects.toBeInstanceOf(AbortedError);
+    // One attempt, no retry: the user asked to stop.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('honours Retry-After on a 429 instead of its own backoff', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        response(429, { headers: { 'retry-after': '0.05' } })
+      )
+      .mockResolvedValueOnce(response(200));
+
+    const started = Date.now();
+    const res = await httpRequest('https://example.test/x', {}, { retries: 1 });
+
+    expect(res.status).toBe(200);
+    expect(Date.now() - started).toBeGreaterThanOrEqual(40);
+  });
+
+  // A transport error that lands *after* the user asked us to stop is
+  // reported as a cancellation, not as a network fault. Tearing a socket down
+  // mid-flight can surface as ECONNRESET rather than AbortError, and calling
+  // that "network error" sends batch callers (add.ts) back around their loop
+  // retrying items the user already cancelled.
+  it('stops retrying and reports a cancellation once the process-level signal aborts', async () => {
+    const controller = new AbortController();
+    setExternalAbortSignal(controller.signal);
+    (global.fetch as jest.Mock).mockImplementation(() => {
+      controller.abort();
+      return Promise.reject(new Error('ECONNRESET'));
+    });
+
+    await expect(
+      httpRequest('https://example.test/x', {}, { retries: 3 })
+    ).rejects.toBeInstanceOf(AbortedError);
+    // One attempt, not four: the user asked us to stop.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // The same transport failure with nobody cancelling stays a NetworkError,
+  // so the classification above is driven by cancellation and not by the
+  // shape of the transport error.
+  it('still reports an uncancelled transport failure as a network error', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('ECONNRESET'));
+
+    await expect(
+      httpRequest('https://example.test/x', {}, { retries: 0 })
+    ).rejects.toBeInstanceOf(NetworkError);
+  });
+
+  // Regression: the backoff between attempts used to watch only the caller's
+  // signal, and no production caller passes one — so a Ctrl-C during a retry
+  // wait was ignored until MAX_BACKOFF_MS elapsed. It must now settle at once.
+  it('interrupts a retry backoff when the process-level signal aborts', async () => {
+    const controller = new AbortController();
+    setExternalAbortSignal(controller.signal);
+    (global.fetch as jest.Mock).mockResolvedValue(
+      response(503, { headers: { 'retry-after': '30' } })
+    );
+
+    const started = Date.now();
+    const pending = httpRequest('https://example.test/x', {}, { retries: 3 });
+    setTimeout(() => controller.abort(), 10);
+
+    await expect(pending).rejects.toBeInstanceOf(Error);
+    // Without the fix this waits out the clamped Retry-After, not ~10ms.
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+
+  // The abort listener is wired onto the per-attempt controller (rather than
+  // relying on AbortSignal.any, which only exists on Node 20+), so a Ctrl-C
+  // interrupts an in-flight fetch on every supported runtime and is reported
+  // as a cancellation, not a timeout.
+  it('reports a Ctrl-C mid-request as a cancellation and never retries', async () => {
+    const controller = new AbortController();
+    setExternalAbortSignal(controller.signal);
+    (global.fetch as jest.Mock).mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            const error = new Error('aborted');
+            error.name = 'AbortError';
+            reject(error);
+          });
+          // A Ctrl-C lands while the request is in flight.
+          queueMicrotask(() => controller.abort());
+        })
+    );
+
+    await expect(
+      httpRequest('https://example.test/x', {}, { retries: 3 })
+    ).rejects.toThrow('was cancelled');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('【场景】200 但 body 非 JSON 【目的】验证 json() 解析兜底 【校验点】异常类型/退出码/文案 【预期】NetworkError 且含非 JSON 提示与状态码', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      response(200, { body: '<html>captive portal</html>' })
+    );
+
+    const res = await httpRequest(
+      'https://example.test/x',
+      {},
+      { label: 'Index' }
+    );
+
+    await expect(res.json()).rejects.toBeInstanceOf(NetworkError);
+    await expect(res.json()).rejects.toThrow(
+      'Index returned a non-JSON body (HTTP 200)'
+    );
+  });
+
+  it('【场景】调用方信号已中止 【目的】验证请求发起前取消检查 【校验点】异常类型与 fetch 调用次数 【预期】AbortedError 且零请求', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      httpRequest('https://example.test/x', {}, { signal: controller.signal })
+    ).rejects.toThrow('Request was cancelled');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('【场景】剩余预算在首次尝试前已耗尽 【目的】验证零请求快速失败（R3-2） 【校验点】fetch 次数与异常文案 【预期】不发起任何请求即 NetworkError，文案明示预算耗尽', async () => {
+    const thrown = await httpRequest(
+      'https://example.test/x',
+      {},
+      { deadlineAt: Date.now() - 1, label: 'Budget test' }
+    ).catch((error) => error);
+
+    expect(thrown).toBeInstanceOf(NetworkError);
+    expect(String(thrown.message)).toContain('total time budget exhausted');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  // P1: Retry-After is the server's explicit instruction and is honored above
+  // the local backoff cap, so a 429 with "Retry-After: 30" actually waits 30s
+  // instead of retrying in 4s and burning the whole budget on a service that
+  // has not recovered. The cap still exists to stop a hostile value.
+  it('honours Retry-After far above the local backoff cap', () => {
+    expect(retryAfterMs(new Headers({ 'retry-after': '300' }))).toBe(
+      MAX_RETRY_AFTER_MS
+    );
+    expect(MAX_RETRY_AFTER_MS).toBeGreaterThan(MAX_BACKOFF_MS);
+  });
+
+  it('keeps a small Retry-After unchanged', () => {
+    expect(retryAfterMs(new Headers({ 'retry-after': '2' }))).toBe(2000);
+  });
+
+  it('【场景】Retry-After 为 HTTP 日期格式 【目的】验证日期解析分支 【校验点】请求次数与最终状态 【预期】按日期等待后成功', async () => {
+    const future = new Date(Date.now() + 60).toUTCString();
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        response(429, { headers: { 'retry-after': future } })
+      )
+      .mockResolvedValueOnce(response(200));
+
+    const res = await httpRequest('https://example.test/x', {}, { retries: 1 });
+
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('【场景】未指定 label 【目的】验证合成错误默认前缀 【校验点】异常文案 【预期】使用 Request 前缀', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('ENOTFOUND'));
+
+    await expect(
+      httpRequest('https://example.test/x', {}, { retries: 0 })
+    ).rejects.toThrow('Request failed: ENOTFOUND');
+  });
+
+  it('【场景】最终一次可重试响应 【目的】验证原样交还且 body 完整 【校验点】状态码/请求次数/body 【预期】429 与缓冲 body 完整返回', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      response(429, { body: '{"n":1}' })
+    );
+
+    const res = await httpRequest('https://example.test/x', {}, { retries: 1 });
+
+    expect(res.status).toBe(429);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(await res.text()).toBe('{"n":1}');
+  });
+});
+
+describe('isExternalAborted', () => {
+  it('【场景】未设置外部信号 【目的】默认不视为中断 【校验点】返回值 【预期】false', () => {
+    setExternalAbortSignal(null);
+    expect(isExternalAborted()).toBe(false);
+  });
+
+  it('【场景】信号触发后 【目的】进程级中断可被本地阶段感知 【校验点】返回值 【预期】触发后为 true', () => {
+    const controller = new AbortController();
+    setExternalAbortSignal(controller.signal);
+    expect(isExternalAborted()).toBe(false);
+    controller.abort();
+    expect(isExternalAborted()).toBe(true);
+    setExternalAbortSignal(null);
+  });
+});

--- a/lib/cli/infra/http.ts
+++ b/lib/cli/infra/http.ts
@@ -1,0 +1,543 @@
+// Single HTTP egress point for the CLI.
+//
+// Problems this solves:
+//
+// 1. Node's global fetch has no default timeout. A half-open socket leaves
+//    `npm run cli -- list` hanging forever, and a CLI has no UI to cancel it.
+//    Every attempt runs under an AbortController with a wall-clock deadline
+//    (override with SIMPLENOTE_CLI_TIMEOUT_MS). The deadline also covers the
+//    body read, not just the response headers: a server that sends headers
+//    then stalls the body would otherwise hang forever after fetch() resolves.
+//
+// 2. Transient upstream failures used to surface as a hard error on the first
+//    hiccup. Callers can opt into bounded retries with exponential backoff and
+//    full jitter (AWS Architecture Blog, "Exponential Backoff And Jitter").
+//    Retries are opt-in per call, never a default, so a note-creating POST is
+//    never replayed and duplicate notes cannot be produced.
+//
+// 3. Retries used to be able to outlive the caller's own budget: three 15s
+//    attempts plus backoff is 45s+ inside a command that promised 120s for a
+//    hundred pages. `deadlineAt` makes the overall budget authoritative — each
+//    attempt is clamped to what is left, and a retry that could not finish in
+//    time is not started at all.
+//
+// Structure: `runAttempt` owns the *transport* (one request, one deadline, one
+// cancellation wiring) and classifies its outcome; `httpRequest` owns the
+// *policy* (what is retryable, how long to wait, when to give up). Keeping the
+// two apart is what removed the previous loop's mid-body `continue` plus a
+// second, unrelated sleep at the bottom of the same iteration.
+
+import { AbortedError, NetworkError, messageOf } from '../domain/errors.ts';
+import { debug } from '../logging.ts';
+import {
+  BASE_BACKOFF_MS,
+  MAX_BACKOFF_MS,
+  MAX_RETRY_AFTER_MS,
+  MIN_ATTEMPT_TIMEOUT_MS,
+  MIN_BACKOFF_MS,
+  envPositiveInt,
+} from '../cli-constants.ts';
+
+export const DEFAULT_TIMEOUT_MS = 15_000;
+export const DEFAULT_MAX_RETRIES = 2;
+
+// Process-level cancellation bridge. `app.ts` installs the AbortSignal from
+// its SIGINT/SIGTERM handler here; every `httpRequest` merges it with the
+// caller's own signal so a Ctrl-C cancels in-flight fetches even when the
+// caller (auth.ts, note-source.ts) did not thread a signal down to this layer.
+//
+// Without this bridge the process-level abort had no path to the per-attempt
+// controller: an interrupt during `export` left the socket open until the
+// per-attempt deadline, the loop kept retrying as if nothing had happened,
+// and the CLI only wound down once `exitWhenIdle` forced it. The signal is
+// module-scoped on purpose — there is exactly one process, so exactly one
+// process-level signal. Tests reset it to `null` in `afterEach`.
+let externalSignal: AbortSignal | null = null;
+
+export function setExternalAbortSignal(signal: AbortSignal | null): void {
+  externalSignal = signal;
+}
+
+/**
+ * True when the process-level signal (SIGINT/SIGTERM, installed by app.ts via
+ * `setExternalAbortSignal`) has fired.
+ *
+ * This is the bridge for work that runs *between* requests — export's local
+ * staging/commit phase has no fetch in flight to cancel, so it checks this
+ * per artefact instead. Same module-scoped source as `externalSignal`: there
+ * is exactly one process, so exactly one process-level signal.
+ */
+export function isExternalAborted(): boolean {
+  return externalSignal?.aborted ?? false;
+}
+
+// Only statuses that mean "the server asked us to come back later". A plain
+// 500 is usually a deterministic server-side bug, so retrying it just
+// multiplies the failure and delays the error the user needs to see. 408 is
+// included because it is the server reporting *its own* read timeout
+// (RFC 9110 15.5.9), which is exactly the transient case retries exist for.
+const RETRYABLE_STATUS = new Set([408, 429, 502, 503, 504]);
+
+/** Longest body excerpt echoed back when a response is not the JSON we expect. */
+const BODY_PREVIEW_LENGTH = 120;
+
+export type HttpResponse = {
+  status: number;
+  ok: boolean;
+  headers: Headers;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+};
+
+export type HttpOptions = {
+  /** Wall-clock deadline for a single attempt. */
+  timeoutMs?: number;
+  /** Extra attempts after the first. Only set this for idempotent requests. */
+  retries?: number;
+  /** Prefix used when this layer has to synthesize an error message. */
+  label?: string;
+  /**
+   * Cancellation from the caller (Ctrl-C, a command giving up on a batch).
+   * Passed explicitly rather than read from a module-level global so that a
+   * unit test, a nested command and the process signal handler cannot
+   * accidentally share — or clobber — each other's cancellation scope.
+   */
+  signal?: AbortSignal;
+  /**
+   * Absolute wall-clock deadline (`Date.now()` milliseconds) covering *all*
+   * attempts, including the waits between them. Set it when the caller has an
+   * overall budget to honour, e.g. a paged index fetch.
+   */
+  deadlineAt?: number;
+};
+
+/**
+ * The per-request timeout in force for this process.
+ *
+ * Exported because callers that compute their own per-attempt budget (the
+ * paged index fetch clamps each page to what is left of the total budget)
+ * have to start from the *configured* limit, not from `DEFAULT_TIMEOUT_MS`.
+ * They used to read the constant directly, which silently made
+ * `SIMPLENOTE_CLI_TIMEOUT_MS` a no-op for `list`/`search`/`export` even
+ * though `--help` advertises it as the per-request timeout.
+ */
+export function perRequestTimeoutMs(): number {
+  return envPositiveInt('SIMPLENOTE_CLI_TIMEOUT_MS', DEFAULT_TIMEOUT_MS);
+}
+
+function backoffMs(attempt: number): number {
+  const ceiling = Math.min(BASE_BACKOFF_MS * 2 ** attempt, MAX_BACKOFF_MS);
+  // Full jitter: random delay in [0, ceiling). A non-zero floor keeps a
+  // "backoff" from becoming an immediate retry.
+  return Math.max(MIN_BACKOFF_MS, Math.floor(Math.random() * ceiling));
+}
+
+/**
+ * `Retry-After` in either documented form (RFC 9110 10.2.3): delay-seconds or
+ * an HTTP-date. Only the seconds form used to be understood, so a server that
+ * answered with a date fell back to our own jitter and hammered it early.
+ *
+ * Returns `null` when the header is absent or unparseable, which means "use
+ * the local backoff instead".
+ */
+export function retryAfterMs(
+  headers: Headers,
+  now: number = Date.now()
+): number | null {
+  const raw = headers.get('retry-after');
+  if (raw === null || raw.trim() === '') {
+    return null;
+  }
+
+  const seconds = Number(raw);
+  const delay = Number.isFinite(seconds)
+    ? seconds * 1_000
+    : Date.parse(raw) - now;
+  if (!Number.isFinite(delay)) {
+    return null;
+  }
+  // Clamped on both ends: a hostile "Retry-After: 86400" must not park the CLI
+  // for a day, and a "0" must not turn the backoff into a hot loop. The upper
+  // bound is MAX_RETRY_AFTER_MS, not the local backoff cap: the header is the
+  // server's explicit instruction, and the local cap exists only to keep
+  // *our* backoff from compounding — it must not shorten what the server told
+  // us to wait (a 429 with "Retry-After: 30" would otherwise retry in 4s and
+  // burn the whole retry budget on a service that has not recovered).
+  return Math.min(Math.max(delay, MIN_BACKOFF_MS), MAX_RETRY_AFTER_MS);
+}
+
+/**
+ * The cancellation sources this layer honours, as one list.
+ *
+ * There are exactly two — the caller's own signal and the process-level one
+ * installed by `app.ts` — and every decision point must consult *both*.
+ * Checking them ad hoc is what let them drift apart: the backoff wait watched
+ * only the caller's signal, while in practice no production caller passes one
+ * (note-source.ts and auth.ts rely entirely on the process bridge), so a
+ * Ctrl-C during a retry wait was simply ignored until the timer expired.
+ */
+function cancellationSignals(signal?: AbortSignal): AbortSignal[] {
+  const signals: AbortSignal[] = [];
+  if (signal) {
+    signals.push(signal);
+  }
+  if (externalSignal) {
+    signals.push(externalSignal);
+  }
+  return signals;
+}
+
+function isCancelled(signal?: AbortSignal): boolean {
+  return cancellationSignals(signal).some((candidate) => candidate.aborted);
+}
+
+function sleep(ms: number, signals: readonly AbortSignal[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signals.some((signal) => signal.aborted)) {
+      reject(new AbortedError('Request aborted'));
+      return;
+    }
+
+    const settle = (): void => {
+      clearTimeout(timer);
+      for (const signal of signals) {
+        signal.removeEventListener('abort', onAbort);
+      }
+    };
+    const onAbort = (): void => {
+      settle();
+      reject(new AbortedError('Request aborted'));
+    };
+    // Deliberately *not* unref'd. An unref'd backoff lets the event loop go
+    // idle between attempts, and bootstrap's idle-exit then tears the process
+    // down mid-retry — exit 0, no output, no error, on a command that never
+    // ran. The wait is bounded by MAX_BACKOFF_MS and always settles, so
+    // holding the loop open for it cannot hang the CLI.
+    const timer = setTimeout(() => {
+      settle();
+      resolve();
+    }, ms);
+    for (const signal of signals) {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+}
+
+function isAbortError(error: unknown): boolean {
+  return (error as { name?: string } | null | undefined)?.name === 'AbortError';
+}
+
+/**
+ * Propagates caller cancellation onto a per-attempt controller.
+ *
+ * `AbortSignal.any` would do this in one call, but it only exists on Node 20+;
+ * on older runtimes a Ctrl-C used to degrade to "keep the request running"
+ * because the merged signal could not be built. Wiring the caller's signal
+ * onto the controller directly works everywhere. The returned cleanup removes
+ * the listener in `finally`, so a long pagination run cannot accumulate
+ * handlers on the long-lived process-level signal.
+ */
+function linkAbort(
+  controller: AbortController,
+  signal?: AbortSignal | null
+): () => void {
+  if (!signal) {
+    return () => undefined;
+  }
+  if (signal.aborted) {
+    controller.abort();
+    return () => undefined;
+  }
+  const handler = (): void => controller.abort();
+  signal.addEventListener('abort', handler, { once: true });
+  return () => signal.removeEventListener('abort', handler);
+}
+
+/** Read the body once, guarding against mocks that omit a `text` method. */
+async function readBody(res: Response): Promise<string> {
+  if (typeof res.text === 'function') {
+    return res.text();
+  }
+  return '';
+}
+
+/**
+ * How long this attempt may take, given the (optional) overall budget.
+ *
+ * `limit` is a hard ceiling — the caller (or SIMPLENOTE_CLI_TIMEOUT_MS) asked
+ * for it. `MIN_ATTEMPT_TIMEOUT_MS` only guards the *other* input: a budget
+ * that is nearly (or already) spent would otherwise produce a 0ms — or
+ * negative — deadline that aborts the request before the socket opens.
+ *
+ * Applying the floor to the result instead, as this used to, silently raised
+ * a deliberately short timeout back to a second, so a sub-second
+ * SIMPLENOTE_CLI_TIMEOUT_MS was ignored on exactly the paged commands
+ * (`list`, `search`, `export`) that are slow enough to want tuning.
+ */
+function attemptTimeoutMs(limit: number, deadlineAt?: number): number {
+  if (deadlineAt === undefined) {
+    return limit;
+  }
+  const remaining = deadlineAt - Date.now();
+  return Math.min(limit, Math.max(MIN_ATTEMPT_TIMEOUT_MS, remaining));
+}
+
+type BufferedResponse = {
+  status: number;
+  ok: boolean;
+  headers: Headers;
+  body: string;
+};
+
+/**
+ * The four things one attempt can end as. Naming them is what lets the policy
+ * loop below read as a decision table instead of a chain of boolean flags:
+ * `timeout` and `cancelled` are terminal, `transport` is retryable, and
+ * `response` hands the status back for the policy to judge.
+ */
+type AttemptResult =
+  | { kind: 'response'; response: BufferedResponse }
+  | { kind: 'timeout'; error: NetworkError }
+  | { kind: 'cancelled'; error: AbortedError }
+  | { kind: 'transport'; error: NetworkError };
+
+async function runAttempt(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+  label: string,
+  signal?: AbortSignal
+): Promise<AttemptResult> {
+  const controller = new AbortController();
+  // One controller serves both the per-attempt deadline and any caller cancel.
+  // `timedOut` keeps the two apart so the message says which one fired.
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+  // Each source gets its own listener so it can be removed independently in
+  // `finally`. A long pagination run otherwise accumulates one abort handler
+  // per attempt on the long-lived process signal, and an interrupt fired
+  // during a previous attempt could not reach this attempt's controller.
+  const unlinks = cancellationSignals(signal).map((source) =>
+    linkAbort(controller, source)
+  );
+
+  try {
+    const res = await fetch(url, {
+      ...init,
+      signal: controller.signal,
+      // A 3xx must never be followed silently: cross-origin redirects do not
+      // strip a custom header like X-Simperium-Token (Fetch only drops
+      // Authorization/Cookie), so following one could leak the bearer token to
+      // an unrelated host. All three base URLs are fixed authoritative HTTPS
+      // endpoints that never legitimately redirect, so treat a redirect as a
+      // transport fault and let the read path's retry policy decide.
+      redirect: 'error',
+    });
+    // Buffered *inside* the deadline window: a caller left holding an
+    // unconsumed stream pins a socket, and a server that sends headers then
+    // stalls the body would never time out.
+    const body = await readBody(res);
+    return {
+      kind: 'response',
+      response: {
+        status: res.status,
+        ok: res.ok,
+        headers: res.headers,
+        body,
+      },
+    };
+  } catch (error) {
+    // Cancellation is checked first: when a Ctrl-C and the deadline race, the
+    // user's intent is the more useful thing to report. Both sources count —
+    // production callers (note-source.ts, auth.ts) pass no signal of their
+    // own, so checking only `signal` reported every Ctrl-C as a timeout.
+    if (isCancelled(signal)) {
+      return {
+        kind: 'cancelled',
+        error: new AbortedError(`${label} was cancelled`),
+      };
+    }
+    if (timedOut) {
+      return {
+        kind: 'timeout',
+        error: new NetworkError(`${label} timed out after ${timeoutMs}ms`),
+      };
+    }
+    if (isAbortError(error)) {
+      return {
+        kind: 'cancelled',
+        error: new AbortedError(`${label} was cancelled`),
+      };
+    }
+    return {
+      kind: 'transport',
+      error: new NetworkError(`${label} failed: ${messageOf(error)}`),
+    };
+  } finally {
+    clearTimeout(timer);
+    for (const unlink of unlinks) {
+      unlink();
+    }
+  }
+}
+
+function parseJson(body: string, label: string, status: number): unknown {
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    // An unguarded JSON.parse surfaced as "Unexpected token < in JSON at
+    // position 0", which tells the user nothing about which call failed or
+    // that they were handed an HTML error page.
+    const preview = body
+      .slice(0, BODY_PREVIEW_LENGTH)
+      .replace(/\s+/g, ' ')
+      .trim();
+    throw new NetworkError(
+      `${label} returned a non-JSON body (HTTP ${status})${
+        preview ? `: ${preview}` : ''
+      }`
+    );
+  }
+}
+
+function buffered(res: BufferedResponse, label: string): HttpResponse {
+  return {
+    status: res.status,
+    ok: res.ok,
+    headers: res.headers,
+    json: async () => parseJson(res.body, label, res.status),
+    text: async () => res.body,
+  };
+}
+
+/**
+ * Waits out a backoff, or reports that waiting is pointless.
+ *
+ * Returns `false` when the overall deadline would elapse before (or just
+ * after) the retry could run — starting an attempt we know cannot finish only
+ * delays the error the caller is waiting for.
+ */
+async function waitBeforeRetry(
+  delayMs: number,
+  deadlineAt: number | undefined,
+  signal?: AbortSignal
+): Promise<boolean> {
+  if (deadlineAt !== undefined && Date.now() + delayMs >= deadlineAt) {
+    return false;
+  }
+  await sleep(delayMs, cancellationSignals(signal));
+  return true;
+}
+
+/**
+ * fetch with a hard deadline and optional retries.
+ *
+ * The body is read inside the deadline window and returned buffered, so status
+ * handling stays with the caller (`401 -> AuthError`, `404 -> undefined`) but
+ * the response is already fully received — no dangling body that can hang a
+ * pipe or leak a socket.
+ */
+export async function httpRequest(
+  url: string,
+  init: RequestInit = {},
+  options: HttpOptions = {}
+): Promise<HttpResponse> {
+  const perAttemptLimit = options.timeoutMs ?? perRequestTimeoutMs();
+  const retries = Math.max(0, options.retries ?? 0);
+  const label = options.label ?? 'Request';
+  const { signal, deadlineAt } = options;
+
+  let lastError: Error = new NetworkError(`${label} failed`);
+
+  for (let attempt = 0; ; attempt++) {
+    // Cheap pre-check: a signal that fired during the previous backoff (or
+    // before the first attempt) must not open another socket. The process-
+    // level signal is checked here too, so an interrupt that landed between
+    // attempts is reported as a cancellation rather than starting a fresh
+    // socket that is doomed to be torn down.
+    if (isCancelled(signal)) {
+      throw new AbortedError(`${label} was cancelled`);
+    }
+    // A deadline that already elapsed must not open a socket: the attempt
+    // would be clamped to MIN_ATTEMPT_TIMEOUT_MS and burn a second just to
+    // time out. Pagination callers (note-source.ts) check the budget
+    // themselves, but a direct httpRequest caller gets the same fail-fast
+    // here instead of a guaranteed timeout.
+    if (deadlineAt !== undefined && Date.now() >= deadlineAt) {
+      // First attempt: the budget was already gone before we started — say so
+      // explicitly instead of the generic placeholder. After a retryable
+      // response, lastError carries the real status and is more useful.
+      throw attempt === 0
+        ? new NetworkError(`${label} failed: total time budget exhausted`)
+        : lastError;
+    }
+
+    // Computed once and reused: attemptTimeoutMs reads Date.now(), so calling
+    // it twice would give the debug line a different value than the attempt.
+    const timeoutMs = attemptTimeoutMs(perAttemptLimit, deadlineAt);
+    debug(
+      `HTTP ${init.method ?? 'GET'} ${url} (attempt ${attempt + 1}, timeout ${timeoutMs}ms)`
+    );
+    const result = await runAttempt(url, init, timeoutMs, label, signal);
+
+    if (result.kind === 'response') {
+      const { response } = result;
+      debug(`HTTP ${response.status} ${url}`);
+      // The final attempt's response is returned rather than thrown, even for
+      // a retryable status, so the caller keeps ownership of status-to-error
+      // mapping (401 -> AuthError, 404 -> undefined, ...).
+      if (attempt >= retries || !RETRYABLE_STATUS.has(response.status)) {
+        return buffered(response, label);
+      }
+      lastError = new NetworkError(`${label} failed: HTTP ${response.status}`);
+      // An interrupt that landed with the response in hand must not be turned
+      // into another attempt: the user asked to stop, and the retry would
+      // open a fresh socket only to be cancelled the instant it starts.
+      // Reported as a cancellation (not the HTTP status) so batch callers
+      // like add.ts stop the run instead of counting the interrupted attempt
+      // as a server failure, and the CLI prints "cancelled" rather than a
+      // status that blames the network for the user's own Ctrl-C.
+      if (isCancelled(signal)) {
+        throw new AbortedError(`${label} was cancelled`);
+      }
+      const delay = retryAfterMs(response.headers) ?? backoffMs(attempt);
+      debug(
+        `HTTP ${response.status} ${url} is retryable; backing off ${delay}ms`
+      );
+      if (await waitBeforeRetry(delay, deadlineAt, signal)) {
+        continue;
+      }
+      throw lastError;
+    }
+
+    // A deadline that already elapsed will elapse again: replaying the attempt
+    // multiplies the wait (3 x 15s) without changing the outcome. A cancelled
+    // request is one the user explicitly asked us to stop. Both are terminal.
+    if (result.kind !== 'transport') {
+      debug(`${result.kind} ${url}: ${result.error.message}`);
+      throw result.error;
+    }
+
+    lastError = result.error;
+    // The retry budget is exhausted, OR the run was cancelled: either way
+    // there is no point starting another attempt. Checking cancellation here
+    // (rather than only at the loop top) is what makes a Ctrl-C during a
+    // transport failure stop after one attempt instead of N.
+    if (attempt >= retries || isCancelled(signal)) {
+      debug(`transport failure ${url}: ${result.error.message}`);
+      throw lastError;
+    }
+    // Computed once and reused: backoffMs rolls Math.random(), so the value
+    // the debug line reports must be the value actually waited on.
+    const delay = backoffMs(attempt);
+    debug(
+      `transport failure ${url}: ${result.error.message}; backing off ${delay}ms`
+    );
+    if (!(await waitBeforeRetry(delay, deadlineAt, signal))) {
+      throw lastError;
+    }
+  }
+}

--- a/lib/cli/jest.config.cjs
+++ b/lib/cli/jest.config.cjs
@@ -1,0 +1,33 @@
+// Coverage gate for the CLI module. Not auto-picked-up by `npx jest lib/cli`
+// (jest resolves upward from cwd to the root jest.config.js and stops), so it
+// must be invoked explicitly: `npx jest --config lib/cli/jest.config.cjs
+// --coverage`. Keeping it separate means the repo-wide suite stays as it is
+// while the module gets its own enforceable floor.
+//
+// `.cjs` rather than `.js` on purpose: jest treats config files as CommonJS,
+// and a `.cjs` extension keeps that true even if package.json gains a
+// `"type": "module"` field later.
+module.exports = {
+  setupFilesAfterEnv: ['<rootDir>/../../setup-tests.js'],
+  roots: ['<rootDir>'],
+  // The CLI is a Node program (fetch/streams/process); jsdom would inject a
+  // DOM global the code never uses and slow every suite down for nothing.
+  testEnvironment: 'node',
+  testRegex: '(__tests__/.*\\.test\\.ts)$',
+  transform: {
+    // babel.config.js is a root-level config that babel only reads from its
+    // cwd (here: lib/cli, the rootDir). `rootMode: "upward"` makes babel walk
+    // up to the repository root where the config actually lives; without it
+    // the TS preset is never applied and every .ts file fails to parse.
+    '^.+\\.[jt]sx?$': ['babel-jest', { rootMode: 'upward' }],
+  },
+  collectCoverageFrom: [
+    '<rootDir>/*.ts',
+    '<rootDir>/commands/*.ts',
+    '<rootDir>/domain/*.ts',
+    '<rootDir>/infra/*.ts',
+  ],
+  coverageThreshold: {
+    global: { statements: 80, branches: 75, functions: 80, lines: 80 },
+  },
+};

--- a/lib/cli/logging.ts
+++ b/lib/cli/logging.ts
@@ -1,0 +1,23 @@
+/**
+ * Request-level diagnostics for `--verbose` / SIMPLENOTE_CLI_DEBUG=1.
+ *
+ * Debug lines always go to stderr: stdout is the machine channel for --json
+ * and must stay byte-clean. The flag is module-level on purpose so infra
+ * layers (http, note-source) can emit without threading a context object
+ * through every call.
+ */
+let verbose = false;
+
+export function setVerbose(value: boolean): void {
+  verbose = value;
+}
+
+export function isVerbose(): boolean {
+  return verbose;
+}
+
+export function debug(message: string): void {
+  if (verbose) {
+    console.error(`[cli] ${message}`);
+  }
+}

--- a/lib/cli/note-source.ts
+++ b/lib/cli/note-source.ts
@@ -1,0 +1,401 @@
+import type { BucketObject } from './vendor/types.ts';
+import { randomUUID } from 'crypto';
+import { API_BASE, APP_ID } from './config.ts';
+import {
+  httpRequest,
+  perRequestTimeoutMs,
+  DEFAULT_MAX_RETRIES,
+} from './infra/http.ts';
+import type { HttpResponse } from './infra/http.ts';
+import { debug } from './logging.ts';
+import {
+  AuthError,
+  ConflictError,
+  NetworkError,
+  NotFoundError,
+  RateLimitError,
+} from './domain/errors.ts';
+import type { FindOptions, NewNote, NoteSource } from './domain/types.ts';
+import { sanitizeNote } from './domain/note.ts';
+import { isTrashed } from './domain/trash.ts';
+import {
+  MAX_PAGES,
+  DEFAULT_TOTAL_TIMEOUT_MS,
+  INDEX_PAGE_SIZE,
+  envPositiveInt,
+} from './cli-constants.ts';
+import type * as T from './vendor/types.ts';
+
+// Reads are safe to replay, so they get bounded retries. Writes never do:
+// Simperium POST creates/updates an object, and replaying one after an
+// ambiguous timeout is how duplicate notes get made.
+const READ_OPTIONS = { retries: DEFAULT_MAX_RETRIES, label: 'Simperium read' };
+const WRITE_OPTIONS = { retries: 0, label: 'Simperium write' };
+
+// Authentication failures are their own class so the CLI can exit 2 ("log in
+// again") instead of 3 ("network"), which is what a caller needs to branch on.
+function unauthorizedError(): AuthError {
+  return new AuthError('Unauthorized: invalid access token');
+}
+
+function conflictError(status: number): ConflictError {
+  if (status === 409 || status === 412) {
+    return new ConflictError(`Simperium rejected the write: HTTP ${status}`);
+  }
+  return new ConflictError('Simperium rejected the write');
+}
+
+function assertUsableStatus(res: HttpResponse): void {
+  if (res.status === 401 || res.status === 403) {
+    throw unauthorizedError();
+  }
+  if (res.status === 409 || res.status === 412) {
+    throw conflictError(res.status);
+  }
+  // A versioned POST can land a 404 when the object was deleted concurrently
+  // ("specified object version does not exist"). Reads never reach here —
+  // `get()` returns undefined on 404 first — so this is a write-path
+  // classification: "the note is gone", not "the network misbehaved".
+  if (res.status === 404) {
+    throw new NotFoundError('Simperium object not found (HTTP 404)');
+  }
+  if (!res.ok) {
+    const message = `Simperium API error: HTTP ${res.status}`;
+    // 429 is a distinct, actionable cause (the server asked us to slow down),
+    // not a generic outage — a batch caller can stop on the first one instead
+    // of grinding through doomed requests.
+    throw res.status === 429
+      ? new RateLimitError(`Too many requests (HTTP 429). ${message}`)
+      : new NetworkError(message);
+  }
+}
+
+function parseVersionHeader(res: HttpResponse): number {
+  const versionHeader = res.headers.get('X-Simperium-Version');
+  const version = Number(versionHeader);
+  if (!Number.isInteger(version) || version < 1) {
+    // The note is already created server-side; failing the whole command here
+    // would push callers to retry and make duplicates. Degrade to 0 and still
+    // hand back the id we received.
+    return 0;
+  }
+  return version;
+}
+
+/**
+ * A single note as returned by `get`: the bucket object plus the version the
+ * server attached to this read (via the `X-Simperium-Version` header), which
+ * is the base a subsequent write should be computed against.
+ */
+type NoteWithVersion = BucketObject<T.Note> & { version?: number };
+
+function totalTimeoutMs(): number {
+  return envPositiveInt(
+    'SIMPLENOTE_CLI_TOTAL_TIMEOUT_MS',
+    DEFAULT_TOTAL_TIMEOUT_MS
+  );
+}
+
+type IndexPage = {
+  entries: Array<{ id: string; d: unknown }>;
+  mark?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * A page cursor we are willing to follow.
+ *
+ * Anything that is not a usable cursor ends pagination instead of being sent
+ * back to the server. A non-string mark never matched the `seenMarks` guard
+ * (a `Set<string>`) nor the `page.mark === mark` check, so a server echoing
+ * numeric marks defeated both loop terminators and only stopped at MAX_PAGES
+ * — a hundred wasted round trips before the error.
+ */
+function normalizeMark(raw: unknown): string | undefined {
+  if (typeof raw === 'string') {
+    return raw === '' ? undefined : raw;
+  }
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return String(raw);
+  }
+  return undefined;
+}
+
+/**
+ * Structural check on an index page before the pagination loop walks it.
+ *
+ * `httpRequest` guarantees the body *parsed* as JSON; it says nothing about
+ * its shape. A 200 carrying `{}`, `null`, a bare array or `{"index": null}` —
+ * all of which a captive portal or a misconfigured proxy can produce — used to
+ * reach `for (const entry of page.index)` and throw a raw
+ * `TypeError: page.index is not iterable`: exit 99 with a stack trace and no
+ * hint that the *server* answered with something unusable. Rejecting it here
+ * turns that into the NetworkError the CLI already knows how to report
+ * (exit 3, "run it again / check your connection").
+ *
+ * Individual entries follow the same boundary rule as `sanitizeNote`: one
+ * unusable record is dropped, it does not fail the whole run. An entry with no
+ * string id is unusable by definition — every downstream verb (`show`, `edit`,
+ * `rm`) addresses notes by that id.
+ */
+function parseIndexPage(payload: unknown): IndexPage {
+  if (!isRecord(payload) || !Array.isArray(payload.index)) {
+    throw new NetworkError(
+      'Simperium index returned an unexpected payload (no "index" array)'
+    );
+  }
+
+  const entries: Array<{ id: string; d: unknown }> = [];
+  for (const entry of payload.index) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    const { id } = entry;
+    if (typeof id !== 'string' || id === '') {
+      continue;
+    }
+    entries.push({ id, d: entry.d });
+  }
+
+  return { entries, mark: normalizeMark(payload.mark) };
+}
+
+async function fetchIndexPage(
+  bucket: string,
+  token: string,
+  mark: string | undefined,
+  deadlineAt: number,
+  timeoutMs: number
+): Promise<IndexPage> {
+  const params = new URLSearchParams({
+    data: 'true',
+    limit: String(INDEX_PAGE_SIZE),
+  });
+  if (mark) {
+    params.set('mark', mark);
+  }
+
+  // Keep one page (including its read retries) inside the command's total
+  // budget. `deadlineAt` is the absolute wall-clock deadline, computed once by
+  // `find()` and handed down: `httpRequest` clamps every attempt to what is
+  // left of it and skips a backoff that could not finish in time. Without it
+  // the 2 read retries plus their backoff could each run a full `timeoutMs`
+  // and blow past the total budget by tens of seconds, because `find()` only
+  // checks the budget *between* pages.
+  //
+  // The clamping itself is deliberately not repeated here. This used to
+  // pre-shrink `timeoutMs` against the very deadline `httpRequest` clamps
+  // against anyway, so the outer copy was dead weight — and being written
+  // against DEFAULT_TIMEOUT_MS rather than the configured value, it also
+  // swallowed SIMPLENOTE_CLI_TIMEOUT_MS on every paged verb (`list`,
+  // `search`, `export`) even though `--help` advertises it.
+  const options = {
+    ...READ_OPTIONS,
+    timeoutMs,
+    deadlineAt,
+  };
+
+  const res = await httpRequest(
+    `${API_BASE}/${APP_ID}/${bucket}/index?${params}`,
+    { headers: { 'X-Simperium-Token': token } },
+    options
+  );
+  assertUsableStatus(res);
+  return parseIndexPage(await res.json());
+}
+
+export function createNoteSource(token: string): NoteSource {
+  async function find(options?: FindOptions): Promise<BucketObject<T.Note>[]> {
+    // Default keeps the whole index (export needs the trash half); the
+    // commands that never touch trashed notes (`list`, `search`, `add`) opt
+    // out so those records are dropped before they are retained in memory.
+    const includeTrashed = options?.includeTrashed ?? true;
+    const startedAt = Date.now();
+    // One deadline for the whole pagination run, shared by every page (and
+    // parsed from the environment exactly once per command). The per-request
+    // timeout is read once here for the same reason: a thousand-page fetch
+    // should not re-parse the environment a thousand times.
+    const deadlineAt = startedAt + totalTimeoutMs();
+    const perPageTimeout = perRequestTimeoutMs();
+    const all: BucketObject<T.Note>[] = [];
+    const seenMarks = new Set<string>();
+    // Duplicate ids across pages (a note moved between pages while the
+    // pagination snapshot drifted) are dropped, first occurrence wins — the
+    // same "later page overwrites" trap the export path avoided with a Map.
+    const seenIds = new Set<string>();
+    let mark: string | undefined;
+    let pages = 0;
+
+    while (true) {
+      // Anti-runaway: a server that returns a fresh, never-repeating mark on
+      // every page would otherwise spin forever while memory grows. The
+      // seen-set catches cycle repeats; this catch catches monotonic drift.
+      if (++pages > MAX_PAGES) {
+        throw new NetworkError(
+          `Index pagination did not terminate after ${pages} pages`
+        );
+      }
+      if (Date.now() > deadlineAt) {
+        throw new NetworkError('Index fetch exceeded the total time budget');
+      }
+
+      const page = await fetchIndexPage(
+        'note',
+        token,
+        mark,
+        deadlineAt,
+        perPageTimeout
+      );
+      debug(
+        `index page ${pages}: ${all.length} notes so far (mark: ${mark === undefined ? 'none' : mark})`
+      );
+      for (const entry of page.entries) {
+        // Normalize at the boundary: the index can return entries whose data
+        // blob is missing entirely, or present but with unusable fields
+        // (no `systemTags`, a non-array `tags`, a stringified date). The
+        // first kind is dropped; the second is repaired with defaults, so
+        // `search`/`export` — which dereference note fields through code
+        // shared with the desktop app — cannot crash on a dirty record.
+        const data = sanitizeNote(entry.d);
+        if (data === undefined) {
+          continue;
+        }
+        if (!includeTrashed && isTrashed(data)) {
+          continue;
+        }
+        if (seenIds.has(entry.id)) {
+          continue;
+        }
+        seenIds.add(entry.id);
+        all.push({ id: entry.id, data });
+      }
+      // Stop on a missing mark, an unchanged mark, or a mark we have already
+      // followed. Without the seen-set a server that cycles marks would spin
+      // this loop forever while memory grows.
+      if (!page.mark || page.mark === mark || seenMarks.has(page.mark)) {
+        debug(`index fetch finished: ${pages} page(s), ${all.length} notes`);
+        break;
+      }
+      seenMarks.add(page.mark);
+      mark = page.mark;
+    }
+    return all;
+  }
+
+  async function get(id: string): Promise<NoteWithVersion | undefined> {
+    const res = await httpRequest(
+      `${API_BASE}/${APP_ID}/note/i/${encodeURIComponent(id)}`,
+      { headers: { 'X-Simperium-Token': token } },
+      READ_OPTIONS
+    );
+    if (res.status === 404) {
+      debug(`get ${id}: 404`);
+      return undefined;
+    }
+    assertUsableStatus(res);
+    // Same boundary rule as find(): a payload with no usable record is
+    // treated as absent rather than handed to consumers half-formed.
+    const data = sanitizeNote(await res.json());
+    if (data === undefined) {
+      return undefined;
+    }
+    // The version header is the base the next POST should carry (`/v/{v}`),
+    // so an edit merges with — instead of clobbering — concurrent changes.
+    const version = parseVersionHeader(res);
+    debug(`get ${id}: OK, version ${version}`);
+    return version > 0 ? { id, data, version } : { id, data };
+  }
+
+  async function postNote(
+    id: string,
+    noteData: T.Note,
+    baseVersion?: number
+  ): Promise<{ version: number }> {
+    const ccid = randomUUID();
+    // `/v/{version}` tells the server which object version this change was
+    // computed against. Without it the full stale body is applied to the
+    // latest state, silently overwriting fields another client changed since
+    // the read; with it the server treats the write as an increment from the
+    // read version and merges concurrent edits per field.
+    const versionPath = baseVersion === undefined ? '' : `/v/${baseVersion}`;
+    debug(
+      `write ${id} (baseVersion: ${baseVersion === undefined ? 'none' : baseVersion})`
+    );
+    const res = await httpRequest(
+      `${API_BASE}/${APP_ID}/note/i/${encodeURIComponent(id)}${versionPath}?ccid=${ccid}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Simperium-Token': token,
+        },
+        body: JSON.stringify(noteData),
+      },
+      WRITE_OPTIONS
+    );
+    assertUsableStatus(res);
+    const version = parseVersionHeader(res);
+    debug(`write ${id}: OK, version ${version}`);
+    return { version };
+  }
+
+  async function update(
+    id: string,
+    content: string
+  ): Promise<{ version: number }> {
+    const existing = await get(id);
+    if (!existing) {
+      throw new NotFoundError(`Note not found: ${id}`);
+    }
+    if (isTrashed(existing.data)) {
+      throw new ConflictError(`Note is in the trash: ${id}`);
+    }
+    if (existing.version === undefined) {
+      // Without a version the POST below would be a blind write (`versionPath =
+      // ''`), applying the full stale body to the latest state and silently
+      // clobbering fields another client changed since the read. That is the
+      // exact hazard `/v/{version}` exists to prevent, so fail loudly instead
+      // of silently losing the concurrent-merge protection. (A missing header
+      // happens when a proxy/gateway strips X-Simperium-Version.)
+      throw new ConflictError(
+        `Cannot safely update note ${id}: the server did not return a ` +
+          `version (X-Simperium-Version missing), so a blind write could ` +
+          `overwrite concurrent changes. Retry the command.`
+      );
+    }
+
+    return postNote(
+      id,
+      {
+        ...existing.data,
+        content,
+        modificationDate: Math.floor(Date.now() / 1000),
+      },
+      existing.version
+    );
+  }
+
+  async function create(
+    note: NewNote
+  ): Promise<{ id: string; version: number }> {
+    const id = randomUUID();
+    const now = Math.floor(Date.now() / 1000);
+    const noteData: T.Note = {
+      content: note.content,
+      creationDate: now,
+      modificationDate: now,
+      deleted: false,
+      publishURL: '',
+      shareURL: '',
+      systemTags: note.systemTags ?? ['markdown'],
+      tags: note.tags ?? [],
+    };
+    const { version } = await postNote(id, noteData);
+    return { id, version };
+  }
+
+  return { find, get, update, create };
+}

--- a/lib/cli/package-lock.json
+++ b/lib/cli/package-lock.json
@@ -1,0 +1,647 @@
+{
+  "name": "simplenote-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "simplenote-cli",
+      "version": "0.1.0",
+      "license": "GPL-2.0",
+      "dependencies": {
+        "jszip": "3.10.1",
+        "lodash": "4.18.1",
+        "remove-markdown": "0.6.0",
+        "sanitize-filename": "1.6.3"
+      },
+      "bin": {
+        "simplenote-cli": "dist/cli.js"
+      },
+      "devDependencies": {
+        "esbuild": "^0.28.1"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/remove-markdown": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.6.0.tgz",
+      "integrity": "sha512-B9g8yo5Zp1wXfZ77M1RLpqI7xrBBERkp7+3/Btm9N/uZV5xhXZjzIxDbCKz7CSj141lWDuCnQuH12DKLUv4Ghw==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/lib/cli/package.json
+++ b/lib/cli/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "simplenote-cli",
+  "version": "0.1.0",
+  "description": "Simplenote command-line client",
+  "license": "GPL-2.0",
+  "main": "dist/cli.js",
+  "bin": {
+    "simplenote-cli": "dist/cli.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "node scripts/build.mjs",
+    "build:sea": "node scripts/build.mjs && node scripts/sea.mjs",
+    "test": "jest",
+    "coverage": "jest --config jest.config.cjs --coverage",
+    "prepack": "npm run build"
+  },
+  "engines": {
+    "node": "^18.13.0 || ^20.0.0 || >=22.0.0"
+  },
+  "dependencies": {
+    "jszip": "3.10.1",
+    "lodash": "4.18.1",
+    "remove-markdown": "0.6.0",
+    "sanitize-filename": "1.6.3"
+  },
+  "devDependencies": {
+    "esbuild": "^0.28.1"
+  }
+}

--- a/lib/cli/scripts/build.mjs
+++ b/lib/cli/scripts/build.mjs
@@ -1,0 +1,42 @@
+import { build } from 'esbuild';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+
+mkdirSync(join(root, 'dist'), { recursive: true });
+
+await build({
+  entryPoints: [join(root, 'bootstrap.ts')],
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: ['node18'],
+  banner: { js: '#!/usr/bin/env node' },
+  // `platform: 'node'` already marks Node built-ins as external; the explicit
+  // list is a defensive declaration of the subpaths we rely on, so a reader
+  // does not have to infer them from the imports.
+  external: [
+    'readline/promises',
+    'stream/promises',
+    'fs/promises',
+    'timers/promises',
+  ],
+  // Stamp the version into the bundle so packaged copies (dist/cli.js, the SEA
+  // executable) report what they were built from even when no package.json
+  // sits next to them. `getVersion()` reads this first and falls back to the
+  // manifest chain only when it is absent (source/tests).
+  define: {
+    'process.env.SIMPLENOTE_CLI_VERSION': JSON.stringify(pkg.version),
+  },
+  outfile: join(root, 'dist', 'cli.js'),
+  logLevel: 'info',
+});
+
+writeFileSync(
+  join(root, 'dist', 'package.json'),
+  JSON.stringify({ name: pkg.name, version: pkg.version }, null, 2)
+);

--- a/lib/cli/scripts/install.mjs
+++ b/lib/cli/scripts/install.mjs
@@ -1,0 +1,115 @@
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+const dist = join(root, 'dist');
+const exe = join(dist, 'simplenote-cli.exe');
+const versionManifest = join(dist, 'package.json');
+
+const userBin = join(process.env.USERPROFILE ?? '', '.local', 'bin');
+const installed = join(userBin, 'simplenote-cli.exe');
+// Namespaced so it cannot clobber another tool's package.json in the same
+// directory; uninstall() below removes the same name.
+const installedManifest = join(userBin, 'simplenote-cli.package.json');
+
+function fail(message) {
+  console.error(`\u2717 ${message}`);
+  process.exit(1);
+}
+
+function step(label) {
+  console.log(`\u2192 ${label}`);
+}
+
+function uninstall() {
+  for (const path of [installed, installedManifest]) {
+    try {
+      unlinkSync(path);
+      console.log(`\u2713 removed ${path}`);
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        console.log(`  ${path} not installed, skipping.`);
+      } else {
+        console.error(`  ${error.message}`);
+        process.exit(1);
+      }
+    }
+  }
+  console.log('\u2713 uninstalled.');
+}
+
+if (process.argv[2] === '--uninstall') {
+  uninstall();
+  process.exit(0);
+}
+
+if (!existsSync(exe)) {
+  fail(
+    `Binary not found at ${exe}. Run \`npm run build:sea\` inside lib/cli ` +
+      `first; install only copies the SEA artifact into your PATH.`
+  );
+}
+
+if (!existsSync(versionManifest)) {
+  fail(
+    `Version manifest not found at ${versionManifest}; SEA artifact incomplete.`
+  );
+}
+
+if (!existsSync(userBin)) {
+  fail(
+    `User bin directory ${userBin} does not exist. Add it to your PATH first, ` +
+      `or pass an explicit destination as the second argument.`
+  );
+}
+
+step(`Copying ${exe} -> ${installed}`);
+try {
+  mkdirSync(userBin, { recursive: true });
+  copyFileSync(exe, installed);
+} catch (error) {
+  fail(`copy failed: ${error.message}`);
+}
+
+step(`Copying ${versionManifest} -> ${installedManifest}`);
+try {
+  copyFileSync(versionManifest, installedManifest);
+} catch (error) {
+  fail(`manifest copy failed: ${error.message}`);
+}
+
+step(`Smoke test: simplenote-cli --version`);
+// Expected version comes from the manifest the build produced, never a
+// hard-coded literal — the check would otherwise fail with a misleading
+// message on the next version bump.
+const expectedVersion = JSON.parse(
+  readFileSync(versionManifest, 'utf8')
+).version;
+const probe = spawnSync('simplenote-cli', ['--version'], {
+  encoding: 'utf8',
+  shell: false,
+});
+if (probe.stdout) process.stdout.write(probe.stdout);
+if (probe.stderr) process.stderr.write(probe.stderr);
+if (probe.status !== 0) {
+  fail(`installed binary exited with code ${probe.status}`);
+}
+if (!probe.stdout.includes(expectedVersion)) {
+  fail(
+    `installed binary did not report ${expectedVersion} (got: ${probe.stdout.trim()})`
+  );
+}
+
+console.log('\u2713 installed.');
+console.log(`  PATH directory : ${userBin}`);
+console.log(`  command name   : simplenote-cli`);
+console.log(`  uninstall with : node lib/cli/scripts/install.mjs --uninstall`);

--- a/lib/cli/scripts/sea.mjs
+++ b/lib/cli/scripts/sea.mjs
@@ -1,0 +1,216 @@
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+const dist = join(root, 'dist');
+const cliJs = join(dist, 'cli.js');
+const blob = join(dist, 'sea.blob');
+const configPath = join(dist, 'sea-config.json');
+const exeName =
+  process.platform === 'win32' ? 'simplenote-cli.exe' : 'simplenote-cli';
+const outExe = join(dist, exeName);
+
+// Sentinel fuse expected by recent Node SEA releases (NODE_SEA_FUSE_... in
+// src/node_sea.cc). Older releases used a different constant; using the wrong
+// one makes postject report "Could not find the sentinel ... in the binary".
+// The host version is preflighted below so the failure message names the real
+// cause instead of a postject error.
+const SENTINEL_FUSE = 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2';
+
+function fail(message) {
+  console.error(`\u2717 ${message}`);
+  process.exit(1);
+}
+
+// The CLI's runtime floor is Node 18.13 (readline's {signal} option); the SEA
+// host must at least match it so the bundled artifact behaves like the source.
+const [nodeMajor, nodeMinor] = process.versions.node
+  .split('.')
+  .map((part) => Number(part));
+if (nodeMajor < 18 || (nodeMajor === 18 && nodeMinor < 13)) {
+  fail(
+    `SEA build requires Node >=18.13 (got ${process.version}). ` +
+      `Upgrade and rerun.`
+  );
+}
+
+function step(label) {
+  console.log(`\u2192 ${label}`);
+}
+
+/**
+ * Locate an upstream, unmodified Node binary to use as the SEA host.
+ *
+ * Sandboxed or tool-wrapped distributions (e.g. some IDE-managed runtimes)
+ * can ship a node.exe with the original signature stripped, which makes
+ * `postject` fail with "signature seems corrupted" / "Could not find the
+ * sentinel ... in the binary". Falling back to a standard install keeps the
+ * build reproducible on such hosts.
+ *
+ * Returns an absolute path, or throws if nothing usable is found.
+ */
+function resolveHostNode() {
+  const userProfile = process.env.USERPROFILE ?? '';
+  const localAppData = process.env.LOCALAPPDATA ?? '';
+  const roots = [
+    join(localAppData, 'nodejs', 'node.exe'),
+    'C:/Program Files/nodejs/node.exe',
+    'C:/Program Files (x86)/nodejs/node.exe',
+  ];
+  for (const candidate of roots) {
+    if (candidate && existsSync(candidate)) return candidate;
+  }
+  // ~/.trae-cn/binaries/node holds `versions/<x.y.z>/node.exe`; pick the
+  // newest numeric subdir under versions.
+  const versionsRoot = join(
+    userProfile,
+    '.trae-cn',
+    'binaries',
+    'node',
+    'versions'
+  );
+  try {
+    const entries = readdirSync(versionsRoot)
+      .filter((name) => /^\d+\.\d+\.\d+$/.test(name))
+      .sort()
+      .reverse();
+    if (entries.length) {
+      const perVersion = join(versionsRoot, entries[0], 'node.exe');
+      if (existsSync(perVersion)) return perVersion;
+    }
+  } catch {
+    // ignore; fall through
+  }
+  // Last resort: trust the running node.exe (works on hosts without IDE
+  // sandboxes; on those, the standard path above usually wins first).
+  if (existsSync(process.execPath)) return process.execPath;
+  throw new Error(
+    `No standard node.exe found. Looked under ${roots.join(', ')} and ` +
+      `${versionsRoot}. Install Node 18.13+ from nodejs.org and rerun.`
+  );
+}
+
+if (!existsSync(cliJs)) {
+  fail(
+    `dist/cli.js not found at ${cliJs}. Run \`npm run build\` inside lib/cli ` +
+      `first; sea bundles whatever the esbuild step produced.`
+  );
+}
+
+const hostNode = resolveHostNode();
+step(`Using host node: ${hostNode}`);
+
+// 1. SEA config: bundle the esbuild output as the entry point. `main` and
+//    `output` are resolved against the spawn cwd; absolute paths keep the
+//    script independent of where it is invoked from.
+writeFileSync(
+  configPath,
+  JSON.stringify(
+    {
+      main: cliJs,
+      output: blob,
+      disableExperimentalSEAWarning: true,
+      useSnapshot: false,
+      useCodeCache: false,
+    },
+    null,
+    2
+  )
+);
+
+// 2. Generate the SEA blob from the bundled CLI. Run the host node from the
+//    dist directory so the optional "main" path semantics stay stable if
+//    anyone switches back to a relative path in the future.
+step('Generating SEA blob with --experimental-sea-config');
+const seaGen = spawnSync(hostNode, ['--experimental-sea-config', configPath], {
+  cwd: dist,
+  stdio: 'inherit',
+});
+if (seaGen.status !== 0) {
+  fail(
+    `${hostNode} --experimental-sea-config exited with code ${seaGen.status}. ` +
+      `SEA requires Node 18.13+; current version is ${process.version}.`
+  );
+}
+if (!existsSync(blob)) {
+  fail(`SEA blob not produced at ${blob}`);
+}
+
+// 3. Copy the host node binary as our distribution exe.
+step(`Copying ${hostNode} -> ${outExe}`);
+try {
+  copyFileSync(hostNode, outExe);
+} catch (error) {
+  fail(`Failed to copy node executable: ${error.message}`);
+}
+
+// 4. Inject the blob with postject. We invoke via npx so the script works
+//    even when postject is not declared as a dependency of lib/cli or the
+//    repo root. SEA itself does not depend on postject, but the official
+//    Node docs ship postject as the documented injection tool.
+step('Injecting SEA blob into the executable');
+const postject = spawnSync(
+  'cmd.exe',
+  [
+    '/c',
+    'npx',
+    '--yes',
+    'postject@1.0.0-alpha.6',
+    outExe,
+    'NODE_SEA_BLOB',
+    blob,
+    '--sentinel-fuse',
+    SENTINEL_FUSE,
+  ],
+  { encoding: 'utf8' }
+);
+if (postject.stdout) process.stdout.write(postject.stdout);
+if (postject.stderr) process.stderr.write(postject.stderr);
+if (postject.status !== 0) {
+  fail(`postject exited with code ${postject.status}.`);
+}
+
+// 5. Smoke test: the resulting exe must answer --version without a Node
+//    runtime on PATH.
+step(`Smoke test: ${outExe} --version`);
+
+// The expected version comes from the manifest written by build.mjs (the
+// same file install.mjs reads), not a hard-coded string that goes stale on
+// the next release.
+const expectedVersion = JSON.parse(
+  readFileSync(join(dist, 'package.json'), 'utf8')
+).version;
+
+const smoke = spawnSync(outExe, ['--version'], { encoding: 'utf8' });
+if (smoke.stdout) process.stdout.write(smoke.stdout);
+if (smoke.stderr) process.stderr.write(smoke.stderr);
+if (smoke.status !== 0) {
+  fail(`smoke test exited with code ${smoke.status}`);
+}
+if (!smoke.stdout.includes(expectedVersion)) {
+  fail(`smoke test did not report the expected version ${expectedVersion}`);
+}
+
+console.log(
+  `\u2713 SEA executable built at ${outExe}. Distribution: copy this single file.`
+);
+
+// 6. Remove build-time intermediates so the dist/ directory only ships what the
+//    runtime needs: the bundled CLI, the version manifest, and the final exe.
+for (const tmp of [blob, configPath]) {
+  try {
+    unlinkSync(tmp);
+  } catch {
+    // ignore — already gone, or never written
+  }
+}

--- a/lib/cli/store.ts
+++ b/lib/cli/store.ts
@@ -1,0 +1,177 @@
+import { promises as fs } from 'fs';
+import { randomBytes } from 'crypto';
+import * as path from 'path';
+import * as os from 'os';
+import { CliError, EXIT_NETWORK, messageOf } from './domain/errors.ts';
+import type { Credentials } from './domain/types.ts';
+
+export const STORE_DIR = path.join(os.homedir(), '.simplenote-cli');
+export const CRED_FILE = path.join(STORE_DIR, 'credentials.json');
+
+/** Matches every temp file this module can create, for logout's sweep. */
+const TMP_PREFIX = `${path.basename(CRED_FILE)}.`;
+const TMP_SUFFIX = '.tmp';
+
+/**
+ * A temp path no concurrent run can collide with.
+ *
+ * The name used to be a fixed `credentials.json.tmp`. Two logins racing — a
+ * second terminal, a retry after a hung run, a script looping — then wrote
+ * the *same* file and renamed it in turn: one process could publish a file
+ * the other was still writing (a truncated token, so the next command sees a
+ * corrupt store), or fail with ENOENT because the other had already renamed
+ * it away. pid plus randomness makes every attempt private.
+ */
+function tempPath(): string {
+  const unique = `${process.pid}.${randomBytes(6).toString('hex')}`;
+  return `${CRED_FILE}.${unique}${TMP_SUFFIX}`;
+}
+
+export async function saveCredentials(credentials: Credentials): Promise<void> {
+  await fs.mkdir(STORE_DIR, { recursive: true, mode: 0o700 });
+  // Write to a private temp file and rename it into place. rename(2) is
+  // atomic within a filesystem, so a crash mid-write can never leave a
+  // half-written credentials file *in place* — the next run either sees the
+  // old token or the new one, never a truncated one.
+  const tmp = tempPath();
+  try {
+    await fs.writeFile(tmp, JSON.stringify(credentials, null, 2), {
+      mode: 0o600,
+    });
+    // `mode` on writeFile is masked by the process umask, which a CLI cannot
+    // assume anything about, so chmod unconditionally: the file holds a live
+    // token and must not be readable by other users on the machine. (On
+    // Windows this is effectively a no-op, which is fine.)
+    await fs.chmod(tmp, 0o600);
+    await fs.rename(tmp, CRED_FILE);
+  } catch (error) {
+    // Any failure — a full disk during the write, a cross-device rename, a
+    // read-only home — must not leave the token behind in a stray temp file.
+    // Only the rename used to be cleaned up, so a failed *write* leaked one
+    // file containing a live token per attempt.
+    await fs.unlink(tmp).catch(() => {});
+    // Re-thrown as a typed error with a precise message: the login itself
+    // succeeded, the token just never reached disk. Before this wrap the raw
+    // fs error surfaced as "Login failed: EACCES …", which read like a network
+    // failure and sent the user down the wrong path (the code was already
+    // consumed server-side, so a retry needs a fresh one).
+    throw new CliError(
+      EXIT_NETWORK,
+      `Could not persist credentials at ${CRED_FILE}: ${messageOf(error)}. The login itself succeeded — re-run login once the store is writable.`
+    );
+  }
+}
+
+export async function loadCredentials(): Promise<Credentials | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(CRED_FILE, 'utf8');
+  } catch {
+    // Missing or unreadable file is simply "not logged in".
+    return null;
+  }
+
+  await warnIfCredentialFileIsGroupReadable();
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return readCredentials(parsed) ?? reportCorrupt();
+  } catch {
+    return reportCorrupt();
+  }
+}
+
+/**
+ * Accepts only a record with two non-empty *string* fields.
+ *
+ * The old truthiness check (`parsed.access_token && parsed.username`) also
+ * accepted a number, an array or an object, which then travelled all the way
+ * into an `X-Simperium-Token` header and came back as an opaque 401 instead
+ * of the actionable "your credentials file is corrupt" this function exists
+ * to print. It also threw outright on a top-level `null`, relying on the
+ * caller's catch to translate a TypeError into the warning.
+ */
+function readCredentials(parsed: unknown): Credentials | null {
+  if (typeof parsed !== 'object' || parsed === null) {
+    return null;
+  }
+  const { access_token: token, username } = parsed as Record<string, unknown>;
+  if (typeof token !== 'string' || token === '') {
+    return null;
+  }
+  if (typeof username !== 'string' || username === '') {
+    return null;
+  }
+  return { access_token: token, username };
+}
+
+/**
+ * A file that exists but cannot be understood is *not* the same as being
+ * logged out: silently returning null used to make users re-login over and
+ * over with no hint that their credential file was corrupt (and that the fix
+ * is to delete it). Warn, then behave as "not logged in".
+ */
+function reportCorrupt(): null {
+  console.error(
+    `Warning: credentials file ${CRED_FILE} is corrupt; ignoring it. ` +
+      'Run `npm run cli -- logout` to remove it, then log in again.'
+  );
+  return null;
+}
+
+/**
+ * POSIX-only self-check: if the credentials file carries group/other read
+ * bits, any other user on the machine can read the live token. Warn with the
+ * fix. On Windows chmod(2) is a no-op and the file's ACLs govern access, so
+ * there is nothing meaningful to check.
+ */
+async function warnIfCredentialFileIsGroupReadable(): Promise<void> {
+  if (process.platform === 'win32') {
+    return;
+  }
+  try {
+    const stat = await fs.stat(CRED_FILE);
+    if ((stat.mode & 0o077) !== 0) {
+      console.error(
+        `Warning: credentials file ${CRED_FILE} is readable by other users ` +
+          `(mode 0${(stat.mode & 0o777).toString(8)}). Run: chmod 600 ${CRED_FILE}`
+      );
+    }
+  } catch {
+    // The file can vanish between the read above and this stat, or stat can
+    // be unsupported: nothing to warn about, stay silent.
+  }
+}
+
+export async function clearCredentials(): Promise<void> {
+  try {
+    await fs.unlink(CRED_FILE);
+  } catch {
+    // ignore missing file
+  }
+  await sweepTempFiles();
+}
+
+/**
+ * Removes temp files a previous run may have left behind.
+ *
+ * "Logout" has to mean *no token is left on disk*. Before the write path was
+ * made crash-safe, a failed save leaked `credentials.json.tmp` with a live
+ * token in it, and that file survived every logout. Best-effort on purpose:
+ * an unreadable store directory must not turn logout into an error.
+ */
+async function sweepTempFiles(): Promise<void> {
+  let names: string[];
+  try {
+    names = await fs.readdir(STORE_DIR);
+  } catch {
+    return;
+  }
+  await Promise.all(
+    names
+      .filter(
+        (name) => name.startsWith(TMP_PREFIX) && name.endsWith(TMP_SUFFIX)
+      )
+      .map((name) => fs.unlink(path.join(STORE_DIR, name)).catch(() => {}))
+  );
+}

--- a/lib/cli/vendor/export/export-notes.ts
+++ b/lib/cli/vendor/export/export-notes.ts
@@ -1,0 +1,43 @@
+import { partition, sortBy } from 'lodash';
+
+import normalizeLineBreak from './normalize-line-break';
+import isEmailTag from '../is-email-tag';
+import { isTrashed } from '../../domain/trash';
+
+import * as T from '../types';
+import { ExportNote } from './types';
+
+const exportNotes = (notes: Map<T.EntityId, T.Note>) => {
+  const activeNotes: ExportNote[] = [];
+  const trashedNotes: ExportNote[] = [];
+  [...notes.entries()].forEach((notePair) => {
+    const [id, note] = notePair;
+    const [collaboratorEmails, tags] = partition(
+      sortBy(note.tags, (a) => a.toLowerCase()),
+      isEmailTag
+    );
+    const parsedNote = Object.assign(
+      {
+        id,
+        content: normalizeLineBreak(note.content),
+        creationDate: new Date(note.creationDate * 1000).toISOString(),
+        lastModified: new Date(note.modificationDate * 1000).toISOString(),
+      },
+      note.systemTags.includes('pinned') && { pinned: true },
+      note.systemTags.includes('markdown') && { markdown: true },
+      tags.length && { tags },
+      note.systemTags.includes('published') &&
+        note?.publishURL && {
+          publicURL: `http://simp.ly/p/${note.publishURL}`,
+        },
+      note.systemTags.includes('shared') &&
+        collaboratorEmails.length && { collaboratorEmails }
+    );
+    isTrashed(note)
+      ? trashedNotes.push(parsedNote)
+      : activeNotes.push(parsedNote);
+  });
+  return Promise.resolve({ activeNotes, trashedNotes });
+};
+
+export default exportNotes;

--- a/lib/cli/vendor/export/normalize-line-break.ts
+++ b/lib/cli/vendor/export/normalize-line-break.ts
@@ -1,0 +1,8 @@
+/**
+ * Normalize line break characters to CRLF
+ * @param content string Content to normalize
+ */
+const normalizeLineBreak = (content: string) =>
+  content.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n');
+
+export default normalizeLineBreak;

--- a/lib/cli/vendor/export/to-zip.ts
+++ b/lib/cli/vendor/export/to-zip.ts
@@ -1,0 +1,36 @@
+import normalizeLineBreak from './normalize-line-break';
+import { prepareNotes } from '../../export-naming.ts';
+import type { ExportNote, GroupedExportNotes } from './types';
+
+type ZipNote = ExportNote & { fileName: string; lastModified?: string };
+
+export const noteExportToZip = (notes: GroupedExportNotes) => {
+  return import(/* webpackChunkName: 'jszip' */ 'jszip').then(
+    ({ default: JSZip }) => {
+      const zip = new JSZip();
+
+      zip.file(
+        'source/notes.json',
+        normalizeLineBreak(JSON.stringify(notes, null, 2))
+      );
+
+      prepareNotes(notes.activeNotes).forEach((note) => {
+        const { content, fileName, lastModified } = note as ZipNote;
+        zip.file(`${fileName}.txt`, content, {
+          date: new Date(lastModified as string),
+        });
+      });
+
+      prepareNotes(notes.trashedNotes).forEach((note) => {
+        const { content, fileName, lastModified } = note as ZipNote;
+        zip.file(`trash/${fileName}.txt`, content, {
+          date: new Date(lastModified as string),
+        });
+      });
+
+      return zip;
+    }
+  );
+};
+
+export default noteExportToZip;

--- a/lib/cli/vendor/export/types.ts
+++ b/lib/cli/vendor/export/types.ts
@@ -1,0 +1,18 @@
+import * as T from '../types';
+
+export type ExportNote = {
+  content: string;
+  collaboratorEmails: T.TagName[];
+  creationDate: T.SecondsEpoch;
+  id: T.EntityId;
+  markdown?: boolean;
+  modificationDate: T.SecondsEpoch;
+  pinned?: boolean;
+  publicURL?: string;
+  tags: T.TagName[];
+};
+
+export type GroupedExportNotes = {
+  activeNotes: ExportNote[];
+  trashedNotes: ExportNote[];
+};

--- a/lib/cli/vendor/filter-notes.ts
+++ b/lib/cli/vendor/filter-notes.ts
@@ -1,0 +1,50 @@
+// Case-insensitive prefix, matching the case-insensitive tag-value matching
+// everywhere else (`TAG:work` filters the same as `tag:work`); a case-sensitive
+// prefix silently degraded `TAG:` to a full-text search for the literal text.
+export const tagPattern = () => /(?:\btag:)([^\s,]+)/gi;
+
+export const withoutTags = (s: string) => s.replace(tagPattern(), '').trim();
+
+export const getTerms = (filterText: string): string[] => {
+  if (!filterText) {
+    return [];
+  }
+
+  const literalsPattern = /(?:")((?:"|[^"])+?)(?:")/g;
+  const boundaryPattern = /[\b\s]/g;
+
+  let match;
+  let storedLastIndex = 0;
+  let withoutLiterals = '';
+
+  const filter = withoutTags(filterText);
+
+  const literals = [];
+  while ((match = literalsPattern.exec(filter)) !== null) {
+    literals.push(match[0].slice(1, -1));
+
+    // anything in between our last saved index and the current match index is a non-literal term
+    // ex: for the search string [ "foo" bar "baz" ] we'll save "bar" as a non-literal here when we match "baz"
+    withoutLiterals += filter.slice(storedLastIndex, match.index);
+
+    // lastIndex is the end of the current match
+    // -- where in the string to start scanning for the next match on the next loop iteration
+    storedLastIndex = literalsPattern.lastIndex;
+  }
+
+  // save any search terms that occur after the last matched literal
+  // i.e. between our last saved index and the end of the string
+  if (
+    (storedLastIndex > 0 || literals.length === 0) &&
+    storedLastIndex < filter.length
+  ) {
+    withoutLiterals += filter.slice(storedLastIndex);
+  }
+
+  const terms = withoutLiterals
+    .split(boundaryPattern)
+    .map((a) => a.trim())
+    .filter((a) => a);
+
+  return [...literals, ...terms];
+};

--- a/lib/cli/vendor/is-email-tag.ts
+++ b/lib/cli/vendor/is-email-tag.ts
@@ -1,0 +1,36 @@
+/**
+ * @module utils/is-email-tag
+ */
+
+import type * as T from './types';
+
+/**
+ * Naively matches what might appear to be an email address
+ *
+ * This is not spec-compliant but it does not need to
+ * be. Users of the app should assume that any tag
+ * name which has the general appearance of a valid
+ * email address will be treated as if they are actual
+ * email addresses and will be used for adding people
+ * to a note as collaborators.
+ *
+ * Three main components are required:
+ *   1. Mailbox piece _before_ the `@`
+ *   2. `@`
+ *   3. Host and domain piece ending in `[some host].[some TLD]`
+ *
+ * @type {RegExp}
+ */
+const naiveEmailPattern = /^(?:[^@]+)@(?:.+)(?:\.[^.]{2,})$/;
+
+/**
+ * Indicates if a given tag name string
+ * represents an email for collaboration
+ *
+ * @param {String} tagName name of tag which might be an email address
+ * @returns {Boolean} whether or not the tag is considered an email address
+ */
+export const isEmailTag = (tagName: T.TagName) =>
+  naiveEmailPattern.test(tagName);
+
+export default isEmailTag;

--- a/lib/cli/vendor/note-utils.ts
+++ b/lib/cli/vendor/note-utils.ts
@@ -1,0 +1,213 @@
+import removeMarkdown from 'remove-markdown';
+import { escapeRegExp } from 'lodash';
+import { getTerms } from './filter-notes';
+
+import * as T from './types';
+
+export interface TitleAndPreview {
+  title: string;
+  preview: string;
+}
+
+export const maxTitleChars = 64;
+export const maxPreviewChars = 200;
+export const MAX_PREVIEW_CACHE_ENTRIES = 1000;
+
+export interface BoundedCache<V> {
+  get(key: string): V | undefined;
+  set(key: string, value: V): void;
+}
+
+/**
+ * Creates a Map-backed cache that evicts the oldest insertion once it exceeds
+ * `maxEntries`. Map iterates in insertion order, so deleting the first key is
+ * an O(1) bounded-cache (a simple LRU approximation; entries are never
+ * re-inserted on read, which is fine for one-shot CLI command lifetimes).
+ */
+export function createBoundedCache<V>(maxEntries: number): BoundedCache<V> {
+  const store = new Map<string, V>();
+  return {
+    get: (key) => store.get(key),
+    set: (key, value) => {
+      store.set(key, value);
+      if (store.size > maxEntries) {
+        const oldest = store.keys().next().value;
+        if (oldest !== undefined) {
+          store.delete(oldest);
+        }
+      }
+    },
+  };
+}
+
+const isLowSurrogate = (c: number) => 0xdc00 <= c && c <= 0xdfff;
+
+/**
+ * Returns a string with markdown stripped
+ *
+ * @param {String} inputString string for which to remove markdown
+ * @returns {String} string with markdown removed
+ */
+const removeMarkdownWithFix = (inputString: string) => {
+  // Workaround for a bug in `remove-markdown`
+  // See https://github.com/stiang/remove-markdown/issues/35
+  return removeMarkdown(inputString.replace(/(\s)\s+/g, '$1'), {
+    stripListLeaders: false,
+  } as Parameters<typeof removeMarkdown>[1]);
+};
+
+export const getTitle = (content: string) => {
+  const titlePattern = new RegExp(`\\s*([^\n]{1,${maxTitleChars}})`, 'g');
+  const titleMatch = titlePattern.exec(content);
+  if (!titleMatch) {
+    return 'New Note…';
+  }
+  const [, title] = titleMatch;
+  return title;
+};
+
+type ContextualMatcher = {
+  terms: string[];
+  regExp: RegExp | undefined;
+};
+
+// Rebuilding the same regex for every note of one search is pure waste: the
+// query is identical across all hits, and the regex has no /g flag, so
+// reusing it cannot leak lastIndex state between notes. Keyed by the raw
+// query string; a CLI command lifetime sees a handful of distinct queries.
+const contextualMatchers = createBoundedCache<ContextualMatcher>(
+  MAX_PREVIEW_CACHE_ENTRIES
+);
+
+function contextualMatcherFor(query: string): ContextualMatcher {
+  const cached = contextualMatchers.get(query);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const terms = getTerms(query);
+  let regExp: RegExp | undefined;
+  // use only the first term of a multi-term query
+  if (terms.length > 0) {
+    const firstTerm = terms[0].toLowerCase();
+    // A single term longer than 30 chars would make `leadingChars` negative
+    // and the quantifier `{0,-N}` an illegal regexp — a search for such a word
+    // crashed with a SyntaxError that surfaced as a network error (exit 3).
+    const leadingChars = Math.max(0, 30 - firstTerm.length);
+
+    // prettier-ignore
+    regExp = new RegExp(
+      '(?:\\s|^)[^\n]' + // split at a word boundary (pattern must be preceded by whitespace or beginning of string)
+        '{0,' + leadingChars + '}' + // up to leadingChars of text before the match
+        escapeRegExp(firstTerm) +
+        '.{0,200}(?=\\s|$)', // up to 200 characters of text after the match, splitting at a word boundary
+      'ims'
+    );
+  }
+  const value = { terms, regExp };
+  contextualMatchers.set(query, value);
+  return value;
+}
+
+/**
+ * Generate preview for note list
+ *
+ * Should gather the first non-whitespace content
+ * for up to three lines and up to 200 characters
+ *
+ * @param content
+ */
+const getPreview = (content: string, searchQuery?: string) => {
+  let preview = '';
+  let lines = 0;
+
+  // contextual note previews
+  if (searchQuery?.trim()) {
+    const { terms, regExp } = contextualMatcherFor(searchQuery);
+
+    if (terms.length > 0 && regExp !== undefined) {
+      const matches = regExp.exec(content);
+      if (matches && matches.length > 0) {
+        // Remove blank lines and note title from the search note preview
+        preview = matches[0]
+          .split('\n')
+          .filter(
+            (line) => line !== '\r' && line !== '' && line !== getTitle(content)
+          )
+          .join('\n');
+        // don't return half of a surrogate pair
+        return isLowSurrogate(preview.charCodeAt(0))
+          ? preview.slice(1)
+          : preview;
+      }
+    }
+  }
+
+  // implicit else: if the query didn't match, fall back to first three lines
+  let index = content.indexOf('\n');
+
+  if (index === -1) {
+    return '';
+  }
+
+  while (index > -1 && lines < 3) {
+    const nextNewline = content.indexOf('\n', index);
+    if (-1 === nextNewline) {
+      return preview + content.slice(index).trim();
+    }
+
+    const nextLine = content.slice(index, nextNewline).trim();
+    if (nextLine) {
+      preview += nextLine + '\n';
+      lines++;
+    }
+
+    index = nextNewline + 1;
+  }
+
+  return preview.trim();
+};
+
+const formatPreview = (stripMarkdown: boolean, s: string): string =>
+  stripMarkdown ? removeMarkdownWithFix(s) || s : s;
+
+const previewCache = createBoundedCache<[TitleAndPreview, boolean, string?]>(
+  MAX_PREVIEW_CACHE_ENTRIES
+);
+
+/**
+ * Returns the title and excerpt for a given note
+ *
+ * @param note generate the previews for this note
+ * @returns title and excerpt (if available)
+ */
+export const noteTitleAndPreview = (
+  note: T.Note,
+  searchQuery?: string
+): TitleAndPreview => {
+  const stripMarkdown = isMarkdown(note);
+  const cached = previewCache.get(note.content);
+  if (cached) {
+    const [value, wasMarkdown, savedQuery] = cached;
+    if (wasMarkdown === stripMarkdown && savedQuery === searchQuery) {
+      return value;
+    }
+  }
+
+  const content = note.content || '';
+  const title = formatPreview(stripMarkdown, getTitle(content));
+  const preview = formatPreview(
+    stripMarkdown,
+    getPreview(content, searchQuery)
+  );
+  const result = { title, preview };
+
+  previewCache.set(note.content, [result, stripMarkdown, searchQuery]);
+
+  return result;
+};
+
+function isMarkdown(note: T.Note): boolean {
+  return note.systemTags.includes('markdown');
+}
+
+export default noteTitleAndPreview;

--- a/lib/cli/vendor/types.ts
+++ b/lib/cli/vendor/types.ts
@@ -1,0 +1,129 @@
+///////////////////////////////////////
+// Simplenote Data Model
+///////////////////////////////////////
+
+export type EntityId = Brand<string, 'EntityId'>;
+
+export type SecondsEpoch = number;
+export type Entity<T> = {
+  id: EntityId;
+  data: T;
+  version: number;
+};
+
+export type TagHash = Brand<string, 'TagHash'> | EntityId;
+export type TagName = Brand<string, 'TagName'>;
+export type SystemTag = 'markdown' | 'pinned' | 'published' | 'shared';
+
+export type Note = {
+  content: string;
+  creationDate: SecondsEpoch;
+  deleted: boolean | 0 | 1;
+  modificationDate: SecondsEpoch;
+  publishURL?: string;
+  shareURL?: string;
+  systemTags: SystemTag[];
+  tags: TagName[];
+};
+
+export type NoteEntity = Entity<Note>;
+
+export type Tag = {
+  index?: number;
+  name: TagName;
+};
+
+export type TagEntity = Entity<Tag>;
+
+export type Preferences = {
+  analytics_enabled: boolean | null;
+};
+
+export type AnalyticsRecord = [string, JSONSerializable | undefined];
+
+export type PreferencesEntity = Entity<Preferences>;
+
+export type VerificationState =
+  | 'dismissed'
+  | 'pending'
+  | 'unknown'
+  | 'unverified'
+  | 'verified';
+
+export type Collection =
+  | { type: 'all' }
+  | { type: 'tag'; tagName: TagName }
+  | { type: 'trash' }
+  | { type: 'untagged' };
+
+///////////////////////////////////////
+// Simperium Types
+///////////////////////////////////////
+export type ConnectionState = 'green' | 'red' | 'offline';
+
+// Local copy of `BucketObject` from the `simperium` npm package. The CLI only
+// needs the type (never the runtime client), and it never declared the
+// dependency — it survived on root node_modules hoisting, which breaks tsc
+// when the module is installed standalone. `id` is a plain string here, the
+// same as @types/simperium's `EntityId` alias, so call sites that hand in
+// strings (parsed index entries, test factories) stay assignment-compatible.
+export type BucketObject<T> = {
+  id: string;
+  data: T;
+  isIndexing?: boolean;
+};
+
+///////////////////////////////////////
+// Application Types
+///////////////////////////////////////
+export type DialogType =
+  | { type: 'ABOUT' }
+  | { type: 'BETA-WARNING' }
+  | { type: 'CLOSE-WINDOW-CONFIRMATION' }
+  | { type: 'IMPORT' }
+  | { type: 'KEYBINDINGS' }
+  | { type: 'LOGOUT-CONFIRMATION' }
+  | { type: 'SETTINGS' }
+  | { type: 'SHARE' }
+  | {
+      type: 'TRASH-TAG-CONFIRMATION';
+      tagName: TagName;
+    };
+export type LineLength = 'full' | 'narrow';
+export type ListDisplayMode = 'expanded' | 'comfy' | 'condensed';
+export type SortType = 'alphabetical' | 'creationDate' | 'modificationDate';
+export type Theme = 'system' | 'light' | 'dark';
+export type TranslatableString = Brand<string, 'TranslatableString'>;
+
+///////////////////////////////////////
+// Language and Platform
+///////////////////////////////////////
+
+export type Brand<T, Name> = T & { __type__: Name };
+
+export type JSONValue =
+  | null
+  | boolean
+  | number
+  | string
+  | Array<JSONValue>
+  | { [key: string]: JSONValue };
+
+export type JSONSerializable = { [key: string]: JSONValue };
+
+export type RecursivePartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? RecursivePartial<U>[]
+    : T[P] extends object
+      ? RecursivePartial<T[P]>
+      : T[P];
+};
+
+// Returns a type with the properties in T not also present in U
+export type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+
+// Either type T or type U, a powered-up union/sum type
+// useful when missing a discriminating property
+export type XOR<T, U> = T | U extends object
+  ? (Without<T, U> & U) | (Without<U, T> & T)
+  : T | U;

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,7 @@
         "stylelint-config-standard": "37.0.0",
         "stylelint-config-standard-scss": "14.0.0",
         "stylelint-prettier": "5.0.3",
+        "tsx": "^4.23.5",
         "typescript": "5.7.3",
         "wait-on": "8.0.2",
         "webpack": "5.97.1",
@@ -2817,6 +2818,448 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -9191,6 +9634,48 @@
       },
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -18375,6 +18860,25 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tsx": {
+      "version": "4.23.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
+      "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tty-browserify": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "make lint",
     "format": "make format",
     "build": "make build",
+    "cli": "node --import tsx --dns-result-order=ipv4first bin/simplenote-cli.js",
     "deploy": "./bin/deploy.sh",
     "prepare": "git config --local core.hooksPath .githooks"
   },
@@ -25,7 +26,7 @@
     "url": "git://github.com/Automattic/simplenote-electron.git"
   },
   "engines": {
-    "node": ">= 12.14.1",
+    "node": "^18.0.0 || ^20.0.0 || >=22.0.0",
     "npm": ">= 6.13.7"
   },
   "browserslist": [
@@ -108,6 +109,7 @@
     "stylelint-config-standard": "37.0.0",
     "stylelint-config-standard-scss": "14.0.0",
     "stylelint-prettier": "5.0.3",
+    "tsx": "^4.23.5",
     "typescript": "5.7.3",
     "wait-on": "8.0.2",
     "webpack": "5.97.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "allowJs": true,
     "jsx": "react",
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "strict": true,
     "isolatedModules": true,


### PR DESCRIPTION
…ile distribution, and launch-gap remediation

Problem
- No standalone entry or distribution: bin/ lacked a CLI shim, and command logic was mixed into the process-lifecycle bootstrap, making the CLI impossible to unit-test or to package and install independently.
- Password login failed in production shapes: config.json was resolved relative to process.cwd(), yielding an empty app_key (and an opaque 401) when run from a subdirectory or a packaged build; the repo's config.json ships a development app key (history-analyst-dad) that does not match the production APP_ID (chalk-bump-f49), so password authorize always 401s with no guidance.
- Networking lacked timeouts and budget: global fetch has no default timeout, so a half-open socket hangs forever; retries could outlive the caller's total budget; SIGINT/SIGTERM could not cancel in-flight requests.
- Export was not atomic: artifacts were written in place and the markdown writer deleted active/ and trash/ before writing, so a crash, full disk, or interrupt left a truncated export or lost both the old and new copies.
- add import semantics were broken: no controlled concurrency (same-fingerprint races duplicated notes); fingerprints ignored line-break/case/Unicode normalization, so cross-platform export→import round-trips re-imported duplicates.
- Tag and search inconsistencies: tags could contain whitespace, commas, or newlines (unsearchable via tag: queries and breaking exported markdown); tag: matching was case-sensitive and not Unicode-normalized; overly long search terms could crash; blank queries were not guarded.
- Output and sorting defects: list output did not escape tab/CR, breaking column layout; sort used difference-based comparison with precision/NaN hazards.
- Dependency and baseline issues: lodash had known vulnerabilities; tight coupling to simperium; version was not baked at build time; the unit-test baseline (423 tests) had 26 coverage gaps.

Architecture
- Layering (top to bottom; each layer depends only on layers below it): app.ts (process lifecycle, dispatch, exit codes, signals) → commands/*.ts (one user-facing verb each: login/logout/whoami/list/show/search/edit/create/add/export) → auth.ts (password login + magic-link request/code flows) → export-helpers.ts (staging/commit/rollback transaction) + export-naming.ts (pure filename pipeline) → note-source.ts (Simperium bucket find/get/update/create) + content-input.ts (--file= reading) → cli-args.ts (argv parsing) + command-help.ts (per-command help) + store.ts (credential persistence, atomic write + 0600) → config.ts (app key/version resolution) + logging.ts (debug output) → infra/http.ts (single fetch egress: timeout, retry, budget, cancellation) → domain/*.ts (pure types, sorting, trash rules, tags, top-k, error taxonomy) + vendor/*.ts (read-only desktop-app mirrors)
- bin/simplenote-cli(.js) → bootstrap.ts (thin shim) → app.ts: importing app.ts has no side effects and is fully unit-testable; bootstrap.ts runs the CLI.

Features
- Complete command set with exit-code contract 0-99: 0 ok / 1 usage / 2 auth / 3 network / 4 not found / 5 conflict / 6 aborted / 7 partial / 99 unexpected.
- login: password via SIMPLENOTE_USER + SIMPLENOTE_PASSWORD, or magic-link (requestLoginEmail + 6-char code); never retried (authorize rate-limits; complete-login burns a single-use code); 429 classified as RateLimitError (exit 3); 401 guides to magic-link; credentials stored with atomic write + chmod 0600.
- list/search: tab-separated summaries sorted by modification date desc (three-way comparator, top-k via topBy); --limit/--json/--include-trashed; output escapes tab/CR; search supports tag: filters (case-insensitive + NFC-normalized), one precompiled regex per term, blank-query guard, no crash on overlong terms.
- show/edit/create: --json / --content= / --file= / positional input; blank content rejected (exit 1); trash-aware (edit trashed note → exit 5, show missing → exit 4); `--` terminator for dash-prefixed content.
- add: batch import from a JSON array file with sha1 fingerprints (content line-break + NFC normalized, tags case/dedup-normalized) for cross-platform idempotency; per-key serialized controlled concurrency; consecutive failures ≥5 abort early; partial failures exit 7.
- export: json/markdown/zip/all via a two-phase transaction — all artifacts staged as .part, then commitAll swaps them in as one unit (.bak backups + rollback on failure); sweepStale restores backups instead of deleting; format enum and empty --output validated.
- Config/version: ancestor-anchor discovery bounded at the repo root; SIMPLENOTE_APP_KEY overrides config.json (production-key injection channel); version baked at build time (SIMPLENOTE_CLI_VERSION) with package.json fallback.
- Networking: per-attempt wall-clock deadline covering body read (SIMPLENOTE_CLI_TIMEOUT_MS), bounded exponential-backoff + full-jitter retries for idempotent calls only, authoritative total budget (SIMPLENOTE_CLI_TOTAL_TIMEOUT_MS), process-level abort bridge for SIGINT/SIGTERM.
- Packaging: SEA single-file executable (simplenote-cli.exe) via scripts/build.mjs (esbuild bundle + version bake) + scripts/sea.mjs (Node>=18.13 preflight, sentinel fuse, postject host probing) + scripts/install.mjs (install to ~/.local/bin with version manifest); lib/cli ships its own package.json (simplenote-cli 0.1.0) and README.

Implementation
- Added bin/simplenote-cli and bin/simplenote-cli.js entries; bootstrap is now a thin shim while argv dispatch, signals, and exit codes moved into app.ts (side-effect-free and unit-testable).
- config.ts walks ancestor anchors (moduleAnchors/projectBoundedAnchors) bounded at the repo root and added SIMPLENOTE_APP_KEY as the injection channel for a production key; getVersion supports a build-time esbuild-baked version with manifest and fallback.
- infra/http.ts is now the single fetch egress: per-attempt wall-clock deadline (covering body read), bounded retries with exponential backoff + full jitter (opt-in for idempotent calls only), an authoritative total budget, and a process-level abort bridge (setExternalAbortSignal/isExternalAborted).
- export now uses a two-phase transaction: every artifact is staged under .part first, then commitAll swaps them in as one unit (old artifacts parked as .bak with rollback on failure); sweepStale restores backups instead of deleting them; --format enum and empty --output are validated.
- add imports with per-key serialized controlled concurrency; fingerprints unify NFC + line-break normalization + case/dedup-normalized tags for stable idempotency across platforms; consecutive failures ≥5 abort early; partial failures exit 7.
- domain/tags.ts is the single normalization source: rejects whitespace/commas/newlines, dedups, and NFC-normalizes; search tag: filtering is case-insensitive and NFC-normalized with one precompiled regex per term; blank queries are guarded; list/search escape tab/CR.
- domain/sort.ts uses a three-way comparator to eliminate precision/NaN hazards; topBy unifies top-k; --limit/--include-trashed/--json follow the exit-code contract.
- auth.ts distinguishes 429 (RateLimitError → exit 3) from auth failures (exit 2) and guides users to magic-link on 401; login/code flows never retry (authorize rate-limits; complete-login burns a single-use code).
- SEA packaging: scripts/build.mjs (esbuild bundle + version bake), scripts/sea.mjs (Node SEA single file, Node>=18.13 preflight, sentinel fuse, postject host probing), scripts/install.mjs (local install to ~/.local/bin with a version manifest).
- Completed 26 unit-test gaps (including infra/http, export-naming, tags) and added domain/__tests__/tags.test.ts, raising the baseline from 423 to 585.

Impact
- New self-contained lib/cli module with bin entries covering the full command set (login/logout/whoami/list/show/search/edit/create/add/export) and an exit-code contract 0-99; HELP/README documentation updated alongside.
- Production-account e2e regression: 73 PASS / 1 FAIL (F-1: password login fails because the dev app key does not match the production APP_ID — an architectural constraint, not a regression; magic-link is the working alternative).
- 30 suites / 585 unit tests green; eslint 0 errors; SEA single-file executable installable locally.
- vendor/ remains a read-only mirror of the desktop app; desktop behavior untouched; repo-root package.json/tsconfig/eslint/.buildkite integrated for CLI build and test.

Tests
- npx jest lib/cli: 30 suites / 585 tests, all passed (0 failures). Per-suite breakdown: __tests__/add.test.ts: 44 | app.test.ts: 62 | auth.test.ts: 25 | bootstrap.test.ts: 5 | cli-args.test.ts: 63 | cli-constants.test.ts: 12 | command-help.test.ts: 9 | config.test.ts: 23 | content-input.test.ts: 5 | contract/note-source.contract.test.ts: 6 | create.test.ts: 16 | edit.test.ts: 15 | export-helpers.test.ts: 43 | export-publish.test.ts: 2 | export-to-zip.test.ts: 3 | export.test.ts: 21 | list.test.ts: 17 | logging.test.ts: 4 | note-source.test.ts: 51 | search.test.ts: 26 | show.test.ts: 10 | store.test.ts: 18 | whoami.test.ts: 4 | domain/errors.test.ts: 13 | domain/note.test.ts: 18 | domain/sort.test.ts: 13 | domain/tags.test.ts: 9 | domain/top.test.ts: 9 | domain/trash.test.ts: 4 | infra/http.test.ts: 35.
- npx eslint lib/cli: 0 errors; npx tsc --noEmit lib/cli: 0 errors.
- Production e2e: P1 read-only 19/19, P2 write round-trip 22/22, P3 export 9/9, P4 login/logout 9 PASS/1 FAIL (F-1), P5 fault injection 5/5, P6 cleanup 5/5, P7 final verification 4/4.
- git diff --cached --check clean; commits squashed (17→1) and pushed to origin/feature/cli.

### Fix

<!--
**_(Required)_** Add a concise description of what you fixed. If this is related
to an issue, add a link to it. If applicable, add screenshots, animations, or
videos to help illustrate the fix.
-->

### Test

<!--
**_(Required)_** List the steps to test the behavior. For example:
> 1. Go to...
> 2. Tap on...
> 3. See error...
-->

1.
2.
3.

### Release

<!--
**_(Required)_** Add a concise statement to `RELEASE-NOTES.md` if the changes should be included in release notes. Include details about updating the notes in this section. For example:

> `RELEASE-NOTES.md` was updated with:
>
> > Added markdown support

If the changes should not be included in release notes, add a statement to this section. For example:

> These changes do not require release notes.
-->
