### PR TITLE
Fix blank Markdown previews from search results

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,6 +6,10 @@
 
 - Simplified markdown sanitation
 
+### Fixes
+
+- Fixed Markdown previews appearing blank when viewing notes from search results
+
 ## [v2.27.0]
 
 ### Enhancements

--- a/lib/note-detail/render-to-node.test.ts
+++ b/lib/note-detail/render-to-node.test.ts
@@ -1,0 +1,14 @@
+import { renderToNode } from './render-to-node';
+
+describe('renderToNode', () => {
+  it('renders and highlights search matches in a detached element', async () => {
+    const renderTarget = document.createElement('div');
+
+    await renderToNode(renderTarget, 'Simplenote content', 'simplenote');
+
+    expect(renderTarget.textContent).toContain('Simplenote content');
+    expect(renderTarget.querySelector('.search-match')?.textContent).toBe(
+      'Simplenote'
+    );
+  });
+});

--- a/lib/note-detail/render-to-node.ts
+++ b/lib/note-detail/render-to-node.ts
@@ -71,7 +71,7 @@ export const renderToNode = (
       );
 
       const nodes: Text[] = [];
-      let currentNode: Node | null = treeWalker.currentNode;
+      let currentNode: Node | null = treeWalker.nextNode();
 
       while (currentNode) {
         nodes.push(currentNode as Text);


### PR DESCRIPTION
### Fix

Fixes #3364.

Markdown previews could render as a blank note when a search query was active. The preview is rendered into a detached element, but the search-highlighting TreeWalker started from its root element and treated that root as a text node. This caused a null `parentNode` error before the rendered content could be copied back into the visible preview.

Start the traversal at the first matching text node instead, and add a regression test covering search highlighting in a detached render target.

Forum report: https://forums.simplenote.com/forums/topic/markdown-preview-broken-during-find/#post-6679

### Test

Reviewer reproduction:

1. Enable Markdown for a note containing a searchable term.
2. Search for that term and open the note from the search results.
3. Switch to Markdown preview and confirm the rendered note remains visible with the match highlighted.

Automated verification performed:

- `npx jest --config=./jest.config.js lib/note-detail/render-to-node.test.ts --runInBand`
- `npm test` — 24/24 suites passed; 168 tests passed and 1 skipped
- `npm run lint` — completed with 0 errors (32 existing warnings)

### Release

`RELEASE-NOTES.md` was updated with:

> Fixed Markdown previews appearing blank when viewing notes from search results